### PR TITLE
Serialization feature for writing BigDecimal in plain form

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -255,6 +255,15 @@ public enum SerializationFeature implements ConfigFeature
      * Feature is disabled by default, so that no special handling is done.
      */
     WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED(false),
+
+    /**
+     * Feature that determines whether {@link java.math.BigDecimal} entries are
+     * serialized using {@link java.math.BigDecimal#toPlainString()} to prevent
+     * values to be written using scientific notation.
+     * <p>
+     * Feature is disabled by default.
+     */
+    WRITE_BIGDECIMAL_AS_PLAIN(false),
     
     /**
      * Feature that determines whether {@link java.util.Map} entries are first

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializers.java
@@ -240,7 +240,11 @@ public class NumberSerializers
         {
             // As per [JACKSON-423], handling for BigInteger and BigDecimal was missing!
             if (value instanceof BigDecimal) {
-                jgen.writeNumber((BigDecimal) value);
+                if (provider.isEnabled(SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN)) {
+                    jgen.writeNumber(((BigDecimal) value).toPlainString());
+                } else {
+                    jgen.writeNumber((BigDecimal) value);
+                }
             } else if (value instanceof BigInteger) {
                 jgen.writeNumber((BigInteger) value);
                 

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestJdkTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestJdkTypes.java
@@ -31,6 +31,17 @@ public class TestJdkTypes
         assertEquals("{\"pi\":3.14159265}", str);
     }
     
+    public void testBigDecimalAsPlainString()
+        throws Exception
+    {
+        MAPPER.enable(SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN);
+        Map<String, Object> map = new HashMap<String, Object>();
+        String PI_STR = "3.00000000";
+        map.put("pi", new BigDecimal(PI_STR));
+        String str = MAPPER.writeValueAsString(map);
+        assertEquals("{\"pi\":3.00000000}", str);
+    }
+    
     /**
      * Unit test related to [JACKSON-155]
      */


### PR DESCRIPTION
In Java, BigDecimal.toString() writes out numbers in engineering form in certain cases. When this happens during serialization, the output may not be compatible with all JSON parsers.
- new BigDecimal("0.0").toString() gives "0.0"
- new BigDecimal("0.0000000").toString() gives "0E-8"

When enabled, the SerializationFeature I added prevents BigDecimal to use the scientific form.
