### PR TITLE
skip writing type info for unwrapped properties

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -108,6 +108,21 @@ public enum SerializationFeature implements ConfigFeature
      */
     WRAP_EXCEPTIONS(true),
 
+	/**
+	 * Feature that determines what happens when an object which
+	 * normally has type information included by Jackson is used
+	 * in conjunction with {@link com.fasterxml.jackson.annotation.JsonUnwrapped}.
+	 * In the default (enabled) state, an error will be thrown when
+	 * an unwrapped object has type information. When disabled, the
+	 * object will be unwrapped and the type information discarded.
+	 *<p>
+	 * Feature is enabled by default.
+	 *
+	 * @since 2.4
+	 */
+	FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS(true),
+
+
     /*
     /******************************************************
     /* Output life cycle features

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanSerializer.java
@@ -1,13 +1,16 @@
 package com.fasterxml.jackson.databind.ser.impl;
 
-import java.io.IOException;
-
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.jsontype.*;
-import com.fasterxml.jackson.databind.ser.*;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
 import com.fasterxml.jackson.databind.util.NameTransformer;
+
+import java.io.IOException;
 
 public class UnwrappingBeanSerializer
     extends BeanSerializerBase
@@ -121,6 +124,10 @@ public class UnwrappingBeanSerializer
     public void serializeWithType(Object bean, JsonGenerator jgen, SerializerProvider provider, TypeSerializer typeSer)
         throws IOException, JsonGenerationException
     {
+	    if (provider.isEnabled(SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS)) {
+		    throw new JsonGenerationException("Unwrapped property contains type information.");
+	    }
+
         if (_objectIdWriter != null) {
             _serializeWithObjectId(bean, jgen, provider, typeSer);
             return;

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestUnwrappedWithTypeInfo.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestUnwrappedWithTypeInfo.java
@@ -1,0 +1,86 @@
+package com.fasterxml.jackson.databind.ser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.Test;
+
+// Tests for [#81]
+public class TestUnwrappedWithTypeInfo extends BaseMapTest
+{
+
+	@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="@type")
+	@JsonTypeName("OuterType")
+	static class Outer {
+
+		private @JsonProperty String p1;
+		public String getP1() { return p1; }
+		public void setP1(String p1) { this.p1 = p1; }
+
+
+		private Inner inner;
+		public void setInner(Inner inner) { this.inner = inner; }
+
+		@JsonUnwrapped
+		public Inner getInner() {
+			return inner;
+		}
+	}
+
+	@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="@type")
+	@JsonTypeName("InnerType")
+	static class Inner {
+
+		private @JsonProperty String p2;
+		public String getP2() { return p2; }
+		public void setP2(String p2) { this.p2 = p2; }
+
+	}
+    
+    /*
+    /**********************************************************
+    /* Tests, serialization
+    /**********************************************************
+     */
+
+    public void testDefaultUnwrappedWithTypeInfo() throws Exception
+    {
+	    Outer outer = new Outer();
+	    outer.setP1("101");
+
+	    Inner inner = new Inner();
+	    inner.setP2("202");
+	    outer.setInner(inner);
+
+	    ObjectMapper mapper = new ObjectMapper();
+
+        try {
+	        mapper.writeValueAsString(outer);
+        } catch (JsonGenerationException ex) {
+	        return; // expected
+        }
+
+	    fail("Expected exception to be thrown.");
+    }
+
+	public void testUnwrappedWithTypeInfoAndFeatureDisabled() throws Exception
+	{
+		Outer outer = new Outer();
+		outer.setP1("101");
+
+		Inner inner = new Inner();
+		inner.setP2("202");
+		outer.setInner(inner);
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper = mapper.disable(SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS);
+
+		String json = mapper.writeValueAsString(outer);
+		assertEquals("{\"@type\":\"OuterType\",\"p1\":\"101\",\"p2\":\"202\"}", json);
+	}
+}


### PR DESCRIPTION
Attempts to address #81 by skipping the writing of type id information for properties which are being unwrapped.
