### PR TITLE
JsonNode, MissingNode, ValueNode: some simplifications 

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -324,7 +324,7 @@ public abstract class JsonNode
      *   if this node is an array and has specified element.
      *   Null otherwise.
      */
-    public JsonNode get(int index) { return null; }
+    public abstract JsonNode get(int index);
 
     /**
      * Method for accessing value of the specified field of

--- a/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
  * conversions. 
  */
 public final class MissingNode
-    extends BaseJsonNode
+    extends ValueNode
 {
     private final static MissingNode instance = new MissingNode();
 
@@ -51,12 +51,6 @@ public final class MissingNode
     public boolean asBoolean(boolean defaultValue);
     */
     
-    @Override
-    public JsonNode path(String fieldName) { return this; }
-
-    @Override
-    public JsonNode path(int index) { return this; }
-
     @Override
     public final void serialize(JsonGenerator jg, SerializerProvider provider)
         throws IOException, JsonProcessingException

--- a/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
@@ -39,18 +39,6 @@ public abstract class ValueNode
         serialize(jg, provider);
         typeSer.writeTypeSuffixForScalar(this, jg);
     }
-    
-    /*
-    /**********************************************************************
-    /* Public API, path handling
-    /**********************************************************************
-     */
-
-    @Override
-    public JsonNode path(String fieldName) { return MissingNode.getInstance(); }
-
-    @Override
-    public JsonNode path(int index) { return MissingNode.getInstance(); }
 
     /*
     /**********************************************************************
@@ -60,4 +48,58 @@ public abstract class ValueNode
 
     @Override
     public String toString() { return asText(); }
+
+    /*
+     **********************************************************************
+     * Navigation methods
+     **********************************************************************
+     */
+
+    @Override
+    public final JsonNode get(int index)
+    {
+        return null;
+    }
+
+    @Override
+    public final JsonNode path(int index)
+    {
+        return MissingNode.getInstance();
+    }
+
+    @Override
+    public final boolean has(int index)
+    {
+        return false;
+    }
+
+    @Override
+    public final boolean hasNonNull(int index)
+    {
+        return false;
+    }
+
+    @Override
+    public final JsonNode get(String fieldName)
+    {
+        return null;
+    }
+
+    @Override
+    public final JsonNode path(String fieldName)
+    {
+        return MissingNode.getInstance();
+    }
+
+    @Override
+    public final boolean has(String fieldName)
+    {
+        return false;
+    }
+
+    @Override
+    public final boolean hasNonNull(String fieldName)
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
- Make ValueNode implement .get(), .has(), .path(), .hasNonNull() for both array
  indices; make all of them final.
- Make .get(int) in JsonNode abstract, all derivate classes implement it now.
- Make MissingNode inherit ValueNode instead of BaseJsonNode.
