### PR TITLE
Implemented the required attribute for JSON schema generation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsonschema/SchemaAware.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonschema/SchemaAware.java
@@ -20,4 +20,15 @@ public interface SchemaAware
      */
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         throws JsonMappingException;
+    
+    /**
+     * Get the representation of the schema to which this serializer will conform.
+     *
+     * @param provider The serializer provider.
+     * @param isOptional Is the type optional
+     * @param typeHint A hint about the type.
+     * @return <a href="http://json-schema.org/">Json-schema</a> for this serializer.
+     */
+    public JsonNode getSchema(SerializerProvider provider, Type typeHint, boolean isOptional)
+        throws JsonMappingException;
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -86,6 +86,21 @@ public abstract class StdSerializer<T>
         return createSchemaNode("string");
     }
     
+    /**
+     * Default implementation simply claims type is "string"; usually
+     * overriden by custom serializers.
+     */
+    @Override
+    public JsonNode getSchema(SerializerProvider provider, Type typeHint, boolean isOptional)
+        throws JsonMappingException
+    {
+    	ObjectNode schema = (ObjectNode) getSchema(provider, typeHint);
+    	if (!isOptional) {
+    		schema.put("required", !isOptional);
+    	}
+        return schema;
+    }
+    
     protected ObjectNode createObjectNode() {
         return JsonNodeFactory.instance.objectNode();
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/TestGenerateJsonSchema.java
@@ -1,10 +1,11 @@
 package com.fasterxml.jackson.databind.jsonschema;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsonschema.JsonSchema;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -25,7 +26,9 @@ public class TestGenerateJsonSchema
         private String property2;
         private String[] property3;
         private Collection<Float> property4;
-
+        @JsonProperty(required=true)
+        private String property5;
+        
         public int getProperty1()
         {
             return property1;
@@ -65,6 +68,16 @@ public class TestGenerateJsonSchema
         {
             this.property4 = property4;
         }
+        
+        public String getProperty5()
+        {
+            return property5;
+        }
+
+        public void setProperty5(String property5)
+        {
+            this.property5 = property5;
+        }
     }
 
     public class TrivialBean {
@@ -91,6 +104,7 @@ public class TestGenerateJsonSchema
         throws Exception
     {
         JsonSchema jsonSchema = MAPPER.generateJsonSchema(SimpleBean.class);
+        
         assertNotNull(jsonSchema);
 
         // test basic equality, and that equals() handles null, other obs


### PR DESCRIPTION
Implemented the required attribute for the bean classes that have properties annotated with an annotation that requires the value to be present, determined by it's annotation introspector.  
