### PR TITLE
Avoid setting explName to true if name is null in POJOPropertyBuilder

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -523,11 +523,11 @@ public class POJOPropertyBuilder
     /**
      * @deprecated Since 2.4 call method that takes additional 'explName' argument, to indicate
      *   whether name of property was provided by annotation (and not derived from accessor name);
-     *   this method simply passes 'true' for it.
+     *   this method assumes the name is explicit if it is non-null.
      */
     @Deprecated
     public void addField(AnnotatedField a, String name, boolean visible, boolean ignored) {
-        addField(a, _propName(name), true, visible, ignored);
+        addField(a, _propName(name), name != null, visible, ignored);
     }
 
     @Deprecated
@@ -538,11 +538,11 @@ public class POJOPropertyBuilder
     /**
      * @deprecated Since 2.4 call method that takes additional 'explName' argument, to indicate
      *   whether name of property was provided by annotation (and not derived from accessor name);
-     *   this method simply passes 'true' for it.
+     *   this method assumes the name is explicit if it is non-null.
      */
     @Deprecated
     public void addCtor(AnnotatedParameter a, String name, boolean visible, boolean ignored) {
-        addCtor(a, _propName(name), true, visible, ignored);
+        addCtor(a, _propName(name), name != null, visible, ignored);
     }
     @Deprecated
     public void addCtor(AnnotatedParameter a, String name, boolean explName, boolean visible, boolean ignored) {
@@ -552,11 +552,11 @@ public class POJOPropertyBuilder
     /**
      * @deprecated Since 2.4 call method that takes additional 'explName' argument, to indicate
      *   whether name of property was provided by annotation (and not derived from accessor name);
-     *   this method simply passes 'true' for it.
+     *   this method assumes the name is explicit if it is non-null.
      */
     @Deprecated
     public void addGetter(AnnotatedMethod a, String name, boolean visible, boolean ignored) {
-        addGetter(a, _propName(name), true, visible, ignored);
+        addGetter(a, _propName(name), name != null, visible, ignored);
     }
     @Deprecated
     public void addGetter(AnnotatedMethod a, String name, boolean explName, boolean visible, boolean ignored) {
@@ -566,11 +566,11 @@ public class POJOPropertyBuilder
     /**
      * @deprecated Since 2.4 call method that takes additional 'explName' argument, to indicate
      *   whether name of property was provided by annotation (and not derived from accessor name);
-     *   this method simply passes 'true' for it.
+     *   this method assumes the name is explicit if it is non-null.
      */
     @Deprecated
     public void addSetter(AnnotatedMethod a, String name, boolean visible, boolean ignored) {
-        addSetter(a, _propName(name), true, visible, ignored);
+        addSetter(a, _propName(name), name != null, visible, ignored);
     }
     @Deprecated
     public void addSetter(AnnotatedMethod a, String name, boolean explName, boolean visible, boolean ignored) {


### PR DESCRIPTION
This change enables backwards compatibility of Jackson 2.4.0 with modules relying on the 2.3 API (e.g., jackson-module-scala 2.3.X).

Prior to this change, old versions of jackson-module-scala would receive this exception, when running with Jacskon 2.4:

```
java.lang.IllegalArgumentException: Can not pass true for 'explName' if name is null/empty
    at com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder$Linked.<init>(POJOPropertyBuilder.java:955)
```

Note that this behavior is effectively what jackson-module-scala does in 2.4.0: [ScalaPropertiesCollector#211](https://github.com/FasterXML/jackson-module-scala/blob/master/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaPropertiesCollector.scala#L211)
