### PR TITLE
MissingNode: fix bug in is{Value,Container,MissingNode}() contract

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
@@ -34,6 +34,12 @@ public final class MissingNode
     
     public static MissingNode getInstance() { return instance; }
 
+    @Override
+    public boolean isValueNode()
+    {
+        return false;
+    }
+
     @Override public JsonToken asToken() { return JsonToken.NOT_AVAILABLE; }
 
     @Override


### PR DESCRIPTION
The Javadoc says that for any given node, only one such method may return true.

For MissingNode however, true was returned for both isMissingNode() and
isValueNode().
