### PR TITLE
Error when using As.EXISTING_PROPERTY

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -79,6 +79,8 @@ public class StdTypeResolverBuilder
         switch (_includeAs) {
         case WRAPPER_ARRAY:
             return new AsArrayTypeSerializer(idRes, null);
+        case EXISTING_PROPERTY:
+          return null;
         case PROPERTY:
             return new AsPropertyTypeSerializer(idRes, null,
                     _typeProperty);
@@ -106,6 +108,7 @@ public class StdTypeResolverBuilder
         case WRAPPER_ARRAY:
             return new AsArrayTypeDeserializer(baseType, idRes,
                     _typeProperty, _typeIdVisible, _defaultImpl);
+        case EXISTING_PROPERTY:
         case PROPERTY:
             return new AsPropertyTypeDeserializer(baseType, idRes,
                     _typeProperty, _typeIdVisible, _defaultImpl);


### PR DESCRIPTION
Although `include = As.EXISTING_PROPERTY` can be used in the `@JsonTypeInfo` annotation, at runtime the following error is throw: `java.lang.IllegalStateException: Do not know how to construct standard type serializer for inclusion type: EXISTING_PROPERTY`
