### PR TITLE
Close some gaps to allow using the tryToResolveUnresolved flows

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
@@ -118,12 +118,23 @@ public abstract class DefaultDeserializationContext
             _objectIdResolvers.add(resolver);
         }
 
-        ReadableObjectId entry = new ReadableObjectId(key);
+        ReadableObjectId entry = createReadableObjectId(key);
         entry.setResolver(resolver);
         _objectIds.put(key, entry);
         return entry;
     }
-    
+
+    /**
+     * Factory method to create a new instance of ReadableObjectId or its
+     * subclass. It is ment to be overriden when custom ReadableObjectId is
+     * needed for tryToResolveUnresolvedObjectId.
+     * @param key The key to associate with the new ReadableObjectId
+     * @return New ReadableObjectId instance
+     */
+    protected ReadableObjectId createReadableObjectId(IdKey key) {
+        return new ReadableObjectId(key);
+    }
+
     @Deprecated // since 2.4
     @Override
     public ReadableObjectId findObjectId(Object id, ObjectIdGenerator<?> gen) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ReadableObjectId.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ReadableObjectId.java
@@ -110,7 +110,16 @@ public class ReadableObjectId
     {
         return false;
     }
-    
+
+    /**
+     * Allow access to the resolver in case anybody wants to use it directly in
+     * DeserializationContext::tryToResolveUnresolvedObjectId.
+     * @return The registered resolver
+     */
+    public ObjectIdResolver getResolver() {
+        return _resolver;
+    }
+
     @Override
     public String toString() {
         return String.valueOf(_key);


### PR DESCRIPTION
There are two ways the resolving can be done:

1)

- override ReadableObjectId and implement tryToResolveUnresolved
- override DefaultDeserializationContext and override
  createReadableObjectId to return your new ReadableObjectID subclasses

2)

- override DefaultDeserializationContext and implement
  tryToResolveUnresolvedObjectId. The code has access to
  the registered resolved using roid.getResolver() and can use
  it to do any necessary handling.