### PR TITLE
Fix Infinite recursion (StackOverflowError) when serializing a SOAP object.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -45,11 +45,11 @@ public class OptionalHandlerFactory implements java.io.Serializable
         String className = rawType.getName();
         String factoryName;
         
-        if (className.startsWith(PACKAGE_PREFIX_JAVAX_XML)
-                || hasSupertypeStartingWith(rawType, PACKAGE_PREFIX_JAVAX_XML)) {
-            factoryName = SERIALIZERS_FOR_JAVAX_XML;
-        } else if (doesImplement(rawType, CLASS_NAME_DOM_NODE)) {
+        if (doesImplement(rawType, CLASS_NAME_DOM_NODE)) {
             return (JsonSerializer<?>) instantiate(SERIALIZER_FOR_DOM_NODE);
+        }
+        if (className.startsWith(PACKAGE_PREFIX_JAVAX_XML) || hasSupertypeStartingWith(rawType, PACKAGE_PREFIX_JAVAX_XML)) {
+            factoryName = SERIALIZERS_FOR_JAVAX_XML;
         } else {
             return null;
         }

--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestSOAP.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestSOAP.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.databind.ext;
+
+import javax.xml.soap.Detail;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestSOAP extends com.fasterxml.jackson.databind.BaseMapTest {
+
+    public void testSerializeSOAP() throws SOAPException, JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        SOAPFactory fac = SOAPFactory.newInstance();
+        Detail detailElement = fac.createDetail();
+        detailElement.setTextContent("test");
+        String result = objectMapper.writer().writeValueAsString(detailElement);
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
I had to to rearrange slightly the OptionalHandlerFactory#findSerializer logic to use the DOMSerializer when handling a SOAP object to fix an infinite recursion.
Look at TestSOAP for a test case.