### PR TITLE
Handle null type id for polymorphic values that use external type id

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -156,9 +156,7 @@ public class ExternalTypeHandler
                     typeId = _properties[i].getDefaultTypeId();
                 }
             } else if (_tokens[i] == null) {
-                SettableBeanProperty prop = _properties[i].getProperty();
-                throw ctxt.mappingException("Missing property '%s' for external type id '%s'",
-                        prop.getName(), _properties[i].getTypePropertyName());
+                continue;
             }
             _deserializeAndSet(jp, ctxt, bean, i, typeId);
         }
@@ -191,9 +189,7 @@ public class ExternalTypeHandler
                 }
                 typeId = _properties[i].getDefaultTypeId();
             } else if (_tokens[i] == null) {
-                SettableBeanProperty prop = _properties[i].getProperty();
-                throw ctxt.mappingException("Missing property '%s' for external type id '%s'",
-                        prop.getName(), _properties[i].getTypePropertyName());
+                continue;
             }
             values[i] = _deserialize(jp, ctxt, i, typeId);
         }


### PR DESCRIPTION
Remove exceptions thrown when polymorphic value is null.
If there is a need to force non-null value, this could be provided as an extra property in @JsonTypeInfo, or perhaps use an existing property such as JsonProperty.required.