### PR TITLE
Fix DecimalNode's .equals()/.hashCode(); change the default JsonNodeFactory instance

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -9,8 +9,29 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 
 /**
- * Numeric node that contains values that do not fit in simple
- * integer (int, long) or floating point (double) values.
+ * Numeric node for large decimal numeric values
+ *
+ * <p>The numeric value is stored as a {@link BigDecimal}, with all its
+ * pecularities; the first of which is that two instances of BigDecimal with the
+ * same <i>numeric</i> value may not be {@link Object#equals(Object) equal}. For
+ * instance:</p>
+ *
+ * <pre>
+ *     new BigDecimal("1.0").equals(new BigDecimal("1")); // returns false
+ * </pre>
+ *
+ * <p>However:</p>
+ *
+ * <pre>
+ *     new BigDecimal("1.0").compareTo(new BigDecimal("1")); // returns 0
+ * </pre>
+ *
+ * <p>In order to respect the {@code .equals()/.hashCode()} contract that all
+ * other {@link JsonNode} implementations do, {@link #hashCode()} is implemented
+ * by returning the hashcode of this BigDecimal's {@link
+ * BigDecimal#doubleValue() .doubleValue()}, which returns the same value for
+ * two instances which are numerically equal, and {@link #equals(Object)} is
+ * implemented by the means of {@link BigDecimal#compareTo(Object)}.</p>
  */
 public final class DecimalNode
     extends NumericNode
@@ -109,9 +130,11 @@ public final class DecimalNode
         if (o.getClass() != getClass()) { // final class, can do this
             return false;
         }
-        return ((DecimalNode) o)._value.equals(_value);
+        return ((DecimalNode) o)._value.compareTo(_value) == 0;
     }
 
     @Override
-    public int hashCode() { return _value.hashCode(); }
+    public int hashCode() {
+        return Double.valueOf(_value.doubleValue()).hashCode();
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestNumberNodes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestNumberNodes.java
@@ -179,6 +179,28 @@ public class TestNumberNodes extends NodeTestBase
         assertTrue(DecimalNode.valueOf(BigDecimal.valueOf(Long.MIN_VALUE)).canConvertToLong());
     }
 
+    public void testPathologicallyLongDecimalNodes()
+    {
+        /*
+         * We cannot test each and every decimal value, so we pick one...
+         */
+        final String s1 = "28728731.298098213e-237987123";
+        final String s2 = "287287.31298098213e-237987121";
+        final String s3 = "28728731298098213e-237987132";
+
+        final DecimalNode d1 = DecimalNode.valueOf(new BigDecimal(s1));
+        final DecimalNode d2 = DecimalNode.valueOf(new BigDecimal(s2));
+        final DecimalNode d3 = DecimalNode.valueOf(new BigDecimal(s3));
+
+        assertEquals(d1.hashCode(), d2.hashCode());
+        assertEquals(d2.hashCode(), d3.hashCode());
+
+        assertTrue(d1.equals(d2));
+        assertTrue(d2.equals(d1));
+        assertTrue(d1.equals(d3));
+        assertTrue(d2.equals(d3));
+    }
+
     public void testBigIntegerNode() throws Exception
     {
         BigIntegerNode n = BigIntegerNode.valueOf(BigInteger.ONE);


### PR DESCRIPTION
See discussion at issue #228.

This pull request is for the 2.2 branch.
