### PR TITLE
Respect context default attributes for @JsonCreator invocations.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -136,6 +136,10 @@ public class PropertyValueBuffer
             return _context.findInjectableValue(prop.getInjectableValueId(),
                     prop, null);
         }
+        Object contextDefaultValue = _context.getAttribute(prop.getName());
+        if (contextDefaultValue != null) {
+            return contextDefaultValue;
+        }
         // Second: required?
         if (prop.isRequired()) {
             throw _context.mappingException(String.format("Missing required creator property '%s' (index %d)",

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestCreators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestCreators.java
@@ -304,6 +304,12 @@ public class TestCreators
         assertEquals(42, bean.x);
     }
 
+    public void testSimpleConstructorDefaultAttribute() throws Exception
+    {
+        ConstructorBean bean = MAPPER.readerFor(ConstructorBean.class).withAttribute("x", 42).readValue("{}");
+        assertEquals(42, bean.x);
+    }
+
     // [JACKSON-850]
     public void testNoArgsFactory() throws Exception
     {


### PR DESCRIPTION
Found this when trying to use jackson-databind in conjunction with https://github.com/google/auto/tree/master/value which introduces null checks that I was expecting to avoid by setting default values into the context. Let me know if this makes any sense.