### PR TITLE
Add hashCode implementations where there are none

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/BooleanNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BooleanNode.java
@@ -78,6 +78,11 @@ public class BooleanNode
     }
 
     @Override
+    public int hashCode() {
+        return Boolean.valueOf(_value).hashCode();
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         /* 11-Mar-2013, tatu: Apparently ClassLoaders can manage to load

--- a/src/main/java/com/fasterxml/jackson/databind/node/IntNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/IntNode.java
@@ -129,5 +129,5 @@ public class IntNode
     }
 
     @Override
-        public int hashCode() { return _value; }
+    public int hashCode() { return _value; }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
@@ -95,4 +95,9 @@ public final class MissingNode
         // toString() should never return null
         return "";
     }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
@@ -53,4 +53,9 @@ public final class NullNode
     {
         return (o == this);
     }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
@@ -45,6 +45,8 @@ public abstract class ValueNode
         typeSer.writeTypeSuffixForScalar(this, jg);
     }
 
+    @Override public abstract int hashCode();
+
     /*
     /**********************************************************************
     /* Base impls for standard methods


### PR DESCRIPTION
Fixes issues when using .hashCode for any node that contains either Boolean, Null, etc values