### PR TITLE
Output the @JsonTypeInfo information when serializing untyped attributes and collections

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -432,6 +432,14 @@ public abstract class SerializerProvider
             BeanProperty property)
         throws JsonMappingException
     {
+        return findTypedValueSerializer(valueType, true, property);
+    }
+
+    @SuppressWarnings("unchecked")
+    private JsonSerializer<Object> findValueSerializer0(Class<?> valueType,
+            BeanProperty property)
+        throws JsonMappingException
+    {
         // Fast lookup from local lookup thingy works?
         JsonSerializer<Object> ser = _knownSerializers.untypedValueSerializer(valueType);
         if (ser == null) {
@@ -474,7 +482,15 @@ public abstract class SerializerProvider
      *   may be checked to create contextual serializers.
      */
     @SuppressWarnings("unchecked")
-    public JsonSerializer<Object> findValueSerializer(JavaType valueType, BeanProperty property)
+    public JsonSerializer<Object> findValueSerializer(JavaType valueType,
+            BeanProperty property)
+        throws JsonMappingException
+    {
+        return findTypedValueSerializer(valueType, true, property);
+    }
+
+    @SuppressWarnings("unchecked")
+    private JsonSerializer<Object> findValueSerializer0(JavaType valueType, BeanProperty property)
         throws JsonMappingException
     {
         // Fast lookup from local lookup thingy works?
@@ -596,7 +612,7 @@ public abstract class SerializerProvider
         }
 
         // Well, let's just compose from pieces:
-        ser = findValueSerializer(valueType, property);
+        ser = findValueSerializer0(valueType, property);
         TypeSerializer typeSer = _serializerFactory.createTypeSerializer(_config,
                 _config.constructType(valueType));
         if (typeSer != null) {
@@ -641,7 +657,7 @@ public abstract class SerializerProvider
         }
 
         // Well, let's just compose from pieces:
-        ser = findValueSerializer(valueType, property);
+        ser = findValueSerializer0(valueType, property);
         TypeSerializer typeSer = _serializerFactory.createTypeSerializer(_config, valueType);
         if (typeSer != null) {
             typeSer = typeSer.forProperty(property);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestCustomTypeIdResolver.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestCustomTypeIdResolver.java
@@ -120,7 +120,7 @@ public class TestCustomTypeIdResolver extends BaseMapTest
         CustomResolver.initTypes = types;
         String json = MAPPER.writeValueAsString(new CustomBean[] { new CustomBeanImpl(28) });
         assertEquals("[{\"*\":{\"x\":28}}]", json);
-        assertEquals(1, types.size());
+        assertEquals(2, types.size());
         assertEquals(CustomBean.class, types.get(0).getRawClass());
 
         types = new ArrayList<JavaType>();

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestUntypedPolymorphicSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestUntypedPolymorphicSerialization.java
@@ -1,0 +1,63 @@
+package com.fasterxml.jackson.databind.ser;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.*;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestUntypedPolymorphicSerialization extends TestCase {
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = ClassA.class)
+    @JsonSubTypes({
+            @JsonSubTypes.Type(name = "a", value = ClassA.class),
+            @JsonSubTypes.Type(name = "b", value = ClassB.class)
+    })
+    public static interface BaseInterface
+    {
+        public String getBase();
+    }
+
+    public static class ClassA implements BaseInterface {
+        @Override
+        public String getBase() {
+            return "base-a";
+        }
+
+        public String getClassA() {
+            return "class-a";
+        }
+    }
+
+    public static class ClassB implements BaseInterface
+    {
+        @Override
+        public String getBase() {
+            return "base-a";
+        }
+
+        public String getClassB() {
+            return "class-b";
+        }
+    }
+
+    public static class Container {
+        public List<Object> values = new ArrayList<Object>();
+    }
+
+    public void testTypedSerialization() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Container cont = new Container();
+        cont.values.add(new ClassA());
+        cont.values.add(new ClassB());
+
+        String str = mapper.writeValueAsString(cont);
+
+        // Check that the "type" property is output
+        assertTrue(str.contains("\"type\":\"a\""));
+        assertTrue(str.contains("\"type\":\"b\""));
+    }
+}


### PR DESCRIPTION
I encountered a problem when serializing untyped collections (e.g. `List<Object>`) containing objects from a class tree using `@JsonTypeInfo` and `@JsonTypeName` annotations: the additional property indicating the object's type is not serialized.

Jackson only outputs the type property for root objects or for collections and attributes typed with the base class (the one having the `@JsonTypeInfo`).

The problem can be traced back to `SerializerProvider` where `findValueSerializer` is called for untyped properties and collections whereas `findTypedValueSerializer` is called for typed ones.

I changed `SerializerProvider` so that `findValueSerializer` is always routed to `findTypedValueSerializer`. This solves the issue, but one test is failing:

```
Failed tests:   testMixedRefsIssue188(com.fasterxml.jackson.databind.struct.TestObjectId): null 
expected:<...er":null,"reports":[[2]},{"id":2,"name":"Second","manager":1,"reports":[]}]]}>
 but was:<...er":null,"reports":[[{"id":2,"name":"Second","manager":1,"reports":[]}]},2]]}>
```

Understanding this side effect is currently beyond my understanding of Jackson's internals. Is the proposed solution the right approach? Any idea on what causes the test to fail?
