### PR TITLE
Fix exception from multiple setXxx() methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -421,12 +421,21 @@ public class POJOPropertyBuilder
 
     protected int _setterPriority(AnnotatedMethod m)
     {
-        final String name = m.getName();
-        if (name.startsWith("set") && name.length() > 3) {
-            // should we check capitalization?
-            return 1;
-        }
-        return 2;
+		final String name = m.getName();
+		int priority = 20;
+		if(name.startsWith("set") && name.length() > 3) {
+			// should we check capitalization?
+			priority = 10;
+		}
+		Class params[] = m.getAnnotated().getParameterTypes();
+		if(params.length != 1)
+			return priority + 10;			// we don't want setters with multiple args
+		Class clazz = params[0];
+		if(clazz.isPrimitive())				// primitive types are good!
+			return priority - 5;
+		if(clazz.equals(String.class))
+			return priority - 3;			// strings are good too.
+		return priority;					// objects in general are ok.
     }
     
     /*


### PR DESCRIPTION
This issue arises in particular on Samsung devices where there is a conflict in Samsung's implementation of Drawable. The two methods are:
public void android.graphics.drawable.Drawable.setImagePath(java.lang.String)
public void android.graphics.drawable.Drawable.setImagePath(android.util.TypedValue)

The previous code threw an exception in this case because it could not choose between the two methods.

This patch makes setter selection prefer setXX methods with one argument and, in order, primitive types, String, then other objects. 
