### PR TITLE
Implementation of custom object id resolution.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DatabindContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DatabindContext.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.databind;
 import java.lang.reflect.Type;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
-
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.databind.annotation.NoClass;
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
@@ -159,7 +159,20 @@ public abstract class DatabindContext
         }
         return gen.forScope(objectIdInfo.getScope());
     }
-    
+
+    public ObjectIdResolver objectIdResolverInstance(Annotated annotated, ObjectIdInfo objectIdInfo)
+    {
+        Class<? extends ObjectIdResolver> implClass = objectIdInfo.getResolverType();
+        final MapperConfig<?> config = getConfig();
+        HandlerInstantiator hi = config.getHandlerInstantiator();
+        ObjectIdResolver resolver = (hi == null) ? null : hi.resolverIdGeneratorInstance(config, annotated, implClass);
+        if (resolver == null) {
+            resolver = ClassUtil.createInstance(implClass, config.canOverrideAccessModifiers());
+        }
+
+        return resolver;
+    }
+
     /**
      * Helper method to use to construct a {@link Converter}, given a definition
      * that may be either actual converter instance, or Class for instantiating one.

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -7,6 +7,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.deser.*;
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.databind.deser.impl.TypeWrappedDeserializer;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.ObjectIdInfo;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -420,8 +422,10 @@ public abstract class DeserializationContext
      * Method called to find and return entry corresponding to given
      * Object Id: will add an entry if necessary, and never returns null
      */
-    public abstract ReadableObjectId findObjectId(Object id,
-            ObjectIdGenerator<?> generator);
+    public abstract ReadableObjectId findObjectId(Object id, ObjectIdGenerator<?> generator, ObjectIdResolver resolver);
+
+    @Deprecated
+    public abstract ReadableObjectId findObjectId(Object id, ObjectIdGenerator<?> generator);
 
     /**
      * Method called to ensure that every object id encounter during processing

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/HandlerInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/HandlerInstantiator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.cfg;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.introspect.Annotated;
@@ -123,6 +124,11 @@ public abstract class HandlerInstantiator
         return null;
     }
 
+    public ObjectIdResolver resolverIdGeneratorInstance(MapperConfig<?> config, Annotated annotated, Class<?> implClass)
+    {
+        return null;
+    }
+
     /**
      * Method called to construct a NamingStrategy instance used for specified
      * class.
@@ -143,4 +149,5 @@ public abstract class HandlerInstantiator
             Annotated annotated, Class<?> implClass) {
         return null;
     }
+
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/AbstractDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/AbstractDeserializer.java
@@ -196,9 +196,9 @@ public class AbstractDeserializer
         throws IOException, JsonProcessingException
     {
         Object id = _objectIdReader.readObjectReference(jp, ctxt);
-        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator);
+        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator, _objectIdReader.resolver);
         // do we have it resolved?
-        Object pojo = roid.item;
+        Object pojo = roid.resolve();
         if (pojo == null) { // not yet; should wait...
             throw new IllegalStateException("Could not resolve Object Id ["+id+"] -- unresolved forward-reference?");
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -9,9 +9,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.impl.*;
 import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer;
@@ -579,6 +578,7 @@ public abstract class BeanDeserializerBase
                 JavaType idType;
                 SettableBeanProperty idProp;
                 ObjectIdGenerator<?> idGen;
+                ObjectIdResolver resolver = ctxt.objectIdResolverInstance(accessor, objectIdInfo);
                 if (implClass == ObjectIdGenerators.PropertyGenerator.class) {
                     PropertyName propName = objectIdInfo.getPropertyName();
                     idProp = findProperty(propName);
@@ -596,7 +596,7 @@ public abstract class BeanDeserializerBase
                 }
                 JsonDeserializer<?> deser = ctxt.findRootValueDeserializer(idType);
                 oir = ObjectIdReader.construct(idType, objectIdInfo.getPropertyName(),
-                		idGen, deser, idProp);
+                		idGen, deser, idProp, resolver);
             }
         }
         // either way, need to resolve serializer:
@@ -967,7 +967,7 @@ public abstract class BeanDeserializerBase
             id = _convertObjectId(jp, ctxt, rawId, idDeser);
         }
 
-        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator);
+        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator, _objectIdReader.resolver);
         roid.bindItem(pojo);
         // also: may need to set a property value as well
         SettableBeanProperty idProp = _objectIdReader.idProperty;
@@ -1070,9 +1070,9 @@ public abstract class BeanDeserializerBase
         throws IOException, JsonProcessingException
     {
         Object id = _objectIdReader.readObjectReference(jp, ctxt);
-        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator);
+        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator, _objectIdReader.resolver);
         // do we have it resolved?
-        Object pojo = roid.item;
+        Object pojo = roid.resolve();
         if (pojo == null) { // not yet; should wait...
             throw new UnresolvedForwardReference("Could not resolve Object Id ["+id+"] (for "
                     +_beanType+").", jp.getCurrentLocation(), roid);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.cfg.DeserializerFactoryConfig;
@@ -369,6 +369,8 @@ public class BeanDeserializerFactory
         SettableBeanProperty idProp;
         ObjectIdGenerator<?> gen;
 
+        ObjectIdResolver resolver = ctxt.objectIdResolverInstance(beanDesc.getClassInfo(), objectIdInfo);
+
         // Just one special case: Property-based generator is trickier
         if (implClass == ObjectIdGenerators.PropertyGenerator.class) { // most special one, needs extra work
             PropertyName propName = objectIdInfo.getPropertyName();
@@ -388,7 +390,7 @@ public class BeanDeserializerFactory
         // also: unlike with value deserializers, let's just resolve one we need here
         JsonDeserializer<?> deser = ctxt.findRootValueDeserializer(idType);
         builder.setObjectIdReader(ObjectIdReader.construct(idType,
-                objectIdInfo.getPropertyName(), gen, deser, idProp));
+                objectIdInfo.getPropertyName(), gen, deser, idProp, resolver));
     }
     
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/fasterxml/jackson/databind/deser/UnresolvedForwardReference.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/UnresolvedForwardReference.java
@@ -40,7 +40,7 @@ public final class UnresolvedForwardReference extends JsonMappingException {
     }
 
     public Object getUnresolvedId() {
-        return _roid.id;
+        return _roid.getKey().key;
     }
 
     public void addUnresolvedId(Object id, Class<?> type, JsonLocation where) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ObjectIdReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ObjectIdReader.java
@@ -3,6 +3,8 @@ package com.fasterxml.jackson.databind.deser.impl;
 import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
@@ -26,7 +28,12 @@ public class ObjectIdReader
      * the key.
      */
     public final ObjectIdGenerator<?> generator;
