### PR TITLE
also parse scientific notation as a double/decimal

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
@@ -455,7 +455,7 @@ public class NumberDeserializers
                     return Double.NaN;
                 }
                 try {
-                    if (text.indexOf('.') >= 0) { // floating point
+                    if (text.indexOf('.') >= 0 || text.indexOf('E') >= 0) { // floating point
                         if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
                             return new BigDecimal(text);
                         }


### PR DESCRIPTION
`BigDecimal` and `Double`'s `.toString` uses scientific notation when the number has more than 6 decimal points.

So, when you have a Jackson generated JSON payload, you may end up with something like 

```
{"my-double": "3E-8"}
```

will fail with a NumberFormatException:

```
! java.lang.NumberFormatException: For input string: "3E-8"
! at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
! at java.lang.Long.parseLong(Long.java:589)
! at java.lang.Long.parseLong(Long.java:631)
! at com.fasterxml.jackson.databind.util.TokenBuffer$Parser.getNumberValue(TokenBuffer.java:1392)
! at com.fasterxml.jackson.databind.util.TokenBuffer$Parser.getDoubleValue(TokenBuffer.java:1340)
! at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer.deserialize(UntypedObjectDeserializer.java:207)
! at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringMap(MapDeserializer.java:430) 
! at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:312)
```

It's a bit of a corner case; for me, I was converting a class with a non-standard descendant of `Number` (`scala.math.BigDecimal`) into a `Map<String, Object>` and it only broke once I got smaller numbers.

Happy to write a unit test if that helps; I only didn't because I opened this from the github web UI.