### PR TITLE
Get rid of custom empty iterator classes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -31,9 +31,6 @@ import com.fasterxml.jackson.core.TreeNode;
 public abstract class JsonNode
     implements TreeNode, Iterable<JsonNode>
 {
-    protected final static List<JsonNode> NO_NODES = Collections.emptyList();
-    protected final static List<String> NO_STRINGS = Collections.emptyList();
-
     /*
     /**********************************************************
     /* Construction, related
@@ -679,21 +676,27 @@ public abstract class JsonNode
      * field names (keys) are not included, only values.
      * For other types of nodes, returns empty iterator.
      */
-    public Iterator<JsonNode> elements() { return NO_NODES.iterator(); }
+    public Iterator<JsonNode> elements()
+    {
+        return Collections.emptyIterator();
+    }
 
     /**
      * Method for accessing names of all fields for this Node, iff
      * this node is a JSON Object node.
      */
-    public Iterator<String> fieldNames() { return NO_STRINGS.iterator(); }
+    public Iterator<String> fieldNames()
+    {
+        return Collections.emptyIterator();
+    }
 
     /**
      * @return Iterator that can be used to traverse all key/value pairs for
      *   object nodes; empty iterator (no contents) for other types
      */
-    public Iterator<Map.Entry<String, JsonNode>> fields() {
-        Collection<Map.Entry<String, JsonNode>> coll = Collections.emptyList();
-        return coll.iterator();
+    public Iterator<Map.Entry<String, JsonNode>> fields()
+    {
+        return Collections.emptyIterator();
     }
     
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ArrayNode.java
@@ -77,7 +77,9 @@ public class ArrayNode
     @Override
     public Iterator<JsonNode> elements()
     {
-        return (_children == null) ? NoNodesIterator.instance() : _children.iterator();
+        return _children == null
+            ? Collections.<JsonNode>emptyIterator()
+            : _children.iterator();
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/node/ContainerNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ContainerNode.java
@@ -132,46 +132,4 @@ public abstract class ContainerNode<T extends ContainerNode<T>>
     /* Helper classes
     /**********************************************************
      */
-
-    protected static class NoNodesIterator
-        implements Iterator<JsonNode>
-    {
-        final static NoNodesIterator instance = new NoNodesIterator();
-
-        private NoNodesIterator() { }
-
-        public static NoNodesIterator instance() { return instance; }
-
-//      @Override
-        public boolean hasNext() { return false; }
-//      @Override
-        public JsonNode next() { throw new NoSuchElementException(); }
-
-//      @Override
-        public void remove() {
-            // could as well throw IllegalOperationException?
-            throw new IllegalStateException();
-        }
-    }
-
-    protected static class NoStringsIterator
-        implements Iterator<String>
-    {
-        final static NoStringsIterator instance = new NoStringsIterator();
-
-        private NoStringsIterator() { }
-
-        public static NoStringsIterator instance() { return instance; }
-
-//      @Override
-        public boolean hasNext() { return false; }
-//      @Override
-        public String next() { throw new NoSuchElementException(); }
-
-//      @Override
-        public void remove() {
-            // could as well throw IllegalOperationException?
-            throw new IllegalStateException();
-        }
-    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -79,7 +79,9 @@ public class ObjectNode
     @Override
     public Iterator<JsonNode> elements()
     {
-        return (_children == null) ? NoNodesIterator.instance() : _children.values().iterator();
+        return _children == null
+            ? Collections.<JsonNode>emptyIterator()
+            : _children.values().iterator();
     }
 
     @Override
@@ -95,8 +97,11 @@ public class ObjectNode
     }
 
     @Override
-    public Iterator<String> fieldNames() {
-        return (_children == null) ? NoStringsIterator.instance() : _children.keySet().iterator();
+    public Iterator<String> fieldNames()
+    {
+        return _children == null
+            ? Collections.<String>emptyIterator()
+            : _children.keySet().iterator();
     }
 
     @Override
@@ -124,10 +129,9 @@ public class ObjectNode
     @Override
     public Iterator<Map.Entry<String, JsonNode>> fields()
     {
-        if (_children == null) {
-            return NoFieldsIterator.instance;
-        }
-        return _children.entrySet().iterator();
+        return _children == null
+            ? Collections.<Map.Entry<String, JsonNode>>emptyIterator()
+            : _children.entrySet().iterator();
     }
 
     @Override


### PR DESCRIPTION
These classes implemented Iterator<T> and implemented the .hasNext(), .next()
and .remove() method exactly as Collections.emptyIterator() does.

Use the latter instead.
