### PR TITLE
This change will generate JSON as required if the Java class contains the @XMLElement(required=true).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@ com.fasterxml.jackson.core.io,
 com.fasterxml.jackson.core.util,
 com.fasterxml.jackson.core.type,
 org.xml.sax,org.w3c.dom, org.w3c.dom.bootstrap, org.w3c.dom.ls,
-javax.xml.datatype, javax.xml.namespace, javax.xml.parsers
+javax.xml.datatype, javax.xml.namespace, javax.xml.parsers, javax.xml.bind.annotation
 </Import-Package>
               <Private-Package>
 </Private-Package>

--- a/src/main/java/com/fasterxml/jackson/databind/jsonschema/SchemaAware.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonschema/SchemaAware.java
@@ -20,4 +20,15 @@ public interface SchemaAware
      */
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         throws JsonMappingException;
+    
+    /**
+     * Get the representation of the schema to which this serializer will conform.
+     *
+     * @param provider The serializer provider.
+     * @param isOptional Is the type optional
+     * @param typeHint A hint about the type.
+     * @return <a href="http://json-schema.org/">Json-schema</a> for this serializer.
+     */
+    public JsonNode getSchema(SerializerProvider provider, Type typeHint, boolean isOptional)
+        throws JsonMappingException;
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -86,6 +86,21 @@ public abstract class StdSerializer<T>
         return createSchemaNode("string");
     }
     
+    /**
+     * Default implementation simply claims type is "string"; usually
+     * overriden by custom serializers.
+     */
+    @Override
+    public JsonNode getSchema(SerializerProvider provider, Type typeHint, boolean isOptional)
+        throws JsonMappingException
+    {
+    	ObjectNode schema = (ObjectNode) getSchema(provider, typeHint);
+    	if (!isOptional) {
+    		schema.put("required", !isOptional);
+    	}
+        return schema;
+    }
+    
     protected ObjectNode createObjectNode() {
         return JsonNodeFactory.instance.objectNode();
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/TestGenerateJsonSchema.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.databind.jsonschema;
 
 import java.util.*;
 
+import javax.xml.bind.annotation.XmlElement;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsonschema.JsonSchema;
@@ -25,7 +27,9 @@ public class TestGenerateJsonSchema
         private String property2;
         private String[] property3;
         private Collection<Float> property4;
-
+        @XmlElement(required=true)
+        private String property5;
+        
         public int getProperty1()
         {
             return property1;
@@ -65,6 +69,16 @@ public class TestGenerateJsonSchema
         {
             this.property4 = property4;
         }
+        
+        public String getProperty5()
+        {
+            return property5;
+        }
+
+        public void setProperty5(String property5)
+        {
+            this.property5 = property5;
+        }
     }
 
     public class TrivialBean {
@@ -91,6 +105,7 @@ public class TestGenerateJsonSchema
         throws Exception
     {
         JsonSchema jsonSchema = MAPPER.generateJsonSchema(SimpleBean.class);
+        
         assertNotNull(jsonSchema);
 
         // test basic equality, and that equals() handles null, other obs
@@ -125,6 +140,10 @@ public class TestGenerateJsonSchema
         assertEquals("array", property4Schema.get("type").asText());
         assertEquals(false, property4Schema.path("required").booleanValue());
         assertEquals("number", property4Schema.get("items").get("type").asText());
+        JsonNode property5Schema = propertiesSchema.get("property5");
+        assertNotNull(property5Schema);
+        assertEquals("string", property5Schema.get("type").asText());
+        assertEquals(true, property5Schema.path("required").booleanValue());
     }
 
     /**


### PR DESCRIPTION
To add context, we are generating our Java classes from an XSD.  The Java classes contain the @XMLElement(required=true) annotation if it is required.  This change will add the required attribute when generating the JSON schema from the Java class.
