### PR TITLE
Patch for preventing replacing of `final` `Map`, `Collection` values

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -402,8 +402,30 @@ public enum DeserializationFeature implements ConfigFeature
      * 
      * @since 2.1
      */
-    EAGER_DESERIALIZER_FETCH(true)
-    
+    EAGER_DESERIALIZER_FETCH(true),
+
+    /**
+     * Feature that determine whether the deserialization process is allowed
+     * to replace a final collection or map instance field value.
+     * Set to false, it allows to maintain collection or map specific implementation
+     * by taking advantage of the mutability nature of most collection and map implementations.
+     *
+     * Feature is enabled by default for backward compatibility
+     *
+     * @since 2.7
+     */
+    CAN_OVERRIDE_FINAL_COLLECTION_OR_MAP_INSTANCE(true),
+
+    /**
+     * Feature that determine wether the map and collection deserializer should
+     * clear a potentially provided instance - of collection or map - before performing
+     * modifications on the given instance.
+     *
+     * Feature is disabled by default
+     *
+     * @since 2.7
+     */
+    CLEAR_EXISTING_COLLECTION_OR_MAP_BEFORE_DESERIALIZATION(false)
     ;
 
     private final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.impl.ReadableObjectId.Referring;
-import com.fasterxml.jackson.databind.deser.std.ContainerDeserializerBase;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 /**
@@ -235,6 +234,9 @@ public class CollectionDeserializer
             (valueDes.getObjectIdReader() == null) ? null :
                 new CollectionReferringAccumulator(_collectionType.getContentType().getRawClass(), result);
 
+        if(ctxt.isEnabled(DeserializationFeature.CLEAR_EXISTING_COLLECTION_OR_MAP_BEFORE_DESERIALIZATION)){
+            result.clear();
+        }
         JsonToken t;
         while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
             try {
@@ -308,6 +310,9 @@ public class CollectionDeserializer
         } catch (Exception e) {
             // note: pass Object.class, not Object[].class, as we need element type for error info
             throw JsonMappingException.wrapWithPath(e, Object.class, result.size());
+        }
+        if(ctxt.isEnabled(DeserializationFeature.CLEAR_EXISTING_COLLECTION_OR_MAP_BEFORE_DESERIALIZATION)){
+            result.clear();
         }
         result.add(value);
         return result;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -358,6 +358,9 @@ public class MapDeserializer
         if (t != JsonToken.START_OBJECT && t != JsonToken.FIELD_NAME) {
             throw ctxt.mappingException(getMapClass());
         }
+        if(ctxt.isEnabled(DeserializationFeature.CLEAR_EXISTING_COLLECTION_OR_MAP_BEFORE_DESERIALIZATION)){
+            result.clear();
+        }
         if (_standardStringKey) {
             _readAndBindStringMap(p, ctxt, result);
             return result;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestConfig.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestConfig.java
@@ -69,6 +69,9 @@ public class TestConfig
         assertFalse(cfg.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS));
 
         assertTrue(cfg.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+
+        assertTrue(cfg.isEnabled(DeserializationFeature.CAN_OVERRIDE_FINAL_COLLECTION_OR_MAP_INSTANCE));
+        assertFalse(cfg.isEnabled(DeserializationFeature.CLEAR_EXISTING_COLLECTION_OR_MAP_BEFORE_DESERIALIZATION));
     }
 
     public void testOverrideIntrospectors()


### PR DESCRIPTION
Fix https://github.com/FasterXML/jackson-databind/issues/966
