### PR TITLE
Fix #913: Properly copy MappingJsonFactory features

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/MappingJsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MappingJsonFactory.java
@@ -33,6 +33,14 @@ public class MappingJsonFactory
         }
     }
 
+    public MappingJsonFactory(JsonFactory src, ObjectMapper mapper)
+    {
+        super(src, mapper);
+        if (mapper == null) {
+          setCodec(new ObjectMapper(this));
+        }
+    }
+
     /**
      * We'll override the method to return more specific type; co-variance
      * helps here
@@ -46,7 +54,7 @@ public class MappingJsonFactory
     {
         _checkInvalidCopy(MappingJsonFactory.class);
         // note: as with base class, must NOT copy mapper reference
-        return new MappingJsonFactory(null);
+        return new MappingJsonFactory(this, null);
     }
     
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -159,6 +159,9 @@ public class ObjectMapperTest extends BaseMapTest
         assertFalse(m.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
         InjectableValues inj = new InjectableValues.Std();
         m.setInjectableValues(inj);
+        assertFalse(m.isEnabled(JsonParser.Feature.ALLOW_COMMENTS));
+        m.enable(JsonParser.Feature.ALLOW_COMMENTS);
+        assertTrue(m.isEnabled(JsonParser.Feature.ALLOW_COMMENTS));
 
         // // First: verify that handling of features is decoupled:
         
@@ -193,6 +196,10 @@ public class ObjectMapperTest extends BaseMapTest
         assertEquals(0, m2.getSerializationConfig().mixInCount());
         assertEquals(1, m.getDeserializationConfig().mixInCount());
         assertEquals(0, m2.getDeserializationConfig().mixInCount());
+
+        // [Issue#913]: Ensure JsonFactory Features copied
+        assertTrue(m2.isEnabled(JsonParser.Feature.ALLOW_COMMENTS));
+        
     }
 
     public void testAnnotationIntrospectorCopyin() 


### PR DESCRIPTION
Fixes issue with copying MappingJsonFactory (and therefore ObjectMapper) not properly copying features.

https://github.com/FasterXML/jackson-databind/issues/913