### PR TITLE
support json schema generation for @JsonUnwrapped (#271)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/JsonFormatVisitorNullWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/JsonFormatVisitorNullWrapper.java
@@ -1,0 +1,87 @@
+package com.fasterxml.jackson.databind.ser.impl;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
+
+/**
+ * Default "empty" implementation, useful as the base to start on; especially as
+ * it is guaranteed to implement all the method of the interface, even if new
+ * methods are getting added.
+ */
+class JsonFormatVisitorNullWrapper implements JsonFormatVisitorWrapper {
+	protected SerializerProvider _provider;
+
+	public JsonFormatVisitorNullWrapper() {
+	}
+
+	public JsonFormatVisitorNullWrapper(SerializerProvider p) {
+		_provider = p;
+	}
+
+	@Override
+	public SerializerProvider getProvider() {
+		return _provider;
+	}
+
+	@Override
+	public void setProvider(SerializerProvider p) {
+		_provider = p;
+	}
+
+	@Override
+	public JsonObjectFormatVisitor expectObjectFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonArrayFormatVisitor expectArrayFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonStringFormatVisitor expectStringFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonNumberFormatVisitor expectNumberFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonIntegerFormatVisitor expectIntegerFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonBooleanFormatVisitor expectBooleanFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonNullFormatVisitor expectNullFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonAnyFormatVisitor expectAnyFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+	@Override
+	public JsonMapFormatVisitor expectMapFormat(JavaType type)
+			throws JsonMappingException {
+		return null;
+	}
+
+};

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanPropertyWriter.java
@@ -3,15 +3,16 @@ package com.fasterxml.jackson.databind.ser.impl;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.ser.*;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.util.NameTransformer;
 
 /**
@@ -135,21 +136,28 @@ public class UnwrappingBeanPropertyWriter
     /**********************************************************
      */
 
-    // TODO: if/how to change this? Base class has this
-/*    
     @Override
-    public void depositSchemaProperty(JsonObjectFormatVisitor objectVisitor)
-        throws JsonMappingException
-    {
-        if (objectVisitor != null) {
-            if (isRequired()) {
-                objectVisitor.property(this); 
-            } else {
-                objectVisitor.optionalProperty(this);
-            }
+    public void depositSchemaProperty(final JsonObjectFormatVisitor visitor)
+            throws JsonMappingException {
+        SerializerProvider provider = visitor.getProvider();
+        JsonSerializer<Object> ser = provider
+                .findValueSerializer(this.getType(), this)
+                .unwrappingSerializer(_nameTransformer);
+        
+        if (ser.isUnwrappingSerializer()) {
+            ser.acceptJsonFormatVisitor(new JsonFormatVisitorNullWrapper(provider) {
+                // an unwrapping serializer will always expect ObjectFormat,
+                // hence, the other cases do not have to be implemented
+                @Override
+                public JsonObjectFormatVisitor expectObjectFormat(JavaType type)
+                        throws JsonMappingException {
+                    return visitor;
+                }
+            }, this.getType());
+        } else {
+            super.depositSchemaProperty(visitor);
         }
     }
-    */
     
     // Override needed to support legacy JSON Schema generator
     @Override


### PR DESCRIPTION
This pull request relates to #271 which only fixed the "old" schema generation method.
The "new" json schema generation approach (jackson-module-jsonSchema) did not yet handle the JsonUnwrapped annotation.
This patch adds this support by overriding the depositSchemaProperty method of UnwrappingBeanPropertyWriter. 
An updated test for verifying the correct behavior is in a separate commit (in jackson-module-jsonSchema).
