### PR TITLE
Fixing {Object,Array}Deserializer's illegal nullValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ target
 .settings
 
 # IDEA
+.idea
 *.iml
 *.ipr
 *.iws

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.node.*;
  */
 @SuppressWarnings("serial")
 public class JsonNodeDeserializer
-    extends BaseNodeDeserializer
+    extends BaseNodeDeserializer<JsonNode>
 {
     /**
      * Singleton instance of generic deserializer for {@link JsonNode}.
@@ -21,7 +21,7 @@ public class JsonNodeDeserializer
      */
     private final static JsonNodeDeserializer instance = new JsonNodeDeserializer();
 
-    protected JsonNodeDeserializer() { }
+    protected JsonNodeDeserializer() { super(JsonNode.class); }
 
     /**
      * Factory method for accessing deserializer for specific node type
@@ -43,6 +43,11 @@ public class JsonNodeDeserializer
     /* Actual deserializer implementations
     /**********************************************************
      */
+
+    @Override
+    public JsonNode getNullValue() {
+        return NullNode.getInstance();
+    }
 
     /**
      * Implementation that will produce types of any JSON nodes; not just one
@@ -70,13 +75,13 @@ public class JsonNodeDeserializer
      */
 
     final static class ObjectDeserializer
-        extends BaseNodeDeserializer
+        extends BaseNodeDeserializer<ObjectNode>
     {
         private static final long serialVersionUID = 1L;
 
         protected final static ObjectDeserializer _instance = new ObjectDeserializer();
 
-        protected ObjectDeserializer() { }
+        protected ObjectDeserializer() { super(ObjectNode.class); }
 
         public static ObjectDeserializer getInstance() { return _instance; }
         
@@ -96,13 +101,13 @@ public class JsonNodeDeserializer
     }
         
     final static class ArrayDeserializer
-        extends BaseNodeDeserializer
+        extends BaseNodeDeserializer<ArrayNode>
     {
         private static final long serialVersionUID = 1L;
 
         protected final static ArrayDeserializer _instance = new ArrayDeserializer();
 
-        protected ArrayDeserializer() { }
+        protected ArrayDeserializer() { super(ArrayNode.class); }
 
         public static ArrayDeserializer getInstance() { return _instance; }
         
@@ -123,12 +128,12 @@ public class JsonNodeDeserializer
  * implementations
  */
 @SuppressWarnings("serial")
-abstract class BaseNodeDeserializer
-    extends StdDeserializer<JsonNode>
+abstract class BaseNodeDeserializer<T extends JsonNode>
+    extends StdDeserializer<T>
 {
-    public BaseNodeDeserializer()
+    public BaseNodeDeserializer(Class<T> vc)
     {
-        super(JsonNode.class);
+        super(vc);
     }
     
     @Override
@@ -140,16 +145,6 @@ abstract class BaseNodeDeserializer
          * a priori. So:
          */
         return typeDeserializer.deserializeTypedFromAny(jp, ctxt);
-    }
-
-    @Override
-    public JsonNode getNullValue() {
-        return NullNode.getInstance();
-    }
-
-    @Override
-    public Class<?> handledType() {
-        return JsonNode.class;
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestTreeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestTreeDeserialization.java
@@ -1,8 +1,9 @@
 package com.fasterxml.jackson.databind.node;
 
-import java.io.*;
-
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 
 /**
  * This unit test suite tries to verify that JsonNode-based trees
@@ -114,5 +115,25 @@ public class TestTreeDeserialization
         n = root.get("x");
         assertNotNull(n);
         assertTrue(n.isNull());
+    }
+
+    final static class CovarianceBean {
+        ObjectNode _object;
+        ArrayNode _array;
+
+        public void setObject(ObjectNode n) { _object = n; }
+        public void setArray(ArrayNode n) { _array = n; }
+    }
+
+    public void testNullHandlingCovariance() throws Exception
+    {
+        String JSON = "{\"object\" : null, \"array\" : null }";
+        CovarianceBean bean = objectMapper().readValue(JSON, CovarianceBean.class);
+
+        ObjectNode on = bean._object;
+        assertNull(on);
+
+        ArrayNode an = bean._array;
+        assertNull(an);
     }
 }


### PR DESCRIPTION
As of the fix for #186, BaseNodeDeserializer is not covariant in its null value type. Specifically, trying to deserialize a bean with an ObjectNode or ArrayNode property will fail with something similar to the following error:

```
com.fasterxml.jackson.databind.JsonMappingException: Problem deserializing property 'object' (expected type: [simple type, class com.fasterxml.jackson.databind.node.ObjectNode]; actual type: com.fasterxml.jackson.databind.node.NullNode), problem: argument type mismatch (through reference chain: com.fasterxml.jackson.databind.node.CovarianceBean["object"])
    at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:552)
    at com.fasterxml.jackson.databind.deser.impl.MethodProperty.set(MethodProperty.java:117)
    at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:99)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:253)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
...
Caused by: java.lang.IllegalArgumentException: argument type mismatch
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at com.fasterxml.jackson.databind.deser.impl.MethodProperty.set(MethodProperty.java:115)
    ... 28 more
```

Or, if trying to use a @JsonCreator constructor:

```
com.fasterxml.jackson.databind.JsonMappingException: Instantiation of [simple type, class ...] value failed: argument type mismatch (through reference chain: ...)
    at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.wrapException(StdValueInstantiator.java:440)
    at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:244)
    at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:158)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:352)
    at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:977)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:276)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:121)
    at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:2888)
    at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2113)
...
Caused by: java.lang.IllegalArgumentException: argument type mismatch
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
    at com.fasterxml.jackson.databind.introspect.AnnotatedConstructor.call(AnnotatedConstructor.java:125)
    at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:240)
    ... 38 more
```
