### PR TITLE
include JsonLocation in more mapping exceptions

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
@@ -143,7 +143,7 @@ public abstract class ValueInstantiator
      * null or empty List.
      */
     public Object createUsingDefault(DeserializationContext ctxt) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "
+        throw ctxt.mappingException("Can not instantiate value of type "
                 +getValueTypeDesc()+"; no default creator found");
     }
 
@@ -156,7 +156,7 @@ public abstract class ValueInstantiator
      * a non-empty List of arguments.
      */
     public Object createFromObjectWith(DeserializationContext ctxt, Object[] args) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()+" with arguments");
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()+" with arguments");
     }
 
     /**
@@ -164,7 +164,7 @@ public abstract class ValueInstantiator
      * an intermediate "delegate" value to pass to createor method
      */
     public Object createUsingDelegate(DeserializationContext ctxt, Object delegate) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()+" using delegate");
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()+" using delegate");
     }
     
     /*
@@ -179,22 +179,22 @@ public abstract class ValueInstantiator
     }
 
     public Object createFromInt(DeserializationContext ctxt, int value) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "
+        throw ctxt.mappingException("Can not instantiate value of type "
                 +getValueTypeDesc()+" from Integer number ("+value+", int)");
     }
 
     public Object createFromLong(DeserializationContext ctxt, long value) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "
+        throw ctxt.mappingException("Can not instantiate value of type "
                 +getValueTypeDesc()+" from Integer number ("+value+", long)");
     }
 
     public Object createFromDouble(DeserializationContext ctxt, double value) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "
+        throw ctxt.mappingException("Can not instantiate value of type "
                 +getValueTypeDesc()+" from Floating-point number ("+value+", double)");
     }
     
     public Object createFromBoolean(DeserializationContext ctxt, boolean value) throws IOException {
-        throw new JsonMappingException("Can not instantiate value of type "
+        throw ctxt.mappingException("Can not instantiate value of type "
                 +getValueTypeDesc()+" from Boolean value ("+value+")");
     }
 
@@ -274,7 +274,7 @@ public abstract class ValueInstantiator
                 return null;
             }
         }
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()
                 +" from String value ('"+value+"'); no single-String constructor/factory method");
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -307,7 +307,7 @@ public class StdValueInstantiator
         } catch (ExceptionInInitializerError e) {
             throw wrapException(e);
         }
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()
                 +" from Integral number ("+value+"); no single-int-arg constructor/factory method");
     }
 
@@ -324,7 +324,7 @@ public class StdValueInstantiator
         } catch (ExceptionInInitializerError e) {
             throw wrapException(e);
         }
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()
                 +" from Long integral number ("+value+"); no single-long-arg constructor/factory method");
     }
 
@@ -341,7 +341,7 @@ public class StdValueInstantiator
         } catch (ExceptionInInitializerError e) {
             throw wrapException(e);
         }
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()
                 +" from Floating-point number ("+value+"); no one-double/Double-arg constructor/factory method");
     }
 
@@ -358,7 +358,7 @@ public class StdValueInstantiator
         } catch (ExceptionInInitializerError e) {
             throw wrapException(e);
         }
-        throw new JsonMappingException("Can not instantiate value of type "+getValueTypeDesc()
+        throw ctxt.mappingException("Can not instantiate value of type "+getValueTypeDesc()
                 +" from Boolean value ("+value+"); no single-boolean/Boolean-arg constructor/factory method");
     }
     

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestBeanDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestBeanDeserializer.java
@@ -264,6 +264,7 @@ public class TestBeanDeserializer extends BaseMapTest
             fail("Should not accept Empty String for POJO");
         } catch (JsonProcessingException e) {
             verifyException(e, "from String value");
+            assertValidLocation(e.getLocation());
         }
 
         // should be ok to enable dynamically:

--- a/src/test/java/com/fasterxml/jackson/test/BaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/test/BaseTest.java
@@ -350,6 +350,11 @@ public abstract class BaseTest
         }
     }
 
+    protected void assertValidLocation(JsonLocation location) {
+        assertNotNull("Should have non-null location", location);
+        assertTrue("Should have positive line number", location.getLineNr() > 0);
+    }
+
     protected void verifyException(Throwable e, String... matches)
     {
         String msg = e.getMessage();


### PR DESCRIPTION
It can be difficult to determine what input data is invalid when that data does not match the type expected, especially when the user is not aware of the Java details. Consider the message:

> Can not instantiate value of type [map type; class java.util.LinkedHashMap, [simple type, class java.lang.Object] -> [simple type, class java.lang.Object]] from String value; no single-String constructor/factory method (through reference chain: com.example.YamlConfig["loops"])```

This change includes the JsonLocation for various cases such as this. I find having this location info to be more helpful for certain types of users compared to the more technical, internal info in the message.

I'm not sure if I wedged the tests in the right place, though putting it in TestObjectMapperBeanDeserializer did prevent some duplication.

Thanks,
Andy
