### PR TITLE
Fixed wrong array copy result in ArrayBuilders.insertInListNoDup

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/ArrayBuilders.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ArrayBuilders.java
@@ -238,7 +238,7 @@ public final class ArrayBuilders
                 }
                 // otherwise move things around
                 T[] result = (T[]) Array.newInstance(array.getClass().getComponentType(), len);
-                System.arraycopy(array, 0, result, 1, ix);
+                System.arraycopy(array, 0, result, 0, len);
                 result[ix] = element;
                 return result;
             }

--- a/src/test/java/com/fasterxml/jackson/databind/util/ArrayBuildersTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ArrayBuildersTest.java
@@ -7,9 +7,15 @@ public class ArrayBuildersTest {
 
 	@Test
 	public void testInsertInListNoDup() {
-		String [] arr = new String[]{"me", "you", "him"};
-		ArrayBuilders.insertInListNoDup(arr, "you");
-		Assert.assertArrayEquals(arr, new String[]{"me", "you", "him"});
+        String [] arr = new String[]{"me", "you", "him"};
+        String [] newarr = ArrayBuilders.insertInListNoDup(arr, "you");
+        Assert.assertArrayEquals(newarr, arr);
+
+        newarr = ArrayBuilders.insertInListNoDup(arr, "me");
+        Assert.assertArrayEquals(newarr, arr);
+
+        newarr = ArrayBuilders.insertInListNoDup(arr, "him");
+        Assert.assertArrayEquals(newarr, arr);
 	}
 
 }


### PR DESCRIPTION
This bug caused a NullPointerException issue when module registration is duplicated
