### PR TITLE
Make ObjectNode's set* return ObjectNode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -298,7 +298,7 @@ public class ObjectNode
      *
      * @since 2.1
      */
-    public JsonNode set(String fieldName, JsonNode value)
+    public ObjectNode set(String fieldName, JsonNode value)
     {
         if (value == null) {
             value = nullNode();
@@ -317,7 +317,7 @@ public class ObjectNode
      *
      * @since 2.1
      */
-    public JsonNode setAll(Map<String,JsonNode> properties)
+    public ObjectNode setAll(Map<String,JsonNode> properties)
     {
         for (Map.Entry<String, JsonNode> en : properties.entrySet()) {
             JsonNode n = en.getValue();
@@ -339,7 +339,7 @@ public class ObjectNode
      *
      * @since 2.1
      */
-    public JsonNode setAll(ObjectNode other)
+    public ObjectNode setAll(ObjectNode other)
     {
         _children.putAll(other._children);
         return this;
@@ -373,7 +373,7 @@ public class ObjectNode
      * 
      * @since 2.1
      */
-    public JsonNode without(String fieldName)
+    public ObjectNode without(String fieldName)
     {
         _children.remove(fieldName);
         return this;


### PR DESCRIPTION
Those methods exist for chaining, but the JsonNode return type make them awkward for this purpose. Since we're returning `this`, which must be an ObjectNode, it'd be nicer to indicate that in the type so users can chain multiple set calls together.