### PR TITLE
Fix for problem with array casting in BeanDeserializerBase

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -422,7 +422,7 @@ public abstract class BasicDeserializerFactory
                 boolean useProps = _checkIfCreatorPropertyBased(intr, ctor, argDef);
 
                 if (useProps) {
-                    CreatorProperty[] properties = new CreatorProperty[1];
+                    SettableBeanProperty[] properties = new SettableBeanProperty[1];
                     PropertyName name = (argDef == null) ? null : argDef.getFullName();
                     AnnotatedParameter arg = ctor.getParameter(0);
                     properties[0] = constructCreatorProperty(ctxt, beanDesc, name, 0, arg,
@@ -447,7 +447,7 @@ public abstract class BasicDeserializerFactory
             //   do, with some constraints. But that will require bit post processing...
 
             AnnotatedParameter nonAnnotatedParam = null;
-            CreatorProperty[] properties = new CreatorProperty[argCount];
+            SettableBeanProperty[] properties = new SettableBeanProperty[argCount];
             int explicitNameCount = 0;
             int implicitWithCreatorCount = 0;
             int injectCount = 0;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -435,10 +435,11 @@ public abstract class SettableBeanProperty
     /**
      * Method for accessing index of the creator property: for other
      * types of properties will simply return -1.
+     * 20.06.2015 bojanv55 - had a problem when returning -1 when deser. ref. object
      * 
      * @since 2.1
      */
-    public int getCreatorIndex() { return -1; }
+    public int getCreatorIndex() { return _propertyIndex; }
     
     /**
      * Accessor for id of injectable value, if this bean property supports

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.deser.CreatorProperty;
+import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator;
 import com.fasterxml.jackson.databind.introspect.*;
@@ -60,9 +61,9 @@ public class CreatorCollector
     protected boolean _hasNonDefaultCreator = false;
 
     // when there are injectable values along with delegate:
-    protected CreatorProperty[] _delegateArgs;
+    protected SettableBeanProperty[] _delegateArgs;
 
-    protected CreatorProperty[] _propertyBasedArgs;
+    protected SettableBeanProperty[] _propertyBasedArgs;
 
     protected AnnotatedParameter _incompleteParameter;
 
@@ -171,14 +172,14 @@ public class CreatorCollector
     }
 
     public void addDelegatingCreator(AnnotatedWithParams creator, boolean explicit,
-            CreatorProperty[] injectables)
+            SettableBeanProperty[] injectables)
     {
         verifyNonDup(creator, C_DELEGATE, explicit);
         _delegateArgs = injectables;
     }
     
     public void addPropertyCreator(AnnotatedWithParams creator, boolean explicit,
-            CreatorProperty[] properties)
+            SettableBeanProperty[] properties)
     {
         verifyNonDup(creator, C_PROPS, explicit);
         // [JACKSON-470] Better ensure we have no duplicate names either...

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -37,13 +37,13 @@ public class StdValueInstantiator
     // // // With-args (property-based) construction
 
     protected AnnotatedWithParams _withArgsCreator;
-    protected CreatorProperty[] _constructorArguments;
+    protected SettableBeanProperty[] _constructorArguments;
 
     // // // Delegate construction
     
     protected JavaType _delegateType;
     protected AnnotatedWithParams _delegateCreator;
-    protected CreatorProperty[] _delegateArguments;
+    protected SettableBeanProperty[] _delegateArguments;
     
     // // // Scalar construction
 
@@ -100,8 +100,8 @@ public class StdValueInstantiator
      * three), and clear other properties
      */
     public void configureFromObjectSettings(AnnotatedWithParams defaultCreator,
-            AnnotatedWithParams delegateCreator, JavaType delegateType, CreatorProperty[] delegateArgs,
-            AnnotatedWithParams withArgsCreator, CreatorProperty[] constructorArgs)
+            AnnotatedWithParams delegateCreator, JavaType delegateType, SettableBeanProperty[] delegateArgs,
+            AnnotatedWithParams withArgsCreator, SettableBeanProperty[] constructorArgs)
     {
         _defaultCreator = defaultCreator;
         _delegateCreator = delegateCreator;
@@ -247,7 +247,7 @@ public class StdValueInstantiator
             final int len = _delegateArguments.length;
             Object[] args = new Object[len];
             for (int i = 0; i < len; ++i) {
-                CreatorProperty prop = _delegateArguments[i];
+                SettableBeanProperty prop = _delegateArguments[i];
                 if (prop == null) { // delegate
                     args[i] = delegate;
                 } else { // nope, injectable:


### PR DESCRIPTION
Without this fix, this line casts an exception when it tries to put ObjectIdReferenceProperty inside CreatorProperty array.

 if (creatorProps[i] == origProp) {
                            creatorProps[i] = prop;
                            break;
                        }