### PR TITLE
Rename creator properties in _renameProperties()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -666,6 +666,16 @@ public class POJOPropertiesCollector
                 } else {
                     old.addAll(prop);
                 }
+
+                // replace the creatorProperty too, if there is one
+                if (_creatorProperties != null) {
+                    for (int i = 0; i < _creatorProperties.size(); ++i) {
+                        if (_creatorProperties.get(i).getInternalName() == prop.getInternalName()) {
+                            _creatorProperties.set(i, prop);
+                            break;
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
In `POJOPropertiesCollector`, the `_renameProperties()` method does not also rename the entries in the `_creatorProperties` collection. For normal databinds this does not matter, because in Java the only way for a creator property to exist is in the presence of an annotation, which will have already indicated the correct name.

However in Scala, the derived class determines the creator properties' names from the variable name (currently from debug information, eventually from Scala reflection). Annotations can later override this name; without this patch, the `_sortProperties()` method will later add back the original property under the old name (because the creator properties are sorted at the front of the property list).

This is not a required change, as the derived class could override `_renameProperties()` and re-implement this behavior, but I felt that not renaming creators was an oversight rather than designed behavior.
