### PR TITLE
Fixed array delegate creator not being fully functional

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1258,6 +1258,18 @@ public abstract class BeanDeserializerBase
                 wrapInstantiationProblem(e, ctxt);
             }
         }
+        // fallback to non-array delegate
+        if (_delegateDeserializer != null) {
+            try {
+                Object bean = _valueInstantiator.createUsingArrayDelegate(ctxt, _delegateDeserializer.deserialize(p, ctxt));
+                if (_injectables != null) {
+                    injectValues(ctxt, bean);
+                }
+                return bean;
+            } catch (Exception e) {
+                wrapInstantiationProblem(e, ctxt);
+            }
+        }
         if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
             JsonToken t = p.nextToken();
             if (t == JsonToken.END_ARRAY && ctxt.isEnabled(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -77,6 +77,12 @@ public abstract class BeanDeserializerBase
      * to be used for deserializing from JSON Object.
      */
     protected JsonDeserializer<Object> _delegateDeserializer;
+
+    /**
+     * Deserializer that is used iff array-delegate-based creator
+     * is to be used for deserializing from JSON Object.
+     */
+    protected JsonDeserializer<Object> _arrayDelegateDeserializer;
     
     /**
      * If the bean needs to be instantiated using constructor
@@ -526,22 +532,20 @@ public abstract class BeanDeserializerBase
                         +": value instantiator ("+_valueInstantiator.getClass().getName()
                         +") returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'");
             }
-            AnnotatedWithParams delegateCreator = _valueInstantiator.getDelegateCreator();
-            // Need to create a temporary property to allow contextual deserializers:
-            BeanProperty.Std property = new BeanProperty.Std(TEMP_PROPERTY_NAME,
-                    delegateType, null, _classAnnotations, delegateCreator,
-                    PropertyMetadata.STD_OPTIONAL);
+            _delegateDeserializer = _findDelegateDeserializer(ctxt, delegateType,
+                    _valueInstantiator.getDelegateCreator());
+        }
 
-            TypeDeserializer td = delegateType.getTypeHandler();
-            if (td == null) {
-                td = ctxt.getConfig().findTypeDeserializer(delegateType);
+        // and array-delegate-based constructor:
+        if (_valueInstantiator.canCreateUsingArrayDelegate()) {
+            JavaType delegateType = _valueInstantiator.getArrayDelegateType(ctxt.getConfig());
+            if (delegateType == null) {
+                throw new IllegalArgumentException("Invalid array-delegate-creator definition for "+_beanType
+                        +": value instantiator ("+_valueInstantiator.getClass().getName()
+                        +") returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'");
             }
-            JsonDeserializer<Object> dd = findDeserializer(ctxt, delegateType, property);
-            if (td != null) {
-                td = td.forProperty(property);
-                dd = new TypeWrappedDeserializer(td, dd);
-            }
-            _delegateDeserializer = dd;
+            _arrayDelegateDeserializer = _findDelegateDeserializer(ctxt, delegateType,
+                    _valueInstantiator.getArrayDelegateCreator());
         }
 
         // And now that we know CreatorProperty instances are also resolved can finally create the creator:
@@ -563,6 +567,26 @@ public abstract class BeanDeserializerBase
         // may need to disable vanilla processing, if unwrapped handling was enabled...
         _vanillaProcessing = _vanillaProcessing && !_nonStandardCreation;
     }
+
+    private JsonDeserializer<Object> _findDelegateDeserializer(DeserializationContext ctxt, JavaType delegateType,
+            AnnotatedWithParams delegateCreator) throws JsonMappingException {
+        // Need to create a temporary property to allow contextual deserializers:
+        BeanProperty.Std property = new BeanProperty.Std(TEMP_PROPERTY_NAME,
+                delegateType, null, _classAnnotations, delegateCreator,
+                PropertyMetadata.STD_OPTIONAL);
+
+        TypeDeserializer td = delegateType.getTypeHandler();
+        if (td == null) {
+            td = ctxt.getConfig().findTypeDeserializer(delegateType);
+        }
+        JsonDeserializer<Object> dd = findDeserializer(ctxt, delegateType, property);
+        if (td != null) {
+            td = td.forProperty(property);
+            return new TypeWrappedDeserializer(td, dd);
+        }
+        return dd;
+    }
+
 
     /**
      * Helper method that can be used to see if specified property is annotated
@@ -1223,9 +1247,9 @@ public abstract class BeanDeserializerBase
 
     public Object deserializeFromArray(JsonParser p, DeserializationContext ctxt) throws IOException
     {
-        if (_delegateDeserializer != null) {
+        if (_arrayDelegateDeserializer != null) {
             try {
-                Object bean = _valueInstantiator.createUsingArrayDelegate(ctxt, _delegateDeserializer.deserialize(p, ctxt));
+                Object bean = _valueInstantiator.createUsingArrayDelegate(ctxt, _arrayDelegateDeserializer.deserialize(p, ctxt));
                 if (_injectables != null) {
                     injectValues(ctxt, bean);
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
@@ -99,6 +99,13 @@ public abstract class ValueInstantiator
     public boolean canCreateUsingDelegate() { return false; }
 
     /**
+     * Method that can be called to check whether a array-delegate-based creator
+     * (single-arg constructor or factory method)
+     * is available for this instantiator
+     */
+    public boolean canCreateUsingArrayDelegate() { return false; }
+
+    /**
      * Method that can be called to check whether a property-based creator
      * (argument-taking constructor or factory method)
      * is available to instantiate values from JSON Object
@@ -127,6 +134,15 @@ public abstract class ValueInstantiator
      * pass that to instantiator.
      */
     public JavaType getDelegateType(DeserializationConfig config) { return null; }
+
+    /**
+     * Method that can be used to determine what is the type of array delegate
+     * type to use, if any; if no delegates are used, will return null. If
+     * non-null type is returned, deserializer will bind JSON into specified
+     * type (using standard deserializer for that type), and pass that to
+     * instantiator.
+     */
+    public JavaType getArrayDelegateType(DeserializationConfig config) { return null; }
     
     /*
     /**********************************************************
@@ -238,6 +254,16 @@ public abstract class ValueInstantiator
      * this method may return null .
      */
     public AnnotatedWithParams getDelegateCreator() { return null; }
+
+    /**
+     * Method that can be called to try to access member (constructor,
+     * static factory method) that is used as the "array delegate creator".
+     * Note that implementations not required to return actual object
+     * they use (or, they may use some other instantiation) method.
+     * That is, even if {@link #canCreateUsingArrayDelegate()} returns true,
+     * this method may return null .
+     */
+    public AnnotatedWithParams getArrayDelegateCreator() { return null; }
 
     /**
      * Method that can be called to try to access member (constructor,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -201,6 +201,11 @@ public class StdValueInstantiator
     public boolean canCreateUsingDelegate() {
         return _delegateType != null;
     }
+
+    @Override
+    public boolean canCreateUsingArrayDelegate() {
+        return _arrayDelegateType != null;
+    }
     
     @Override
     public boolean canCreateFromObjectWith() {
@@ -210,6 +215,11 @@ public class StdValueInstantiator
     @Override
     public JavaType getDelegateType(DeserializationConfig config) {
         return _delegateType;
+    }
+
+    @Override
+    public JavaType getArrayDelegateType(DeserializationConfig config) {
+        return _arrayDelegateType;
     }
 
     @Override
@@ -357,6 +367,11 @@ public class StdValueInstantiator
     @Override
     public AnnotatedWithParams getDelegateCreator() {
         return _delegateCreator;
+    }
+
+    @Override
+    public AnnotatedWithParams getArrayDelegateCreator() {
+        return _arrayDelegateCreator;
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
@@ -8,19 +8,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestObjectOrArrayDeserialization extends BaseMapTest
 {
+    public static class SomeObject {
+        public String someField;
+    }
 
     public static class ArrayOrObject {
-        private final List<Object> objects;
-        private final Object object;
+        private final List<SomeObject> objects;
+        private final SomeObject object;
 
         @JsonCreator
-        public ArrayOrObject(List<Object> objects) {
+        public ArrayOrObject(List<SomeObject> objects) {
             this.objects = objects;
             this.object = null;
         }
 
         @JsonCreator
-        public ArrayOrObject(Object object) {
+        public ArrayOrObject(SomeObject object) {
             this.objects = null;
             this.object = object;
         }
@@ -45,4 +48,5 @@ public class TestObjectOrArrayDeserialization extends BaseMapTest
         assertEquals("expected objects field to have size 2", 2, arrayOrObject.objects.size());
         assertNull("expected object field to be null", arrayOrObject.object);
     }
+
 }


### PR DESCRIPTION
This is follow-up to #1010.

This implementation proposed in #1010 is incomplete. This is due to the test case not being sufficient. Here's the test case from #1010: 

```java
    public class ArrayOrObject {
        private final List<Object> objects;
        private final Object object;

        @JsonCreator public ArrayOrObject(List<Object> objects) {
            this.objects = objects;
            this.object = null;
        }

        @JsonCreator public ArrayOrObject(Object object) {
            this.objects = null;
            this.object = object;
        }
    }
```

The problem is that, to my surprise, a JSON array is deserializable into an instance of `Object`, so this test passes if the deserialization of both `{}` and `[]` go through the second creator, which is obviously not what I expect. Therefore, I have changed the test to the following:

```java
    public class SomeObject {
        public String someField;
    }

    public class ArrayOrObject {
        private final List<SomeObject> objects;
        private final SomeObject object;

        @JsonCreator public ArrayOrObject(List<SomeObject> objects) {
            this.objects = objects;
            this.object = null;
        }

        @JsonCreator public ArrayOrObject(SomeObject object) {
            this.objects = null;
            this.object = object;
        }
    }
```

Now Jackson refuses to deserialize arrays into instances of `SomeObject`. Starting from there I completed the implementation so that the new test case passes.