### PR TITLE
Support for array delegate creator

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1225,7 +1225,7 @@ public abstract class BeanDeserializerBase
     {
         if (_delegateDeserializer != null) {
             try {
-                Object bean = _valueInstantiator.createUsingDelegate(ctxt, _delegateDeserializer.deserialize(p, ctxt));
+                Object bean = _valueInstantiator.createUsingArrayDelegate(ctxt, _delegateDeserializer.deserialize(p, ctxt));
                 if (_injectables != null) {
                     injectValues(ctxt, bean);
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
@@ -171,6 +171,15 @@ public abstract class ValueInstantiator
                 getValueTypeDesc());
     }
 
+    /**
+     * Method to called to create value instance from JSON Array using
+     * an intermediate "delegate" value to pass to createor method
+     */
+    public Object createUsingArrayDelegate(DeserializationContext ctxt, Object delegate) throws IOException {
+        throw ctxt.mappingException("Can not instantiate value of type %s using delegate",
+                getValueTypeDesc());
+    }
+
     /*
     /**********************************************************
     /* Instantiation methods for JSON scalar types

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
@@ -87,50 +87,13 @@ public class CreatorCollector
 
     public ValueInstantiator constructValueInstantiator(DeserializationConfig config)
     {
-        JavaType delegateType;
-        boolean maybeVanilla = !_hasNonDefaultCreator;
-
-        if (maybeVanilla || (_creators[C_DELEGATE] == null)) {
-            delegateType = null;
-        } else {
-            // need to find type...
-            int ix = 0;
-            if (_delegateArgs != null) {
-                for (int i = 0, len = _delegateArgs.length; i < len; ++i) {
-                    if (_delegateArgs[i] == null) { // marker for delegate itself
-                        ix = i;
-                        break;
-                    }
-                }
-            }
-            delegateType = _creators[C_DELEGATE].getParameterType(ix);
-        }
-
-        JavaType arrayDelegateType;
-
-        if (maybeVanilla || (_creators[C_ARRAY_DELEGATE] == null)) {
-            arrayDelegateType = null;
-        } else {
-            // need to find type...
-            int ix = 0;
-            if (_arrayDelegateArgs != null) {
-                for (int i = 0, len = _arrayDelegateArgs.length; i < len; ++i) {
-                    if (_arrayDelegateArgs[i] == null) { // marker for delegate itself
-                        ix = i;
-                        break;
-                    }
-                }
-            }
-            arrayDelegateType = _creators[C_ARRAY_DELEGATE].getParameterType(ix);
-        }
-
+        final JavaType delegateType = _computeDelegateType(_creators[C_DELEGATE], _delegateArgs);
+        final JavaType arrayDelegateType = _computeDelegateType(_creators[C_ARRAY_DELEGATE], _arrayDelegateArgs);
         final JavaType type = _beanDesc.getType();
 
         // Any non-standard creator will prevent; with one exception: int-valued constructor
         // that standard containers have can be ignored
-        maybeVanilla &= !_hasNonDefaultCreator;
-
-        if (maybeVanilla) {
+        if (!_hasNonDefaultCreator) {
             /* 10-May-2014, tatu: If we have nothing special, and we are dealing with one
              *   of "well-known" types, can create a non-reflection-based instantiator.
              */
@@ -302,6 +265,25 @@ public class CreatorCollector
     /* Helper methods
     /**********************************************************
      */
+
+    private JavaType _computeDelegateType(AnnotatedWithParams creator, SettableBeanProperty[] delegateArgs)
+    {
+        if (!_hasNonDefaultCreator || (creator == null)) {
+            return null;
+        } else {
+            // need to find type...
+            int ix = 0;
+            if (delegateArgs != null) {
+                for (int i = 0, len = delegateArgs.length; i < len; ++i) {
+                    if (delegateArgs[i] == null) { // marker for delegate itself
+                        ix = i;
+                        break;
+                    }
+                }
+            }
+            return creator.getParameterType(ix);
+        }
+    }
 
     private <T extends AnnotatedMember> T _fixAccess(T member)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
@@ -28,6 +28,7 @@ public class CreatorCollector
     protected final static int C_BOOLEAN = 5;
     protected final static int C_DELEGATE = 6;
     protected final static int C_PROPS = 7;
+    protected final static int C_ARRAY_DELEGATE = 8;
 
     protected final static String[] TYPE_DESCS = new String[] {
         "default",
@@ -50,7 +51,7 @@ public class CreatorCollector
      * 
      * @since 2.5
      */
-    protected final AnnotatedWithParams[] _creators = new AnnotatedWithParams[8];
+    protected final AnnotatedWithParams[] _creators = new AnnotatedWithParams[9];
 
     /**
      * Bitmask of creators that were explicitly marked as creators; false for auto-detected
@@ -64,6 +65,8 @@ public class CreatorCollector
 
     // when there are injectable values along with delegate:
     protected SettableBeanProperty[] _delegateArgs;
+
+    protected SettableBeanProperty[] _arrayDelegateArgs;
 
     protected SettableBeanProperty[] _propertyBasedArgs;
 
@@ -103,6 +106,24 @@ public class CreatorCollector
             delegateType = _creators[C_DELEGATE].getParameterType(ix);
         }
 
+        JavaType arrayDelegateType;
+
+        if (maybeVanilla || (_creators[C_ARRAY_DELEGATE] == null)) {
+            arrayDelegateType = null;
+        } else {
+            // need to find type...
+            int ix = 0;
+            if (_arrayDelegateArgs != null) {
+                for (int i = 0, len = _arrayDelegateArgs.length; i < len; ++i) {
+                    if (_arrayDelegateArgs[i] == null) { // marker for delegate itself
+                        ix = i;
+                        break;
+                    }
+                }
+            }
+            arrayDelegateType = _creators[C_ARRAY_DELEGATE].getParameterType(ix);
+        }
+
         final JavaType type = _beanDesc.getType();
 
         // Any non-standard creator will prevent; with one exception: int-valued constructor
@@ -129,6 +150,7 @@ public class CreatorCollector
         inst.configureFromObjectSettings(_creators[C_DEFAULT],
                 _creators[C_DELEGATE], delegateType, _delegateArgs,
                 _creators[C_PROPS], _propertyBasedArgs);
+        inst.configureFromArraySettings(_creators[C_ARRAY_DELEGATE], arrayDelegateType, _arrayDelegateArgs);
         inst.configureFromStringCreator(_creators[C_STRING]);
         inst.configureFromIntCreator(_creators[C_INT]);
         inst.configureFromLongCreator(_creators[C_LONG]);
@@ -176,8 +198,13 @@ public class CreatorCollector
     public void addDelegatingCreator(AnnotatedWithParams creator, boolean explicit,
             SettableBeanProperty[] injectables)
     {
-        verifyNonDup(creator, C_DELEGATE, explicit);
-        _delegateArgs = injectables;
+        if (creator.getParameterType(0).isCollectionLikeType()) {
+            verifyNonDup(creator, C_ARRAY_DELEGATE, explicit);
+            _arrayDelegateArgs = injectables;
+        } else {
+            verifyNonDup(creator, C_DELEGATE, explicit);
+            _delegateArgs = injectables;
+        }
     }
     
     public void addPropertyCreator(AnnotatedWithParams creator, boolean explicit,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -282,7 +282,8 @@ public class StdValueInstantiator
     public Object createUsingArrayDelegate(DeserializationContext ctxt, Object delegate) throws IOException
     {
         if (_arrayDelegateCreator == null) { // sanity-check; caller should check
-            throw new IllegalStateException("No delegate constructor for "+getValueTypeDesc());
+            // try falling back to the classic delegate
+            return createUsingDelegate(ctxt, delegate);
         }
         try {
             // First simple case: just delegate, no injectables

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -252,13 +252,17 @@ public class StdValueInstantiator
     @Override
     public Object createUsingDelegate(DeserializationContext ctxt, Object delegate) throws IOException
     {
-        return createUsingDelegate(_delegateCreator, _delegateArguments, ctxt, delegate);
+        return _createUsingDelegate(_delegateCreator, _delegateArguments, ctxt, delegate);
     }
 
     @Override
     public Object createUsingArrayDelegate(DeserializationContext ctxt, Object delegate) throws IOException
     {
-        return createUsingDelegate(_arrayDelegateCreator, _arrayDelegateArguments, ctxt, delegate);
+        if (_arrayDelegateCreator == null) { // sanity-check; caller should check
+            // fallback to the classic delegate creator
+            return createUsingDelegate(ctxt, delegate);
+        }
+        return _createUsingDelegate(_arrayDelegateCreator, _arrayDelegateArguments, ctxt, delegate);
     }
     
     /*
@@ -451,7 +455,7 @@ public class StdValueInstantiator
     /**********************************************************
      */
 
-    private Object createUsingDelegate(
+    private Object _createUsingDelegate(
             AnnotatedWithParams delegateCreator,
             SettableBeanProperty[] delegateArguments,
             DeserializationContext ctxt,

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.Map;
+
+public class TestObjectOrArrayDeserialization extends BaseMapTest {
+
+    public static class ArrayOrObject {
+        private final List<Object> objects;
+        private final Object object;
+
+        @JsonCreator public ArrayOrObject(List<Object> objects) {
+            this.objects = objects;
+            this.object = null;
+        }
+
+        @JsonCreator public ArrayOrObject(Object object) {
+            this.objects = null;
+            this.object = object;
+        }
+    }
+
+    public void testObjectCase() throws Exception {
+        ArrayOrObject arrayOrObject = objectMapper().readValue("{}", ArrayOrObject.class);
+        assertNull("expected objects field to be null", arrayOrObject.objects);
+        assertNotNull("expected object field not to be null", arrayOrObject.object);
+    }
+
+    public void testEmptyArrayCase() throws Exception {
+        ArrayOrObject arrayOrObject = objectMapper().readValue("[]", ArrayOrObject.class);
+        assertNotNull("expected objects field not to be null", arrayOrObject.objects);
+        assertTrue("expected objects field to be an empty list", arrayOrObject.objects.isEmpty());
+        assertNull("expected object field to be null", arrayOrObject.object);
+    }
+
+    public void testNotEmptyArrayCase() throws Exception {
+        ArrayOrObject arrayOrObject = objectMapper().readValue("[{}, {}]", ArrayOrObject.class);
+        assertNotNull("expected objects field not to be null", arrayOrObject.objects);
+        assertEquals("expected objects field to have size 2", 2, arrayOrObject.objects.size());
+        assertNull("expected object field to be null", arrayOrObject.object);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.deser;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Map;
@@ -25,20 +26,20 @@ public class TestObjectOrArrayDeserialization extends BaseMapTest {
     }
 
     public void testObjectCase() throws Exception {
-        ArrayOrObject arrayOrObject = objectMapper().readValue("{}", ArrayOrObject.class);
+        ArrayOrObject arrayOrObject = new ObjectMapper().readValue("{}", ArrayOrObject.class);
         assertNull("expected objects field to be null", arrayOrObject.objects);
         assertNotNull("expected object field not to be null", arrayOrObject.object);
     }
 
     public void testEmptyArrayCase() throws Exception {
-        ArrayOrObject arrayOrObject = objectMapper().readValue("[]", ArrayOrObject.class);
+        ArrayOrObject arrayOrObject = new ObjectMapper().readValue("[]", ArrayOrObject.class);
         assertNotNull("expected objects field not to be null", arrayOrObject.objects);
         assertTrue("expected objects field to be an empty list", arrayOrObject.objects.isEmpty());
         assertNull("expected object field to be null", arrayOrObject.object);
     }
 
     public void testNotEmptyArrayCase() throws Exception {
-        ArrayOrObject arrayOrObject = objectMapper().readValue("[{}, {}]", ArrayOrObject.class);
+        ArrayOrObject arrayOrObject = new ObjectMapper().readValue("[{}, {}]", ArrayOrObject.class);
         assertNotNull("expected objects field not to be null", arrayOrObject.objects);
         assertEquals("expected objects field to have size 2", 2, arrayOrObject.objects.size());
         assertNull("expected object field to be null", arrayOrObject.object);


### PR DESCRIPTION
Hello, and thank you for Jackson. :)

Currently, as far as I can tell, Jackson supports 8 creators (methods or constructors annotated with `@JsonCreator`) on any type at the same time: 1 default (no-arg), 1 using properties (`@JsonProperty` annotated args), 1 delegate (1 non-primitive arg), 5 primitive (1 primitive arg). This can be seen in the `CreatorCollector` class. If a type has 2 creators that fall in the same category, only one of them is picked up.

This means you cannot have something like this...

```java
    public class ArrayOrObject {
        private final List<Object> objects;
        private final Object object;

        @JsonCreator public ArrayOrObject(List<Object> objects) {
            this.objects = objects;
            this.object = null;
        }

        @JsonCreator public ArrayOrObject(Object object) {
            this.objects = null;
            this.object = object;
        }
    }
```

...because both creators have a non-primitive arg and fall in the category of delegate creators. Deserialization will work for either a JSON array or JSON object and fail for the other, when both are required. To my knowledge, supporting such a construct requires a custom deserializer or a deserializer modifier. Another way is to have a creator accept a `JsonNode` argument. Both of these approach require quite a lot of work.

This matters because it is a valid real-world use case. For example, the `items` property of a schema in the JSON Schema Draft 4 spec can be either a single schema or an array of schemas. Notice that a single schema has different semantics from a array with a single schema in it, so `ACCEPT_SINGLE_VALUE_AS_ARRAY` doesn't help.

Tinkering with the code, I fail to see why Jackson could not support an additional creator for arrays. Of course, it increases the chances of ambiguity, but there's probably ways to mitigate that.

Instead of going too far into consequences right now, I've written a quick proof of concept in this PR. It makes the example work. I thought we could discuss from there. Here's how it works: when a delegate creator is detected and added to the `CreatorCollector`, if the argument of the creator is collection-like, then the creator is stored in a different place. It is then passed like other creators to the `StdValueInstanciator`, which exposes a new method `createUsingArrayDelegate`, that `BeanDeserializerBase` uses in the array case (`deserializeFromArray` method).

What do you think of this feature? Would it be useful? Do you see any impediments to its implementation? Is the POC going in the right direction?