### PR TITLE
Plumbing for alternate ClassIntrospector

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/Module.java
+++ b/src/main/java/com/fasterxml/jackson/databind/Module.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.fasterxml.jackson.databind.deser.KeyDeserializers;
 import com.fasterxml.jackson.databind.deser.ValueInstantiators;
+import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.Serializers;
@@ -213,7 +214,17 @@ public abstract class Module
          *    constructing POJO values during deserialization
          */
         public void addValueInstantiators(ValueInstantiators instantiators);
-        
+
+        /**
+         * Method for replacing the default class introspector with a derived class that
+         * overrides specific behavior.
+         *
+         * @param ci Derived class of ClassIntrospector with overriden behavior
+         *
+         * @since 2.2
+         */
+        public void setClassIntrospector(ClassIntrospector ci);
+
         /**
          * Method for registering specified {@link AnnotationIntrospector} as the highest
          * priority introspector (will be chained with existing introspector(s) which

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -630,7 +630,13 @@ public class ObjectMapper
                 DeserializerFactory df = mapper._deserializationContext._factory.withValueInstantiators(instantiators);
                 mapper._deserializationContext = mapper._deserializationContext.with(df);
             }
-            
+
+//          @Override
+            public void setClassIntrospector(ClassIntrospector ci) {
+                mapper._deserializationConfig = mapper._deserializationConfig.with(ci);
+                mapper._serializationConfig = mapper._serializationConfig.with(ci);
+            }
+
 //          @Override
             public void insertAnnotationIntrospector(AnnotationIntrospector ai) {
                 mapper._deserializationConfig = mapper._deserializationConfig.withInsertedAnnotationIntrospector(ai);


### PR DESCRIPTION
Replacement request for #111. This pull request adds the plumbing needed for a module to replace the default ClassIntrospector with an alternate derived implementation. It is intended for use by the Scala module, which needs to take a very different approach to bean introspection than is done for Java code.
