### PR TITLE
fixed javadoc for WRAP_ROOT_VALUE

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -30,7 +30,7 @@ public enum SerializationFeature implements ConfigFeature
      * class name).
      * Feature is mostly intended for JAXB compatibility.
      *<p>
-     * Feature is enabled by default.
+     * Feature is disabled by default.
      */
     WRAP_ROOT_VALUE(false),
 


### PR DESCRIPTION
WRAP_ROOT_VALUE is disabled by default
