### PR TITLE
Attempt to create new object before failing on missing reference

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
@@ -145,6 +145,11 @@ public abstract class DefaultDeserializationContext
         UnresolvedForwardReference exception = null;
         for (Entry<IdKey,ReadableObjectId> entry : _objectIds.entrySet()) {
             ReadableObjectId roid = entry.getValue();
+
+            if (roid.hasReferringProperties()) {
+                roid.attemptResolvingByCreating();
+            }
+
             if (roid.hasReferringProperties()) {
                 if (exception == null) {
                     exception = new UnresolvedForwardReference("Unresolved forward references for: ");

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ReadableObjectId.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ReadableObjectId.java
@@ -74,6 +74,19 @@ public class ReadableObjectId
         }
     }
 
+    public void attemptResolvingByCreating() {
+        Object createdItem = _resolver.createItem(_key);
+        if (createdItem != null) {
+            try {
+                bindItem(createdItem);
+            } catch (IOException ex) {
+                // Ignore binding exception, we will fail with
+                // UnresolvedForwardReference anyway
+                ex.printStackTrace();
+            }
+        }
+    }
+
     public Object resolve(){
          return (item = _resolver.resolveId(_key));
     }


### PR DESCRIPTION
This adds a final resolving attempt using the ObjectIdResolver's
create(key) method. This should allow customizing the resolving
behaviour at the end of the deserialization.

If the create method returns null (the default behaviour), Jackson
will throw the UnresolvedForwardReference as usual.

This should be applied together with my other pull request to
jackson-annotations and together solve the issue #670.