### PR TITLE
Provide JsonSerializer that has the Parent Bean Reference as a paremeter

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonSerializerWithParentBeanRef.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonSerializerWithParentBeanRef.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.databind;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public abstract class JsonSerializerWithParentBeanRef<T> extends JsonSerializer<T> {
+
+	@Override
+	public void serialize(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+		throw new RuntimeException("Not Implemented");
+	}
+
+	abstract public void serialize(T value, JsonGenerator jgen, SerializerProvider provider, final Object parentBeanReference) throws IOException, JsonProcessingException;
+}

--- a/src/main/java/com/fasterxml/jackson/databind/JsonSerializerWithParentBeanRef.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonSerializerWithParentBeanRef.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public abstract class JsonSerializerWithParentBeanRef<T> extends JsonSerializer<T> {
 
 	@Override
-	public void serialize(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+	final public void serialize(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
 		throw new RuntimeException("Not Implemented");
 	}
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.ser;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -7,6 +8,7 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.*;
@@ -501,11 +503,7 @@ public class BeanPropertyWriter extends PropertyWriter
             }
         }
         jgen.writeFieldName(_name);
-        if (_typeSerializer == null) {
-            ser.serialize(value, jgen, prov);
-        } else {
-            ser.serializeWithType(value, jgen, prov, _typeSerializer);
-        }
+        serialize(bean, jgen, prov, value, ser);
     }
 
     /**
@@ -572,11 +570,7 @@ public class BeanPropertyWriter extends PropertyWriter
                 return;
             }
         }
-        if (_typeSerializer == null) {
-            ser.serialize(value, jgen, prov);
-        } else {
-            ser.serializeWithType(value, jgen, prov, _typeSerializer);
-        }
+        serialize(bean, jgen, prov, value, ser);
     }
 
     /**
@@ -740,4 +734,17 @@ public class BeanPropertyWriter extends PropertyWriter
         sb.append(')');
         return sb.toString();
     }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	private void serialize(Object bean, JsonGenerator jgen, SerializerProvider prov, final Object value, JsonSerializer<Object> ser) throws JsonProcessingException, IOException {
+    	if (_typeSerializer == null) {
+    		if (ser instanceof JsonSerializerWithParentBeanRef) {
+    			((JsonSerializerWithParentBeanRef)ser).serialize(value, jgen, prov, bean);	
+    		} else {
+    			ser.serialize(value, jgen, prov);
+    		}
+        } else {
+            ser.serializeWithType(value, jgen, prov, _typeSerializer);
+        }		
+	}
 }


### PR DESCRIPTION
# Provide JsonSerializer that has the Parent Bean Reference as a paremeter to the serialize method

Example usage: 


	import java.io.IOException;
	import java.time.YearMonth;

	import com.fasterxml.jackson.core.JsonGenerator;
	import com.fasterxml.jackson.core.JsonProcessingException;
	import com.fasterxml.jackson.databind.JsonSerializerWithParentBeanRef;
	import com.fasterxml.jackson.databind.SerializerProvider;
	import com.xx.lib.taxform.FormType;
	import com.xx.util.TGConversionUtils;

	public class YearMonthAsPeriodSerializer extends JsonSerializerWithParentBeanRef<YearMonth> {
		final public static YearMonthAsPeriodSerializer INSTANCE = new YearMonthAsPeriodSerializer();

		YearMonthAsPeriodSerializer() {}

		@Override
		public void serialize(final YearMonth yearMonth, final JsonGenerator generator, final SerializerProvider provider, final Object parentBeanReference) throws IOException, JsonProcessingException {
			FormType formType = null;
			if (parentBeanReference != null) {
				try {
					formType = (FormType)parentBeanReference.getClass().getMethod("getFormType").invoke(parentBeanReference);
				} catch (Exception ig) {
				}	
			}
			if (yearMonth == null) {
				generator.writeNull();
			} else {
                // now you can use both parent field properties to make decisions how to serialize
				generator.writeString(formType + yearMonth); 
			}
		}
	}
