### PR TITLE
Fixing the logic in the isEmpty method. 

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/IterableSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/IterableSerializer.java
@@ -43,7 +43,7 @@ public class IterableSerializer
     @Override
     public boolean isEmpty(Iterable<?> value) {
         // Not really good way to implement this, but has to do for now:
-        return (value == null) || value.iterator().hasNext();
+        return (value == null) || !value.iterator().hasNext();
     }
 
     @Override


### PR DESCRIPTION
Quite possibly this particular method in IterableSerializer is not currently used, but I just noticed the logic was wrong.
