### PR TITLE
Can't deserialize to a bean that has Creator props

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestValueUpdate.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestValueUpdate.java
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.test.BaseTest;
+
+public class TestValueUpdate
+    extends BaseTest
+{
+    static class Bean
+    {
+        private String a;
+        private String b;
+
+        @JsonCreator
+        public Bean(@JsonProperty("a") String a, @JsonProperty("b") String b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+
+        String getA() {
+            return a;
+        }
+
+        void setA(String a) {
+            this.a = a;
+        }
+
+        String getB() {
+            return b;
+        }
+
+        void setB(String b) {
+            this.b = b;
+        }
+    }
+
+    public void testValueUpdateWithCreator() throws Exception
+    {
+        Bean bean = new Bean("abc", "def");
+        new ObjectMapper().reader(Bean.class).withValueToUpdate(bean).readValue("{\"a\":\"ghi\",\"b\":\"jkl\"}");
+        assertEquals("ghi", bean.getA());
+        assertEquals("jkl", bean.getB());
+    }
+
+}


### PR DESCRIPTION
This patch adds a test for what ought to be a valid use case, using `ObjectReader.withValueToUpdate` on a bean class that has creator properties.

This issue contributed to FasterXML/jackson-module-scala#83, which I attempted to work around by inhibiting the "creator property"-ness of the particular property, but which then broke using creators for instantiation in some cases.

So, I need to revert my original "fix", but that leaves this issue open. I'll begin working on the solution, but any pointers you have will be helpful.
