### PR TITLE
Include licensing information in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,14 @@
   <description>General data-binding functionality for Jackson: works on core streaming API</description>
   <url>http://github.com/FasterXML/jackson</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <scm>
     <connection>scm:git:git@github.com:FasterXML/jackson-databind.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-databind.git</developerConnection>


### PR DESCRIPTION
Reports are generated from this information to ensure usage of licenses