### PR TITLE
Make FAIL_ON_UNKNOWN_PROPERTIES 'false' by default.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -104,7 +104,7 @@ public enum DeserializationFeature implements ConfigFeature
      * {@link JsonMappingException} will be thrown if an unknown property
      * is encountered).
      */
-    FAIL_ON_UNKNOWN_PROPERTIES(true),
+    FAIL_ON_UNKNOWN_PROPERTIES(false),
 
     /**
      * Feature that determines whether encountering of JSON null

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -139,7 +139,7 @@ public class ObjectMapperTest extends BaseMapTest
     public void testCopy() throws Exception
     {
         ObjectMapper m = new ObjectMapper();
-        assertTrue(m.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+        assertFalse(m.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
         m.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         assertFalse(m.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
         InjectableValues inj = new InjectableValues.Std();

--- a/src/test/java/com/fasterxml/jackson/databind/TestObjectMapperBeanDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/TestObjectMapperBeanDeserializer.java
@@ -317,7 +317,8 @@ public class TestObjectMapperBeanDeserializer
     public void testUnknownFields() throws Exception
     {
         try {
-            TestBean bean = MAPPER.readValue("{ \"foobar\" : 3 }", TestBean.class);
+            ObjectMapper mapper = MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+            TestBean bean = mapper.readValue("{ \"foobar\" : 3 }", TestBean.class);
             fail("Expected an exception, got bean: "+bean);
         } catch (JsonMappingException jse) {
             ;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestBeanDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestBeanDeserializer.java
@@ -304,6 +304,7 @@ public class TestBeanDeserializer extends BaseMapTest
         
         // first, verify default settings which do not accept improper case
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         assertFalse(mapper.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES));
         
         try {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestConfig.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestConfig.java
@@ -68,7 +68,7 @@ public class TestConfig
         assertFalse(cfg.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
         assertFalse(cfg.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS));
 
-        assertTrue(cfg.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+        assertFalse(cfg.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
     }
 
     public void testOverrideIntrospectors()

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestExceptionHandling.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestExceptionHandling.java
@@ -31,7 +31,7 @@ public class TestExceptionHandling
     {
         UnrecognizedPropertyException exc = null;
         try {
-            new ObjectMapper().readValue("{\"bar\":3}", Bean.class);
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true).readValue("{\"bar\":3}", Bean.class);
         } catch (UnrecognizedPropertyException e) {
             exc = e;
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestSetterlessProperties.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestSetterlessProperties.java
@@ -66,6 +66,7 @@ public class TestSetterlessProperties
         throws Exception
     {
         ObjectMapper m = new ObjectMapper();
+        m = m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         // by default, it should be enabled
         assertTrue(m.isEnabled(MapperFeature.USE_GETTERS_AS_SETTERS));
         m.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
@@ -100,6 +101,7 @@ public class TestSetterlessProperties
     {
         ObjectMapper m = new ObjectMapper();
         m.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
+        m = m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         // so this should fail now without a setter
         try {
             m.readValue

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestInferredMutators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestInferredMutators.java
@@ -1,9 +1,6 @@
 package com.fasterxml.jackson.databind.introspect;
 
-import com.fasterxml.jackson.databind.BaseMapTest;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.*;
 
 public class TestInferredMutators extends BaseMapTest
 {
@@ -31,6 +28,7 @@ public class TestInferredMutators extends BaseMapTest
     public void testFinalFieldIgnoral() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
+        mapper = mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         // default value is 'enabled', for backwards compatibility
         assertTrue(mapper.isEnabled(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS));
         mapper.disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS);
@@ -47,6 +45,7 @@ public class TestInferredMutators extends BaseMapTest
     {
         final String JSON = "{\"x\":2}";
         ObjectMapper mapper = new ObjectMapper();
+        mapper = mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         // First: default case, inference enabled:
         assertTrue(mapper.isEnabled(MapperFeature.INFER_PROPERTY_MUTATORS));
         Point p = mapper.readValue(JSON,  Point.class);
@@ -54,6 +53,7 @@ public class TestInferredMutators extends BaseMapTest
 
         // but without it, should fail:
         mapper = new ObjectMapper();
+        mapper = mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         mapper.disable(MapperFeature.INFER_PROPERTY_MUTATORS);
         try {
             p = mapper.readValue(JSON,  Point.class);

--- a/src/test/java/com/fasterxml/jackson/databind/seq/ReadRecoveryTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/seq/ReadRecoveryTest.java
@@ -25,7 +25,8 @@ public class ReadRecoveryTest extends BaseMapTest
     public void testRootBeans() throws Exception
     {
         final String JSON = aposToQuotes("{'a':3} {'b':5}");
-        MappingIterator<Bean> it = MAPPER.reader(Bean.class).readValues(JSON);
+        ObjectMapper mapper = MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+        MappingIterator<Bean> it = mapper.reader(Bean.class).readValues(JSON);
         // First one should be fine
         assertTrue(it.hasNextValue());
         Bean bean = it.nextValue();


### PR DESCRIPTION
This scenario happens a lot:

1. Somebody writes a client that uses Jackson to consume an API.
2. The API developers add a property.
3. The addition of the property breaks existing clients because they're configured by default to fail on unknown properties.
4. The developer of the client comes to me to ask why their client is so brittle.
5. I tell them that they have to provide a special configuration setting.
6. They ask me why Jackson, by default, fails on unknown properties.
7. I have no answer.

So why _does_ Jackson fail on unknown properties by default? I can't think of any other binding libraries that fail on unknown properties (e.g. JAXB).

How 'bout changing the default?
