### PR TITLE
j.u.Concurrent* -> j.u.concurrent.Concurrent*

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -105,12 +105,13 @@ public abstract class BasicDeserializerFactory
          */
         _mapFallbacks.put("java.util.NavigableMap", TreeMap.class);
         try {
-            Class<?> key = Class.forName("java.util.ConcurrentNavigableMap");
-            Class<?> value = Class.forName("java.util.ConcurrentSkipListMap");
+            Class<?> key = Class.forName("java.util.concurrent.ConcurrentNavigableMap");
+            Class<?> value = Class.forName("java.util.concurrent.ConcurrentSkipListMap");
             @SuppressWarnings("unchecked")
                 Class<? extends Map<?,?>> mapValue = (Class<? extends Map<?,?>>) value;
             _mapFallbacks.put(key.getName(), mapValue);
         } catch (ClassNotFoundException cnfe) { // occurs on 1.5
+        } catch (SecurityException se) { // might occur in applets, see stackoverflow.com/questions/12345068
         }
     }
 


### PR DESCRIPTION
The package names of the concurrent maps, to be `Class.forName()`'ed at runtime was wrong. I guess this code path has just never been tested.

I also catch SecurityException, as that might be thrown when jackson is embedded in an applet, see http://stackoverflow.com/questions/12345068/
