### PR TITLE
Fixes issue raised in #587

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -438,9 +438,10 @@ public abstract class BasicDeserializerFactory
             if (argCount == 1) {
                 BeanPropertyDefinition propDef = (propDefs == null) ? null : propDefs[0];
                 boolean hasExplicitName = (propDef != null) && propDef.isExplicitlyNamed();
+                boolean hasInternalCreator = isCreator && (propDef != null) && propDef.getInternalName() != null;
                 Object injectId = intr.findInjectableValueId(ctor.getParameter(0));
 
-                if (hasExplicitName || (injectId != null)) {
+                if (hasExplicitName || hasInternalCreator || (injectId != null)) {
                     CreatorProperty[] properties = new CreatorProperty[1];
                     PropertyName name = (propDef == null) ? null : propDef.getFullName();
                     properties[0] = constructCreatorProperty(ctxt, beanDesc, name, 0, ctor.getParameter(0), injectId);

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestScalaLikeImplicitProperties.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestScalaLikeImplicitProperties.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.failing;
+package com.fasterxml.jackson.databind.creators;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.*;


### PR DESCRIPTION
This change addresses the issue I raised in #587, where types with the creator annotation (whether through annotation or simulation) were not being detected unless they had an explicit name. The change additionally checks for an internal name _and_ the presence of the creator annotation, and directs them down the same deserializer factory path as with explicit names.

Since the Scala-like tests are now passing, this change also moves them out of the failing tests directory.

I haven't had a chance to confirm with Java 8 yet, but I suspect this change will also allow the tests added in FasterXML/jackson-module-parameter-names#10 to pass.
