### PR TITLE
Co-variant return for createContextual

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -127,7 +127,7 @@ implements ContextualDeserializer
      * for.
      */
     @Override
-    public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
+    public CollectionDeserializer createContextual(DeserializationContext ctxt,
             BeanProperty property) throws JsonMappingException
     {
         // May need to resolve types for delegate-based creators:


### PR DESCRIPTION
As discussed in #3. No new tests fail that aren't currently failing, so I'm pretty sure it's a safe change.
