### PR TITLE
Use equals() to compare strings contents

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -687,7 +687,7 @@ public class POJOPropertiesCollector
                 // replace the creatorProperty too, if there is one
                 if (_creatorProperties != null) {
                     for (int i = 0; i < _creatorProperties.size(); ++i) {
-                        if (_creatorProperties.get(i).getInternalName() == prop.getInternalName()) {
+                        if (_creatorProperties.get(i).getInternalName().equals(prop.getInternalName())) {
                             _creatorProperties.set(i, prop);
                             break;
                         }


### PR DESCRIPTION
I believe we want to do the usual thing here and compare string contents instead of string references. If we really want to compare references we should probably add a comment explaining why.
