### PR TITLE
Fixed a NullPointerException when trying to call getPathReference() in JsonMappingException

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
@@ -356,6 +356,9 @@ public class JsonMappingException
 
     protected void _appendPathDesc(StringBuilder sb)
     {
+        if (_path == null) {
+            return;
+        }
         Iterator<Reference> it = _path.iterator();
         while (it.hasNext()) {
             sb.append(it.next().toString());


### PR DESCRIPTION
Fixed a NullPointerException when trying to call getPathReference() when no path has been prepended.

This occurred when I was actually trying to serialise a JsonMappingException, the BeanSerializer called getPathReference() which caused the _appendPathDesc to throw a NPE.
