### PR TITLE
Fix DecimalNode's .equals()/.hashCode(); change the default JsonNodeFactory instance

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -116,11 +116,11 @@ public class DecimalNode
         if (o == this) return true;
         if (o == null) return false;
         if (o instanceof DecimalNode) {
-            return ((DecimalNode) o)._value.equals(_value);
+            return ((DecimalNode) o)._value.compareTo(_value) == 0;
         }
         return false;
     }
 
     @Override
-    public int hashCode() { return _value.hashCode(); }
+    public int hashCode() { return Double.valueOf(doubleValue()).hashCode(); }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestNumberNodes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestNumberNodes.java
@@ -184,6 +184,33 @@ public class TestNumberNodes extends NodeTestBase
         assertTrue(DecimalNode.valueOf(BigDecimal.valueOf(Long.MIN_VALUE)).canConvertToLong());
     }
 
+    public void testDecimalNodeEqualsHashCode()
+    {
+        /*
+         * We want DecimalNodes with equivalent _numeric_ values to be equal;
+         * this is not the case for BigDecimal where "1.0" and "1" are not
+         * equal!
+         */
+        BigDecimal b1 = BigDecimal.ONE;
+        BigDecimal b2 = new BigDecimal("1.0");
+        BigDecimal b3 = new BigDecimal("0.01e2");
+        BigDecimal b4 = new BigDecimal("1000e-3");
+
+        DecimalNode node1 = new DecimalNode(b1);
+        DecimalNode node2 = new DecimalNode(b2);
+        DecimalNode node3 = new DecimalNode(b3);
+        DecimalNode node4 = new DecimalNode(b4);
+
+        assertEquals(node1.hashCode(), node2.hashCode());
+        assertEquals(node2.hashCode(), node3.hashCode());
+        assertEquals(node3.hashCode(), node4.hashCode());
+
+        assertEquals(node1, node2);
+        assertEquals(node2, node1);
+        assertEquals(node2, node3);
+        assertEquals(node3, node4);
+    }
+
     public void testBigIntegerNode() throws Exception
     {
         BigIntegerNode n = BigIntegerNode.valueOf(BigInteger.ONE);


### PR DESCRIPTION
See discussion at issue #228.

This pull request is for the master branch.
