### PR TITLE
ArrayNode: not quite final yet, don't use .getClass() in .equals() 

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ArrayNode.java
@@ -810,7 +810,7 @@ public class ArrayNode
     {
         if (o == this) return true;
         if (o == null) return false;
-        if (o.getClass() != getClass()) { // final class, can do this
+        if (!(o instanceof ArrayNode)) {
             return false;
         }
         ArrayNode other = (ArrayNode) o;


### PR DESCRIPTION
Hopefully, in 2.3+ this class will be final. Until now, make subclasses able to
fulfill the .equals() contract.
