### PR TITLE
TokenBuffer: fix compile error

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -506,7 +506,6 @@ public class TokenBuffer
         _reportUnsupportedOperation();
     }
 
-    @Override
     public void writeRaw(SerializableString text) throws IOException, JsonGenerationException {
         _reportUnsupportedOperation();
     }


### PR DESCRIPTION
The method this annotation was appended to did not override any method from a
superclass.
