### PR TITLE
Allow failing on `null` values for creator (`DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES`)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -230,6 +230,22 @@ public enum DeserializationFeature implements ConfigFeature
      * @since 2.6
      */
     FAIL_ON_MISSING_CREATOR_PROPERTIES(false),
+
+    /**
+     * Feature that determines what happens if one or more Creator properties (properties
+     * bound to parameters of Creator method (constructor or static factory method))
+     * are are bound to null values - either from the JSON or as a default value. This
+     * is useful if you want to avoid nulls in your codebase, and particularly useful
+     * if you are using Java or Scala optionals for non-mandatory fields.
+     *<p>
+     * Note that having an injectable value counts as "not missing".
+     *<p>
+     * Feature is disabled by default, so that no exception is thrown for missing creator
+     * property values, unless they are explicitly marked as `required`.
+     *
+     * @since 2.6
+     */
+    FAIL_ON_NULL_CREATOR_PROPERTIES(false),
     
     /**
      * Feature that determines whether Jackson code should catch

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -145,9 +145,17 @@ public class PropertyValueBuffer
             throw _context.mappingException("Missing creator property '%s' (index %d); DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES enabled",
                     prop.getName(), prop.getCreatorIndex());
         }
+
         // Third: default value
         JsonDeserializer<Object> deser = prop.getValueDeserializer();
-        return deser.getNullValue(_context);
+        Object value = deser.getNullValue(_context);
+
+        if (_context.isEnabled(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES) && value == null) {
+            throw _context.mappingException("Null value for creator property '%s'; DeserializationFeature.FAIL_ON_NULL_FOR_CREATOR_PARAMETERS enabled",
+                    prop.getName(), prop.getCreatorIndex());
+        }
+
+        return value;
     }
 
     /*


### PR DESCRIPTION
In relation to this discussion: https://github.com/FasterXML/jackson-databind/issues/988 and this issue in Scala: https://github.com/FasterXML/jackson-module-scala/issues/203 I would like to provide a way for deserialization to fail when a value is missing for a property except when the property is a type of optional.

In Scala the default value should be a None, but that is handled by the custom deserializers in the Jackson Scala Module and isn't a concern here. What I've done here is added a hook that will fail on null default values - ensuring that no values can be null. That's what we are really trying to achieve with optionals - to enforce there are no nulls in the codebase.

I belive this pull request is useful to anyone - using Java or Scala - that wants to avoid nulls in their codebase. It's still possible to return a different value from  getNullValue so it won't just work for optionals - any type who's getNullValue doesn't return a null.

This is just an example pull request. I'm happy to put more effort into it if you are happy to go ahead with the idea.