### PR TITLE
Fix #894 - derived TypeFactory: fix TypeParser problem

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -97,7 +97,7 @@ public final class TypeFactory
      */
     protected final TypeModifier[] _modifiers;
     
-    protected final TypeParser _parser;
+    protected TypeParser _parser;
     
     /**
      * ClassLoader used by this factory (Issue #624)
@@ -129,16 +129,16 @@ public final class TypeFactory
     public TypeFactory withModifier(TypeModifier mod) 
     {
        if (mod == null) { // mostly for unit tests
-          return new TypeFactory(_parser, _modifiers, _classLoader);
+    	   return factoryWithModifiedParser(_parser, _modifiers, _classLoader);
        }
        if (_modifiers == null) {
-          return new TypeFactory(_parser, new TypeModifier[] { mod }, _classLoader);
+          return factoryWithModifiedParser(_parser, new TypeModifier[] { mod }, _classLoader);
        }
-       return new TypeFactory(_parser, ArrayBuilders.insertInListNoDup(_modifiers, mod), _classLoader);
+       return factoryWithModifiedParser(_parser, ArrayBuilders.insertInListNoDup(_modifiers, mod), _classLoader);
     }
     
     public TypeFactory withClassLoader(ClassLoader classLoader) {
-       return new TypeFactory(_parser, _modifiers, classLoader);
+       return factoryWithModifiedParser(_parser, _modifiers, classLoader);
     }
 
     /**
@@ -1282,5 +1282,15 @@ public final class TypeFactory
         current.setSuperType(t);
         t.setSubType(current);
         return current;
+    }
+    
+    private void setTypeParser(TypeParser p) {
+    	this._parser = p;
+    }
+    
+    private TypeFactory factoryWithModifiedParser(TypeParser p, TypeModifier[] mods, ClassLoader classLoader) {
+       TypeFactory f = new TypeFactory(p, mods, classLoader);
+ 	   f.setTypeParser(p.withFactory(f));
+ 	   return f;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeParser.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeParser.java
@@ -21,6 +21,10 @@ public class TypeParser
         _factory = f;
     }
 
+    public TypeParser withFactory(TypeFactory f) {
+    	return new TypeParser(f);
+    }
+    
     public JavaType parse(String canonical)
         throws IllegalArgumentException
     {


### PR DESCRIPTION
Derived TypeFactory (instantiated using with... method) should have a new TypeParser which points to itself.

I've created the issue https://github.com/FasterXML/jackson-databind/issues/894 to explain the situation.
Since it's a catch-22 situation because a new TypeFactory has a TypeParser which has to point to itself, I had to change TypeParser variable _parser on TypeFactory not to be final and create a (private method) setter to set the new TypeParser. I hope it's ok with you this way.
The new TypeParser works correctly only if using the newly created TypeFactory (when it's a ClassLoader issue) because the original TypeFactory doesn't have it.
I'd love to see this included in the next release because we're using 2.6.1 in production now and this problem forces us to continue with the Thread switch hack to allow finding the class.