### PR TITLE
Don't generate a spurious NullNode after parsing an embedded object.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -276,6 +276,7 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
                 return node;
             case JsonTokenId.ID_EMBEDDED_OBJECT:
                 node.add(_fromEmbedded(p, ctxt, nodeFactory));
+                break;
             case JsonTokenId.ID_STRING:
                 node.add(nodeFactory.textNode(p.getText()));
                 break;


### PR DESCRIPTION
Add missing break statement.

I found this while playing with CBOR:

```java
        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
        final CBORFactory factory = new CBORFactory(new ObjectMapper());
        final CBORGenerator g = factory.createGenerator(baos);

        g.writeStartArray();
        g.writeBinary(new byte[] { 0x10 });
        g.writeEndArray();
        g.close();

        final TreeNode tree = factory.createParser(baos.toByteArray()).readValueAsTree();
        System.out.println(tree); // ["EA==",null]
```
