### PR TITLE
Add support for maps with java.util.Locale keys to the set of StdKeyDeserializers

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.deser.std;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Locale;
 import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -224,6 +225,22 @@ public abstract class StdKeyDeserializer
              *   here, so let's not bother even trying...
              */
             return Float.valueOf((float) _parseDouble(key));
+        }
+    }
+
+    @JacksonStdImpl
+    final static class LocaleKD extends StdKeyDeserializer {
+        protected JdkDeserializers.LocaleDeserializer _localeDeserializer;
+
+        LocaleKD() { super(Locale.class); _localeDeserializer = new JdkDeserializers.LocaleDeserializer();}
+
+        @Override
+        protected Locale _parse(String key, DeserializationContext ctxt) throws JsonMappingException {
+            try {
+                return _localeDeserializer._deserialize(key,ctxt);
+            } catch (IOException e) {
+                throw ctxt.weirdKeyException(_keyClass, key, "unable to parse key as locale");
+            }
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -14,11 +14,15 @@ import com.fasterxml.jackson.databind.util.EnumResolver;
  * Helper class used to contain simple/well-known key deserializers.
  * Following kinds of Objects can be handled currently:
  *<ul>
- * <li>Primitive wrappers</li>
+ * <li>Primitive wrappers (Boolean, Byte, Char, Short, Integer, Float, Long, Double)</li>
  * <li>Enums (usually not needed, since EnumMap doesn't call us)</li>
+ * <li>{@link java.util.Date}</li>
+ * <li>{@link java.util.Calendar}</li>
+ * <li>{@link java.util.UUID}</li>
+ * <li>{@link java.util.Locale}</li>
  * <li>Anything with constructor that takes a single String arg
  *   (if not explicitly @JsonIgnore'd)</li>
- * <li>Anything with 'static T valueOf(String)' factory method
+ * <li>Anything with {@code static T valueOf(String)} factory method
  *   (if not explicitly @JsonIgnore'd)</li>
  *</ul>
  */
@@ -39,6 +43,7 @@ public class StdKeyDeserializers
         add(new StdKeyDeserializer.DateKD());
         add(new StdKeyDeserializer.CalendarKD());
         add(new StdKeyDeserializer.UuidKD());
+        add(new StdKeyDeserializer.LocaleKD());
     }
 
     private void add(StdKeyDeserializer kdeser)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestMapDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestMapDeserialization.java
@@ -359,6 +359,20 @@ public class TestMapDeserialization
          assertEquals(UUID.class, ob.getClass());
          assertEquals(key, ob);
     }
+
+    public void testLocaleKeyMap() throws Exception {
+        Locale key = Locale.CHINA;
+        String JSON = "{ \"" + key + "\":4}";
+        Map<Locale, Object> result = MAPPER.readValue(JSON, new TypeReference<Map<Locale, Object>>() {
+        });
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        Object ob = result.keySet().iterator().next();
+        assertNotNull(ob);
+        assertEquals(Locale.class, ob.getClass());
+        assertEquals(key, ob);
+    }
+
     
     /*
     /**********************************************************


### PR DESCRIPTION
The current support for key deserializers causes issues when a Map has a key with a type of java.util.Locale.

Locale has a single-argument string constructor that the delegating deserializer calls when it is used as the key for a map. This is not usually the correct constructor. The existing JdkDeserializer support for Locale is re-used in this patch. 

A test case is also included, and the javadoc for the method is updated to reflect the addition of locale support.
