### PR TITLE
BeanDeserializerBase (2.6.0 regression): only update creatorProps with CreatorPropertys

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -481,7 +481,7 @@ public abstract class BeanDeserializerBase
                     // 18-May-2015, tatu: _Should_ start with consistent set. But can we really
                     //   fully count on this? May need to revisit in future; seems to hold for now.
                     for (int i = 0, len = creatorProps.length; i < len; ++i) {
-                        if (creatorProps[i] == origProp) {
+                        if (creatorProps[i] == origProp && prop instanceof CreatorProperty) {
                             creatorProps[i] = prop;
                             break;
                         }

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestCreatorsWithIdentity.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestCreatorsWithIdentity.java
@@ -1,0 +1,55 @@
+package com.fasterxml.jackson.databind.creators;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author dharaburda
+ */
+public class TestCreatorsWithIdentity extends BaseMapTest {
+
+  @JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property="id", scope=Parent.class)
+  public static class Parent {
+    @JsonProperty("id")
+    String id;
+
+    @JsonProperty
+    String parentProp;
+
+    @JsonCreator
+    public Parent(@JsonProperty("parentProp") String parentProp) {
+      this.parentProp = parentProp;
+    }
+  }
+
+
+  public static class Child {
+    @JsonProperty
+    Parent parent;
+
+    @JsonProperty
+    String childProp;
+
+    @JsonCreator
+    public Child(@JsonProperty("parent") Parent parent, @JsonProperty("childProp") String childProp) {
+      this.parent = parent;
+      this.childProp = childProp;
+    }
+  }
+
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+  public void test() throws IOException {
+    String parentStr = "{\"id\" : \"1\", \"parentProp\" : \"parent\"}";
+    String childStr = "{\"childProp\" : \"child\", \"parent\" : " + parentStr + "}";
+    Parent parent = JSON_MAPPER.readValue(parentStr, Parent.class);
+    Child child = JSON_MAPPER.readValue(childStr, Child.class);
+  }
+
+}


### PR DESCRIPTION
It looks like the fix to issue [#795] introduced a bug as illustrated by the test case. An `ArrayStoreException` occurs when attempting to assign an `ObjectIdReferenceProperty` to the `creatorProps` array, understandably.  Others have mentioned this on a similar (but I believe un-related) issue [here](https://github.com/FasterXML/jackson-databind/issues/687#issuecomment-113097184) and [here](https://github.com/FasterXML/jackson-databind/issues/687#issuecomment-124600369).

Doing something like `Arrays.copyOf(...)` when the `CreatorProperty` array is returned from the value instantiator [here](https://github.com/dharaburda/jackson-databind/blob/4d4ddae6ee2f3f755fe25666082f8703015b23e7/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java#L412) prevents the `ArrayStoreException` but seems to cause downstream problems.  Only updating `creatorProps` with an actual `CreatorProperty` seems reasonable to me but I am not super familiar with jackson internals.