### PR TITLE
JsonNodeFactory: work around an old bug with BigDecimal and zero

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 public final class DecimalNode
     extends NumericNode
 {
+    public static final DecimalNode ZERO = new DecimalNode(BigDecimal.ZERO);
+
     private final static BigDecimal MIN_INTEGER = BigDecimal.valueOf(Integer.MIN_VALUE);
     private final static BigDecimal MAX_INTEGER = BigDecimal.valueOf(Integer.MAX_VALUE);
     private final static BigDecimal MIN_LONG = BigDecimal.valueOf(Long.MIN_VALUE);

--- a/src/main/java/com/fasterxml/jackson/databind/node/JsonNodeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/JsonNodeFactory.java
@@ -222,7 +222,24 @@ public class JsonNodeFactory
      */
     public NumericNode numberNode(BigDecimal v)
     {
-        return DecimalNode.valueOf(_cfgBigDecimalExact ? v : v.stripTrailingZeros());
+        /*
+         * If the user wants the exact representation of this big decimal,
+         * return the value directly
+         */
+        if (_cfgBigDecimalExact)
+            return DecimalNode.valueOf(v);
+
+        /*
+         * If the user has asked to strip trailing zeroes, however, there is
+         * this bug to account for:
+         *
+         * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6480539
+         *
+         * In short: zeroes are never stripped out of 0! We therefore _have_
+         * to compare with BigDecimal.ZERO...
+         */
+        return v.compareTo(BigDecimal.ZERO) == 0 ? DecimalNode.ZERO
+            : DecimalNode.valueOf(v.stripTrailingZeros());
     }
 
     /*


### PR DESCRIPTION
This is the bug in question:

http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6480539

In short: BigDecimal's .stripTrainlingZeroes() does not work at all on decimals
which value is _exactly_ 0:
- new BigDecimal("0.0100").stripTrailingZeroes() has a scale of 2, as expected;
- new BigDecimal("0") has a scale of 0;
- new BigDecimal("0.000").stripTrailingZeroes() has a scale of... 3!

To work around this bug, when the user asks to create a decimal node, compare
the given value with BigDecimal.ZERO, and if the result is 0, return
DecimalNode.ZERO (newly created by this patch), which is a "new
DecimalNode(BigDecimal.ZERO)".