-    
+
+    /**
+     * 
+     */
+    public final ObjectIdResolver resolver;
+
     /**
      * Deserializer used for deserializing id values.
      */
@@ -42,13 +49,21 @@ public class ObjectIdReader
     
     @SuppressWarnings("unchecked")
     protected ObjectIdReader(JavaType t, PropertyName propName, ObjectIdGenerator<?> gen,
-            JsonDeserializer<?> deser, SettableBeanProperty idProp)
+            JsonDeserializer<?> deser, SettableBeanProperty idProp, ObjectIdResolver resolver)
     {
         _idType = t;
         propertyName = propName;
         generator = gen;
+        this.resolver = resolver;
         _deserializer = (JsonDeserializer<Object>) deser;
         idProperty = idProp;
+    }
+
+    @Deprecated // since 2.4
+    protected ObjectIdReader(JavaType t, PropertyName propName, ObjectIdGenerator<?> gen,
+            JsonDeserializer<?> deser, SettableBeanProperty idProp)
+    {
+        this(t,propName, gen, deser, idProp, new SimpleObjectIdResolver());
     }
 
     @Deprecated // since 2.3
@@ -65,9 +80,17 @@ public class ObjectIdReader
      */
     public static ObjectIdReader construct(JavaType idType, PropertyName propName,
             ObjectIdGenerator<?> generator, JsonDeserializer<?> deser,
+            SettableBeanProperty idProp, ObjectIdResolver resolver)
+    {
+        return new ObjectIdReader(idType, propName, generator, deser, idProp, resolver);
+    }
+
+    @Deprecated // since 2.4
+    public static ObjectIdReader construct(JavaType idType, PropertyName propName,
+            ObjectIdGenerator<?> generator, JsonDeserializer<?> deser,
             SettableBeanProperty idProp)
     {
-        return new ObjectIdReader(idType, propName, generator, deser, idProp);
+        return construct(idType, propName, generator, deser, idProp, new SimpleObjectIdResolver());
     }
     
     @Deprecated // since 2.3

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ObjectIdValueProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ObjectIdValueProperty.java
@@ -91,7 +91,7 @@ public final class ObjectIdValueProperty
     {
         // note: no null checks (unlike usually); deserializer should fail if one found
         Object id = _valueDeserializer.deserialize(jp, ctxt);
-        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator);
+        ReadableObjectId roid = ctxt.findObjectId(id, _objectIdReader.generator, _objectIdReader.resolver);
         roid.bindItem(instance);
         // also: may need to set a property value as well
         SettableBeanProperty idProp = _objectIdReader.idProperty;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -113,7 +113,7 @@ public final class PropertyValueBuffer
     {
         if (_objectIdReader != null) {
             if (_idValue != null) {
-                ReadableObjectId roid = ctxt.findObjectId(_idValue, _objectIdReader.generator);
+                ReadableObjectId roid = ctxt.findObjectId(_idValue, _objectIdReader.generator, _objectIdReader.resolver);
                 roid.bindItem(bean);
                 // also: may need to set a property value as well
                 SettableBeanProperty idProp = _objectIdReader.idProperty;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -459,7 +459,7 @@ public class JacksonAnnotationIntrospector
         }
         // In future may need to allow passing namespace?
         PropertyName name = new PropertyName(info.property());
-        return new ObjectIdInfo(name, info.scope(), info.generator());
+        return new ObjectIdInfo(name, info.scope(), info.generator(), info.resolver());
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/ObjectIdInfo.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/ObjectIdInfo.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.databind.introspect;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
 import com.fasterxml.jackson.databind.PropertyName;
 
 /**
@@ -13,10 +15,19 @@ public class ObjectIdInfo
 {
     protected final PropertyName _propertyName;
     protected final Class<? extends ObjectIdGenerator<?>> _generator;
+    private final Class<? extends ObjectIdResolver> _resolver;
     protected final Class<?> _scope;
     protected final boolean _alwaysAsId;
 
-    public ObjectIdInfo(PropertyName name, Class<?> scope, Class<? extends ObjectIdGenerator<?>> gen) {
+    public ObjectIdInfo(PropertyName name, Class<?> scope, Class<? extends ObjectIdGenerator<?>> gen,
+            Class<? extends ObjectIdResolver> resolver)
+    {
+        this(name, scope, gen, false, resolver);
+    }
+
+    @Deprecated // since 2.4
+    public ObjectIdInfo(PropertyName name, Class<?> scope, Class<? extends ObjectIdGenerator<?>> gen)
+    {
         this(name, scope, gen, false);
     }
 
@@ -28,10 +39,18 @@ public class ObjectIdInfo
     protected ObjectIdInfo(PropertyName prop, Class<?> scope, Class<? extends ObjectIdGenerator<?>> gen,
             boolean alwaysAsId)
     {
+        this(prop, scope, gen, alwaysAsId, SimpleObjectIdResolver.class);
+
+    }
+
+    protected ObjectIdInfo(PropertyName prop, Class<?> scope, Class<? extends ObjectIdGenerator<?>> gen,
+            boolean alwaysAsId, Class<? extends ObjectIdResolver> resolver)
+    {
         _propertyName = prop;
         _scope = scope;
         _generator = gen;
         _alwaysAsId = alwaysAsId;
+        _resolver = resolver;
     }
 
     public ObjectIdInfo withAlwaysAsId(boolean state) {
@@ -44,6 +63,7 @@ public class ObjectIdInfo
     public PropertyName getPropertyName() { return _propertyName; }
     public Class<?> getScope() { return _scope; }
     public Class<? extends ObjectIdGenerator<?>> getGeneratorType() { return _generator; }
+    public Class<? extends ObjectIdResolver> getResolverType() { return _resolver; }
     public boolean getAlwaysAsId() { return _alwaysAsId; }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -389,7 +389,7 @@ public abstract class BeanSerializerBase
                 // no ObjectId override, but maybe ObjectIdRef?
                 if (oiw != null) {
                     objectIdInfo = intr.findObjectReferenceInfo(accessor,
-                            new ObjectIdInfo(NAME_FOR_OBJECT_REF, null, null));
+                            new ObjectIdInfo(NAME_FOR_OBJECT_REF, null, null, null));
                     oiw = _objectIdWriter.withAlwaysAsId(objectIdInfo.getAlwaysAsId());
                 }
             } else {

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestObjectIdDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestObjectIdDeserialization.java
@@ -8,9 +8,13 @@ import java.util.Map.Entry;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference;
 import com.fasterxml.jackson.databind.deser.UnresolvedId;
 import com.fasterxml.jackson.databind.struct.TestObjectId.Company;
@@ -21,6 +25,8 @@ import com.fasterxml.jackson.databind.struct.TestObjectId.Employee;
  */
 public class TestObjectIdDeserialization extends BaseMapTest
 {
+    private static final String POOL_KEY = "POOL";
+
     // // Classes for external id use
     
     @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class, property="id")
@@ -126,6 +132,50 @@ public class TestObjectIdDeserialization extends BaseMapTest
             // Ensure that it is never called with null because of unresolved reference.
             assertNotNull(value);
             values.put(field, value);
+        }
+    }
+
+    static class CustomResolutionWrapper {
+        public List<WithCustomResolution> data;
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id", resolver = PoolResolver.class)
+    static class WithCustomResolution {
+        public int id;
+        public int data;
+
+        public WithCustomResolution(int id, int data)
+        {
+            this.id = id;
+            this.data = data;
+        }
+    }
+
+    public static class PoolResolver implements ObjectIdResolver {
+        private Map<Object,WithCustomResolution> _pool;
+
+        public PoolResolver() {}
+        public PoolResolver(Map<Object,WithCustomResolution> pool){ _pool = pool; }
+
+        @Override
+        public void bindItem(IdKey id, Object pojo){ }
+
+        @Override
+        public Object resolveId(IdKey id){ return _pool.get(id.key); }
+
+        @Override
+        public boolean canUseFor(ObjectIdResolver resolverType)
+        {
+            return resolverType.getClass() == getClass() && _pool != null && !_pool.isEmpty();
+        }
+        
+        @Override
+        public ObjectIdResolver newForDeserialization(Object c)
+        {
+            DeserializationContext context = (DeserializationContext)c;
+            @SuppressWarnings("unchecked")
+            Map<Object,WithCustomResolution> pool = (Map<Object,WithCustomResolution>)context.getAttribute(POOL_KEY);
+            return new PoolResolver(pool);
         }
     }
 
@@ -342,5 +392,28 @@ public class TestObjectIdDeserialization extends BaseMapTest
         assertEquals(99, result.node.value);
         assertSame(result.node, result.node.next.node);
         assertEquals(3, result.node.customId);
+    }
+
+    /*
+    /*****************************************************
+    /* Unit tests, custom id resolver
+    /*****************************************************
+     */
+    public void testCustomPoolResolver()
+        throws Exception
+    {
+        Map<Object,WithCustomResolution> pool = new HashMap<Object,WithCustomResolution>();
+        pool.put(1, new WithCustomResolution(1, 1));
+        pool.put(2, new WithCustomResolution(2, 2));
+        pool.put(3, new WithCustomResolution(3, 3));
+        pool.put(4, new WithCustomResolution(4, 4));
+        pool.put(5, new WithCustomResolution(5, 5));
+        ContextAttributes attrs = mapper.getDeserializationConfig().getAttributes().withSharedAttribute(POOL_KEY, pool);
+        String content = "{\"data\":[1,2,3,4,5]}";
+        CustomResolutionWrapper wrapper = mapper.reader(CustomResolutionWrapper.class).with(attrs).readValue(content);
+        assertFalse(wrapper.data.isEmpty());
+        for (WithCustomResolution ob : wrapper.data) {
+            assertSame(pool.get(ob.id), ob);
+        }
     }
 }


### PR DESCRIPTION
This is related to #176, with a larger scope than what was suggested. It handles all resolution of ID with a new interface, `ObjectIdResolver`, which is basically the deserialization twin of `ObjectIdGenerator`.
