### PR TITLE
added addHandler() to ObjectReader

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -457,7 +457,7 @@ public class ObjectReader
         return (newConfig == _config) ? this :  new ObjectReader(this, newConfig);
     }
 
-    public ObjectReader addHandler(DeserializationProblemHandler h) {
+    public ObjectReader withHandler(DeserializationProblemHandler h) {
         DeserializationConfig newConfig = _config.withHandler(h);
         return (newConfig == _config) ? this :  new ObjectReader(this, newConfig);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/filter/TestUnknownPropertyDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/filter/TestUnknownPropertyDeserialization.java
@@ -163,7 +163,7 @@ public class TestUnknownPropertyDeserialization
     {
         ObjectMapper mapper = new ObjectMapper();
         mapper.clearProblemHandlers();
-        TestBean result = mapper.reader(TestBean.class).addHandler(new MyHandler()).readValue(new StringReader(JSON_UNKNOWN_FIELD));
+        TestBean result = mapper.reader(TestBean.class).withHandler(new MyHandler()).readValue(new StringReader(JSON_UNKNOWN_FIELD));
         assertNotNull(result);
         assertEquals(1, result._a);
         assertEquals(-1, result._b);


### PR DESCRIPTION
Jackson 2.0 doesn't expose a decent way to clone an ObjectMapper, like I did in Jackson 1.9. The proper way would've been to use an ObjectReader anyway, but I really need a ProblemHandler during my deserialization. Thus, I've added addHandler() to ObjectReader.

I also added a test which should work, however I can't get it to run since the project fails to build on git clone (snapshot versions of jackson dependencies are not found).

Hope this is OK - I think that sending a pull request is slightly better than reporting an issue :)
