### PR TITLE
Plumbing for alternate ClassIntrospectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target
 *.iml
 *.ipr
 *.iws
+/.idea/

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
@@ -252,6 +252,16 @@ public final class DeserializationConfig
     }
 
     @Override
+    public DeserializationConfig withInsertedClassIntrospector(ClassIntrospector ci) {
+        return _withBase(_base.withInsertedClassIntrospector(ci));
+    }
+
+    @Override
+    public DeserializationConfig withAppendedClassIntrospector(ClassIntrospector ci) {
+        return _withBase(_base.withAppendedClassIntrospector(ci));
+    }
+
+    @Override
     public DeserializationConfig withView(Class<?> view) {
         return (_view == view) ? this : new DeserializationConfig(this, view);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/Module.java
+++ b/src/main/java/com/fasterxml/jackson/databind/Module.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.fasterxml.jackson.databind.deser.KeyDeserializers;
 import com.fasterxml.jackson.databind.deser.ValueInstantiators;
+import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.Serializers;
@@ -231,6 +232,24 @@ public abstract class Module
          * @param ai Annotation introspector to register.
          */
         public void appendAnnotationIntrospector(AnnotationIntrospector ai);
+
+        /**
+         * Method for registering specified {@link ClassIntrospector} as the highest
+         * priority introspector (will be chained with existing introspector(s) which
+         * will be used as fallbacks for cases this introspector does not handle)
+         *
+         * @param ci Class introspector to register.
+         */
+        public void insertClassIntrospector(ClassIntrospector ci);
+
+        /**
+         * Method for registering specified {@link ClassIntrospector} as the lowest
+         * priority introspector, chained with existing introspector(s) and called
+         * as fallback for cases not otherwise handled.
+         *
+         * @param ci Class introspector to register.
+         */
+        public void appendClassIntrospector(ClassIntrospector ci);
 
         /**
          * Method for registering specified classes as subtypes (of supertype(s)

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -644,6 +644,18 @@ public class ObjectMapper
             }
 
 //          @Override
+            public void insertClassIntrospector(ClassIntrospector ci) {
+                mapper._deserializationConfig = mapper._deserializationConfig.withInsertedClassIntrospector(ci);
+                mapper._serializationConfig = mapper._serializationConfig.withInsertedClassIntrospector(ci);
+            }
+
+//          @Override
+            public void appendClassIntrospector(ClassIntrospector ci) {
+                mapper._deserializationConfig = mapper._deserializationConfig.withAppendedClassIntrospector(ci);
+                mapper._serializationConfig = mapper._serializationConfig.withAppendedClassIntrospector(ci);
+            }
+
+//          @Override
             public void registerSubtypes(Class<?>... subtypes) {
                 mapper.registerSubtypes(subtypes);
             }

--- a/src/main/java/com/fasterxml/jackson/databind/SerializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationConfig.java
@@ -199,7 +199,17 @@ public final class SerializationConfig
     public SerializationConfig with(ClassIntrospector ci) {
         return _withBase(_base.withClassIntrospector(ci));
     }
-    
+
+    @Override
+    public SerializationConfig withAppendedClassIntrospector(ClassIntrospector ci) {
+        return _withBase(_base.withAppendedClassIntrospector(ci));
+    }
+
+    @Override
+    public SerializationConfig withInsertedClassIntrospector(ClassIntrospector ci) {
+        return _withBase(_base.withInsertedClassIntrospector(ci));
+    }
+
     /**
      * In addition to constructing instance with specified date format,
      * will enable or disable <code>SerializationFeature.WRITE_DATES_AS_TIMESTAMPS</code>

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/BaseSettings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/BaseSettings.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.Base64Variant;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
+import com.fasterxml.jackson.databind.introspect.ClassIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -164,6 +165,14 @@ public final class BaseSettings
         return new BaseSettings(ci, _annotationIntrospector, _visibilityChecker, _propertyNamingStrategy, _typeFactory,
                 _typeResolverBuilder, _dateFormat, _handlerInstantiator, _locale,
                 _timeZone, _defaultBase64);
+    }
+
+    public BaseSettings withInsertedClassIntrospector(ClassIntrospector ci) {
+        return withClassIntrospector(ClassIntrospectorPair.create(ci, _classIntrospector));
+    }
+
+    public BaseSettings withAppendedClassIntrospector(ClassIntrospector ci) {
+        return withClassIntrospector(ClassIntrospectorPair.create(_classIntrospector, ci));
     }
     
     public BaseSettings withAnnotationIntrospector(AnnotationIntrospector ai) {

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
@@ -186,6 +186,22 @@ public abstract class MapperConfigBase<CFG extends ConfigFeature,
     public abstract T with(ClassIntrospector ci);
 
     /**
+     * Method for constructing and returning a new instance with additional
+     * {@link ClassIntrospector} appended (as the lowest priority one)
+     *
+     * @since 2.2
+     */
+    public abstract T withAppendedClassIntrospector(ClassIntrospector introspector);
+
+    /**
+     * Method for constructing and returning a new instance with additional
+     * {@link ClassIntrospector} inserted (as the highest priority one)
+     *
+     * @since 2.2
+     */
+    public abstract T withInsertedClassIntrospector(ClassIntrospector introspector);
+
+    /**
      * Method for constructing and returning a new instance with different
      * {@link DateFormat}
      * to use.

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/ClassIntrospectorPair.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/ClassIntrospectorPair.java
@@ -1,0 +1,103 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+
+import java.io.Serializable;
+
+/**
+ * Helper class that allows using 2 introspectors such that one
+ * introspector acts as the primary one to use; and second one
+ * as a fallback used if the primary does not provide conclusive
+ * or useful result for a method.
+ *
+ * @since 2.2
+ */
+public class ClassIntrospectorPair
+    extends ClassIntrospector
+    implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    protected final ClassIntrospector _primary, _secondary;
+
+    public ClassIntrospectorPair(ClassIntrospector p, ClassIntrospector s)
+    {
+        _primary = p;
+        _secondary = s;
+    }
+
+    /**
+     * Helper method for constructing a Pair from two given introspectors (if
+     * neither is null); or returning non-null introspector if one is null
+     * (and return just null if both are null)
+     */
+    public static ClassIntrospector create(ClassIntrospector primary,
+            ClassIntrospector secondary)
+    {
+        if (primary == null) {
+            return secondary;
+        }
+        if (secondary == null) {
+            return primary;
+        }
+        return new ClassIntrospectorPair(primary, secondary);
+    }
+
+    @Override
+    public BeanDescription forSerialization(SerializationConfig cfg, JavaType type, MixInResolver r) {
+        BeanDescription result = _primary.forSerialization(cfg, type, r);
+        if (result == null) {
+            result = _secondary.forSerialization(cfg, type, r);
+        }
+        return result;
+    }
+
+    @Override
+    public BeanDescription forDeserialization(DeserializationConfig cfg, JavaType type, MixInResolver r) {
+        BeanDescription result = _primary.forDeserialization(cfg, type, r);
+        if (result == null) {
+            result = _secondary.forDeserialization(cfg, type, r);
+        }
+        return result;
+    }
+
+    @Override
+    public BeanDescription forDeserializationWithBuilder(DeserializationConfig cfg, JavaType type, MixInResolver r) {
+        BeanDescription result = _primary.forDeserializationWithBuilder(cfg, type, r);
+        if (result == null) {
+            result = _secondary.forDeserializationWithBuilder(cfg, type, r);
+        }
+        return result;
+    }
+
+    @Override
+    public BeanDescription forCreation(DeserializationConfig cfg, JavaType type, MixInResolver r) {
+        BeanDescription result = _primary.forCreation(cfg, type, r);
+        if (result == null) {
+            result = _secondary.forCreation(cfg, type, r);
+        }
+        return result;
+    }
+
+    @Override
+    public BeanDescription forClassAnnotations(MapperConfig<?> cfg, JavaType type, MixInResolver r) {
+        BeanDescription result = _primary.forClassAnnotations(cfg, type, r);
+        if (result == null) {
+            result = _secondary.forClassAnnotations(cfg, type, r);
+        }
+        return result;
+    }
+
+    @Override
+    public BeanDescription forDirectClassAnnotations(MapperConfig<?> cfg, JavaType type, MixInResolver r) {
+        BeanDescription result = _primary.forDirectClassAnnotations(cfg, type, r);
+        if (result == null) {
+            result = _secondary.forDirectClassAnnotations(cfg, type, r);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This pull request adds the plumbing needed for a module to add an alternate ClassIntrospector to the ObjectMapper. It is intended for use by the Scala module, which needs to take a very different approach to bean introspection than is done for Java code.
