### PR TITLE
Support content type serializers for -Like types.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
@@ -750,7 +750,8 @@ public class BeanSerializerFactory
         annotatedSerializer = prov.handlePrimaryContextualization(annotatedSerializer, property);
         // And how about polymorphic typing? First special to cover JAXB per-field settings:
         TypeSerializer contentTypeSer = null;
-        if (ClassUtil.isCollectionMapOrArray(type.getRawClass())) {
+        // 16-Feb-2014, cgc: contentType serializers for collection-like and map-like types
+        if (ClassUtil.isCollectionMapOrArray(type.getRawClass()) || type.isCollectionLikeType() || type.isMapLikeType()) {
             contentTypeSer = findPropertyContentTypeSerializer(type, prov.getConfig(), accessor);
         }
         // and if not JAXB collection/array with annotations, maybe regular type info?


### PR DESCRIPTION
This patch is for 2.3, should probably go into 2.4 as well. The change seems safe-ish and all the tests pass, but i wanted to make sure it was in the spirit of the intent of the code.
