### PR TITLE
Annotations are lost in the case of duplicate methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -1056,7 +1056,7 @@ public class POJOPropertyBuilder
      * Node used for creating simple linked lists to efficiently store small sets
      * of things.
      */
-    private final static class Linked<T>
+    protected final static class Linked<T>
     {
         public final T value;
         public final Linked<T> next;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -683,28 +683,28 @@ public class POJOPropertyBuilder
         if (forSerialization) {
             if (_getters != null) {
                 AnnotationMap ann = _mergeAnnotations(0, _getters, _fields, _ctorParameters, _setters);
-                _getters = _getters.withValue(_getters.value.withAnnotations(ann));
+                _getters = _applyAnnotations(_getters, ann);
             } else if (_fields != null) {
                 AnnotationMap ann = _mergeAnnotations(0, _fields, _ctorParameters, _setters);
-                _fields = _fields.withValue(_fields.value.withAnnotations(ann));
+                _fields = _applyAnnotations(_fields, ann);
             }
         } else { // for deserialization
             if (_ctorParameters != null) {
                 AnnotationMap ann = _mergeAnnotations(0, _ctorParameters, _setters, _fields, _getters);
-                _ctorParameters = _ctorParameters.withValue(_ctorParameters.value.withAnnotations(ann));
+                _ctorParameters = _applyAnnotations(_ctorParameters, ann);
             } else if (_setters != null) {
                 AnnotationMap ann = _mergeAnnotations(0, _setters, _fields, _getters);
-                _setters = _setters.withValue(_setters.value.withAnnotations(ann));
+                _setters = _applyAnnotations(_setters, ann);
             } else if (_fields != null) {
                 AnnotationMap ann = _mergeAnnotations(0, _fields, _getters);
-                _fields = _fields.withValue(_fields.value.withAnnotations(ann));
+                _fields = _applyAnnotations(_fields, ann);
             }
         }
     }
 
     private AnnotationMap _mergeAnnotations(int index, Linked<? extends AnnotatedMember>... nodes)
     {
-        AnnotationMap ann = nodes[index].value.getAllAnnotations();
+        AnnotationMap ann = _getAllAnnotations(nodes[index]);
         ++index;
         for (; index < nodes.length; ++index) {
             if (nodes[index] != null) {
@@ -713,7 +713,23 @@ public class POJOPropertyBuilder
         }
         return ann;
     }
-    
+
+    private <T extends AnnotatedMember> AnnotationMap _getAllAnnotations(Linked<T> node) {
+        AnnotationMap ann = node.value.getAllAnnotations();
+        if (node.next != null) {
+            ann = AnnotationMap.merge(ann, _getAllAnnotations(node.next));
+        }
+        return ann;
+    }
+
+    private <T extends AnnotatedMember> Linked<T> _applyAnnotations(Linked<T> node, AnnotationMap ann) {
+        T value = (T) node.value.withAnnotations(ann);
+        if (node.next != null) {
+            node = node.withNext(_applyAnnotations(node.next, ann));
+        }
+        return node.withValue(value);
+    }
+
     private <T> Linked<T> _removeIgnored(Linked<T> node)
     {
         if (node == null) {


### PR DESCRIPTION
This, I believe, is the root cause of a number of the "inconsistent behavior" bugs in the Scala module. For background, a normal Scala class:

``` scala
class Foo(val bar: Int)
```

will have a single accessor method visible to the JVM, `bar()`. `ScalaAnnotationIntrospector` will report an implicit name of "bar" for this method, which enables its use as a a getter.

Scala provides an annotation for end users to provide compatibility for libraries that are not Scala aware:

``` scala
class Foo(@scala.beans.BeanProperty val bar: Int)
```

This class will have two accessors, `bar()` and `getBar()`. The first will be reported and enabled as above, and the second will be detected by Jackson's normal property detection. They'll be merged into the same property, and the duplicate resolution code in `POJOPropertyBuilder#getGetter` will resolve the duplication and discard the extras.

The error is in merging annotations between the duplicates, and in merging annotations from creators into the `AnnotatedMethod` instances that represent them. The problem with the current code is that it only merges annotations from and into the *last* detected getter (the *head* of the linked list). Since reflection method order is non-deterministic in JVM 7+, which of the duplicates gets the annotations merged in is essentially random, though various platforms demonstrate tendencies in one direction or the other.

In the "happy" case, `getBar` is detected last; since it's at the front of the linked list, it will get receive the annotations from the creator. `getBar` is considered "better" by `getGetter` and is retained, so the annotation is visible to code looking for it.

In the "unhappy" case, `bar` is detected last; it will receive the annotations from the creator, but `getBar` will not. `getBar` will be chosen by `getGetter`, and so the creator annotations will be lost, and code looking for it will fail to do so.

The fix covers this use case, and also covers the additional use case that annotations on `bar` and `getBar` were not mutually visible.

The tests use 'isBar' to simulate the implicit naming that occurs in the Scala module. The linked list class also needed to be made `protected` to be visible to the tests.
