### PR TITLE
Consistent usage of deserialize(...) return values

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -1231,8 +1231,7 @@ public class ObjectReader
                 if (valueToUpdate == null) {
                     result = deser.deserialize(jp, ctxt);
                 } else {
-                    deser.deserialize(jp, ctxt, valueToUpdate);
-                    result = valueToUpdate;
+                    result = deser.deserialize(jp, ctxt, valueToUpdate);
                 }
             }
         }


### PR DESCRIPTION
The return value of JsonDeserializer.deserialize(...) not being used confused me. 

Within my custom deserializer, I instantiated a new object (based on valueToUpdate) and returned it from the deserialize method, expecting it to become the deserialization result. But since the return value of the method is not used at all, that did not work, of course. 

Wouldn't it be more intuitive and consistent to use the return value here instead of valueToUpdate as the deserialization result?

I might be missing something, since I'm just a user of jackson and do not have deeper knowledge of its code base, so if there were reasons to handle it like that which I don't know about... feel free to decline my pull request.

Thanks!