### PR TITLE
Adding currency deserialization support in maps

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.util.Calendar;
+import java.util.Currency;
 import java.util.Date;
 import java.util.Locale;
 import java.util.UUID;
@@ -46,6 +47,7 @@ public class StdKeyDeserializer extends KeyDeserializer
     public final static int TYPE_URI = 13;
     public final static int TYPE_URL = 14;
     public final static int TYPE_CLASS = 15;
+    public final static int TYPE_CURRENCY = 16;
 
     final protected int _kind;
     final protected Class<?> _keyClass;
@@ -104,6 +106,9 @@ public class StdKeyDeserializer extends KeyDeserializer
         } else if (raw == Locale.class) {
             FromStringDeserializer<?> deser = FromStringDeserializer.findDeserializer(Locale.class);
             return new StdKeyDeserializer(TYPE_LOCALE, raw, deser);
+        } else if (raw == Currency.class) {
+            FromStringDeserializer<?> deser = FromStringDeserializer.findDeserializer(Currency.class);
+            return new StdKeyDeserializer(TYPE_CURRENCY, raw, deser);
         } else {
             return null;
         }
@@ -183,7 +188,12 @@ public class StdKeyDeserializer extends KeyDeserializer
             } catch (IOException e) {
                 throw ctxt.weirdKeyException(_keyClass, key, "unable to parse key as locale");
             }
-
+        case TYPE_CURRENCY:
+            try {
+                return _deser._deserialize(key, ctxt);
+            } catch (IOException e) {
+                throw ctxt.weirdKeyException(_keyClass, key, "unable to parse key as currency");
+            }
         case TYPE_DATE:
             return ctxt.parseDate(key);
         case TYPE_CALENDAR:

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestMapDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestMapDeserialization.java
@@ -463,6 +463,19 @@ public class TestMapDeserialization
         assertEquals(key, ob);
     }
 
+    public void testCurrencyKeyMap() throws Exception {
+        Currency key = Currency.getInstance("USD");
+        String JSON = "{ \"" + key + "\":4}";
+        Map<Currency, Object> result = MAPPER.readValue(JSON, new TypeReference<Map<Currency, Object>>() {
+        });
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        Object ob = result.keySet().iterator().next();
+        assertNotNull(ob);
+        assertEquals(Currency.class, ob.getClass());
+        assertEquals(key, ob);
+    }
+
     // Test confirming that @JsonCreator may be used with Map Key types
     public void testKeyWithCreator() throws Exception
     {


### PR DESCRIPTION
deserialization for currency as a key for maps is not supported currently in jackson. The support was added taking into consideration the strategies for locale as they are really similar.