### PR TITLE
allow missing build method if its name is empty ""

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -368,10 +368,13 @@ public class BeanDeserializerBuilder
     		String expBuildMethodName)
     {
         // First: validation; must have build method that returns compatible type
-        if (_buildMethod == null) {
+        // ("" means you don't need a build method, just cast the last builder)
+        if (_buildMethod == null && !"".equals(expBuildMethodName)) {
             throw new IllegalArgumentException("Builder class "+_beanDesc.getBeanClass().getName()
                     +" does not have build method '"+expBuildMethodName+"()'");
         }
+
+    if(_buildMethod != null) {
         // also: type of the method must be compatible
         Class<?> rawBuildType = _buildMethod.getRawReturnType();
         Class<?> rawValueType = valueType.getRawClass();
@@ -382,6 +385,7 @@ public class BeanDeserializerBuilder
                     +" has bad return type ("+rawBuildType.getName()
                     +"), not compatible with POJO type ("+valueType.getRawClass().getName()+")");
         }
+    }
         // And if so, we can try building the deserializer
         Collection<SettableBeanProperty> props = _properties.values();
         BeanPropertyMap propertyMap = BeanPropertyMap.construct(props, _caseInsensitivePropertyComparison);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -117,6 +117,7 @@ public class BuilderBasedDeserializer
     protected final Object finishBuild(DeserializationContext ctxt, Object builder)
             throws IOException
     {
+        if(null==_buildMethod) return builder;
         try {
             return _buildMethod.getMember().invoke(builder);
         } catch (Exception e) {


### PR DESCRIPTION
This allows builder-like objects whose class is its own builder class,
no need to convert later from the Builder type to the "real" type
with a final build()

This works well for immutable classes with Project Lombok if you use lombok's @Wither and was the best way I found to be able to integrate jackson and lombok

Missing unit test for now, so not quite ready for merge, but thought I'd start the PR anyway in case of any other feedback
