### PR TITLE
Restore covariant returns on BeanPropertyDefiniton subclasses.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -76,6 +76,12 @@ public class POJOPropertyBuilder
     /**********************************************************
      */
 
+    @Deprecated // since 2.3
+    @Override
+    public POJOPropertyBuilder withName(String newName) {
+        return withSimpleName(newName);
+    }
+
     @Override
     public POJOPropertyBuilder withName(PropertyName newName) {
         return new POJOPropertyBuilder(this, newName);

--- a/src/main/java/com/fasterxml/jackson/databind/util/SimpleBeanPropertyDefinition.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/SimpleBeanPropertyDefinition.java
@@ -79,6 +79,12 @@ public class SimpleBeanPropertyDefinition
     /**********************************************************
      */
 
+    @Deprecated // since 2.3
+    @Override
+    public SimpleBeanPropertyDefinition withName(String newName) {
+        return withSimpleName(newName);
+    }
+
     @Override
     public SimpleBeanPropertyDefinition withSimpleName(String newName) {
         if (_name.equals(newName)) {


### PR DESCRIPTION
Referring the earlier conversation on `BeanPropertyDefinition`. This patch restores the co-variant return types on subclasses, to keep backwards compatibility.
