### PR TITLE
Add fluent API for adding mixins

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -908,7 +908,7 @@ public class ObjectMapper
      * @param mixinSource Class (or interface) whose annotations are to
      *   be "added" to target's annotations, overriding as necessary
      *
-     * @deprecated replaced by a fluent form of the method; {@link #addMixIn(Class, Class)}.
+     * @deprecated Replaced by a fluent form of the method; {@link #addMixIn(Class, Class)}.
      */
     @Deprecated
     public final void addMixInAnnotations(Class<?> target, Class<?> mixinSource)


### PR DESCRIPTION
Change the mixin call in ObjectMapper so it's fluent like some of the other ObjectMapper methods.
