### PR TITLE
Support type modifiers in type id name resolution.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeNameIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeNameIdResolver.java
@@ -82,7 +82,7 @@ public class TypeNameIdResolver
     @Override
     public String idFromValue(Object value)
     {
-        Class<?> cls = value.getClass();
+        Class<?> cls = _typeFactory.constructType(value.getClass()).getRawClass();
         final String key = cls.getName();
         String name;
         synchronized (_typeToId) {

--- a/src/test/java/com/fasterxml/jackson/databind/module/TestTypeModifierNameResolution.java
+++ b/src/test/java/com/fasterxml/jackson/databind/module/TestTypeModifierNameResolution.java
@@ -1,0 +1,58 @@
+package com.fasterxml.jackson.databind.module;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeBindings;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.type.TypeModifier;
+import com.fasterxml.jackson.test.BaseTest;
+
+import java.lang.reflect.Type;
+
+public class TestTypeModifierNameResolution extends BaseTest {
+
+	interface MyType {
+		String getData();
+		void setData(String data);
+	}
+
+	static class MyTypeImpl implements MyType {
+		private String data;
+
+		public String getData() {
+			return data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+	}
+
+	static class CustomTypeModifier extends TypeModifier {
+		@Override
+		public JavaType modifyType(JavaType type, Type jdkType, TypeBindings context, TypeFactory typeFactory) {
+			if (type.getRawClass().equals(MyTypeImpl.class)) {
+				return typeFactory.constructType(MyType.class);
+			}
+			return type;
+		}
+	}
+
+	@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.WRAPPER_OBJECT)
+	public interface Mixin { }
+
+	// Expect that the TypeModifier kicks in when the type id is written.
+	public void testTypeModiferNameResolution() throws Exception
+	{
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.setTypeFactory(mapper.getTypeFactory().withModifier(new CustomTypeModifier()));
+		mapper.addMixInAnnotations(MyType.class, Mixin.class);
+
+		MyType obj = new MyTypeImpl();
+		obj.setData("something");
+
+		String s = mapper.writer().writeValueAsString(obj);
+		assertTrue(s.startsWith("{\"TestTypeModifierNameResolution$MyType\":"));
+	}
+}


### PR DESCRIPTION
This commit adds the ability to use type modifiers in conjunction with TypeNameIdResolver. Previously, the type name was resolved from the actual type. This change makes use of the type modifier to resolve against the modified type.

The included test patches just the one resolver, which fixed my use case. It may be the case that the other resolution strategies should also account for the presence of type modifiers. Any guidance there would be appreciated. Thanks!
