### PR TITLE
Reorganize find methods in JsonNode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BaseJsonNode.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.databind.node;
 
 import java.io.IOException;
-import java.util.List;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,11 +28,6 @@ public abstract class BaseJsonNode
      */
 
     @Override
-    public JsonNode findValue(String fieldName) {
-        return null;
-    }
-
-    @Override
     public final JsonNode findPath(String fieldName)
     {
         JsonNode value = findValue(fieldName);
@@ -42,28 +36,7 @@ public abstract class BaseJsonNode
         }
         return value;
     }
-    
-    // note: co-variant return type
-    @Override
-    public ObjectNode findParent(String fieldName) {
-        return null;
-    }
 
-    @Override
-    public List<JsonNode> findValues(String fieldName, List<JsonNode> foundSoFar) {
-        return foundSoFar;
-    }
-
-    @Override
-    public List<String> findValuesAsText(String fieldName, List<String> foundSoFar) {
-        return foundSoFar;
-    }
-    
-    @Override
-    public List<JsonNode> findParents(String fieldName, List<JsonNode> foundSoFar) {
-        return foundSoFar;
-    }
-    
     /*
     /**********************************************************
     /* Support for traversal-as-stream

--- a/src/main/java/com/fasterxml/jackson/databind/node/ContainerNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ContainerNode.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.databind.node;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 import com.fasterxml.jackson.core.*;
 
@@ -38,27 +37,6 @@ public abstract class ContainerNode<T extends ContainerNode<T>>
     @Override
     public String asText() { return ""; }
 
-    /*
-    /**********************************************************
-    /* Find methods; made abstract again to ensure implementation
-    /**********************************************************
-     */
-
-    @Override
-    public abstract JsonNode findValue(String fieldName);
-    
-    @Override
-    public abstract ObjectNode findParent(String fieldName);
-
-    @Override
-    public abstract List<JsonNode> findValues(String fieldName, List<JsonNode> foundSoFar);
-    
-    @Override
-    public abstract List<JsonNode> findParents(String fieldName, List<JsonNode> foundSoFar);
-
-    @Override
-    public abstract List<String> findValuesAsText(String fieldName, List<String> foundSoFar);
-    
     /*
     /**********************************************************
     /* Methods reset as abstract to force real implementation

--- a/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.node;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.fasterxml.jackson.core.*;
 
@@ -101,5 +102,42 @@ public abstract class ValueNode
     public final boolean hasNonNull(String fieldName)
     {
         return false;
+    }
+
+    /*
+     **********************************************************************
+     * Find methods: all "leaf" nodes return the same for these
+     **********************************************************************
+     */
+
+    @Override
+    public final JsonNode findValue(String fieldName)
+    {
+        return null;
+    }
+
+    // note: co-variant return type
+    @Override
+    public final ObjectNode findParent(String fieldName)
+    {
+        return null;
+    }
+
+    @Override
+    public final List<JsonNode> findValues(String fieldName, List<JsonNode> foundSoFar)
+    {
+        return foundSoFar;
+    }
+
+    @Override
+    public final List<String> findValuesAsText(String fieldName, List<String> foundSoFar)
+    {
+        return foundSoFar;
+    }
+
+    @Override
+    public final List<JsonNode> findParents(String fieldName, List<JsonNode> foundSoFar)
+    {
+        return foundSoFar;
     }
 }


### PR DESCRIPTION
- All value nodes behave the same for these methods: move the default
  implementation out of BaseJsonNode into ValueNode, make them final.
- As a result, there is no need to redeclare them abstract in ContainerNode
  anymore.
