### PR TITLE
Modifiers should be declared in the correct order

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/BeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/BeanProperty.java
@@ -31,8 +31,8 @@ import com.fasterxml.jackson.databind.util.Named;
  */
 public interface BeanProperty extends Named
 {
-    public final static JsonFormat.Value EMPTY_FORMAT = new JsonFormat.Value();
-    public final static JsonInclude.Value EMPTY_INCLUDE = JsonInclude.Value.empty();
+    public static final JsonFormat.Value EMPTY_FORMAT = new JsonFormat.Value();
+    public static final JsonInclude.Value EMPTY_INCLUDE = JsonInclude.Value.empty();
 
     /**
      * Method to get logical name of the property

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -50,7 +50,7 @@ public abstract class DeserializationContext
      * may be very large -- no point in spamming logs with megs of meaningless
      * data.
      */
-    private final static int MAX_ERROR_STR_LEN = 500;
+    private static final int MAX_ERROR_STR_LEN = 500;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
@@ -28,7 +28,7 @@ public class JsonMappingException
      * Let's limit length of reference chain, to limit damage in cases
      * of infinite recursion.
      */
-    final static int MAX_REFS_TO_LIST = 1000;
+    static final int MAX_REFS_TO_LIST = 1000;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/MappingIterator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MappingIterator.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.core.*;
  */
 public class MappingIterator<T> implements Iterator<T>, Closeable
 {
-    protected final static MappingIterator<?> EMPTY_ITERATOR =
+    protected static final MappingIterator<?> EMPTY_ITERATOR =
         new MappingIterator<Object>(null, null, null, null, false, null);
 
     /*
@@ -25,24 +25,24 @@ public class MappingIterator<T> implements Iterator<T>, Closeable
     /**
      * State in which iterator is closed
      */
-    protected final static int STATE_CLOSED = 0;
+    protected static final int STATE_CLOSED = 0;
     
     /**
      * State in which value read failed
      */
-    protected final static int STATE_NEED_RESYNC = 1;
+    protected static final int STATE_NEED_RESYNC = 1;
     
     /**
      * State in which no recovery is needed, but "hasNextValue()" needs
      * to be called first
      */
-    protected final static int STATE_MAY_HAVE_VALUE = 2;
+    protected static final int STATE_MAY_HAVE_VALUE = 2;
 
     /**
      * State in which "hasNextValue()" has been succesfully called
      * and deserializer can be called to fetch value
      */
-    protected final static int STATE_HAS_VALUE = 3;
+    protected static final int STATE_HAS_VALUE = 3;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -255,26 +255,26 @@ public class ObjectMapper
     // Quick little shortcut, to avoid having to use global TypeFactory instance...
     // 19-Oct-2015, tatu: Not sure if this is really safe to do; let's at least allow
     //   some amount of introspection
-    private final static JavaType JSON_NODE_TYPE =
+    private static final JavaType JSON_NODE_TYPE =
             SimpleType.constructUnsafe(JsonNode.class);
 //            TypeFactory.defaultInstance().constructType(JsonNode.class);
 
     // 16-May-2009, tatu: Ditto ^^^
-    protected final static AnnotationIntrospector DEFAULT_ANNOTATION_INTROSPECTOR = new JacksonAnnotationIntrospector();
+    protected static final AnnotationIntrospector DEFAULT_ANNOTATION_INTROSPECTOR = new JacksonAnnotationIntrospector();
 
-    protected final static VisibilityChecker<?> STD_VISIBILITY_CHECKER = VisibilityChecker.Std.defaultInstance();
+    protected static final VisibilityChecker<?> STD_VISIBILITY_CHECKER = VisibilityChecker.Std.defaultInstance();
 
     /**
      * @deprecated Since 2.6, do not use: will be removed in 2.7 or later
      */
     @Deprecated
-    protected final static PrettyPrinter _defaultPrettyPrinter = new DefaultPrettyPrinter();
+    protected static final PrettyPrinter _defaultPrettyPrinter = new DefaultPrettyPrinter();
 
     /**
      * Base settings contain defaults used for all {@link ObjectMapper}
      * instances.
      */
-    protected final static BaseSettings DEFAULT_BASE = new BaseSettings(
+    protected static final BaseSettings DEFAULT_BASE = new BaseSettings(
             null, // can not share global ClassIntrospector any more (2.5+)
             DEFAULT_ANNOTATION_INTROSPECTOR,
             STD_VISIBILITY_CHECKER, null, TypeFactory.defaultInstance(),
@@ -427,7 +427,7 @@ public class ObjectMapper
      * no type information is needed for base type), or type-wrapped
      * deserializers (if it is needed)
      */
-    final protected ConcurrentHashMap<JavaType, JsonDeserializer<Object>> _rootDeserializers
+    protected final ConcurrentHashMap<JavaType, JsonDeserializer<Object>> _rootDeserializers
         = new ConcurrentHashMap<JavaType, JsonDeserializer<Object>>(64, 0.6f, 2);
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -39,7 +39,7 @@ public class ObjectReader
 {
     private static final long serialVersionUID = 1L; // since 2.5
 
-    private final static JavaType JSON_NODE_TYPE = SimpleType.constructUnsafe(JsonNode.class);
+    private static final JavaType JSON_NODE_TYPE = SimpleType.constructUnsafe(JsonNode.class);
 
     /*
     /**********************************************************
@@ -146,7 +146,7 @@ public class ObjectReader
      * Root-level cached deserializers.
      * Passed by {@link ObjectMapper}, shared with it.
      */
-    final protected ConcurrentHashMap<JavaType, JsonDeserializer<Object>> _rootDeserializers;
+    protected final ConcurrentHashMap<JavaType, JsonDeserializer<Object>> _rootDeserializers;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -36,7 +36,7 @@ public class ObjectWriter
      * We need to keep track of explicit disabling of pretty printing;
      * easiest to do by a token value.
      */
-    protected final static PrettyPrinter NULL_PRETTY_PRINTER = new MinimalPrettyPrinter();
+    protected static final PrettyPrinter NULL_PRETTY_PRINTER = new MinimalPrettyPrinter();
 
     /*
     /**********************************************************
@@ -1208,12 +1208,12 @@ public class ObjectWriter
      * 
      * @since 2.5
      */
-    public final static class GeneratorSettings
+    public static final class GeneratorSettings
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;
 
-        public final static GeneratorSettings empty = new GeneratorSettings(null, null, null, null);
+        public static final GeneratorSettings empty = new GeneratorSettings(null, null, null, null);
 
         /**
          * To allow for dynamic enabling/disabling of pretty printing,
@@ -1330,12 +1330,12 @@ public class ObjectWriter
      * 
      * @since 2.5
      */
-    public final static class Prefetch
+    public static final class Prefetch
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;
 
-        public final static Prefetch empty = new Prefetch(null, null, null);
+        public static final Prefetch empty = new Prefetch(null, null, null);
         
         /**
          * Specified root serialization type to use; can be same

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyMetadata.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyMetadata.java
@@ -13,11 +13,11 @@ public class PropertyMetadata
 {
     private static final long serialVersionUID = -1;
 
-    public final static PropertyMetadata STD_REQUIRED = new PropertyMetadata(Boolean.TRUE, null, null, null);
+    public static final PropertyMetadata STD_REQUIRED = new PropertyMetadata(Boolean.TRUE, null, null, null);
 
-    public final static PropertyMetadata STD_OPTIONAL = new PropertyMetadata(Boolean.FALSE, null, null, null);
+    public static final PropertyMetadata STD_OPTIONAL = new PropertyMetadata(Boolean.FALSE, null, null, null);
 
-    public final static PropertyMetadata STD_REQUIRED_OR_OPTIONAL = new PropertyMetadata(null, null, null, null);
+    public static final PropertyMetadata STD_REQUIRED_OR_OPTIONAL = new PropertyMetadata(null, null, null, null);
     
     /**
      * Three states: required, not required and unknown; unknown represented

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
@@ -16,8 +16,8 @@ public class PropertyName
 {
     private static final long serialVersionUID = 1L; // 2.5
 
-    private final static String _USE_DEFAULT = "";
-    private final static String _NO_NAME = "";
+    private static final String _USE_DEFAULT = "";
+    private static final String _NO_NAME = "";
 
     /**
      * Special placeholder value that indicates that name to use should be
@@ -25,14 +25,14 @@ public class PropertyName
      * null, as null means "no information available, whereas this value
      * indicates explicit defaulting.
      */
-    public final static PropertyName USE_DEFAULT = new PropertyName(_USE_DEFAULT, null);
+    public static final PropertyName USE_DEFAULT = new PropertyName(_USE_DEFAULT, null);
 
     /**
      * Special placeholder value that indicates that there is no name associated.
      * Exact semantics to use (if any) depend on actual annotation in use, but
      * commonly this value disables behavior for which name would be needed.
      */
-    public final static PropertyName NO_NAME = new PropertyName(new String(_NO_NAME), null);
+    public static final PropertyName NO_NAME = new PropertyName(new String(_NO_NAME), null);
     
     /**
      * Basic name of the property.

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
@@ -166,7 +166,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     /**********************************************************
      */
     
-    public static abstract class PropertyNamingStrategyBase extends PropertyNamingStrategy
+    public abstract static class PropertyNamingStrategyBase extends PropertyNamingStrategy
     {
         @Override
         public String nameForField(MapperConfig<?> config, AnnotatedField field, String defaultName)

--- a/src/main/java/com/fasterxml/jackson/databind/SerializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationConfig.java
@@ -41,11 +41,11 @@ public final class SerializationConfig
     private static final long serialVersionUID = 1;
 
     // since 2.6
-    protected final static PrettyPrinter DEFAULT_PRETTY_PRINTER = new DefaultPrettyPrinter();
+    protected static final PrettyPrinter DEFAULT_PRETTY_PRINTER = new DefaultPrettyPrinter();
 
     // since 2.7
     // Default is "USE_DEFAULTS, USE_DEFAULTS"
-    protected final static JsonInclude.Value DEFAULT_INCLUSION = JsonInclude.Value.empty();
+    protected static final JsonInclude.Value DEFAULT_INCLUSION = JsonInclude.Value.empty();
     
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -48,9 +48,9 @@ public abstract class SerializerProvider
      * cached for faster resolution. Usually this isn't needed, but maybe it
      * is in some cases?
      */
-    protected final static boolean CACHE_UNKNOWN_MAPPINGS = false;
+    protected static final boolean CACHE_UNKNOWN_MAPPINGS = false;
 
-    public final static JsonSerializer<Object> DEFAULT_NULL_KEY_SERIALIZER =
+    public static final JsonSerializer<Object> DEFAULT_NULL_KEY_SERIALIZER =
         new FailingSerializer("Null key for a Map not allowed in JSON (use a converting NullKeySerializer?)");
 
     /**
@@ -62,7 +62,7 @@ public abstract class SerializerProvider
      *<p>
      * NOTE: changed to <code>protected</code> for 2.3; no need to be publicly available.
      */
-    protected final static JsonSerializer<Object> DEFAULT_UNKNOWN_SERIALIZER = new UnknownSerializer();
+    protected static final JsonSerializer<Object> DEFAULT_UNKNOWN_SERIALIZER = new UnknownSerializer();
 
     /*
     /**********************************************************
@@ -73,13 +73,13 @@ public abstract class SerializerProvider
     /**
      * Serialization configuration to use for serialization processing.
      */
-    final protected SerializationConfig _config;
+    protected final SerializationConfig _config;
 
     /**
      * View used for currently active serialization, if any.
      * Only set for non-blueprint instances.
      */
-    final protected Class<?> _serializationView;
+    protected final Class<?> _serializationView;
     
     /*
     /**********************************************************
@@ -91,7 +91,7 @@ public abstract class SerializerProvider
      * Factory used for constructing actual serializer instances.
      * Only set for non-blueprint instances.
      */
-    final protected SerializerFactory _serializerFactory;
+    protected final SerializerFactory _serializerFactory;
 
     /*
     /**********************************************************
@@ -102,7 +102,7 @@ public abstract class SerializerProvider
     /**
      * Cache for doing type-to-value-serializer lookups.
      */
-    final protected SerializerCache _serializerCache;
+    protected final SerializerCache _serializerCache;
 
     /**
      * Lazily-constructed holder for per-call attributes.

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/ContextAttributes.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/ContextAttributes.java
@@ -64,9 +64,9 @@ public abstract class ContextAttributes
     {
         private static final long serialVersionUID = 1L;
 
-        protected final static Impl EMPTY = new Impl(Collections.emptyMap());
+        protected static final Impl EMPTY = new Impl(Collections.emptyMap());
 
-        protected final static Object NULL_SURROGATE = new Object();
+        protected static final Object NULL_SURROGATE = new Object();
         
         /**
          * Shared attributes that we can not modify in-place.

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/DeserializerFactoryConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/DeserializerFactoryConfig.java
@@ -14,10 +14,10 @@ public class DeserializerFactoryConfig
 {
     private static final long serialVersionUID = 1L; // since 2.5
 
-    protected final static Deserializers[] NO_DESERIALIZERS = new Deserializers[0];
-    protected final static BeanDeserializerModifier[] NO_MODIFIERS = new BeanDeserializerModifier[0];
-    protected final static AbstractTypeResolver[] NO_ABSTRACT_TYPE_RESOLVERS = new AbstractTypeResolver[0];
-    protected final static ValueInstantiators[] NO_VALUE_INSTANTIATORS = new ValueInstantiators[0];
+    protected static final Deserializers[] NO_DESERIALIZERS = new Deserializers[0];
+    protected static final BeanDeserializerModifier[] NO_MODIFIERS = new BeanDeserializerModifier[0];
+    protected static final AbstractTypeResolver[] NO_ABSTRACT_TYPE_RESOLVERS = new AbstractTypeResolver[0];
+    protected static final ValueInstantiators[] NO_VALUE_INSTANTIATORS = new ValueInstantiators[0];
 
     /**
      * By default we plug default key deserializers using as "just another" set of
@@ -25,7 +25,7 @@ public class DeserializerFactoryConfig
      * 
      * @since 2.2
      */
-    protected final static KeyDeserializers[] DEFAULT_KEY_DESERIALIZERS = new KeyDeserializers[] {
+    protected static final KeyDeserializers[] DEFAULT_KEY_DESERIALIZERS = new KeyDeserializers[] {
         new StdKeyDeserializers()
     };
     

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java
@@ -42,12 +42,12 @@ public abstract class MapperConfig<T extends MapperConfig<T>>
     /**
      * @since 2.7
      */
-    protected final static JsonInclude.Value EMPTY_INCLUDE = JsonInclude.Value.empty();
+    protected static final JsonInclude.Value EMPTY_INCLUDE = JsonInclude.Value.empty();
 
     /**
      * @since 2.7
      */
-    protected final static JsonFormat.Value EMPTY_FORMAT = JsonFormat.Value.empty();
+    protected static final JsonFormat.Value EMPTY_FORMAT = JsonFormat.Value.empty();
 
     /**
      * Set of shared mapper features enabled.

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
@@ -28,7 +28,7 @@ public abstract class MapperConfigBase<CFG extends ConfigFeature,
     extends MapperConfig<T>
     implements java.io.Serializable
 {
-    private final static int DEFAULT_MAPPER_FEATURES = collectFeatureDefaults(MapperFeature.class);
+    private static final int DEFAULT_MAPPER_FEATURES = collectFeatureDefaults(MapperFeature.class);
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/SerializerFactoryConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/SerializerFactoryConfig.java
@@ -16,9 +16,9 @@ public final class SerializerFactoryConfig
      * Constant for empty <code>Serializers</code> array (which by definition
      * is stateless and reusable)
      */
-    protected final static Serializers[] NO_SERIALIZERS = new Serializers[0];
+    protected static final Serializers[] NO_SERIALIZERS = new Serializers[0];
 
-    protected final static BeanSerializerModifier[] NO_MODIFIERS = new BeanSerializerModifier[0];
+    protected static final BeanSerializerModifier[] NO_MODIFIERS = new BeanSerializerModifier[0];
     
     /**
      * List of providers for additional serializers, checked before considering default

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -35,24 +35,24 @@ public abstract class BasicDeserializerFactory
     extends DeserializerFactory
     implements java.io.Serializable
 {
-    private final static Class<?> CLASS_OBJECT = Object.class;
-    private final static Class<?> CLASS_STRING = String.class;
-    private final static Class<?> CLASS_CHAR_BUFFER = CharSequence.class;
-    private final static Class<?> CLASS_ITERABLE = Iterable.class;
-    private final static Class<?> CLASS_MAP_ENTRY = Map.Entry.class;
+    private static final Class<?> CLASS_OBJECT = Object.class;
+    private static final Class<?> CLASS_STRING = String.class;
+    private static final Class<?> CLASS_CHAR_BUFFER = CharSequence.class;
+    private static final Class<?> CLASS_ITERABLE = Iterable.class;
+    private static final Class<?> CLASS_MAP_ENTRY = Map.Entry.class;
 
     /**
      * We need a placeholder for creator properties that don't have name
      * but are marked with `@JsonWrapped` annotation.
      */
-    protected final static PropertyName UNWRAPPED_CREATOR_PARAM_NAME = new PropertyName("@JsonUnwrapped");
+    protected static final PropertyName UNWRAPPED_CREATOR_PARAM_NAME = new PropertyName("@JsonUnwrapped");
     
     /* We do some defaulting for abstract Map classes and
      * interfaces, to avoid having to use exact types or annotations in
      * cases where the most common concrete Maps will do.
      */
     @SuppressWarnings("rawtypes")
-    final static HashMap<String, Class<? extends Map>> _mapFallbacks =
+    static final HashMap<String, Class<? extends Map>> _mapFallbacks =
         new HashMap<String, Class<? extends Map>>();
     static {
         _mapFallbacks.put(Map.class.getName(), LinkedHashMap.class);
@@ -69,7 +69,7 @@ public abstract class BasicDeserializerFactory
      * cases where the most common concrete Collection will do.
      */
     @SuppressWarnings("rawtypes")
-    final static HashMap<String, Class<? extends Collection>> _collectionFallbacks =
+    static final HashMap<String, Class<? extends Collection>> _collectionFallbacks =
         new HashMap<String, Class<? extends Collection>>();
     static {
         _collectionFallbacks.put(Collection.class.getName(), ArrayList.class);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -31,7 +31,7 @@ public abstract class BeanDeserializerBase
 {
     private static final long serialVersionUID = 1;
 
-    protected final static PropertyName TEMP_PROPERTY_NAME = new PropertyName("#temporary-name");
+    protected static final PropertyName TEMP_PROPERTY_NAME = new PropertyName("#temporary-name");
 
     /*
     /**********************************************************
@@ -47,17 +47,17 @@ public abstract class BeanDeserializerBase
      *<p> 
      * Transient since annotations only used during construction.
      */
-    final private transient Annotations _classAnnotations;
+    private final transient Annotations _classAnnotations;
 
     /**
      * Declared type of the bean this deserializer handles.
      */
-    final protected JavaType _beanType;
+    protected final JavaType _beanType;
 
     /**
      * Requested shape from bean class annotations.
      */
-    final protected JsonFormat.Shape _serializationShape;
+    protected final JsonFormat.Shape _serializationShape;
     
     /*
     /**********************************************************
@@ -116,7 +116,7 @@ public abstract class BeanDeserializerBase
      * Mapping of property names to properties, built when all properties
      * to use have been successfully resolved.
      */
-    final protected BeanPropertyMap _beanProperties;
+    protected final BeanPropertyMap _beanProperties;
 
     /**
      * List of {@link ValueInjector}s, if any injectable values are
@@ -124,7 +124,7 @@ public abstract class BeanDeserializerBase
      * This includes injectors used for injecting values via setters
      * and fields, but not ones passed through constructor parameters.
      */
-    final protected ValueInjector[] _injectables;
+    protected final ValueInjector[] _injectables;
 
     /**
      * Fallback setter used for handling any properties that are not
@@ -138,25 +138,25 @@ public abstract class BeanDeserializerBase
      * track of recognized but ignorable properties: these will
      * be skipped without errors or warnings.
      */
-    final protected HashSet<String> _ignorableProps;
+    protected final HashSet<String> _ignorableProps;
 
     /**
      * Flag that can be set to ignore and skip unknown properties.
      * If set, will not throw an exception for unknown properties.
      */
-    final protected boolean _ignoreAllUnknown;
+    protected final boolean _ignoreAllUnknown;
 
     /**
      * Flag that indicates that some aspect of deserialization depends
      * on active view used (if any)
      */
-    final protected boolean _needViewProcesing;
+    protected final boolean _needViewProcesing;
     
     /**
      * We may also have one or more back reference fields (usually
      * zero or one).
      */
-    final protected Map<String, SettableBeanProperty> _backRefs;
+    protected final Map<String, SettableBeanProperty> _backRefs;
     
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -25,11 +25,11 @@ public class BeanDeserializerBuilder
     /**********************************************************
      */
 
-    final protected BeanDescription _beanDesc;
+    protected final BeanDescription _beanDesc;
 
-    final protected boolean _defaultViewInclusion;
+    protected final boolean _defaultViewInclusion;
     
-    final protected boolean _caseInsensitivePropertyComparison;
+    protected final boolean _caseInsensitivePropertyComparison;
     
     /*
     /**********************************************************
@@ -40,7 +40,7 @@ public class BeanDeserializerBuilder
     /**
      * Properties to deserialize collected so far.
      */
-    final protected Map<String, SettableBeanProperty> _properties
+    protected final Map<String, SettableBeanProperty> _properties
         = new LinkedHashMap<String, SettableBeanProperty>();
     
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -36,9 +36,9 @@ public class BeanDeserializerFactory
     /**
      * Signature of <b>Throwable.initCause</b> method.
      */
-    private final static Class<?>[] INIT_CAUSE_PARAMS = new Class<?>[] { Throwable.class };
+    private static final Class<?>[] INIT_CAUSE_PARAMS = new Class<?>[] { Throwable.class };
 
-    private final static Class<?>[] NO_VIEWS = new Class<?>[0];
+    private static final Class<?>[] NO_VIEWS = new Class<?>[0];
     
     /*
     /**********************************************************
@@ -50,7 +50,7 @@ public class BeanDeserializerFactory
      * Globally shareable thread-safe instance which has no additional custom deserializers
      * registered
      */
-    public final static BeanDeserializerFactory instance = new BeanDeserializerFactory(
+    public static final BeanDeserializerFactory instance = new BeanDeserializerFactory(
             new DeserializerFactoryConfig());
 
     public BeanDeserializerFactory(DeserializerFactoryConfig config) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DataFormatReaders.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DataFormatReaders.java
@@ -24,7 +24,7 @@ public class DataFormatReaders
      * much less (4 bytes or so) is needed, but we will allow bit more
      * leniency to support data formats that need more complex heuristics.
      */
-    public final static int DEFAULT_MAX_INPUT_LOOKAHEAD = 64;
+    public static final int DEFAULT_MAX_INPUT_LOOKAHEAD = 64;
     
     /**
      * Ordered list of readers which both represent data formats to

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
@@ -311,7 +311,7 @@ public abstract class DefaultDeserializationContext
     /**
      * Actual full concrete implementation
      */
-    public final static class Impl extends DefaultDeserializationContext
+    public static final class Impl extends DefaultDeserializationContext
     {
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
@@ -39,7 +39,7 @@ public final class DeserializerCache
      * (should very quickly converge to zero after startup), let's
      * define a relatively low concurrency setting.
      */
-    final protected ConcurrentHashMap<JavaType, JsonDeserializer<Object>> _cachedDeserializers
+    protected final ConcurrentHashMap<JavaType, JsonDeserializer<Object>> _cachedDeserializers
         = new ConcurrentHashMap<JavaType, JsonDeserializer<Object>>(64, 0.75f, 4);
 
     /**
@@ -47,7 +47,7 @@ public final class DeserializerCache
      * completed deserializers, to resolve cyclic dependencies. This is the
      * map used for storing deserializers before they are fully complete.
      */
-    final protected HashMap<JavaType, JsonDeserializer<Object>> _incompleteDeserializers
+    protected final HashMap<JavaType, JsonDeserializer<Object>> _incompleteDeserializers
         = new HashMap<JavaType, JsonDeserializer<Object>>(8);
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerFactory.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.type.*;
  */
 public abstract class DeserializerFactory
 {
-    protected final static Deserializers[] NO_DESERIALIZERS = new Deserializers[0];
+    protected static final Deserializers[] NO_DESERIALIZERS = new Deserializers[0];
 
     /*
     /********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -30,7 +30,7 @@ public class SettableAnyProperty
     /**
      * Annotated variant is needed for JDK serialization only
      */
-    final protected AnnotatedMethod _setter;
+    protected final AnnotatedMethod _setter;
 
     protected final JavaType _type;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
@@ -18,14 +18,14 @@ public class BeanAsArrayBuilderDeserializer
     /**
      * Deserializer we delegate operations that we can not handle.
      */
-    final protected BeanDeserializerBase _delegate;
+    protected final BeanDeserializerBase _delegate;
 
     /**
      * Properties in order expected to be found in JSON array.
      */
-    final protected SettableBeanProperty[] _orderedProperties;
+    protected final SettableBeanProperty[] _orderedProperties;
 
-    final protected AnnotatedMethod _buildMethod;
+    protected final AnnotatedMethod _buildMethod;
         
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -111,7 +111,7 @@ System.err.printf("#%02d: %s\n", i>>1, (hashed[i] == null) ? "-" : hashed[i]);
         _spillCount = spillCount;
     }
     
-    private final static int findSize(int size)
+    private static final int findSize(int size)
     {
         if (size <= 5) {
             return 8;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
@@ -20,31 +20,31 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 public class CreatorCollector
 {
     // Since 2.5
-    protected final static int C_DEFAULT = 0;
-    protected final static int C_STRING = 1;
-    protected final static int C_INT = 2;
-    protected final static int C_LONG = 3;
-    protected final static int C_DOUBLE = 4;
-    protected final static int C_BOOLEAN = 5;
-    protected final static int C_DELEGATE = 6;
-    protected final static int C_PROPS = 7;
-    protected final static int C_ARRAY_DELEGATE = 8;
+    protected static final int C_DEFAULT = 0;
+    protected static final int C_STRING = 1;
+    protected static final int C_INT = 2;
+    protected static final int C_LONG = 3;
+    protected static final int C_DOUBLE = 4;
+    protected static final int C_BOOLEAN = 5;
+    protected static final int C_DELEGATE = 6;
+    protected static final int C_PROPS = 7;
+    protected static final int C_ARRAY_DELEGATE = 8;
 
-    protected final static String[] TYPE_DESCS = new String[] {
+    protected static final String[] TYPE_DESCS = new String[] {
         "default",
         "String", "int", "long", "double", "boolean",
         "delegate", "property-based"
     };
 
     /// Type of bean being created
-    final protected BeanDescription _beanDesc;
+    protected final BeanDescription _beanDesc;
 
-    final protected boolean _canFixAccess;
+    protected final boolean _canFixAccess;
 
     /**
      * @since 2.7
      */
-    final protected boolean _forceAccess;
+    protected final boolean _forceAccess;
     
     /**
      * Set of creators we have collected so far
@@ -344,15 +344,15 @@ public class CreatorCollector
     /**********************************************************
      */
 
-    protected final static class Vanilla
+    protected static final class Vanilla
         extends ValueInstantiator
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;
 
-        public final static int TYPE_COLLECTION = 1;
-        public final static int TYPE_MAP = 2;
-        public final static int TYPE_HASH_MAP = 3;
+        public static final int TYPE_COLLECTION = 1;
+        public static final int TYPE_MAP = 2;
+        public static final int TYPE_HASH_MAP = 3;
 
         private final int _type;
         

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -291,7 +291,7 @@ public class ExternalTypeHandler
         }
     }
 
-    private final static class ExtTypedProperty
+    private static final class ExtTypedProperty
     {
         private final SettableBeanProperty _property;
         private final TypeDeserializer _typeDeserializer;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/FieldProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/FieldProperty.java
@@ -22,14 +22,14 @@ public final class FieldProperty
 {
     private static final long serialVersionUID = 1L;
 
-    final protected AnnotatedField _annotated;
+    protected final AnnotatedField _annotated;
 
     /**
      * Actual field to set when deserializing this property.
      * Transient since there is no need to persist; only needed during
      * construction of objects.
      */
-    final protected transient Field _field;
+    protected final transient Field _field;
 
     public FieldProperty(BeanPropertyDefinition propDef, JavaType type,
             TypeDeserializer typeDeser, Annotations contextAnnotations, AnnotatedField field)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/InnerClassProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/InnerClassProperty.java
@@ -31,7 +31,7 @@ public final class InnerClassProperty
      * Transient since there is no need to persist; only needed during
      * construction of objects.
      */
-    final protected transient Constructor<?> _creator;
+    protected final transient Constructor<?> _creator;
     
     /**
      * Serializable version of single-arg constructor we use for value instantiation.

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ObjectIdReferenceProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ObjectIdReferenceProperty.java
@@ -93,7 +93,7 @@ public class ObjectIdReferenceProperty extends SettableBeanProperty
         return _forward.setAndReturn(instance, value);
     }
 
-    public final static class PropertyReferring extends Referring {
+    public static final class PropertyReferring extends Referring {
         private final ObjectIdReferenceProperty _parent;
         public final Object _pojo;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValue.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValue.java
@@ -43,7 +43,7 @@ public abstract class PropertyValue
      * Property value that used when assigning value to property using
      * a setter method or direct field access.
      */
-    final static class Regular
+    static final class Regular
         extends PropertyValue
     {
         final SettableBeanProperty _property;
@@ -69,7 +69,7 @@ public abstract class PropertyValue
      * value arguments, allowing setting multiple different
      * properties using single method).
      */
-    final static class Any
+    static final class Any
         extends PropertyValue
     {
         final SettableAnyProperty _property;
@@ -96,7 +96,7 @@ public abstract class PropertyValue
      * Property value type used when storing entries to be added
      * to a Map.
      */
-    final static class Map
+    static final class Map
         extends PropertyValue
     {
         final Object _key;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ReadableObjectId.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ReadableObjectId.java
@@ -135,7 +135,7 @@ public class ReadableObjectId
     /**********************************************************
      */
 
-    public static abstract class Referring {
+    public abstract static class Referring {
         private final UnresolvedForwardReference _reference;
         private final Class<?> _beanType;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/TypeWrappedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/TypeWrappedDeserializer.java
@@ -20,8 +20,8 @@ public final class TypeWrappedDeserializer
 {
     private static final long serialVersionUID = 1L;
 
-    final protected TypeDeserializer _typeDeserializer;
-    final protected JsonDeserializer<Object> _deserializer;
+    protected final TypeDeserializer _typeDeserializer;
+    protected final JsonDeserializer<Object> _deserializer;
 
     @SuppressWarnings("unchecked")
     public TypeWrappedDeserializer(TypeDeserializer typeDeser, JsonDeserializer<?> deser)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -348,7 +348,7 @@ public class CollectionDeserializer
         return result;
     }
 
-    public final static class CollectionReferringAccumulator {
+    public static final class CollectionReferringAccumulator {
         private final Class<?> _elementType;
         private final Collection<Object> _result;
 
@@ -407,7 +407,7 @@ public class CollectionDeserializer
      * object associated with {@link #_id} comes before the values in
      * {@link #next}.
      */
-    private final static class CollectionReferring extends Referring {
+    private static final class CollectionReferring extends Referring {
         private final CollectionReferringAccumulator _parent;
         public final List<Object> next = new ArrayList<Object>();
         

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 @SuppressWarnings("serial")
 public class DateDeserializers
 {
-    private final static HashSet<String> _classNames = new HashSet<String>();
+    private static final HashSet<String> _classNames = new HashSet<String>();
     static {
         Class<?>[] numberTypes = new Class<?>[] {
             Calendar.class,
@@ -244,7 +244,7 @@ public class DateDeserializers
      */
     public static class DateDeserializer extends DateBasedDeserializer<Date>
     {
-        public final static DateDeserializer instance = new DateDeserializer();
+        public static final DateDeserializer instance = new DateDeserializer();
 
         public DateDeserializer() { super(Date.class); }
         public DateDeserializer(DateDeserializer base, DateFormat df, String formatString) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
@@ -182,18 +182,18 @@ public abstract class FromStringDeserializer<T> extends StdScalarDeserializer<T>
     {
         private static final long serialVersionUID = 1;
 
-        public final static int STD_FILE = 1;
-        public final static int STD_URL = 2;
-        public final static int STD_URI = 3;
-        public final static int STD_CLASS = 4;
-        public final static int STD_JAVA_TYPE = 5;
-        public final static int STD_CURRENCY = 6;
-        public final static int STD_PATTERN = 7;
-        public final static int STD_LOCALE = 8;
-        public final static int STD_CHARSET = 9;
-        public final static int STD_TIME_ZONE = 10;
-        public final static int STD_INET_ADDRESS = 11;
-        public final static int STD_INET_SOCKET_ADDRESS = 12;
+        public static final int STD_FILE = 1;
+        public static final int STD_URL = 2;
+        public static final int STD_URI = 3;
+        public static final int STD_CLASS = 4;
+        public static final int STD_JAVA_TYPE = 5;
+        public static final int STD_CURRENCY = 6;
+        public static final int STD_PATTERN = 7;
+        public static final int STD_LOCALE = 8;
+        public static final int STD_CHARSET = 9;
+        public static final int STD_TIME_ZONE = 10;
+        public static final int STD_INET_ADDRESS = 11;
+        public static final int STD_INET_SOCKET_ADDRESS = 12;
 
         protected final int _kind;
         

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.*;
  */
 public class JdkDeserializers
 {
-    private final static HashSet<String> _classNames = new HashSet<String>();
+    private static final HashSet<String> _classNames = new HashSet<String>();
     static {
         // note: can skip primitive types; other ways to check them:
         Class<?>[] types = new Class<?>[] {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
@@ -49,11 +49,11 @@ public class JsonLocationInstantiator extends ValueInstantiator
                 _int(args[3]), _int(args[4]));
     }
 
-    private final static long _long(Object o) {
+    private static final long _long(Object o) {
         return (o == null) ? 0L : ((Number) o).longValue();
     }
 
-    private final static int _int(Object o) {
+    private static final int _int(Object o) {
         return (o == null) ? 0 : ((Number) o).intValue();
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -20,7 +20,7 @@ public class JsonNodeDeserializer
      * Singleton instance of generic deserializer for {@link JsonNode}.
      * Only used for types other than JSON Object and Array.
      */
-    private final static JsonNodeDeserializer instance = new JsonNodeDeserializer();
+    private static final JsonNodeDeserializer instance = new JsonNodeDeserializer();
 
     protected JsonNodeDeserializer() { super(JsonNode.class); }
 
@@ -80,12 +80,12 @@ public class JsonNodeDeserializer
     /**********************************************************
      */
 
-    final static class ObjectDeserializer
+    static final class ObjectDeserializer
         extends BaseNodeDeserializer<ObjectNode>
     {
         private static final long serialVersionUID = 1L;
 
-        protected final static ObjectDeserializer _instance = new ObjectDeserializer();
+        protected static final ObjectDeserializer _instance = new ObjectDeserializer();
 
         protected ObjectDeserializer() { super(ObjectNode.class); }
 
@@ -106,12 +106,12 @@ public class JsonNodeDeserializer
          }
     }
         
-    final static class ArrayDeserializer
+    static final class ArrayDeserializer
         extends BaseNodeDeserializer<ArrayNode>
     {
         private static final long serialVersionUID = 1L;
 
-        protected final static ArrayDeserializer _instance = new ArrayDeserializer();
+        protected static final ArrayDeserializer _instance = new ArrayDeserializer();
 
         protected ArrayDeserializer() { super(ArrayNode.class); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -597,7 +597,7 @@ public class MapDeserializer
         reference.getRoid().appendReferring(referring);
     }
 
-    private final static class MapReferringAccumulator {
+    private static final class MapReferringAccumulator {
         private final Class<?> _valueType;
         private Map<Object,Object> _result;
         /**
@@ -655,7 +655,7 @@ public class MapDeserializer
      * The resolved object associated with {@link #key} comes before the values in
      * {@link #next}.
      */
-    final static class MapReferring extends Referring {
+    static final class MapReferring extends Referring {
         private final MapReferringAccumulator _parent;
 
         public final Map<Object, Object> next = new LinkedHashMap<Object, Object>();

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NullifyingDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NullifyingDeserializer.java
@@ -17,7 +17,7 @@ public class NullifyingDeserializer
 {
     private static final long serialVersionUID = 1L;
 
-    public final static NullifyingDeserializer instance = new NullifyingDeserializer();
+    public static final NullifyingDeserializer instance = new NullifyingDeserializer();
     
     public NullifyingDeserializer() { super(Object.class); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
  */
 public class NumberDeserializers
 {
-    private final static HashSet<String> _classNames = new HashSet<String>();
+    private static final HashSet<String> _classNames = new HashSet<String>();
     static {
         // note: can skip primitive types; other ways to check them:
         Class<?>[] numberTypes = new Class<?>[] {
@@ -159,13 +159,13 @@ public class NumberDeserializers
      */
 
     @JacksonStdImpl
-    public final static class BooleanDeserializer
+    public static final class BooleanDeserializer
         extends PrimitiveOrWrapperDeserializer<Boolean>
     {
         private static final long serialVersionUID = 1L;
 
-        final static BooleanDeserializer primitiveInstance = new BooleanDeserializer(Boolean.TYPE, Boolean.FALSE);
-        final static BooleanDeserializer wrapperInstance = new BooleanDeserializer(Boolean.class, null);
+        static final BooleanDeserializer primitiveInstance = new BooleanDeserializer(Boolean.TYPE, Boolean.FALSE);
+        static final BooleanDeserializer wrapperInstance = new BooleanDeserializer(Boolean.class, null);
 
         public BooleanDeserializer(Class<Boolean> cls, Boolean nvl)
         {
@@ -195,8 +195,8 @@ public class NumberDeserializers
     {
         private static final long serialVersionUID = 1L;
 
-        final static ByteDeserializer primitiveInstance = new ByteDeserializer(Byte.TYPE, (byte) 0);
-        final static ByteDeserializer wrapperInstance = new ByteDeserializer(Byte.class, null);
+        static final ByteDeserializer primitiveInstance = new ByteDeserializer(Byte.TYPE, (byte) 0);
+        static final ByteDeserializer wrapperInstance = new ByteDeserializer(Byte.class, null);
         
         public ByteDeserializer(Class<Byte> cls, Byte nvl)
         {
@@ -216,8 +216,8 @@ public class NumberDeserializers
     {
         private static final long serialVersionUID = 1L;
 
-        final static ShortDeserializer primitiveInstance = new ShortDeserializer(Short.TYPE, Short.valueOf((short)0));
-        final static ShortDeserializer wrapperInstance = new ShortDeserializer(Short.class, null);
+        static final ShortDeserializer primitiveInstance = new ShortDeserializer(Short.TYPE, Short.valueOf((short)0));
+        static final ShortDeserializer wrapperInstance = new ShortDeserializer(Short.class, null);
         
         public ShortDeserializer(Class<Short> cls, Short nvl)
         {
@@ -238,8 +238,8 @@ public class NumberDeserializers
     {
         private static final long serialVersionUID = 1L;
 
-        final static CharacterDeserializer primitiveInstance = new CharacterDeserializer(Character.TYPE, '\0');
-        final static CharacterDeserializer wrapperInstance = new CharacterDeserializer(Character.class, null);
+        static final CharacterDeserializer primitiveInstance = new CharacterDeserializer(Character.TYPE, '\0');
+        static final CharacterDeserializer wrapperInstance = new CharacterDeserializer(Character.class, null);
         
         public CharacterDeserializer(Class<Character> cls, Character nvl)
         {
@@ -285,13 +285,13 @@ public class NumberDeserializers
     }
 
     @JacksonStdImpl
-    public final static class IntegerDeserializer
+    public static final class IntegerDeserializer
         extends PrimitiveOrWrapperDeserializer<Integer>
     {
         private static final long serialVersionUID = 1L;
 
-        final static IntegerDeserializer primitiveInstance = new IntegerDeserializer(Integer.TYPE, Integer.valueOf(0));
-        final static IntegerDeserializer wrapperInstance = new IntegerDeserializer(Integer.class, null);
+        static final IntegerDeserializer primitiveInstance = new IntegerDeserializer(Integer.TYPE, Integer.valueOf(0));
+        static final IntegerDeserializer wrapperInstance = new IntegerDeserializer(Integer.class, null);
         
         public IntegerDeserializer(Class<Integer> cls, Integer nvl) {
             super(cls, nvl);
@@ -323,13 +323,13 @@ public class NumberDeserializers
     }
 
     @JacksonStdImpl
-    public final static class LongDeserializer
+    public static final class LongDeserializer
         extends PrimitiveOrWrapperDeserializer<Long>
     {
         private static final long serialVersionUID = 1L;
 
-        final static LongDeserializer primitiveInstance = new LongDeserializer(Long.TYPE, Long.valueOf(0L));
-        final static LongDeserializer wrapperInstance = new LongDeserializer(Long.class, null);
+        static final LongDeserializer primitiveInstance = new LongDeserializer(Long.TYPE, Long.valueOf(0L));
+        static final LongDeserializer wrapperInstance = new LongDeserializer(Long.class, null);
         
         public LongDeserializer(Class<Long> cls, Long nvl) {
             super(cls, nvl);
@@ -354,8 +354,8 @@ public class NumberDeserializers
     {
         private static final long serialVersionUID = 1L;
 
-        final static FloatDeserializer primitiveInstance = new FloatDeserializer(Float.TYPE, 0.f);
-        final static FloatDeserializer wrapperInstance = new FloatDeserializer(Float.class, null);
+        static final FloatDeserializer primitiveInstance = new FloatDeserializer(Float.TYPE, 0.f);
+        static final FloatDeserializer wrapperInstance = new FloatDeserializer(Float.class, null);
         
         public FloatDeserializer(Class<Float> cls, Float nvl) {
             super(cls, nvl);
@@ -374,8 +374,8 @@ public class NumberDeserializers
     {
         private static final long serialVersionUID = 1L;
 
-        final static DoubleDeserializer primitiveInstance = new DoubleDeserializer(Double.TYPE, 0.d);
-        final static DoubleDeserializer wrapperInstance = new DoubleDeserializer(Double.class, null);
+        static final DoubleDeserializer primitiveInstance = new DoubleDeserializer(Double.TYPE, 0.d);
+        static final DoubleDeserializer wrapperInstance = new DoubleDeserializer(Double.class, null);
         
         public DoubleDeserializer(Class<Double> cls, Double nvl) {
             super(cls, nvl);
@@ -411,7 +411,7 @@ public class NumberDeserializers
     public static class NumberDeserializer
         extends StdScalarDeserializer<Object>
     {
-        public final static NumberDeserializer instance = new NumberDeserializer();
+        public static final NumberDeserializer instance = new NumberDeserializer();
         
         public NumberDeserializer() {
             super(Number.class);
@@ -528,7 +528,7 @@ public class NumberDeserializers
     public static class BigIntegerDeserializer
         extends StdScalarDeserializer<BigInteger>
     {
-        public final static BigIntegerDeserializer instance = new BigIntegerDeserializer();
+        public static final BigIntegerDeserializer instance = new BigIntegerDeserializer();
 
         public BigIntegerDeserializer() { super(BigInteger.class); }
 
@@ -583,7 +583,7 @@ public class NumberDeserializers
     public static class BigDecimalDeserializer
         extends StdScalarDeserializer<BigDecimal>
     {
-        public final static BigDecimalDeserializer instance = new BigDecimalDeserializer();
+        public static final BigDecimalDeserializer instance = new BigDecimalDeserializer();
  
         public BigDecimalDeserializer() { super(BigDecimal.class); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
@@ -127,7 +127,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
      */
 
     @JacksonStdImpl
-    final static class CharDeser
+    static final class CharDeser
         extends PrimitiveArrayDeserializers<char[]>
     {
         private static final long serialVersionUID = 1L;
@@ -210,7 +210,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
      */
 
     @JacksonStdImpl
-    final static class BooleanDeser
+    static final class BooleanDeser
         extends PrimitiveArrayDeserializers<boolean[]>
     {
         private static final long serialVersionUID = 1L;
@@ -264,7 +264,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
      * to int/long/shorts): base64 encoded data.
      */
     @JacksonStdImpl
-    final static class ByteDeser
+    static final class ByteDeser
         extends PrimitiveArrayDeserializers<byte[]>
     {
         private static final long serialVersionUID = 1L;
@@ -350,7 +350,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     }
 
     @JacksonStdImpl
-    final static class ShortDeser
+    static final class ShortDeser
         extends PrimitiveArrayDeserializers<short[]>
     {
         private static final long serialVersionUID = 1L;
@@ -398,12 +398,12 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     }
 
     @JacksonStdImpl
-    final static class IntDeser
+    static final class IntDeser
         extends PrimitiveArrayDeserializers<int[]>
     {
         private static final long serialVersionUID = 1L;
 
-        public final static IntDeser instance = new IntDeser();
+        public static final IntDeser instance = new IntDeser();
         
         public IntDeser() { super(int[].class); }
         protected IntDeser(IntDeser base, Boolean unwrapSingle) {
@@ -449,12 +449,12 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     }
 
     @JacksonStdImpl
-    final static class LongDeser
+    static final class LongDeser
         extends PrimitiveArrayDeserializers<long[]>
     {
         private static final long serialVersionUID = 1L;
 
-        public final static LongDeser instance = new LongDeser();
+        public static final LongDeser instance = new LongDeser();
 
         public LongDeser() { super(long[].class); }
         protected LongDeser(LongDeser base, Boolean unwrapSingle) {
@@ -499,7 +499,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     }
 
     @JacksonStdImpl
-    final static class FloatDeser
+    static final class FloatDeser
         extends PrimitiveArrayDeserializers<float[]>
     {
         private static final long serialVersionUID = 1L;
@@ -549,7 +549,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     }
 
     @JacksonStdImpl
-    final static class DoubleDeser
+    static final class DoubleDeser
         extends PrimitiveArrayDeserializers<double[]>
     {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -32,7 +32,7 @@ public abstract class StdDeserializer<T>
      *
      * @since 2.6
      */
-    protected final static int F_MASK_INT_COERCIONS = 
+    protected static final int F_MASK_INT_COERCIONS =
             DeserializationFeature.USE_BIG_INTEGER_FOR_INTS.getMask()
             | DeserializationFeature.USE_LONG_FOR_INTS.getMask();
     
@@ -42,7 +42,7 @@ public abstract class StdDeserializer<T>
      * types deserializer handles (which may be as generic
      * as {@link Object} in some case)
      */
-    final protected Class<?> _valueClass;
+    protected final Class<?> _valueClass;
 
     protected StdDeserializer(Class<?> vc) {
         _valueClass = vc;
@@ -807,7 +807,7 @@ public abstract class StdDeserializer<T>
      * Helper method for encapsulating calls to low-level double value parsing; single place
      * just because we need a work-around that must be applied to all calls.
      */
-    protected final static double parseDouble(String numStr) throws NumberFormatException
+    protected static final double parseDouble(String numStr) throws NumberFormatException
     {
         // avoid some nasty float representations... but should it be MIN_NORMAL or MIN_VALUE?
         if (NumberInput.NASTY_SMALL_DOUBLE.equals(numStr)) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -32,25 +32,25 @@ public class StdKeyDeserializer extends KeyDeserializer
 {
     private static final long serialVersionUID = 1L;
 
-    public final static int TYPE_BOOLEAN = 1;
-    public final static int TYPE_BYTE = 2;
-    public final static int TYPE_SHORT = 3;
-    public final static int TYPE_CHAR = 4;
-    public final static int TYPE_INT = 5;
-    public final static int TYPE_LONG = 6;
-    public final static int TYPE_FLOAT = 7;
-    public final static int TYPE_DOUBLE = 8;
-    public final static int TYPE_LOCALE = 9;
-    public final static int TYPE_DATE = 10;
-    public final static int TYPE_CALENDAR = 11;
-    public final static int TYPE_UUID = 12;
-    public final static int TYPE_URI = 13;
-    public final static int TYPE_URL = 14;
-    public final static int TYPE_CLASS = 15;
-    public final static int TYPE_CURRENCY = 16;
+    public static final int TYPE_BOOLEAN = 1;
+    public static final int TYPE_BYTE = 2;
+    public static final int TYPE_SHORT = 3;
+    public static final int TYPE_CHAR = 4;
+    public static final int TYPE_INT = 5;
+    public static final int TYPE_LONG = 6;
+    public static final int TYPE_FLOAT = 7;
+    public static final int TYPE_DOUBLE = 8;
+    public static final int TYPE_LOCALE = 9;
+    public static final int TYPE_DATE = 10;
+    public static final int TYPE_CALENDAR = 11;
+    public static final int TYPE_UUID = 12;
+    public static final int TYPE_URI = 13;
+    public static final int TYPE_URL = 14;
+    public static final int TYPE_CLASS = 15;
+    public static final int TYPE_CURRENCY = 16;
 
-    final protected int _kind;
-    final protected Class<?> _keyClass;
+    protected final int _kind;
+    protected final Class<?> _keyClass;
 
     /**
      * Some types that are deserialized using a helper deserializer.
@@ -240,11 +240,11 @@ public class StdKeyDeserializer extends KeyDeserializer
      */
 
     @JacksonStdImpl
-    final static class StringKD extends StdKeyDeserializer
+    static final class StringKD extends StdKeyDeserializer
     {
         private static final long serialVersionUID = 1L;
-        private final static StringKD sString = new StringKD(String.class);
-        private final static StringKD sObject = new StringKD(Object.class);
+        private static final StringKD sString = new StringKD(String.class);
+        private static final StringKD sObject = new StringKD(Object.class);
         
         private StringKD(Class<?> nominalType) { super(-1, nominalType); }
 
@@ -276,13 +276,13 @@ public class StdKeyDeserializer extends KeyDeserializer
      * that must recognize FIELD_NAMEs as text!) to reuse existing
      * handlers as key handlers.
      */
-    final static class DelegatingKD
+    static final class DelegatingKD
         extends KeyDeserializer // note: NOT the std one
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;
 
-        final protected Class<?> _keyClass;
+        protected final Class<?> _keyClass;
 
         protected final JsonDeserializer<?> _delegate;
         
@@ -314,7 +314,7 @@ public class StdKeyDeserializer extends KeyDeserializer
     }
      
     @JacksonStdImpl
-    final static class EnumKD extends StdKeyDeserializer
+    static final class EnumKD extends StdKeyDeserializer
     {
         private static final long serialVersionUID = 1L;
 
@@ -350,7 +350,7 @@ public class StdKeyDeserializer extends KeyDeserializer
      * Key deserializer that calls a single-string-arg constructor
      * to instantiate desired key type.
      */
-    final static class StringCtorKeyDeserializer extends StdKeyDeserializer
+    static final class StringCtorKeyDeserializer extends StdKeyDeserializer
     {
         private static final long serialVersionUID = 1L;
 
@@ -372,7 +372,7 @@ public class StdKeyDeserializer extends KeyDeserializer
      * Key deserializer that calls a static no-args factory method
      * to instantiate desired key type.
      */
-    final static class StringFactoryKeyDeserializer extends StdKeyDeserializer
+    static final class StringFactoryKeyDeserializer extends StdKeyDeserializer
     {
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
@@ -22,7 +22,7 @@ public final class StringArrayDeserializer
 {
     private static final long serialVersionUID = 2L;
 
-    public final static StringArrayDeserializer instance = new StringArrayDeserializer();
+    public static final StringArrayDeserializer instance = new StringArrayDeserializer();
 
     /**
      * Value serializer to use, if not the standard one (which is inlined)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
@@ -16,7 +16,7 @@ public final class StringDeserializer extends StdScalarDeserializer<String>
     /**
      * @since 2.2
      */
-    public final static StringDeserializer instance = new StringDeserializer();
+    public static final StringDeserializer instance = new StringDeserializer();
     
     public StringDeserializer() { super(String.class); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -18,7 +18,7 @@ public class ThrowableDeserializer
 {
     private static final long serialVersionUID = 1L;
 
-    protected final static String PROP_NAME_MESSAGE = "message";
+    protected static final String PROP_NAME_MESSAGE = "message";
 
     /*
     /************************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
@@ -14,7 +14,7 @@ public class UUIDDeserializer extends FromStringDeserializer<UUID>
 {
     private static final long serialVersionUID = 1L;
 
-    final static int[] HEX_DIGITS = new int[127];
+    static final int[] HEX_DIGITS = new int[127];
     static {
         Arrays.fill(HEX_DIGITS, -1);
         for (int i = 0; i < 10; ++i) { HEX_DIGITS['0' + i] = i; }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
@@ -35,13 +35,13 @@ public class UntypedObjectDeserializer
 {
     private static final long serialVersionUID = 1L;
 
-    protected final static Object[] NO_OBJECTS = new Object[0];
+    protected static final Object[] NO_OBJECTS = new Object[0];
 
     /**
      * @deprecated Since 2.3, construct a new instance, needs to be resolved
      */
     @Deprecated
-    public final static UntypedObjectDeserializer instance = new UntypedObjectDeserializer(null, null);
+    public static final UntypedObjectDeserializer instance = new UntypedObjectDeserializer(null, null);
 
     /*
     /**********************************************************
@@ -477,7 +477,7 @@ public class UntypedObjectDeserializer
     {
         private static final long serialVersionUID = 1L;
 
-        public final static Vanilla std = new Vanilla();
+        public static final Vanilla std = new Vanilla();
 
         public Vanilla() { super(Object.class); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/exc/PropertyBindingException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/PropertyBindingException.java
@@ -76,7 +76,7 @@ public abstract class PropertyBindingException
      * Somewhat arbitrary limit, but let's try not to create uselessly
      * huge error messages
      */
-    private final static int MAX_DESC_LENGTH = 1000;
+    private static final int MAX_DESC_LENGTH = 1000;
 
     @Override
     public String getMessageSuffix()

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
@@ -24,7 +24,7 @@ public class CoreXMLDeserializers extends Deserializers.Base
      * configuration, if any); and since instantion (esp. implementation
      * introspection) can be expensive we better reuse the instance.
      */
-    final static DatatypeFactory _dataTypeFactory;
+    static final DatatypeFactory _dataTypeFactory;
     static {
         try {
             _dataTypeFactory = DatatypeFactory.newInstance();
@@ -56,9 +56,9 @@ public class CoreXMLDeserializers extends Deserializers.Base
     /**********************************************************
      */
 
-    protected final static int TYPE_DURATION = 1;
-    protected final static int TYPE_G_CALENDAR = 2;
-    protected final static int TYPE_QNAME = 3;
+    protected static final int TYPE_DURATION = 1;
+    protected static final int TYPE_G_CALENDAR = 2;
+    protected static final int TYPE_QNAME = 3;
 
     /**
      * Combo-deserializer that supports deserialization of somewhat optional

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
@@ -47,7 +47,7 @@ public class CoreXMLSerializers extends Serializers.Base
         extends StdSerializer<XMLGregorianCalendar>
         implements ContextualSerializer
     {
-        final static XMLGregorianCalendarSerializer instance = new XMLGregorianCalendarSerializer();
+        static final XMLGregorianCalendarSerializer instance = new XMLGregorianCalendarSerializer();
 
         final JsonSerializer<Object> _delegate;
         

--- a/src/main/java/com/fasterxml/jackson/databind/ext/DOMDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/DOMDeserializer.java
@@ -20,7 +20,7 @@ public abstract class DOMDeserializer<T> extends FromStringDeserializer<T>
 {
     private static final long serialVersionUID = 1L;
 
-    private final static DocumentBuilderFactory _parserFactory;
+    private static final DocumentBuilderFactory _parserFactory;
     static {
         _parserFactory = DocumentBuilderFactory.newInstance();
         // yup, only cave men do XML without recognizing namespaces...

--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -25,25 +25,25 @@ public class OptionalHandlerFactory implements java.io.Serializable
      * more dynamic, we better only figure out handlers completely dynamically, if and
      * when they are needed. To do this we need to assume package prefixes.
      */
-    private final static String PACKAGE_PREFIX_JAVAX_XML = "javax.xml.";
+    private static final String PACKAGE_PREFIX_JAVAX_XML = "javax.xml.";
 
-    private final static String SERIALIZERS_FOR_JAVAX_XML = "com.fasterxml.jackson.databind.ext.CoreXMLSerializers";
-    private final static String DESERIALIZERS_FOR_JAVAX_XML = "com.fasterxml.jackson.databind.ext.CoreXMLDeserializers";
+    private static final String SERIALIZERS_FOR_JAVAX_XML = "com.fasterxml.jackson.databind.ext.CoreXMLSerializers";
+    private static final String DESERIALIZERS_FOR_JAVAX_XML = "com.fasterxml.jackson.databind.ext.CoreXMLDeserializers";
 
     // Plus we also have a single serializer for DOM Node:
 //    private final static String CLASS_NAME_DOM_NODE = "org.w3c.dom.Node";
 //    private final static String CLASS_NAME_DOM_DOCUMENT = "org.w3c.dom.Document";
-    private final static String SERIALIZER_FOR_DOM_NODE = "com.fasterxml.jackson.databind.ext.DOMSerializer";
-    private final static String DESERIALIZER_FOR_DOM_DOCUMENT = "com.fasterxml.jackson.databind.ext.DOMDeserializer$DocumentDeserializer";
-    private final static String DESERIALIZER_FOR_DOM_NODE = "com.fasterxml.jackson.databind.ext.DOMDeserializer$NodeDeserializer";
+    private static final String SERIALIZER_FOR_DOM_NODE = "com.fasterxml.jackson.databind.ext.DOMSerializer";
+    private static final String DESERIALIZER_FOR_DOM_DOCUMENT = "com.fasterxml.jackson.databind.ext.DOMDeserializer$DocumentDeserializer";
+    private static final String DESERIALIZER_FOR_DOM_NODE = "com.fasterxml.jackson.databind.ext.DOMDeserializer$NodeDeserializer";
 
-    private final static String DESERIALIZER_FOR_PATH = "com.fasterxml.jackson.databind.ext.PathDeserializer";
+    private static final String DESERIALIZER_FOR_PATH = "com.fasterxml.jackson.databind.ext.PathDeserializer";
 
     // // Since 2.7, we will assume DOM classes are always found, both due to JDK 1.6 minimum
     // // and because Android (and presumably GAE) have these classes
 
-    private final static Class<?> CLASS_DOM_NODE;
-    private final static Class<?> CLASS_DOM_DOCUMENT;
+    private static final Class<?> CLASS_DOM_NODE;
+    private static final Class<?> CLASS_DOM_DOCUMENT;
 
     static {
         Class<?> doc = null, node = null;
@@ -62,7 +62,7 @@ public class OptionalHandlerFactory implements java.io.Serializable
     // // (note: also assume it comes from JDK so that ClassLoader issues with OSGi
     // // can, I hope, be avoided?)
     
-    private final static Class<?> CLASS_JAVA7_PATH;
+    private static final Class<?> CLASS_JAVA7_PATH;
     static {
         Class<?> cls = null;
         try {
@@ -74,7 +74,7 @@ public class OptionalHandlerFactory implements java.io.Serializable
         CLASS_JAVA7_PATH = cls;
     }
     
-    public final static OptionalHandlerFactory instance = new OptionalHandlerFactory();
+    public static final OptionalHandlerFactory instance = new OptionalHandlerFactory();
     
     protected OptionalHandlerFactory() { }
 

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedClass.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedClass.java
@@ -19,7 +19,7 @@ public final class AnnotatedClass
     extends Annotated
     implements TypeResolutionContext
 {
-    private final static AnnotationMap[] NO_ANNOTATION_MAPS = new AnnotationMap[0];
+    private static final AnnotationMap[] NO_ANNOTATION_MAPS = new AnnotationMap[0];
 
     /*
     /**********************************************************
@@ -30,20 +30,20 @@ public final class AnnotatedClass
     /**
      * @since 2.7
      */
-    final protected JavaType _type;
+    protected final JavaType _type;
 
     /**
      * Class for which annotations apply, and that owns other
      * components (constructors, methods)
      */
-    final protected Class<?> _class;
+    protected final Class<?> _class;
 
     /**
      * Type bindings to use for members of {@link #_class}.
      *
      * @since 2.7
      */
-    final protected TypeBindings _bindings;
+    protected final TypeBindings _bindings;
 
     /**
      * Ordered set of super classes and interfaces of the
@@ -51,32 +51,32 @@ public final class AnnotatedClass
      *<p>
      * NOTE: changed in 2.7 from List of <code>Class</code>es to List of {@link JavaType}s.
      */
-    final protected List<JavaType> _superTypes;
+    protected final List<JavaType> _superTypes;
 
     /**
      * Filter used to determine which annotations to gather; used
      * to optimize things so that unnecessary annotations are
      * ignored.
      */
-    final protected AnnotationIntrospector _annotationIntrospector;
+    protected final AnnotationIntrospector _annotationIntrospector;
 
     /**
      * @since 2.7
      */
-    final protected TypeFactory _typeFactory;
+    protected final TypeFactory _typeFactory;
     
     /**
      * Object that knows mapping of mix-in classes (ones that contain
      * annotations to add) with their target classes (ones that
      * get these additional annotations "mixed in").
      */
-    final protected MixInResolver _mixInResolver;
+    protected final MixInResolver _mixInResolver;
 
     /**
      * Primary mix-in class; one to use for the annotated class
      * itself. Can be null.
      */
-    final protected Class<?> _primaryMixIn;
+    protected final Class<?> _primaryMixIn;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
@@ -200,7 +200,7 @@ public final class AnnotatedConstructor
      * Field references. It basically just stores declaring class
      * and field name.
      */
-    private final static class Serialization
+    private static final class Serialization
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedField.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedField.java
@@ -178,7 +178,7 @@ public final class AnnotatedField
      * Field references. It basically just stores declaring class
      * and field name.
      */
-    private final static class Serialization
+    private static final class Serialization
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
@@ -11,7 +11,7 @@ public final class AnnotatedMethod
 {
     private static final long serialVersionUID = 1L;
 
-    final protected transient Method _method;
+    protected final transient Method _method;
 
     // // Simple lazy-caching:
 
@@ -269,7 +269,7 @@ public final class AnnotatedMethod
      * Field references. It basically just stores declaring class
      * and field name.
      */
-    private final static class Serialization
+    private static final class Serialization
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
@@ -39,16 +39,16 @@ public class BasicBeanDescription extends BeanDescription
      * information is lazily accessed and constructed; properties
      * are only accessed when they are actually needed.
      */
-    final protected POJOPropertiesCollector _propCollector;
+    protected final POJOPropertiesCollector _propCollector;
     
-    final protected MapperConfig<?> _config;
+    protected final MapperConfig<?> _config;
 
-    final protected AnnotationIntrospector _annotationIntrospector;
+    protected final AnnotationIntrospector _annotationIntrospector;
     
     /**
      * Information collected about the class introspected.
      */
-    final protected AnnotatedClass _classInfo;
+    protected final AnnotatedClass _classInfo;
     
     /**
      * We may need type bindings for the bean type. If so, we'll

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicClassIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicClassIntrospector.java
@@ -28,22 +28,22 @@ public class BasicClassIntrospector
      * @since 2.4
      */
     
-    protected final static BasicBeanDescription STRING_DESC;
+    protected static final BasicBeanDescription STRING_DESC;
     static {
         AnnotatedClass ac = AnnotatedClass.constructWithoutSuperTypes(String.class, null);
         STRING_DESC = BasicBeanDescription.forOtherUse(null, SimpleType.constructUnsafe(String.class), ac);
     }
-    protected final static BasicBeanDescription BOOLEAN_DESC;
+    protected static final BasicBeanDescription BOOLEAN_DESC;
     static {
         AnnotatedClass ac = AnnotatedClass.constructWithoutSuperTypes(Boolean.TYPE, null);
         BOOLEAN_DESC = BasicBeanDescription.forOtherUse(null, SimpleType.constructUnsafe(Boolean.TYPE), ac);
     }
-    protected final static BasicBeanDescription INT_DESC;
+    protected static final BasicBeanDescription INT_DESC;
     static {
         AnnotatedClass ac = AnnotatedClass.constructWithoutSuperTypes(Integer.TYPE, null);
         INT_DESC = BasicBeanDescription.forOtherUse(null, SimpleType.constructUnsafe(Integer.TYPE), ac);
     }
-    protected final static BasicBeanDescription LONG_DESC;
+    protected static final BasicBeanDescription LONG_DESC;
     static {
         AnnotatedClass ac = AnnotatedClass.constructWithoutSuperTypes(Long.TYPE, null);
         LONG_DESC = BasicBeanDescription.forOtherUse(null, SimpleType.constructUnsafe(Long.TYPE), ac);
@@ -56,7 +56,7 @@ public class BasicClassIntrospector
      */
 
     @Deprecated // since 2.5: construct instance directly
-    public final static BasicClassIntrospector instance = new BasicClassIntrospector();
+    public static final BasicClassIntrospector instance = new BasicClassIntrospector();
 
     /**
      * Looks like 'forClassAnnotations()' gets called so frequently that we

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BeanPropertyDefinition.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BeanPropertyDefinition.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.util.Named;
 public abstract class BeanPropertyDefinition
     implements Named
 {
-    protected final static JsonInclude.Value EMPTY_INCLUDE = JsonInclude.Value.empty();
+    protected static final JsonInclude.Value EMPTY_INCLUDE = JsonInclude.Value.empty();
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -33,7 +33,7 @@ public class JacksonAnnotationIntrospector
     private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("unchecked")
-    private final static Class<? extends Annotation>[] ANNOTATIONS_TO_INFER_SER = (Class<? extends Annotation>[])
+    private static final Class<? extends Annotation>[] ANNOTATIONS_TO_INFER_SER = (Class<? extends Annotation>[])
             new Class<?>[] {
         JsonSerialize.class,
         JsonView.class,
@@ -45,7 +45,7 @@ public class JacksonAnnotationIntrospector
     };
 
     @SuppressWarnings("unchecked")
-    private final static Class<? extends Annotation>[] ANNOTATIONS_TO_INFER_DESER = (Class<? extends Annotation>[])
+    private static final Class<? extends Annotation>[] ANNOTATIONS_TO_INFER_DESER = (Class<? extends Annotation>[])
             new Class<?>[] {
         JsonDeserialize.class,
         JsonView.class,

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/MemberKey.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/MemberKey.java
@@ -10,7 +10,7 @@ import java.lang.reflect.Method;
  */
 public final class MemberKey
 {
-    final static Class<?>[] NO_CLASSES = new Class<?>[0];
+    static final Class<?>[] NO_CLASSES = new Class<?>[0];
 
     final String _name;
     final Class<?>[] _argTypes;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/NopAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/NopAnnotationIntrospector.java
@@ -20,7 +20,7 @@ public abstract class NopAnnotationIntrospector
      * "null" introspector: one that never finds any annotation
      * information.
      */
-    public final static NopAnnotationIntrospector instance = new NopAnnotationIntrospector() {
+    public static final NopAnnotationIntrospector instance = new NopAnnotationIntrospector() {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -1116,7 +1116,7 @@ public class POJOPropertyBuilder
      * Node used for creating simple linked lists to efficiently store small sets
      * of things.
      */
-    protected final static class Linked<T>
+    protected static final class Linked<T>
     {
         public final T value;
         public final Linked<T> next;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/VisibilityChecker.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/VisibilityChecker.java
@@ -167,7 +167,7 @@ public interface VisibilityChecker<T extends VisibilityChecker<T>>
          * This is the canonical base instance, configured with default
          * visibility values
          */
-        protected final static Std DEFAULT = new Std(Std.class.getAnnotation(JsonAutoDetect.class));
+        protected static final Std DEFAULT = new Std(Std.class.getAnnotation(JsonAutoDetect.class));
         
         protected final Visibility _getterMinLevel;
         protected final Visibility _isGetterMinLevel;

--- a/src/main/java/com/fasterxml/jackson/databind/jsonschema/JsonSerializableSchema.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonschema/JsonSerializableSchema.java
@@ -28,7 +28,7 @@ public @interface JsonSerializableSchema
      * needed because annotations can not have null as default
      * value.
      */
-    public final static String NO_VALUE = "##irrelevant";
+    public static final String NO_VALUE = "##irrelevant";
 
     /**
      * Property that can be used to indicate id of the type when

--- a/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
@@ -13,12 +13,12 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 public class BigIntegerNode
     extends NumericNode
 {
-    private final static BigInteger MIN_INTEGER = BigInteger.valueOf(Integer.MIN_VALUE);
-    private final static BigInteger MAX_INTEGER = BigInteger.valueOf(Integer.MAX_VALUE);
-    private final static BigInteger MIN_LONG = BigInteger.valueOf(Long.MIN_VALUE);
-    private final static BigInteger MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger MIN_INTEGER = BigInteger.valueOf(Integer.MIN_VALUE);
+    private static final BigInteger MAX_INTEGER = BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final BigInteger MIN_LONG = BigInteger.valueOf(Long.MIN_VALUE);
+    private static final BigInteger MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
     
-    final protected BigInteger _value;
+    protected final BigInteger _value;
     
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/node/BinaryNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BinaryNode.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 public class BinaryNode
     extends ValueNode
 {
-    final static BinaryNode EMPTY_BINARY_NODE = new BinaryNode(new byte[0]);
+    static final BinaryNode EMPTY_BINARY_NODE = new BinaryNode(new byte[0]);
 
     protected final byte[] _data;
 

--- a/src/main/java/com/fasterxml/jackson/databind/node/BooleanNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BooleanNode.java
@@ -16,8 +16,8 @@ public class BooleanNode
 {
     // // Just need two instances...
 
-    public final static BooleanNode TRUE = new BooleanNode(true);
-    public final static BooleanNode FALSE = new BooleanNode(false);
+    public static final BooleanNode TRUE = new BooleanNode(true);
+    public static final BooleanNode FALSE = new BooleanNode(false);
 
     private final boolean _value;
     

--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -16,12 +16,12 @@ public class DecimalNode
 {
     public static final DecimalNode ZERO = new DecimalNode(BigDecimal.ZERO);
 
-    private final static BigDecimal MIN_INTEGER = BigDecimal.valueOf(Integer.MIN_VALUE);
-    private final static BigDecimal MAX_INTEGER = BigDecimal.valueOf(Integer.MAX_VALUE);
-    private final static BigDecimal MIN_LONG = BigDecimal.valueOf(Long.MIN_VALUE);
-    private final static BigDecimal MAX_LONG = BigDecimal.valueOf(Long.MAX_VALUE);
+    private static final BigDecimal MIN_INTEGER = BigDecimal.valueOf(Integer.MIN_VALUE);
+    private static final BigDecimal MAX_INTEGER = BigDecimal.valueOf(Integer.MAX_VALUE);
+    private static final BigDecimal MIN_LONG = BigDecimal.valueOf(Long.MIN_VALUE);
+    private static final BigDecimal MAX_LONG = BigDecimal.valueOf(Long.MAX_VALUE);
 
-    final protected BigDecimal _value;
+    protected final BigDecimal _value;
 
     /* 
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/node/IntNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/IntNode.java
@@ -17,10 +17,10 @@ public class IntNode
 {
     // // // Let's cache small set of common value
 
-    final static int MIN_CANONICAL = -1;
-    final static int MAX_CANONICAL = 10;
+    static final int MIN_CANONICAL = -1;
+    static final int MAX_CANONICAL = 10;
 
-    private final static IntNode[] CANONICALS;
+    private static final IntNode[] CANONICALS;
     static {
         int count = MAX_CANONICAL - MIN_CANONICAL + 1;
         CANONICALS = new IntNode[count];

--- a/src/main/java/com/fasterxml/jackson/databind/node/JsonNodeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/JsonNodeFactory.java
@@ -31,7 +31,7 @@ public class JsonNodeFactory
      * given that this class is stateless, a globally shared singleton
      * can be used.
      */
-    public final static JsonNodeFactory instance = decimalsNormalized;
+    public static final JsonNodeFactory instance = decimalsNormalized;
 
     /**
      * Main constructor

--- a/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 public final class MissingNode
     extends ValueNode
 {
-    private final static MissingNode instance = new MissingNode();
+    private static final MissingNode instance = new MissingNode();
 
     private MissingNode() { }
 

--- a/src/main/java/com/fasterxml/jackson/databind/node/NodeCursor.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/NodeCursor.java
@@ -108,7 +108,7 @@ abstract class NodeCursor
      * than JSON Object and Array).
      * Note that context is NOT created for leaf values.
      */
-    protected final static class RootCursor
+    protected static final class RootCursor
         extends NodeCursor
     {
         protected JsonNode _node;
@@ -148,7 +148,7 @@ abstract class NodeCursor
     /**
      * Cursor used for traversing non-empty JSON Array nodes
      */
-    protected final static class ArrayCursor
+    protected static final class ArrayCursor
         extends NodeCursor
     {
         protected Iterator<JsonNode> _contents;
@@ -188,7 +188,7 @@ abstract class NodeCursor
     /**
      * Cursor used for traversing non-empty JSON Object nodes
      */
-    protected final static class ObjectCursor
+    protected static final class ObjectCursor
         extends NodeCursor
     {
         protected Iterator<Map.Entry<String, JsonNode>> _contents;

--- a/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
@@ -15,7 +15,7 @@ public final class NullNode
 {
     // // Just need a fly-weight singleton
 
-    public final static NullNode instance = new NullNode();
+    public static final NullNode instance = new NullNode();
 
     private NullNode() { }
 

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 public class TextNode
     extends ValueNode
 {
-    final static TextNode EMPTY_STRING_NODE = new TextNode("");
+    static final TextNode EMPTY_STRING_NODE = new TextNode("");
 
     protected final String _value;
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
@@ -48,14 +48,14 @@ public abstract class BasicSerializerFactory
      * about ClassLoader used to load them. Rather, we can just
      * use the class name, and keep things simple and efficient.
      */
-    protected final static HashMap<String, JsonSerializer<?>> _concrete;
+    protected static final HashMap<String, JsonSerializer<?>> _concrete;
     
     /**
      * Actually it may not make much sense to eagerly instantiate all
      * kinds of serializers: so this Map actually contains class references,
      * not instances
      */
-    protected final static HashMap<String, Class<? extends JsonSerializer<?>>> _concreteLazy;
+    protected static final HashMap<String, Class<? extends JsonSerializer<?>>> _concreteLazy;
     
     static {
         HashMap<String, Class<? extends JsonSerializer<?>>> concLazy

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
@@ -44,7 +44,7 @@ public class BeanPropertyWriter
     /**
      * Marker object used to indicate "do not serialize if empty"
      */
-    public final static Object MARKER_FOR_EMPTY = JsonInclude.Include.NON_EMPTY;
+    public static final Object MARKER_FOR_EMPTY = JsonInclude.Include.NON_EMPTY;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.ser.impl.ObjectIdWriter;
  */
 public class BeanSerializerBuilder
 {
-    private final static BeanPropertyWriter[] NO_PROPERTIES = new BeanPropertyWriter[0];
+    private static final BeanPropertyWriter[] NO_PROPERTIES = new BeanPropertyWriter[0];
 
     /*
     /**********************************************************
@@ -24,7 +24,7 @@ public class BeanSerializerBuilder
     /**********************************************************
      */
 
-    final protected BeanDescription _beanDesc;
+    protected final BeanDescription _beanDesc;
 
     protected SerializationConfig _config;
     

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
@@ -62,7 +62,7 @@ public class BeanSerializerFactory
      * thus a single shared global (== singleton) instance can be used
      * without thread-safety issues.
      */
-    public final static BeanSerializerFactory instance = new BeanSerializerFactory(null);
+    public static final BeanSerializerFactory instance = new BeanSerializerFactory(null);
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
@@ -585,7 +585,7 @@ public abstract class DefaultSerializerProvider
      * Concrete implementation that defines factory method(s),
      * defined as final.
      */
-    public final static class Impl extends DefaultSerializerProvider {
+    public static final class Impl extends DefaultSerializerProvider {
         private static final long serialVersionUID = 1L;
 
         public Impl() { super(); }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -15,19 +15,19 @@ import com.fasterxml.jackson.databind.util.*;
 public class PropertyBuilder
 {
     // @since 2.7
-    private final static Object NO_DEFAULT_MARKER = Boolean.FALSE;
+    private static final Object NO_DEFAULT_MARKER = Boolean.FALSE;
     
-    final protected SerializationConfig _config;
-    final protected BeanDescription _beanDesc;
+    protected final SerializationConfig _config;
+    protected final BeanDescription _beanDesc;
 
     /**
      * Default inclusion mode for properties of the POJO for which
      * properties are collected; possibly overridden on
      * per-property basis.
      */
-    final protected JsonInclude.Value _defaultInclusion;
+    protected final JsonInclude.Value _defaultInclusion;
 
-    final protected AnnotationIntrospector _annotationIntrospector;
+    protected final AnnotationIntrospector _annotationIntrospector;
 
     /**
      * If a property has serialization inclusion value of

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/FilteredBeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/FilteredBeanPropertyWriter.java
@@ -28,7 +28,7 @@ public abstract class FilteredBeanPropertyWriter
     /**********************************************************
      */
 
-    private final static class SingleView
+    private static final class SingleView
         extends BeanPropertyWriter
         implements java.io.Serializable
     {
@@ -95,7 +95,7 @@ public abstract class FilteredBeanPropertyWriter
         }
     }
 
-    private final static class MultiView
+    private static final class MultiView
         extends BeanPropertyWriter
         implements java.io.Serializable
     {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/IndexedStringListSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/IndexedStringListSerializer.java
@@ -24,7 +24,7 @@ public final class IndexedStringListSerializer
 {
     private static final long serialVersionUID = 1L;
 
-    public final static IndexedStringListSerializer instance = new IndexedStringListSerializer();
+    public static final IndexedStringListSerializer instance = new IndexedStringListSerializer();
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/PropertySerializerMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/PropertySerializerMap.java
@@ -196,7 +196,7 @@ public abstract class PropertySerializerMap
      * Value class used for returning tuple that has both serializer
      * that was retrieved and new map instance
      */
-    public final static class SerializerAndMapResult
+    public static final class SerializerAndMapResult
     {
         public final JsonSerializer<Object> serializer;
         public final PropertySerializerMap map;
@@ -212,7 +212,7 @@ public abstract class PropertySerializerMap
     /**
      * Trivial container for bundling type + serializer entries.
      */
-    private final static class TypeAndSerializer
+    private static final class TypeAndSerializer
     {
         public final Class<?> type;
         public final JsonSerializer<Object> serializer;
@@ -233,13 +233,13 @@ public abstract class PropertySerializerMap
      * Bogus instance that contains no serializers; used as the default
      * map with new serializers.
      */
-    private final static class Empty extends PropertySerializerMap
+    private static final class Empty extends PropertySerializerMap
     {
         // No root serializers; do not reset when full
-        public final static Empty FOR_PROPERTIES = new Empty(false);
+        public static final Empty FOR_PROPERTIES = new Empty(false);
 
         // Yes, root serializers; do reset when full
-        public final static Empty FOR_ROOT_VALUES = new Empty(true);
+        public static final Empty FOR_ROOT_VALUES = new Empty(true);
 
         protected Empty(boolean resetWhenFull) {
             super(resetWhenFull);
@@ -262,7 +262,7 @@ public abstract class PropertySerializerMap
      * theoretically dynamic or polymorphic types just have single
      * actual type.
      */
-    private final static class Single extends PropertySerializerMap
+    private static final class Single extends PropertySerializerMap
     {
         private final Class<?> _type;
         private final JsonSerializer<Object> _serializer;
@@ -288,7 +288,7 @@ public abstract class PropertySerializerMap
         }
     }
 
-    private final static class Double extends PropertySerializerMap
+    private static final class Double extends PropertySerializerMap
     {
         private final Class<?> _type1, _type2;
         private final JsonSerializer<Object> _serializer1, _serializer2;
@@ -327,7 +327,7 @@ public abstract class PropertySerializerMap
         }
     }
     
-    private final static class Multi extends PropertySerializerMap
+    private static final class Multi extends PropertySerializerMap
     {
         /**
          * Let's limit number of serializers we actually cache; linear
@@ -337,7 +337,7 @@ public abstract class PropertySerializerMap
          * case so for now let's just stop building after hard-coded
          * limit. 8 sounds like a reasonable stab for now.
          */
-        private final static int MAX_ENTRIES = 8;
+        private static final int MAX_ENTRIES = 8;
         
         private final TypeAndSerializer[] _entries;
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/ReadOnlyClassToSerializerMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/ReadOnlyClassToSerializerMap.java
@@ -37,7 +37,7 @@ public final class ReadOnlyClassToSerializerMap
         _buckets = buckets;
     }
     
-    private final static int findSize(int size)
+    private static final int findSize(int size)
     {
         // For small enough results (64 or less), we'll require <= 50% fill rate; otherwise 80%
         int needed = (size <= 64) ? (size + size) : (size + (size >> 2));
@@ -137,7 +137,7 @@ public final class ReadOnlyClassToSerializerMap
     /**********************************************************
      */
 
-    private final static class Bucket
+    private static final class Bucket
     {
         public final JsonSerializer<Object> value;
         public final Bucket next;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleBeanPropertyFilter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleBeanPropertyFilter.java
@@ -288,7 +288,7 @@ public class SimpleBeanPropertyFilter
     {
         private static final long serialVersionUID = 1L;
 
-        final static SerializeExceptFilter INCLUDE_ALL = new SerializeExceptFilter();
+        static final SerializeExceptFilter INCLUDE_ALL = new SerializeExceptFilter();
 
         /**
          * Set of property names to filter out.

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
@@ -68,7 +68,7 @@ public class SimpleFilterProvider
     }
 
     @SuppressWarnings("deprecation")
-    private final static Map<String,PropertyFilter> _convert(Map<String,?> filters)
+    private static final Map<String,PropertyFilter> _convert(Map<String,?> filters)
     {
         HashMap<String,PropertyFilter> result = new HashMap<String,PropertyFilter>();
         for (Map.Entry<String, ?> entry : filters.entrySet()) {
@@ -84,8 +84,8 @@ public class SimpleFilterProvider
         return result;
     }
 
-    @SuppressWarnings("deprecation") 
-    private final static PropertyFilter _convert(BeanPropertyFilter f) {
+    @SuppressWarnings("deprecation")
+    private static final PropertyFilter _convert(BeanPropertyFilter f) {
         return SimpleBeanPropertyFilter.from((BeanPropertyFilter) f);   
     }
     

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringArraySerializer.java
@@ -28,9 +28,9 @@ public class StringArraySerializer
     /* Note: not clean in general, but we are betting against
      * anyone re-defining properties of String.class here...
      */
-    private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(String.class);
+    private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(String.class);
 
-    public final static StringArraySerializer instance = new StringArraySerializer();
+    public static final StringArraySerializer instance = new StringArraySerializer();
 
     /**
      * Value serializer to use, if it's not the standard one

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringCollectionSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringCollectionSerializer.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ser.std.StaticListSerializerBase;
 public class StringCollectionSerializer
     extends StaticListSerializerBase<Collection<String>>
 {
-    public final static StringCollectionSerializer instance = new StringCollectionSerializer();
+    public static final StringCollectionSerializer instance = new StringCollectionSerializer();
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/TypeWrappedSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/TypeWrappedSerializer.java
@@ -16,8 +16,8 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 public final class TypeWrappedSerializer
     extends JsonSerializer<Object>
 {
-    final protected TypeSerializer _typeSerializer;
-    final protected JsonSerializer<Object> _serializer;
+    protected final TypeSerializer _typeSerializer;
+    protected final JsonSerializer<Object> _serializer;
 
     @SuppressWarnings("unchecked")
     public TypeWrappedSerializer(TypeSerializer typeSer, JsonSerializer<?> ser)

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -39,9 +39,9 @@ public abstract class BeanSerializerBase
     implements ContextualSerializer, ResolvableSerializer,
         JsonFormatVisitable, SchemaAware
 {
-    protected final static PropertyName NAME_FOR_OBJECT_REF = new PropertyName("#object-ref");
+    protected static final PropertyName NAME_FOR_OBJECT_REF = new PropertyName("#object-ref");
     
-    final protected static BeanPropertyWriter[] NO_PROPS = new BeanPropertyWriter[0];
+    protected static final BeanPropertyWriter[] NO_PROPS = new BeanPropertyWriter[0];
 
     /*
     /**********************************************************
@@ -52,42 +52,42 @@ public abstract class BeanSerializerBase
     /**
      * Writers used for outputting actual property values
      */
-    final protected BeanPropertyWriter[] _props;
+    protected final BeanPropertyWriter[] _props;
 
     /**
      * Optional filters used to suppress output of properties that
      * are only to be included in certain views
      */
-    final protected BeanPropertyWriter[] _filteredProps;
+    protected final BeanPropertyWriter[] _filteredProps;
 
     /**
      * Handler for {@link com.fasterxml.jackson.annotation.JsonAnyGetter}
      * annotated properties
      */
-    final protected AnyGetterWriter _anyGetterWriter;
+    protected final AnyGetterWriter _anyGetterWriter;
 
     /**
      * Id of the bean property filter to use, if any; null if none.
      */
-    final protected Object _propertyFilterId;
+    protected final Object _propertyFilterId;
 
     /**
      * If using custom type ids (usually via getter, or field), this is the
      * reference to that member.
      */
-    final protected AnnotatedMember _typeId;
+    protected final AnnotatedMember _typeId;
 
     /**
      * If this POJO can be alternatively serialized using just an object id
      * to denote a reference to previously serialized object,
      * this Object will handle details.
      */
-    final protected ObjectIdWriter _objectIdWriter;
+    protected final ObjectIdWriter _objectIdWriter;
 
     /**
      * Requested shape from bean class annotations.
      */
-    final protected JsonFormat.Shape _serializationShape;
+    protected final JsonFormat.Shape _serializationShape;
 
     /*
     /**********************************************************
@@ -245,7 +245,7 @@ public abstract class BeanSerializerBase
         this(src, rename(src._props, unwrapper), rename(src._filteredProps, unwrapper));
     }
     
-    private final static BeanPropertyWriter[] rename(BeanPropertyWriter[] props,
+    private static final BeanPropertyWriter[] rename(BeanPropertyWriter[] props,
             NameTransformer transformer)
     {
         if (props == null || props.length == 0 || transformer == null || transformer == NameTransformer.NOP) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
@@ -85,7 +85,7 @@ public class JsonValueSerializer
     }
 
     @SuppressWarnings("unchecked")
-    private final static Class<Object> _notNullClass(Class<?> cls) {
+    private static final Class<Object> _notNullClass(Class<?> cls) {
         return (cls == null) ? Object.class : (Class<Object>) cls;
     }
     

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
@@ -35,7 +35,7 @@ public class MapSerializer
 {
     private static final long serialVersionUID = 1L;
 
-    protected final static JavaType UNSPECIFIED_TYPE = TypeFactory.unknownType();
+    protected static final JavaType UNSPECIFIED_TYPE = TypeFactory.unknownType();
 
     /**
      * Map-valued property being serialized with this instance

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NullSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NullSerializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 public class NullSerializer
     extends StdSerializer<Object>
 {
-    public final static NullSerializer instance = new NullSerializer();
+    public static final NullSerializer instance = new NullSerializer();
     
     private NullSerializer() { super(Object.class); }
     

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializer.java
@@ -24,7 +24,7 @@ public class NumberSerializer
     /**
      * Static instance that is only to be used for {@link java.lang.Number}.
      */
-    public final static NumberSerializer instance = new NumberSerializer(Number.class);
+    public static final NumberSerializer instance = new NumberSerializer(Number.class);
 
     protected final boolean _isInt;
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializers.java
@@ -108,8 +108,8 @@ public class NumberSerializers {
      */
 
     @JacksonStdImpl
-    public final static class ShortSerializer extends Base<Object> {
-        final static ShortSerializer instance = new ShortSerializer();
+    public static final class ShortSerializer extends Base<Object> {
+        static final ShortSerializer instance = new ShortSerializer();
 
         public ShortSerializer() {
             super(Short.class, JsonParser.NumberType.INT, "number");
@@ -133,7 +133,7 @@ public class NumberSerializers {
      * of bridge methods.
      */
     @JacksonStdImpl
-    public final static class IntegerSerializer extends Base<Object> {
+    public static final class IntegerSerializer extends Base<Object> {
         public IntegerSerializer() {
             super(Integer.class, JsonParser.NumberType.INT, "integer");
         }
@@ -160,8 +160,8 @@ public class NumberSerializers {
      * calling {@link java.lang.Number#intValue}.
      */
     @JacksonStdImpl
-    public final static class IntLikeSerializer extends Base<Object> {
-        final static IntLikeSerializer instance = new IntLikeSerializer();
+    public static final class IntLikeSerializer extends Base<Object> {
+        static final IntLikeSerializer instance = new IntLikeSerializer();
 
         public IntLikeSerializer() {
             super(Number.class, JsonParser.NumberType.INT, "integer");
@@ -175,8 +175,8 @@ public class NumberSerializers {
     }
 
     @JacksonStdImpl
-    public final static class LongSerializer extends Base<Object> {
-        final static LongSerializer instance = new LongSerializer();
+    public static final class LongSerializer extends Base<Object> {
+        static final LongSerializer instance = new LongSerializer();
 
         public LongSerializer() {
             super(Long.class, JsonParser.NumberType.LONG, "number");
@@ -190,8 +190,8 @@ public class NumberSerializers {
     }
 
     @JacksonStdImpl
-    public final static class FloatSerializer extends Base<Object> {
-        final static FloatSerializer instance = new FloatSerializer();
+    public static final class FloatSerializer extends Base<Object> {
+        static final FloatSerializer instance = new FloatSerializer();
 
         public FloatSerializer() {
             super(Float.class, JsonParser.NumberType.FLOAT, "number");
@@ -212,8 +212,8 @@ public class NumberSerializers {
      * on serialization (unlike for most scalar types as of 1.5)
      */
     @JacksonStdImpl
-    public final static class DoubleSerializer extends Base<Object> {
-        final static DoubleSerializer instance = new DoubleSerializer();
+    public static final class DoubleSerializer extends Base<Object> {
+        static final DoubleSerializer instance = new DoubleSerializer();
 
         public DoubleSerializer() {
             super(Double.class, JsonParser.NumberType.DOUBLE, "number");

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/SerializableSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/SerializableSerializer.java
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 public class SerializableSerializer
     extends StdSerializer<JsonSerializable>
 {
-    public final static SerializableSerializer instance = new SerializableSerializer();
+    public static final SerializableSerializer instance = new SerializableSerializer();
 
     // Ugh. Should NOT need this...
-    private final static AtomicReference<ObjectMapper> _mapperReference = new AtomicReference<ObjectMapper>();
+    private static final AtomicReference<ObjectMapper> _mapperReference = new AtomicReference<ObjectMapper>();
     
     protected SerializableSerializer() { super(JsonSerializable.class); }
 
@@ -102,7 +102,7 @@ public class SerializableSerializer
         return objectNode;
     }
     
-    private final static synchronized ObjectMapper _getObjectMapper()
+    private static final synchronized ObjectMapper _getObjectMapper()
     {
         ObjectMapper mapper = _mapperReference.get();
         if (mapper == null) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdArraySerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdArraySerializers.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 @SuppressWarnings("serial")
 public class StdArraySerializers
 {
-    protected final static HashMap<String, JsonSerializer<?>> _arraySerializers =
+    protected static final HashMap<String, JsonSerializer<?>> _arraySerializers =
         new HashMap<String, JsonSerializer<?>>();
     static {
         // Arrays of various types (including common object types)
@@ -86,7 +86,7 @@ public class StdArraySerializers
         extends ArraySerializerBase<boolean[]>
     {
         // as above, assuming no one re-defines primitive/wrapper types
-        private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Boolean.class);
+        private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Boolean.class);
 
         public BooleanArraySerializer() { super(boolean[].class); }
 
@@ -176,7 +176,7 @@ public class StdArraySerializers
     public static class ShortArraySerializer extends TypedPrimitiveArraySerializer<short[]>
     {
         // as above, assuming no one re-defines primitive/wrapper types
-        private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Short.TYPE);
+        private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Short.TYPE);
 
         public ShortArraySerializer() { super(short[].class); }
         public ShortArraySerializer(ShortArraySerializer src, BeanProperty prop,
@@ -343,7 +343,7 @@ public class StdArraySerializers
     public static class IntArraySerializer extends ArraySerializerBase<int[]>
     {
         // as above, assuming no one re-defines primitive/wrapper types
-        private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Integer.TYPE);
+        private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Integer.TYPE);
 
         public IntArraySerializer() { super(int[].class); }
 
@@ -432,7 +432,7 @@ public class StdArraySerializers
     public static class LongArraySerializer extends TypedPrimitiveArraySerializer<long[]>
     {
         // as above, assuming no one re-defines primitive/wrapper types
-        private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Long.TYPE);
+        private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Long.TYPE);
 
         public LongArraySerializer() { super(long[].class); }
         public LongArraySerializer(LongArraySerializer src, BeanProperty prop,
@@ -525,7 +525,7 @@ public class StdArraySerializers
     public static class FloatArraySerializer extends TypedPrimitiveArraySerializer<float[]>
     {
         // as above, assuming no one re-defines primitive/wrapper types
-        private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Float.TYPE);
+        private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Float.TYPE);
         
         public FloatArraySerializer() {
             super(float[].class);
@@ -616,7 +616,7 @@ public class StdArraySerializers
     public static class DoubleArraySerializer extends ArraySerializerBase<double[]>
     {
         // as above, assuming no one re-defines primitive/wrapper types
-        private final static JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Double.TYPE);
+        private static final JavaType VALUE_TYPE = TypeFactory.defaultInstance().uncheckedSimpleType(Double.TYPE);
 
         public DoubleArraySerializer() { super(double[].class); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdKeySerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdKeySerializers.java
@@ -11,9 +11,9 @@ import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
 @SuppressWarnings("serial")
 public class StdKeySerializers
 {
-    protected final static JsonSerializer<Object> DEFAULT_KEY_SERIALIZER = new StdKeySerializer();
+    protected static final JsonSerializer<Object> DEFAULT_KEY_SERIALIZER = new StdKeySerializer();
 
-    protected final static JsonSerializer<Object> DEFAULT_STRING_SERIALIZER = new StringKeySerializer();
+    protected static final JsonSerializer<Object> DEFAULT_STRING_SERIALIZER = new StringKeySerializer();
 
     private StdKeySerializers() { }
 
@@ -104,11 +104,11 @@ public class StdKeySerializers
      * as well as alternative configuration of Enum key serializers.
      */
     public static class Default extends StdSerializer<Object> {
-        final static int TYPE_DATE = 1;
-        final static int TYPE_CALENDAR = 2;
-        final static int TYPE_CLASS = 3;
-        final static int TYPE_ENUM = 4;
-        final static int TYPE_TO_STRING = 5;
+        static final int TYPE_DATE = 1;
+        static final int TYPE_CALENDAR = 2;
+        static final int TYPE_CLASS = 3;
+        static final int TYPE_ENUM = 4;
+        static final int TYPE_TO_STRING = 5;
 
         protected final int _typeId;
         

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -39,7 +39,7 @@ public abstract class StdSerializer<T>
      *
      * @since 2.7
      */
-    private final static Object CONVERTING_CONTENT_CONVERTER_LOCK = new Object();
+    private static final Object CONVERTING_CONTENT_CONVERTER_LOCK = new Object();
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ToStringSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ToStringSerializer.java
@@ -25,7 +25,7 @@ public class ToStringSerializer
     /**
      * Singleton instance to use.
      */
-    public final static ToStringSerializer instance = new ToStringSerializer();
+    public static final ToStringSerializer instance = new ToStringSerializer();
 
     /**
      *<p>

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/UUIDSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/UUIDSerializer.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 public class UUIDSerializer
     extends StdScalarSerializer<UUID>
 {
-    final static char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+    static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
 
     public UUIDSerializer() { super(UUID.class); }
 
@@ -90,7 +90,7 @@ public class UUIDSerializer
 
     }
 
-    private final static byte[] _asBytes(UUID uuid)
+    private static final byte[] _asBytes(UUID uuid)
     {
         byte[] buffer = new byte[16];
         long hi = uuid.getMostSignificantBits();
@@ -102,7 +102,7 @@ public class UUIDSerializer
         return buffer;
     }
 
-    private final static void _appendInt(int value, byte[] buffer, int offset)
+    private static final void _appendInt(int value, byte[] buffer, int offset)
     {
         buffer[offset] = (byte) (value >> 24);
         buffer[++offset] = (byte) (value >> 16);

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBase.java
@@ -15,8 +15,8 @@ public abstract class TypeBase
 {
     private static final long serialVersionUID = 1;
 
-    private final static TypeBindings NO_BINDINGS = TypeBindings.emptyBindings();
-    private final static JavaType[] NO_TYPES = new JavaType[0];
+    private static final TypeBindings NO_BINDINGS = TypeBindings.emptyBindings();
+    private static final JavaType[] NO_TYPES = new JavaType[0];
 
     protected final JavaType _superClass;
 
@@ -34,7 +34,7 @@ public abstract class TypeBase
     /**
      * Lazily initialized external representation of the type
      */
-    volatile transient String _canonicalName;
+    transient volatile String _canonicalName;
 
     /**
      * Main constructor to use by extending classes.

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -13,11 +13,11 @@ public class TypeBindings
 {
     private static final long serialVersionUID = 1L;
 
-    private final static String[] NO_STRINGS = new String[0];
+    private static final String[] NO_STRINGS = new String[0];
 
-    private final static JavaType[] NO_TYPES = new JavaType[0];
+    private static final JavaType[] NO_TYPES = new JavaType[0];
 
-    private final static TypeBindings EMPTY = new TypeBindings(NO_STRINGS, NO_TYPES, null);
+    private static final TypeBindings EMPTY = new TypeBindings(NO_STRINGS, NO_TYPES, null);
 
     // // // Pre-resolved instances for minor optimizations
 
@@ -351,15 +351,15 @@ public class TypeBindings
      * used.
      */
     static class TypeParamStash {
-        private final static TypeVariable<?>[] VARS_ABSTRACT_LIST = AbstractList.class.getTypeParameters();
-        private final static TypeVariable<?>[] VARS_COLLECTION = Collection.class.getTypeParameters();
-        private final static TypeVariable<?>[] VARS_ITERABLE = Iterable.class.getTypeParameters();
-        private final static TypeVariable<?>[] VARS_LIST = List.class.getTypeParameters();
-        private final static TypeVariable<?>[] VARS_ARRAY_LIST = ArrayList.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_ABSTRACT_LIST = AbstractList.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_COLLECTION = Collection.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_ITERABLE = Iterable.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_LIST = List.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_ARRAY_LIST = ArrayList.class.getTypeParameters();
 
-        private final static TypeVariable<?>[] VARS_MAP = Map.class.getTypeParameters();
-        private final static TypeVariable<?>[] VARS_HASH_MAP = HashMap.class.getTypeParameters();
-        private final static TypeVariable<?>[] VARS_LINKED_HASH_MAP = LinkedHashMap.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_MAP = Map.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_HASH_MAP = HashMap.class.getTypeParameters();
+        private static final TypeVariable<?>[] VARS_LINKED_HASH_MAP = LinkedHashMap.class.getTypeParameters();
 
         public static TypeVariable<?>[] paramsFor1(Class<?> erasedType)
         {

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -36,16 +36,16 @@ public final class TypeFactory
 {
     private static final long serialVersionUID = 1L;
 
-    private final static JavaType[] NO_TYPES = new JavaType[0];
+    private static final JavaType[] NO_TYPES = new JavaType[0];
 
     /**
      * Globally shared singleton. Not accessed directly; non-core
      * code should use per-ObjectMapper instance (via configuration objects).
      * Core Jackson code uses {@link #defaultInstance} for accessing it.
      */
-    protected final static TypeFactory instance = new TypeFactory();
+    protected static final TypeFactory instance = new TypeFactory();
 
-    protected final static TypeBindings EMPTY_BINDINGS = TypeBindings.emptyBindings();
+    protected static final TypeBindings EMPTY_BINDINGS = TypeBindings.emptyBindings();
 
     /*
     /**********************************************************
@@ -57,16 +57,16 @@ public final class TypeFactory
     // // // will not be modified, and can be freely shared to streamline
     // // // parts of processing
 
-    private final static Class<?> CLS_STRING = String.class;
-    private final static Class<?> CLS_OBJECT = Object.class;
+    private static final Class<?> CLS_STRING = String.class;
+    private static final Class<?> CLS_OBJECT = Object.class;
 
-    private final static Class<?> CLS_COMPARABLE = Comparable.class;
-    private final static Class<?> CLS_CLASS = Class.class;
-    private final static Class<?> CLS_ENUM = Enum.class;
+    private static final Class<?> CLS_COMPARABLE = Comparable.class;
+    private static final Class<?> CLS_CLASS = Class.class;
+    private static final Class<?> CLS_ENUM = Enum.class;
 
-    private final static Class<?> CLS_BOOL = Boolean.TYPE;
-    private final static Class<?> CLS_INT = Integer.TYPE;
-    private final static Class<?> CLS_LONG = Long.TYPE;
+    private static final Class<?> CLS_BOOL = Boolean.TYPE;
+    private static final Class<?> CLS_INT = Integer.TYPE;
+    private static final Class<?> CLS_LONG = Long.TYPE;
 
     /*
     /**********************************************************
@@ -75,15 +75,15 @@ public final class TypeFactory
      */
 
     // note: these are primitive, hence no super types
-    protected final static SimpleType CORE_TYPE_BOOL = new SimpleType(CLS_BOOL);
-    protected final static SimpleType CORE_TYPE_INT = new SimpleType(CLS_INT);
-    protected final static SimpleType CORE_TYPE_LONG = new SimpleType(CLS_LONG);
+    protected static final SimpleType CORE_TYPE_BOOL = new SimpleType(CLS_BOOL);
+    protected static final SimpleType CORE_TYPE_INT = new SimpleType(CLS_INT);
+    protected static final SimpleType CORE_TYPE_LONG = new SimpleType(CLS_LONG);
 
     // and as to String... well, for now, ignore its super types
-    protected final static SimpleType CORE_TYPE_STRING = new SimpleType(CLS_STRING);
+    protected static final SimpleType CORE_TYPE_STRING = new SimpleType(CLS_STRING);
 
     // @since 2.7
-    protected final static SimpleType CORE_TYPE_OBJECT = new SimpleType(CLS_OBJECT);
+    protected static final SimpleType CORE_TYPE_OBJECT = new SimpleType(CLS_OBJECT);
 
     /**
      * Cache {@link Comparable} because it is both parameteric (relatively costly to
@@ -91,7 +91,7 @@ public final class TypeFactory
      *
      * @since 2.7
      */
-    protected final static SimpleType CORE_TYPE_COMPARABLE = new SimpleType(CLS_COMPARABLE);
+    protected static final SimpleType CORE_TYPE_COMPARABLE = new SimpleType(CLS_COMPARABLE);
 
     /**
      * Cache {@link Enum} because it is parametric AND self-referential (costly to
@@ -99,7 +99,7 @@ public final class TypeFactory
      *
      * @since 2.7
      */
-    protected final static SimpleType CORE_TYPE_ENUM = new SimpleType(CLS_ENUM);
+    protected static final SimpleType CORE_TYPE_ENUM = new SimpleType(CLS_ENUM);
 
     /**
      * Cache {@link Class} because it is nominally parametric, but has no really
@@ -107,7 +107,7 @@ public final class TypeFactory
      *
      * @since 2.7
      */
-    protected final static SimpleType CORE_TYPE_CLASS = new SimpleType(CLS_CLASS);
+    protected static final SimpleType CORE_TYPE_CLASS = new SimpleType(CLS_CLASS);
 
     /**
      * Since type resolution can be expensive (specifically when resolving

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeParser.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeParser.java
@@ -94,7 +94,7 @@ public class TypeParser
                 +"' (remaining: '"+tokens.getRemainingInput()+"'): "+msg);
     }
 
-    final static class MyTokenizer
+    static final class MyTokenizer
         extends StringTokenizer
     {
         protected final String _input;

--- a/src/main/java/com/fasterxml/jackson/databind/util/ArrayBuilders.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ArrayBuilders.java
@@ -86,7 +86,7 @@ public final class ArrayBuilders
     /**********************************************************
      */
 
-    public final static class BooleanBuilder
+    public static final class BooleanBuilder
         extends PrimitiveArrayBuilder<boolean[]>
     {
         public BooleanBuilder() { }
@@ -94,28 +94,28 @@ public final class ArrayBuilders
         public final boolean[] _constructArray(int len) { return new boolean[len]; }
     }
 
-    public final static class ByteBuilder
+    public static final class ByteBuilder
         extends PrimitiveArrayBuilder<byte[]>
     {
         public ByteBuilder() { }
         @Override
         public final byte[] _constructArray(int len) { return new byte[len]; }
     }
-    public final static class ShortBuilder
+    public static final class ShortBuilder
         extends PrimitiveArrayBuilder<short[]>
     {
         public ShortBuilder() { }
         @Override
         public final short[] _constructArray(int len) { return new short[len]; }
     }
-    public final static class IntBuilder
+    public static final class IntBuilder
         extends PrimitiveArrayBuilder<int[]>
     {
         public IntBuilder() { }
         @Override
         public final int[] _constructArray(int len) { return new int[len]; }
     }
-    public final static class LongBuilder
+    public static final class LongBuilder
         extends PrimitiveArrayBuilder<long[]>
     {
         public LongBuilder() { }
@@ -123,14 +123,14 @@ public final class ArrayBuilders
         public final long[] _constructArray(int len) { return new long[len]; }
     }
 
-    public final static class FloatBuilder
+    public static final class FloatBuilder
         extends PrimitiveArrayBuilder<float[]>
     {
         public FloatBuilder() { }
         @Override
         public final float[] _constructArray(int len) { return new float[len]; }
     }
-    public final static class DoubleBuilder
+    public static final class DoubleBuilder
         extends PrimitiveArrayBuilder<double[]>
     {
         public DoubleBuilder() { }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 
 public final class ClassUtil
 {
-    private final static Class<?> CLS_OBJECT = Object.class;
+    private static final Class<?> CLS_OBJECT = Object.class;
 
     /*
     /**********************************************************
@@ -342,7 +342,7 @@ public final class ClassUtil
      *   So let's do somewhat aggressive caching.
      */
 
-    private final static LRUMap<Class<?>,ClassMetadata> sCached = new LRUMap<Class<?>,ClassMetadata>(48, 48);    
+    private static final LRUMap<Class<?>,ClassMetadata> sCached = new LRUMap<Class<?>,ClassMetadata>(48, 48);
 
     /**
      * @since 2.7
@@ -892,7 +892,7 @@ public final class ClassUtil
      */
     private static class EnumTypeLocator
     {
-        final static EnumTypeLocator instance = new EnumTypeLocator();
+        static final EnumTypeLocator instance = new EnumTypeLocator();
 
         private final Field enumSetTypeField;
         private final Field enumMapTypeField;
@@ -970,10 +970,10 @@ public final class ClassUtil
     /**
      * @since 2.7
      */
-    private final static class ClassMetadata
+    private static final class ClassMetadata
     {
-        private final static Annotation[] NO_ANNOTATIONS = new Annotation[0];
-        private final static Ctor[] NO_CTORS = new Ctor[0];
+        private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+        private static final Ctor[] NO_CTORS = new Ctor[0];
 
         private final Class<?> _forClass;
 
@@ -1111,7 +1111,7 @@ public final class ClassUtil
      *
      * @since 2.7
      */
-    public final static class Ctor
+    public static final class Ctor
     {
         public final Constructor<?> _ctor;
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/CompactStringObjectMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/CompactStringObjectMap.java
@@ -22,7 +22,7 @@ public final class CompactStringObjectMap
     /**
      * Shared instance that can be used when there are no contents to Map.
      */
-    private final static CompactStringObjectMap EMPTY = new CompactStringObjectMap(1, 0,
+    private static final CompactStringObjectMap EMPTY = new CompactStringObjectMap(1, 0,
             new Object[4]);
     
     private final int _hashMask, _spillCount;
@@ -75,7 +75,7 @@ public final class CompactStringObjectMap
         return new CompactStringObjectMap(mask, spillCount, hashArea);
     }
 
-    private final static int findSize(int size)
+    private static final int findSize(int size)
     {
         if (size <= 5) {
             return 8;

--- a/src/main/java/com/fasterxml/jackson/databind/util/NameTransformer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NameTransformer.java
@@ -11,9 +11,9 @@ public abstract class NameTransformer
      * Singleton "no-operation" transformer which simply returns given
      * name as is. Used commonly as placeholder or marker.
      */
-    public final static NameTransformer NOP = new NopTransformer();
+    public static final NameTransformer NOP = new NopTransformer();
     
-    protected final static class NopTransformer
+    protected static final class NopTransformer
         extends NameTransformer
         implements java.io.Serializable
     {

--- a/src/main/java/com/fasterxml/jackson/databind/util/ObjectBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ObjectBuffer.java
@@ -15,7 +15,7 @@ public final class ObjectBuffer
      * Also: let's expand by doubling up until 64k chunks (which is 16k entries for
      * 32-bit machines)
      */
-    private final static int SMALL_CHUNK = (1 << 14);
+    private static final int SMALL_CHUNK = (1 << 14);
 
     /**
      * Let's limit maximum size of chunks we use; helps avoid excessive allocation
@@ -23,7 +23,7 @@ public final class ObjectBuffer
      * For now, let's limit to quarter million entries, 1 meg chunks for 32-bit
      * machines.
      */
-    private final static int MAX_CHUNK = (1 << 18);
+    private static final int MAX_CHUNK = (1 << 18);
 
     // // // Data storage
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/PrimitiveArrayBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/PrimitiveArrayBuilder.java
@@ -8,13 +8,13 @@ public abstract class PrimitiveArrayBuilder<T>
     /**
      * Let's start with small chunks; typical usage is for small arrays anyway.
      */
-    final static int INITIAL_CHUNK_SIZE = 12;
+    static final int INITIAL_CHUNK_SIZE = 12;
 
     /**
      * Also: let's expand by doubling up until 64k chunks (which is 16k entries for
      * 32-bit machines)
      */
-    final static int SMALL_CHUNK_SIZE = (1 << 14);
+    static final int SMALL_CHUNK_SIZE = (1 << 14);
 
     /**
      * Let's limit maximum size of chunks we use; helps avoid excessive allocation
@@ -22,7 +22,7 @@ public abstract class PrimitiveArrayBuilder<T>
      * For now, let's limit to quarter million entries, 1 meg chunks for 32-bit
      * machines.
      */
-    final static int MAX_CHUNK_SIZE = (1 << 18);
+    static final int MAX_CHUNK_SIZE = (1 << 18);
 
     // // // Data storage
 
@@ -140,7 +140,7 @@ public abstract class PrimitiveArrayBuilder<T>
      * take type; hence we can implement some aspects of primitive data
      * handling in generic fashion.
      */
-    final static class Node<T>
+    static final class Node<T>
     {
         /**
          * Data stored in this node.

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -31,29 +31,29 @@ public class StdDateFormat
      * to ISO-8601 date formatting standard, when it includes basic undecorated
      * timezone definition
      */
-    protected final static String DATE_FORMAT_STR_ISO8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    protected static final String DATE_FORMAT_STR_ISO8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
     /**
      * Same as 'regular' 8601, but handles 'Z' as an alias for "+0000"
      * (or "UTC")
      */
-    protected final static String DATE_FORMAT_STR_ISO8601_Z = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    protected static final String DATE_FORMAT_STR_ISO8601_Z = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     /**
      * ISO-8601 with just the Date part, no time
      */
-    protected final static String DATE_FORMAT_STR_PLAIN = "yyyy-MM-dd";
+    protected static final String DATE_FORMAT_STR_PLAIN = "yyyy-MM-dd";
 
     /**
      * This constant defines the date format specified by
      * RFC 1123 / RFC 822.
      */
-    protected final static String DATE_FORMAT_STR_RFC1123 = "EEE, dd MMM yyyy HH:mm:ss zzz";
+    protected static final String DATE_FORMAT_STR_RFC1123 = "EEE, dd MMM yyyy HH:mm:ss zzz";
 
     /**
      * For error messages we'll also need a list of all formats.
      */
-    protected final static String[] ALL_FORMATS = new String[] {
+    protected static final String[] ALL_FORMATS = new String[] {
         DATE_FORMAT_STR_ISO8601,
         DATE_FORMAT_STR_ISO8601_Z,
         DATE_FORMAT_STR_RFC1123,
@@ -64,19 +64,19 @@ public class StdDateFormat
      * By default we use UTC for everything, with Jackson 2.7 and later
      * (2.6 and earlier relied on GMT)
      */
-    private final static TimeZone DEFAULT_TIMEZONE;
+    private static final TimeZone DEFAULT_TIMEZONE;
     static {
         DEFAULT_TIMEZONE = TimeZone.getTimeZone("UTC"); // since 2.7
     }
 
-    private final static Locale DEFAULT_LOCALE = Locale.US;
+    private static final Locale DEFAULT_LOCALE = Locale.US;
     
-    protected final static DateFormat DATE_FORMAT_RFC1123;
+    protected static final DateFormat DATE_FORMAT_RFC1123;
 
-    protected final static DateFormat DATE_FORMAT_ISO8601;
-    protected final static DateFormat DATE_FORMAT_ISO8601_Z;
+    protected static final DateFormat DATE_FORMAT_ISO8601;
+    protected static final DateFormat DATE_FORMAT_ISO8601_Z;
 
-    protected final static DateFormat DATE_FORMAT_PLAIN;
+    protected static final DateFormat DATE_FORMAT_PLAIN;
 
     /* Let's construct "blueprint" date format instances: can not be used
      * as is, due to thread-safety issues, but can be used for constructing
@@ -100,7 +100,7 @@ public class StdDateFormat
     /**
      * A singleton instance can be used for cloning purposes, as a blueprint of sorts.
      */
-    public final static StdDateFormat instance = new StdDateFormat();
+    public static final StdDateFormat instance = new StdDateFormat();
     
     /**
      * Caller may want to explicitly override timezone to use; if so,
@@ -119,7 +119,7 @@ public class StdDateFormat
      * @since 2.7
      */
     protected Boolean _lenient;
-    
+
     protected transient DateFormat _formatRFC1123;
     protected transient DateFormat _formatISO8601;
     protected transient DateFormat _formatISO8601_z;
@@ -146,7 +146,7 @@ public class StdDateFormat
         _locale = loc;
         _lenient = lenient;
     }
-    
+
     public static TimeZone getDefaultTimeZone() {
         return DEFAULT_TIMEZONE;
     }
@@ -358,7 +358,7 @@ public class StdDateFormat
     /* Public API, writing
     /**********************************************************
      */
-    
+
     @Override
     public StringBuffer format(Date date, StringBuffer toAppendTo,
             FieldPosition fieldPosition)
@@ -535,7 +535,7 @@ public class StdDateFormat
         return _formatRFC1123.parse(dateStr, pos);
     }
 
-    private final static boolean hasTimeZone(String str)
+    private static final boolean hasTimeZone(String str)
     {
         // Only accept "+hh", "+hhmm" and "+hh:mm" (and with minus), so
         int len = str.length();
@@ -550,7 +550,7 @@ public class StdDateFormat
         return false;
     }
 
-    private final static DateFormat _cloneFormat(DateFormat df, String format,
+    private static final DateFormat _cloneFormat(DateFormat df, String format,
             TimeZone tz, Locale loc, Boolean lenient)
     {
         if (!loc.equals(DEFAULT_LOCALE)) {

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -30,7 +30,7 @@ public class TokenBuffer
  */
     extends JsonGenerator
 {
-    protected final static int DEFAULT_GENERATOR_FEATURES = JsonGenerator.Feature.collectDefaults();
+    protected static final int DEFAULT_GENERATOR_FEATURES = JsonGenerator.Feature.collectDefaults();
 
     /*
     /**********************************************************
@@ -1156,7 +1156,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
     /**********************************************************
      */
 
-    protected final static class Parser
+    protected static final class Parser
         extends ParserMinimalBase
     {
         /*
@@ -1644,15 +1644,15 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
      * use 16 distinct fields and switch statement (slightly more efficient
      * storage, slightly slower access)
      */
-    protected final static class Segment 
+    protected static final class Segment
     {
-        public final static int TOKENS_PER_SEGMENT = 16;
+        public static final int TOKENS_PER_SEGMENT = 16;
         
         /**
          * Static array used for fast conversion between token markers and
          * matching {@link JsonToken} instances
          */
-        private final static JsonToken[] TOKEN_TYPES_BY_INDEX;
+        private static final JsonToken[] TOKEN_TYPES_BY_INDEX;
         static {
             // ... here we know that there are <= 15 values in JsonToken enum
             TOKEN_TYPES_BY_INDEX = new JsonToken[16];

--- a/src/main/java/com/fasterxml/jackson/databind/util/TypeKey.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TypeKey.java
@@ -45,19 +45,19 @@ public class TypeKey
         _hashCode = typed ? typedHash(key) : untypedHash(key);
     }
 
-    public final static int untypedHash(Class<?> cls) {
+    public static final int untypedHash(Class<?> cls) {
         return cls.getName().hashCode();
     }
 
-    public final static int typedHash(Class<?> cls) {
+    public static final int typedHash(Class<?> cls) {
         return cls.getName().hashCode()+1;
     }
 
-    public final static int untypedHash(JavaType type) {
+    public static final int untypedHash(JavaType type) {
         return type.hashCode() - 1;
     }
     
-    public final static int typedHash(JavaType type) {
+    public static final int typedHash(JavaType type) {
         return type.hashCode() - 2;
     }
     

--- a/src/main/java/com/fasterxml/jackson/databind/util/ViewMatcher.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ViewMatcher.java
@@ -8,7 +8,7 @@ public class ViewMatcher implements java.io.Serializable
 {
     private static final long serialVersionUID = 1L;
 
-    protected final static ViewMatcher EMPTY = new ViewMatcher();
+    protected static final ViewMatcher EMPTY = new ViewMatcher();
     
     public boolean isVisibleForView(Class<?> activeView) { return false; }
 
@@ -32,7 +32,7 @@ public class ViewMatcher implements java.io.Serializable
     /**********************************************************
      */
 
-    private final static class Single extends ViewMatcher
+    private static final class Single extends ViewMatcher
     {
         private static final long serialVersionUID = 1L;
 
@@ -44,7 +44,7 @@ public class ViewMatcher implements java.io.Serializable
         }
     }
 
-    private final static class Multi extends ViewMatcher
+    private static final class Multi extends ViewMatcher
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;

--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 public abstract class BaseMapTest
     extends BaseTest
 {
-    private final static Object SINGLETON_OBJECT = new Object();
+    private static final Object SINGLETON_OBJECT = new Object();
     
     /*
     /**********************************************************
@@ -124,7 +124,7 @@ public abstract class BaseMapTest
     /**********************************************************
      */
 
-    private final static ObjectMapper SHARED_MAPPER = new ObjectMapper();
+    private static final ObjectMapper SHARED_MAPPER = new ObjectMapper();
 
     protected ObjectMapper objectMapper() {
         return SHARED_MAPPER;

--- a/src/test/java/com/fasterxml/jackson/databind/BaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseTest.java
@@ -18,18 +18,18 @@ public abstract class BaseTest
     /**********************************************************
      */
 
-    protected final static int SAMPLE_SPEC_VALUE_WIDTH = 800;
-    protected final static int SAMPLE_SPEC_VALUE_HEIGHT = 600;
-    protected final static String SAMPLE_SPEC_VALUE_TITLE = "View from 15th Floor";
-    protected final static String SAMPLE_SPEC_VALUE_TN_URL = "http://www.example.com/image/481989943";
-    protected final static int SAMPLE_SPEC_VALUE_TN_HEIGHT = 125;
-    protected final static String SAMPLE_SPEC_VALUE_TN_WIDTH = "100";
-    protected final static int SAMPLE_SPEC_VALUE_TN_ID1 = 116;
-    protected final static int SAMPLE_SPEC_VALUE_TN_ID2 = 943;
-    protected final static int SAMPLE_SPEC_VALUE_TN_ID3 = 234;
-    protected final static int SAMPLE_SPEC_VALUE_TN_ID4 = 38793;
+    protected static final int SAMPLE_SPEC_VALUE_WIDTH = 800;
+    protected static final int SAMPLE_SPEC_VALUE_HEIGHT = 600;
+    protected static final String SAMPLE_SPEC_VALUE_TITLE = "View from 15th Floor";
+    protected static final String SAMPLE_SPEC_VALUE_TN_URL = "http://www.example.com/image/481989943";
+    protected static final int SAMPLE_SPEC_VALUE_TN_HEIGHT = 125;
+    protected static final String SAMPLE_SPEC_VALUE_TN_WIDTH = "100";
+    protected static final int SAMPLE_SPEC_VALUE_TN_ID1 = 116;
+    protected static final int SAMPLE_SPEC_VALUE_TN_ID2 = 943;
+    protected static final int SAMPLE_SPEC_VALUE_TN_ID3 = 234;
+    protected static final int SAMPLE_SPEC_VALUE_TN_ID4 = 38793;
 
-    protected final static String SAMPLE_DOC_JSON_SPEC = 
+    protected static final String SAMPLE_DOC_JSON_SPEC =
         "{\n"
         +"  \"Image\" : {\n"
         +"    \"Width\" : "+SAMPLE_SPEC_VALUE_WIDTH+",\n"

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -55,7 +55,7 @@ public class ObjectMapperTest extends BaseMapTest
     /**********************************************************
      */
     
-    final static ObjectMapper MAPPER = new ObjectMapper();
+    static final ObjectMapper MAPPER = new ObjectMapper();
     
     public void testProps()
     {

--- a/src/test/java/com/fasterxml/jackson/databind/TestGeneratorUsingMapper.java
+++ b/src/test/java/com/fasterxml/jackson/databind/TestGeneratorUsingMapper.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.core.io.CharacterEscapes;
 
 public class TestGeneratorUsingMapper extends BaseMapTest
 {
-    final static class Pojo
+    static final class Pojo
     {
         public int getX() { return 4; }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/TestObjectMapperBeanDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/TestObjectMapperBeanDeserializer.java
@@ -23,7 +23,7 @@ public class TestObjectMapperBeanDeserializer
     /**********************************************************
      */
 
-    final static class CtorValueBean
+    static final class CtorValueBean
         implements JsonSerializable // so we can output as simple String
     {
         final String _desc;
@@ -54,7 +54,7 @@ public class TestObjectMapperBeanDeserializer
         }
     }
 
-    final static class FactoryValueBean
+    static final class FactoryValueBean
     {
         final String _desc;
 
@@ -80,7 +80,7 @@ public class TestObjectMapperBeanDeserializer
     /**
      * Simple test bean
      */
-    public final static class TestBean
+    public static final class TestBean
     {
         int _x;
         long _y;
@@ -147,7 +147,7 @@ public class TestObjectMapperBeanDeserializer
      * Note: List elements must be something other than what 'untyped' mapper
      * would produce from serialization.
      */
-    public final static class BeanWithList
+    public static final class BeanWithList
     {
         List<CtorValueBean> _beans;
 

--- a/src/test/java/com/fasterxml/jackson/databind/TestParserUsingMapper.java
+++ b/src/test/java/com/fasterxml/jackson/databind/TestParserUsingMapper.java
@@ -10,13 +10,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestParserUsingMapper  extends BaseMapTest
 {
-    final static int TWO_BYTE_ESCAPED = 0x111;
-    final static int THREE_BYTE_ESCAPED = 0x1111;
+    static final int TWO_BYTE_ESCAPED = 0x111;
+    static final int THREE_BYTE_ESCAPED = 0x1111;
 
-    final static SerializedString TWO_BYTE_ESCAPED_STRING = new SerializedString("&111;");
-    final static SerializedString THREE_BYTE_ESCAPED_STRING = new SerializedString("&1111;");
+    static final SerializedString TWO_BYTE_ESCAPED_STRING = new SerializedString("&111;");
+    static final SerializedString THREE_BYTE_ESCAPED_STRING = new SerializedString("&1111;");
     
-    final static class Pojo
+    static final class Pojo
     {
         int _x;
 

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 
 public class TestContextAttributeWithDeser extends BaseMapTest
 {
-    final static String KEY = "foobar";
+    static final String KEY = "foobar";
     
     @SuppressWarnings("serial")
     static class PrefixStringDeserializer extends StdScalarDeserializer<String>

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 
 public class TestContextAttributeWithSer extends BaseMapTest
 {
-    final static String KEY = "foobar";
+    static final String KEY = "foobar";
 
     @SuppressWarnings("serial")
     static class PrefixStringSerializer extends StdScalarSerializer<String>

--- a/src/test/java/com/fasterxml/jackson/databind/convert/ConvertingAbstractSerializer795Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/ConvertingAbstractSerializer795Test.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.util.StdConverter;
 // for [databind#795]
 public class ConvertingAbstractSerializer795Test extends BaseMapTest
 {
-    public static abstract class AbstractCustomType {
+    public abstract static class AbstractCustomType {
         final String value;
         public AbstractCustomType(String v) {
             this.value = v;

--- a/src/test/java/com/fasterxml/jackson/databind/convert/TestArrayConversions.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/TestArrayConversions.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.databind.*;
 public class TestArrayConversions
     extends com.fasterxml.jackson.databind.BaseMapTest
 {
-    final static String OVERFLOW_MSG_BYTE = "out of range of Java byte";
-    final static String OVERFLOW_MSG = "overflow";
+    static final String OVERFLOW_MSG_BYTE = "out of range of Java byte";
+    static final String OVERFLOW_MSG = "overflow";
 
     final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestCreatorWithNamingStrategy556.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestCreatorWithNamingStrategy556.java
@@ -64,7 +64,7 @@ public class TestCreatorWithNamingStrategy556
         MAPPER.setAnnotationIntrospector(new MyParamIntrospector());
     }
 
-    private final static String CTOR_JSON = aposToQuotes("{ 'MyAge' : 42,  'MyName' : 'NotMyRealName' }");
+    private static final String CTOR_JSON = aposToQuotes("{ 'MyAge' : 42,  'MyName' : 'NotMyRealName' }");
     
     public void testRenameViaCtor() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestCreatorWithPolymorphic113.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestCreatorWithPolymorphic113.java
@@ -9,11 +9,11 @@ import com.fasterxml.jackson.databind.*;
  */
 public class TestCreatorWithPolymorphic113 extends BaseMapTest
 {
-    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonSubTypes({@JsonSubTypes.Type(Dog.class)})
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "_class")
-    @JsonSubTypes({  @JsonSubTypes.Type(Dog.class) })
-    public static abstract class Animal {
-        public final static String ID = "id";
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public abstract static class Animal {
+        public static final String ID = "id";
 
         private String id;
 

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestCreators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestCreators.java
@@ -71,7 +71,8 @@ public class TestCreators
 
         private LongFactoryBean(long v) { value = v; }
 
-        @JsonCreator static protected LongFactoryBean valueOf(long v) {
+        @JsonCreator
+        protected static LongFactoryBean valueOf(long v) {
             return new LongFactoryBean(v);
         }
     }
@@ -81,7 +82,8 @@ public class TestCreators
 
         private StringFactoryBean(String v, boolean dummy) { value = v; }
 
-        @JsonCreator static protected StringFactoryBean valueOf(String v) {
+        @JsonCreator
+        protected static StringFactoryBean valueOf(String v) {
             return new StringFactoryBean(v, true);
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestPolymorphicCreators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestPolymorphicCreators.java
@@ -67,7 +67,7 @@ public class TestPolymorphicCreators
             throw new RuntimeException("cannot instantiate " + which);
         }
 
-        abstract public int getWhich();
+        public abstract int getWhich();
 
         public final String getOpt() {
             return opt;

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestPolymorphicDelegating.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestPolymorphicDelegating.java
@@ -9,7 +9,7 @@ public class TestPolymorphicDelegating extends BaseMapTest
     // For [databind#580]
     
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    static abstract class Issue580Base {
+    abstract static class Issue580Base {
     }
 
     static class Issue580Impl extends Issue580Base {

--- a/src/test/java/com/fasterxml/jackson/databind/creators/TestValueInstantiator.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/TestValueInstantiator.java
@@ -43,7 +43,7 @@ public class TestValueInstantiator extends BaseMapTest
         }
     }
 
-    static abstract class InstantiatorBase extends ValueInstantiator
+    abstract static class InstantiatorBase extends ValueInstantiator
     {
         @Override
         public String getValueTypeDesc() {
@@ -54,7 +54,7 @@ public class TestValueInstantiator extends BaseMapTest
         public boolean canCreateUsingDelegate() { return false; }
     }
     
-    static abstract class PolymorphicBeanBase { }
+    abstract static class PolymorphicBeanBase { }
     
     static class PolymorphicBean extends PolymorphicBeanBase
     {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestAbstract.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestAbstract.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.*;
 public class TestAbstract
     extends BaseMapTest
 {
-    static abstract class Abstract {
+    abstract static class Abstract {
         public int x;
     }
     

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestAnnotationIgnore.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestAnnotationIgnore.java
@@ -12,7 +12,7 @@ public class TestAnnotationIgnore
     extends BaseMapTest
 {
     // Class for testing {@link JsonIgnore} annotations with setters
-    final static class SizeClassIgnore
+    static final class SizeClassIgnore
     {
         int _x = 0;
         int _y = 0;
@@ -28,8 +28,8 @@ public class TestAnnotationIgnore
         }
     }
 
-    @JsonIgnoreProperties({ "z" })
-    final static class NoYOrZ
+    @JsonIgnoreProperties({"z"})
+    static final class NoYOrZ
     {
         public int x;
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestAnnotationUsing.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestAnnotationUsing.java
@@ -27,8 +27,8 @@ public class TestAnnotationUsing
      * Class for testing {@link JsonDeserializer} annotation
      * for class itself.
      */
-    @JsonDeserialize(using=ValueDeserializer.class)
-    final static class ValueClass {
+    @JsonDeserialize(using = ValueDeserializer.class)
+    static final class ValueClass {
         int _a;
         
         /* we'll test it by not having default no-arg ctor, and leaving
@@ -43,7 +43,7 @@ public class TestAnnotationUsing
      * Class for testing {@link JsonDeserializer} annotation
      * for a method
      */
-    final static class MethodBean {
+    static final class MethodBean {
         int[] _ints;
 
         /* Note: could be made to work otherwise, except that
@@ -99,7 +99,7 @@ public class TestAnnotationUsing
         }
     }
 
-    private final static class IntsDeserializer extends StdDeserializer<int[]>
+    private static final class IntsDeserializer extends StdDeserializer<int[]>
     {
         public IntsDeserializer() { super(int[].class); }
         @Override
@@ -110,7 +110,7 @@ public class TestAnnotationUsing
         }
     }
 
-    private final static class MapKeyDeserializer extends KeyDeserializer
+    private static final class MapKeyDeserializer extends KeyDeserializer
     {
         @Override
         public Object deserializeKey(String key, DeserializationContext ctxt)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestAnyProperties.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestAnyProperties.java
@@ -111,7 +111,7 @@ public class TestAnyProperties
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    static abstract class Base { }
+    abstract static class Base { }
 
     static class Impl extends Base {
         public String value;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestArrayDeserialization.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 public class TestArrayDeserialization
     extends BaseMapTest
 {
-    public final static class Bean1
+    public static final class Bean1
     {
         int _x, _y;
         List<Bean2> _beans;
@@ -58,7 +58,7 @@ public class TestArrayDeserialization
      * Deserialization from String value will be done via single-arg
      * constructor.
      */
-    public final static class Bean2
+    public static final class Bean2
         implements JsonSerializable // so we can output as simple String
     {
         final String _desc;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestBasicAnnotations.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestBasicAnnotations.java
@@ -25,7 +25,7 @@ public class TestBasicAnnotations
      */
 
     /// Class for testing {@link JsonProperty} annotations
-    final static class SizeClassSetter
+    static final class SizeClassSetter
     {
         int _size;
         int _length;
@@ -46,7 +46,7 @@ public class TestBasicAnnotations
         protected IntWrapper w = new IntWrapper(13);
     }
     
-    final static class SizeClassSetter2
+    static final class SizeClassSetter2
     {
         int _x;
 
@@ -60,7 +60,7 @@ public class TestBasicAnnotations
      * One more, but this time checking for implied setter
      * using @JsonDeserialize
      */
-    final static class SizeClassSetter3
+    static final class SizeClassSetter3
     {
         int _x;
 
@@ -94,7 +94,7 @@ public class TestBasicAnnotations
     /**********************************************************
      */
 
-    final static class IntsDeserializer extends StdDeserializer<int[]>
+    static final class IntsDeserializer extends StdDeserializer<int[]>
     {
         public IntsDeserializer() { super(int[].class); }
         @Override

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestCachingOfDeser.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestCachingOfDeser.java
@@ -52,8 +52,8 @@ public class TestCachingOfDeser extends BaseMapTest
     /**********************************************************
      */
 
-    final static String MAP_INPUT = "{\"map\":{\"a\":1}}";
-    final static String LIST_INPUT = "{\"list\":[1]}";
+    static final String MAP_INPUT = "{\"map\":{\"a\":1}}";
+    static final String LIST_INPUT = "{\"list\":[1]}";
 
     
     // Ok: first, use custom-annotated instance first, then standard

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestCollectionDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestCollectionDeserialization.java
@@ -75,7 +75,7 @@ public class TestCollectionDeserialization
     /**********************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     
     public void testUntypedList() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestConfig.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestConfig.java
@@ -12,10 +12,10 @@ import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
 public class TestConfig
     extends BaseMapTest
 {
-    @JsonAutoDetect(setterVisibility=Visibility.NONE)
-    final static class Dummy { }
+    @JsonAutoDetect(setterVisibility = Visibility.NONE)
+    static final class Dummy { }
 
-    final static class EmptyDummy { }
+    static final class EmptyDummy { }
 
     static class AnnoBean {
         int value = 3;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestGenerics.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestGenerics.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.*;
 public class TestGenerics
     extends BaseMapTest
 {
-    static abstract class BaseNumberBean<T extends Number>
+    abstract static class BaseNumberBean<T extends Number>
     {
         public abstract void setNumber(T value);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestIgnoredTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestIgnoredTypes.java
@@ -47,7 +47,7 @@ public class TestIgnoredTypes extends BaseMapTest
     }
     
     @JsonIgnoreType
-    static abstract class PersonMixin {
+    abstract static class PersonMixin {
     }
     
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestJDKAtomicTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestJDKAtomicTypes.java
@@ -11,9 +11,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public class TestJDKAtomicTypes
     extends com.fasterxml.jackson.databind.BaseMapTest
 {
+    @JsonSubTypes({@JsonSubTypes.Type(Impl.class)})
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
-    @JsonSubTypes({ @JsonSubTypes.Type(Impl.class) })
-    static abstract class Base { }
+    abstract static class Base { }
 
     @JsonTypeName("I")
     static class Impl extends Base {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestJdkTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestJdkTypes.java
@@ -71,7 +71,7 @@ public class TestJdkTypes extends BaseMapTest
 
     // [Issue#429]
     static class StackTraceBean {
-        public final static int NUM = 13;
+        public static final int NUM = 13;
 
         @JsonProperty("Location")
         @JsonDeserialize(using=MyStackTraceElementDeserializer.class)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestSimpleTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestSimpleTypes.java
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 public class TestSimpleTypes
     extends BaseMapTest
 {
-    final static String NAN_STRING = "NaN";
+    static final String NAN_STRING = "NaN";
 
-    final static class BooleanBean {
+    static final class BooleanBean {
         boolean _v;
         void setV(boolean v) { _v = v; }
     }
@@ -33,23 +33,23 @@ public class TestSimpleTypes
         void setV(int v) { _v = v; }
     }
 
-    final static class DoubleBean {
+    static final class DoubleBean {
         double _v;
         void setV(double v) { _v = v; }
     }
 
-    final static class FloatBean {
+    static final class FloatBean {
         float _v;
         void setV(float v) { _v = v; }
     }
     
-    final static class CharacterBean {
+    static final class CharacterBean {
         char _v;
         void setV(char v) { _v = v; }
         char getV() { return _v; }
     }
     
-    final static class CharacterWrapperBean {
+    static final class CharacterWrapperBean {
         Character _v;
         void setV(Character v) { _v = v; }
         Character getV() { return _v; }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestValueAnnotations.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestValueAnnotations.java
@@ -86,7 +86,7 @@ public class TestValueAnnotations
     /* Class for testing valid {@link JsonDeserialize} annotation
      * with 'as' parameter to define concrete class to deserialize to
      */
-    final static class CollectionHolder
+    static final class CollectionHolder
     {
         Collection<String> _strings;
 
@@ -103,7 +103,7 @@ public class TestValueAnnotations
     /* Another class for testing valid {@link JsonDeserialize} annotation
      * with 'as' parameter to define concrete class to deserialize to
      */
-    final static class MapHolder
+    static final class MapHolder
     {
         // Let's also coerce numbers into Strings here
         Map<String,String> _data;
@@ -121,7 +121,7 @@ public class TestValueAnnotations
     /* Another class for testing valid {@link JsonDeserialize} annotation
      * with 'as' parameter, but with array
      */
-    final static class ArrayHolder
+    static final class ArrayHolder
     {
         String[] _strings;
 
@@ -136,7 +136,7 @@ public class TestValueAnnotations
     /* Another class for testing broken {@link JsonDeserialize} annotation
      * with 'as' parameter; one with incompatible type
      */
-    final static class BrokenCollectionHolder
+    static final class BrokenCollectionHolder
     {
         @JsonDeserialize(as=String.class) // not assignable to Collection
         public void setStrings(Collection<String> s) { }
@@ -148,14 +148,14 @@ public class TestValueAnnotations
     /**********************************************************
      */
 
-    final static class StringWrapper
+    static final class StringWrapper
     {
         final String _string;
 
         public StringWrapper(String s) { _string = s; }
     }
 
-    final static class MapKeyHolder
+    static final class MapKeyHolder
     {
         Map<Object, String> _map;
 
@@ -167,7 +167,7 @@ public class TestValueAnnotations
         }
     }
 
-    final static class BrokenMapKeyHolder
+    static final class BrokenMapKeyHolder
     {
         // Invalid: Integer not a sub-class of String
         @JsonDeserialize(keyAs=Integer.class)
@@ -180,7 +180,7 @@ public class TestValueAnnotations
     /**********************************************************
      */
 
-    final static class ListContentHolder
+    static final class ListContentHolder
     {
         List<?> _list;
 
@@ -190,7 +190,7 @@ public class TestValueAnnotations
         }
     }
 
-    final static class InvalidContentClass
+    static final class InvalidContentClass
     {
         /* Such annotation not allowed, since it makes no sense;
          * non-container classes have no contents to annotate (but
@@ -202,7 +202,7 @@ public class TestValueAnnotations
             public void setValue(Object x) { }
     }
 
-    final static class ArrayContentHolder
+    static final class ArrayContentHolder
     {
         Object[] _data;
 
@@ -213,7 +213,7 @@ public class TestValueAnnotations
         }
     }
 
-    final static class MapContentHolder
+    static final class MapContentHolder
     {
         Map<Object,Object> _map;
 

--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestDOM.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestDOM.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestDOM extends com.fasterxml.jackson.databind.BaseMapTest
 {
-    final static String SIMPLE_XML =
+    static final String SIMPLE_XML =
         "<root attr='3'><leaf>Rock &amp; Roll!</leaf><?proc instr?></root>";
-    final static String SIMPLE_XML_NS =
+    static final String SIMPLE_XML_NS =
         "<root ns:attr='abc' xmlns:ns='http://foo' />";
     
     public void testSerializeSimpleNonNS() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/filter/JsonIncludeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/filter/JsonIncludeTest.java
@@ -125,7 +125,7 @@ public class JsonIncludeTest
     /**********************************************************
      */
 
-    final private ObjectMapper MAPPER = new ObjectMapper();
+    private final ObjectMapper MAPPER = new ObjectMapper();
 
     public void testGlobal() throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/databind/filter/MapInclusionTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/filter/MapInclusionTest.java
@@ -26,7 +26,7 @@ public class MapInclusionTest extends BaseMapTest
     /**********************************************************
      */
 
-    final private ObjectMapper MAPPER = objectMapper();
+    private final ObjectMapper MAPPER = objectMapper();
 
     // [databind#588]
     public void testNonNullValueMapViaProp() throws IOException

--- a/src/test/java/com/fasterxml/jackson/databind/filter/TestSimpleSerializationIgnore.java
+++ b/src/test/java/com/fasterxml/jackson/databind/filter/TestSimpleSerializationIgnore.java
@@ -14,7 +14,7 @@ public class TestSimpleSerializationIgnore
     extends BaseMapTest
 {
     // Class for testing enabled {@link JsonIgnore} annotation
-    final static class SizeClassEnabledIgnore
+    static final class SizeClassEnabledIgnore
     {
         @JsonIgnore public int getY() { return 9; }
 
@@ -26,7 +26,7 @@ public class TestSimpleSerializationIgnore
     }
 
     // Class for testing disabled {@link JsonIgnore} annotation
-    final static class SizeClassDisabledIgnore
+    static final class SizeClassDisabledIgnore
     {
         // note: must be public to be seen
         public int getX() { return 3; }

--- a/src/test/java/com/fasterxml/jackson/databind/filter/TestUnknownPropertyDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/filter/TestUnknownPropertyDeserialization.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 public class TestUnknownPropertyDeserialization
     extends BaseMapTest
 {
-    final static String JSON_UNKNOWN_FIELD = "{ \"a\" : 1, \"foo\" : [ 1, 2, 3], \"b\" : -1 }";
+    static final String JSON_UNKNOWN_FIELD = "{ \"a\" : 1, \"foo\" : [ 1, 2, 3], \"b\" : -1 }";
 
     /*
     /**********************************************************
@@ -23,7 +23,7 @@ public class TestUnknownPropertyDeserialization
     /**********************************************************
      */
 
-    final static class TestBean
+    static final class TestBean
     {
         String _unknown;
 
@@ -42,7 +42,7 @@ public class TestUnknownPropertyDeserialization
      * just marks unknown property/ies when encountered, along with
      * Json value of the property.
      */
-    final static class MyHandler
+    static final class MyHandler
         extends DeserializationProblemHandler
     {
         @Override

--- a/src/test/java/com/fasterxml/jackson/databind/interop/TestExternalizable.java
+++ b/src/test/java/com/fasterxml/jackson/databind/interop/TestExternalizable.java
@@ -17,7 +17,7 @@ public class TestExternalizable extends BaseMapTest
      */
     static class MapperHolder {
         private final ObjectMapper mapper = new ObjectMapper();
-        private final static MapperHolder instance = new MapperHolder();
+        private static final MapperHolder instance = new MapperHolder();
         public static ObjectMapper mapper() { return instance.mapper; }
     }
 
@@ -25,7 +25,7 @@ public class TestExternalizable extends BaseMapTest
      * Helper class we need to adapt {@link ObjectOutput} as
      * {@link OutputStream}
      */
-    final static class ExternalizableInput extends InputStream
+    static final class ExternalizableInput extends InputStream
     {
         private final ObjectInput in;
 
@@ -73,7 +73,7 @@ public class TestExternalizable extends BaseMapTest
      * Helper class we need to adapt {@link ObjectOutput} as
      * {@link OutputStream}
      */
-    final static class ExternalizableOutput extends OutputStream
+    static final class ExternalizableOutput extends OutputStream
     {
         private final ObjectOutput out;
 

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/BeanDescriptionTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/BeanDescriptionTest.java
@@ -7,7 +7,7 @@ public class BeanDescriptionTest extends BaseMapTest
 {
     private final ObjectMapper MAPPER = objectMapper();
 
-    private final static String CLASS_DESC = "Description, yay!";
+    private static final String CLASS_DESC = "Description, yay!";
     
     @JsonClassDescription(CLASS_DESC)
     static class DocumentedBean {

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestAnnotionBundles.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestAnnotionBundles.java
@@ -25,7 +25,7 @@ public class TestAnnotionBundles extends com.fasterxml.jackson.databind.BaseMapT
     @JsonProperty("foobar")
     private @interface MyRename { }
 
-    protected final static class Bean {
+    protected static final class Bean {
         @MyIgnoral
         public String getIgnored() { return "foo"; }
  

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestPOJOPropertiesCollector.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestPOJOPropertiesCollector.java
@@ -187,8 +187,8 @@ public class TestPOJOPropertiesCollector
 
     static class PropDescBean
     {
-        public final static String A_DESC = "That's A!";
-        public final static int B_INDEX = 3;
+        public static final String A_DESC = "That's A!";
+        public static final int B_INDEX = 3;
 
         @JsonPropertyDescription(A_DESC)
         public String a;

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestAbstractTypeNames.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestAbstractTypeNames.java
@@ -82,7 +82,7 @@ public class TestAbstractTypeNames  extends BaseMapTest
         public int getValue() { return value; }
     }
 
-    final static class BeanWithAnon {
+    static final class BeanWithAnon {
         public BaseValue bean = new BaseValue() {
             @Override
             public String toString() { return "sub!"; }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestCustomTypeIdResolver.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestCustomTypeIdResolver.java
@@ -13,9 +13,9 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 
 public class TestCustomTypeIdResolver extends BaseMapTest
 {
-    @JsonTypeInfo(use=Id.CUSTOM, include=As.WRAPPER_OBJECT)
     @JsonTypeIdResolver(CustomResolver.class)
-    static abstract class CustomBean { }
+    @JsonTypeInfo(use = Id.CUSTOM, include = As.WRAPPER_OBJECT)
+    abstract static class CustomBean { }
 
     static class CustomBeanImpl extends CustomBean {
         public int x;
@@ -46,7 +46,7 @@ public class TestCustomTypeIdResolver extends BaseMapTest
         }
     }
     
-    static abstract class ExtBean { }
+    abstract static class ExtBean { }
 
     static class ExtBeanImpl extends ExtBean {
         public int y;

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultForObject.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultForObject.java
@@ -17,7 +17,7 @@ public class TestDefaultForObject
     /**********************************************************
      */
 
-    static abstract class AbstractBean { }
+    abstract static class AbstractBean { }
     
     static class StringBean extends AbstractBean { // ha, punny!
         public String name;
@@ -54,7 +54,7 @@ public class TestDefaultForObject
         }
     }
 
-    final static class BeanHolder
+    static final class BeanHolder
     {
         public AbstractBean bean;
         
@@ -62,7 +62,7 @@ public class TestDefaultForObject
         public BeanHolder(AbstractBean b) { bean = b; }
     }
 
-    final static class ObjectHolder
+    static final class ObjectHolder
     {
         public Object value;
 
@@ -79,7 +79,7 @@ public class TestDefaultForObject
         public String subject;
     }
 
-    static public class DomainBeanWrapper {
+    public static class DomainBeanWrapper {
         public String name;
         public Object myBean;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultWithCreators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultWithCreators.java
@@ -14,7 +14,7 @@ public class TestDefaultWithCreators
     /**********************************************************
      */
 
-    static abstract class Job
+    abstract static class Job
     {
         public long id;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestNoTypeInfo.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestNoTypeInfo.java
@@ -12,7 +12,7 @@ public class TestNoTypeInfo extends BaseMapTest
     static interface NoTypeInterface {
     }
     
-    final static class NoType implements NoTypeInterface {
+    static final class NoType implements NoTypeInterface {
         public int a = 3;
     }
     

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestOverlappingTypeIdNames312.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestOverlappingTypeIdNames312.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.databind.*;
 
 public class TestOverlappingTypeIdNames312 extends BaseMapTest
 {
-    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes({
             @JsonSubTypes.Type(name = "a", value = Impl312.class),
             @JsonSubTypes.Type(name = "b", value = Impl312.class)
     })
-    static abstract class Base312 { }
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    abstract static class Base312 { }
 
     static class Impl312 extends Base312 {
         public int x;

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -98,8 +98,8 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
     }
 
     // for [databind#656]
-    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include= JsonTypeInfo.As.WRAPPER_OBJECT, defaultImpl=ImplFor656.class)
-    static abstract class BaseFor656 { }
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT, defaultImpl = ImplFor656.class)
+    abstract static class BaseFor656 { }
 
     static class ImplFor656 extends BaseFor656 {
         public int a;

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
 {
-    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME)
-    static abstract class SuperType {
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+    abstract static class SuperType {
     }
 
     @JsonTypeName("TypeB")
@@ -32,8 +32,8 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
     }
 
     // "Empty" bean, to test [JACKSON-366]
-    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME)
-    static abstract class BaseBean { }
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+    abstract static class BaseBean { }
     
     static class EmptyBean extends BaseBean { }
 
@@ -51,26 +51,26 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
     }
 
     // And then [JACKSON-614]
-    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=As.PROPERTY,
-            property="#type",
-            defaultImpl=DefaultImpl.class)
-    static abstract class SuperTypeWithDefault { }
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY,
+            property = "#type",
+            defaultImpl = DefaultImpl.class)
+    abstract static class SuperTypeWithDefault { }
 
     static class DefaultImpl extends SuperTypeWithDefault {
         public int a;
     }
 
-    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=As.PROPERTY, property="#type")
-    static abstract class SuperTypeWithoutDefault { }
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "#type")
+    abstract static class SuperTypeWithoutDefault { }
 
     static class DefaultImpl505 extends SuperTypeWithoutDefault {
         public int a;
     }
 
-    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=As.PROPERTY, property="type")
-    @JsonSubTypes({ @JsonSubTypes.Type(ImplX.class),
-          @JsonSubTypes.Type(ImplY.class) })
-    static abstract class BaseX { }
+    @JsonSubTypes({@JsonSubTypes.Type(ImplX.class),
+            @JsonSubTypes.Type(ImplY.class)})
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "type")
+    abstract static class BaseX { }
 
     @JsonTypeName("x")
     static class ImplX extends BaseX {

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypesExistingProperty.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypesExistingProperty.java
@@ -17,13 +17,13 @@ public class TestSubtypesExistingProperty extends BaseMapTest {
     /**
      * Polymorphic base class - existing property as simple property on subclasses
      */
-	@JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type",
-	        visible=true)
-	@JsonSubTypes({
-		@Type(value = Apple.class, name = "apple") ,
-		@Type(value = Orange.class, name = "orange") 
-		})
-	static abstract class Fruit {
+    @JsonSubTypes({
+            @Type(value = Apple.class, name = "apple"),
+            @Type(value = Orange.class, name = "orange")
+    })
+    @JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type",
+            visible = true)
+    abstract static class Fruit {
         public String name;
         protected Fruit(String n)  { name = n; }
     }
@@ -65,12 +65,12 @@ public class TestSubtypesExistingProperty extends BaseMapTest {
     /**
      * Polymorphic base class - existing property forced by abstract method
      */
-	@JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type")
-	@JsonSubTypes({
-		@Type(value = Dog.class, name = "doggie") ,
-		@Type(value = Cat.class, name = "kitty") 
-		})
-	static abstract class Animal {
+    @JsonSubTypes({
+            @Type(value = Dog.class, name = "doggie"),
+            @Type(value = Cat.class, name = "kitty")
+    })
+    @JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type")
+    abstract static class Animal {
         public String name;
         
         protected Animal(String n)  { name = n; }
@@ -122,12 +122,12 @@ public class TestSubtypesExistingProperty extends BaseMapTest {
     /**
      * Polymorphic base class - existing property NOT forced by abstract method on base class
      */
-	@JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type")
-	@JsonSubTypes({
-		@Type(value = Accord.class, name = "accord") ,
-		@Type(value = Camry.class, name = "camry") 
-		})
-	static abstract class Car {
+    @JsonSubTypes({
+            @Type(value = Accord.class, name = "accord"),
+            @Type(value = Camry.class, name = "camry")
+    })
+    @JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type")
+    abstract static class Car {
         public String name;        
         protected Car(String n)  { name = n; }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedContainerSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedContainerSerialization.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 public class TestTypedContainerSerialization
 	extends BaseMapTest
 {
-    @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "object-type")
-    @JsonSubTypes( { @Type(value = Dog.class, name = "doggy"),
-        @Type(value = Cat.class, name = "kitty") })
-    static abstract class Animal {
+    @JsonSubTypes({@Type(value = Dog.class, name = "doggy"),
+			@Type(value = Cat.class, name = "kitty")})
+	@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "object-type")
+	abstract static class Animal {
 	    public String name;
 
 	    protected Animal(String n) {
@@ -97,7 +97,7 @@ public class TestTypedContainerSerialization
     static class Issue508A { }
     static class Issue508B extends Issue508A { }
 
-    private final static ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     /*
     /**********************************************************

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedDeserialization.java
@@ -21,8 +21,8 @@ public class TestTypedDeserialization
     /**
      * Polymorphic base class
      */
-    @JsonTypeInfo(use=Id.CLASS, include=As.PROPERTY, property="@classy")
-    static abstract class Animal {
+    @JsonTypeInfo(use = Id.CLASS, include = As.PROPERTY, property = "@classy")
+    abstract static class Animal {
         public String name;
         
         protected Animal(String n)  { name = n; }
@@ -71,8 +71,8 @@ public class TestTypedDeserialization
     }
 
     // base class with no useful info
-    @JsonTypeInfo(use=Id.CLASS, include=As.WRAPPER_ARRAY)
-    static abstract class DummyBase {
+    @JsonTypeInfo(use = Id.CLASS, include = As.WRAPPER_ARRAY)
+    abstract static class DummyBase {
         protected DummyBase(boolean foo) { }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedSerialization.java
@@ -21,8 +21,8 @@ public class TestTypedSerialization
     /**
      * Polymorphic base class
      */
-    @JsonTypeInfo(use=Id.CLASS, include=As.PROPERTY)
-    static abstract class Animal {
+    @JsonTypeInfo(use = Id.CLASS, include = As.PROPERTY)
+    abstract static class Animal {
         public String name;
         
         protected Animal(String n)  { name = n; }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestVisibleTypeId.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestVisibleTypeId.java
@@ -108,9 +108,9 @@ public class TestVisibleTypeId extends BaseMapTest
         public String getType2() { return "type2"; };
     }
 
-    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "name")
-    @JsonSubTypes({ @JsonSubTypes.Type(value=I263Impl.class) })
-    public static abstract class I263Base {
+    @JsonSubTypes({@JsonSubTypes.Type(value = I263Impl.class)})
+    @JsonTypeInfo(use = Id.NAME, property = "name")
+    public abstract static class I263Base {
         @JsonTypeId
         public abstract String getName();
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestWithGenerics.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestWithGenerics.java
@@ -14,9 +14,9 @@ import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
 
 public class TestWithGenerics extends BaseMapTest
 {
+    @JsonSubTypes({@Type(value = Dog.class, name = "doggy")})
     @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "object-type")
-    @JsonSubTypes( { @Type(value = Dog.class, name = "doggy") })
-    static abstract class Animal {
+    abstract static class Animal {
         public String name;
     }    
 

--- a/src/test/java/com/fasterxml/jackson/databind/misc/BeanPropertyMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/misc/BeanPropertyMapTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 // for [databind#884]
 public class BeanPropertyMapTest extends BaseMapTest
 {
-    protected final static JavaType BOGUS_TYPE = TypeFactory.unknownType();
+    protected static final JavaType BOGUS_TYPE = TypeFactory.unknownType();
     
     @SuppressWarnings("serial")
     static class MyObjectIdReader extends ObjectIdReader

--- a/src/test/java/com/fasterxml/jackson/databind/misc/RaceCondition738Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/misc/RaceCondition738Test.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RaceCondition738Test extends BaseMapTest
 {
-    static abstract class AbstractHasSubTypes implements HasSubTypes { }
+    abstract static class AbstractHasSubTypes implements HasSubTypes { }
 
     static class TypeOne extends AbstractHasSubTypes {
         private final String id;

--- a/src/test/java/com/fasterxml/jackson/databind/mixins/TestMixinInheritance.java
+++ b/src/test/java/com/fasterxml/jackson/databind/mixins/TestMixinInheritance.java
@@ -30,13 +30,13 @@ public class TestMixinInheritance
         public String getNameo() { return "Bill"; }
     }
 
-    static abstract class BeanoMixinSuper2 extends Beano2 {
+    abstract static class BeanoMixinSuper2 extends Beano2 {
         @Override
         @JsonProperty("name")
         public abstract String getNameo();
     }
 
-    static abstract class BeanoMixinSub2 extends BeanoMixinSuper2 {
+    abstract static class BeanoMixinSub2 extends BeanoMixinSuper2 {
         @Override
         @JsonProperty("id")
         public abstract int getIdo();

--- a/src/test/java/com/fasterxml/jackson/databind/module/TestSimpleModule.java
+++ b/src/test/java/com/fasterxml/jackson/databind/module/TestSimpleModule.java
@@ -26,7 +26,7 @@ public class TestSimpleModule extends BaseMapTest
     /**
      * Trivial bean that requires custom serializer and deserializer
      */
-    final static class CustomBean
+    static final class CustomBean
     {
         protected String str;
         protected int num;

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestTreeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestTreeDeserialization.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 public class TestTreeDeserialization
     extends BaseMapTest
 {
-    final static class Bean {
+    static final class Bean {
         int _x;
         JsonNode _node;
 
@@ -117,7 +117,7 @@ public class TestTreeDeserialization
         assertTrue(n.isNull());
     }
 
-    final static class CovarianceBean {
+    static final class CovarianceBean {
         ObjectNode _object;
         ArrayNode _array;
 

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestTreeMapperSerializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestTreeMapperSerializer.java
@@ -14,15 +14,15 @@ import com.fasterxml.jackson.databind.*;
 public class TestTreeMapperSerializer
     extends BaseMapTest
 {
-    final static String FIELD1 = "first";
-    final static String FIELD2 = "Second?";
-    final static String FIELD3 = "foo'n \"bar\"";
-    final static String FIELD4 = "4";
+    static final String FIELD1 = "first";
+    static final String FIELD2 = "Second?";
+    static final String FIELD3 = "foo'n \"bar\"";
+    static final String FIELD4 = "4";
 
-    final static String TEXT1 = "Some text & \"stuff\"";
-    final static String TEXT2 = "Some more text:\twith\nlinefeeds and all!";
+    static final String TEXT1 = "Some text & \"stuff\"";
+    static final String TEXT2 = "Some more text:\twith\nlinefeeds and all!";
 
-    final static double DOUBLE_VALUE = 9.25;
+    static final double DOUBLE_VALUE = 9.25;
 
     public void testFromArray()
         throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdDeserialization.java
@@ -190,7 +190,7 @@ public class TestObjectIdDeserialization extends BaseMapTest
 
     private final ObjectMapper MAPPER = new ObjectMapper();
     
-    private final static String EXP_SIMPLE_INT_CLASS = "{\"id\":1,\"value\":13,\"next\":1}";
+    private static final String EXP_SIMPLE_INT_CLASS = "{\"id\":1,\"value\":13,\"next\":1}";
 
     public void testSimpleDeserializationClass() throws Exception
     {
@@ -240,7 +240,7 @@ public class TestObjectIdDeserialization extends BaseMapTest
     }
 
     // Bit more complex, due to extra wrapping etc:
-    private final static String EXP_SIMPLE_INT_PROP = "{\"node\":{\"@id\":1,\"value\":7,\"next\":{\"node\":1}}}";
+    private static final String EXP_SIMPLE_INT_PROP = "{\"node\":{\"@id\":1,\"value\":7,\"next\":{\"node\":1}}}";
         
     public void testSimpleDeserializationProperty() throws Exception
     {
@@ -396,7 +396,7 @@ public class TestObjectIdDeserialization extends BaseMapTest
     /*****************************************************
      */
 
-    private final static String EXP_CUSTOM_VIA_CLASS = "{\"customId\":123,\"value\":-900,\"next\":123}";
+    private static final String EXP_CUSTOM_VIA_CLASS = "{\"customId\":123,\"value\":-900,\"next\":123}";
 
     public void testCustomDeserializationClass() throws Exception
     {
@@ -406,7 +406,7 @@ public class TestObjectIdDeserialization extends BaseMapTest
         assertSame(result, result.next);
     }
 
-    private final static String EXP_CUSTOM_VIA_PROP = "{\"node\":{\"customId\":3,\"value\":99,\"next\":{\"node\":3}}}";
+    private static final String EXP_CUSTOM_VIA_PROP = "{\"node\":{\"customId\":3,\"value\":99,\"next\":{\"node\":3}}}";
     
     public void testCustomDeserializationProperty() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdSerialization.java
@@ -169,7 +169,7 @@ public class TestObjectIdSerialization extends BaseMapTest
     /*****************************************************
      */
 
-    private final static String EXP_SIMPLE_INT_CLASS = "{\"id\":1,\"value\":13,\"next\":1}";
+    private static final String EXP_SIMPLE_INT_CLASS = "{\"id\":1,\"value\":13,\"next\":1}";
     
     private final ObjectMapper MAPPER = objectMapper();
 
@@ -188,7 +188,7 @@ public class TestObjectIdSerialization extends BaseMapTest
     }
     
     // Bit more complex, due to extra wrapping etc:
-    private final static String EXP_SIMPLE_INT_PROP = "{\"node\":{\"@id\":1,\"value\":7,\"next\":{\"node\":1}}}";
+    private static final String EXP_SIMPLE_INT_PROP = "{\"node\":{\"@id\":1,\"value\":7,\"next\":{\"node\":1}}}";
 
     public void testSimpleSerializationProperty() throws Exception
     {
@@ -245,7 +245,7 @@ public class TestObjectIdSerialization extends BaseMapTest
     /*****************************************************
      */
 
-    private final static String EXP_CUSTOM_PROP = "{\"customId\":123,\"value\":-19,\"next\":123}";
+    private static final String EXP_CUSTOM_PROP = "{\"customId\":123,\"value\":-19,\"next\":123}";
     // Test for verifying that custom
     public void testCustomPropertyForClass() throws Exception
     {
@@ -261,7 +261,7 @@ public class TestObjectIdSerialization extends BaseMapTest
         assertEquals(EXP_CUSTOM_PROP, json);
     }
 
-    private final static String EXP_CUSTOM_PROP_VIA_REF = "{\"node\":{\"id\":123,\"value\":7,\"next\":{\"node\":123}}}";
+    private static final String EXP_CUSTOM_PROP_VIA_REF = "{\"node\":{\"id\":123,\"value\":7,\"next\":{\"node\":123}}}";
     // Test for verifying that custom
     public void testCustomPropertyViaProperty() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithPolymorphic.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithPolymorphic.java
@@ -13,9 +13,9 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 
 public class TestObjectIdWithPolymorphic extends BaseMapTest
 {
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class, property="id")
-    static abstract class Base
+    abstract static class Base
     {
         public int value;
         public Base next;
@@ -63,7 +63,7 @@ public class TestObjectIdWithPolymorphic extends BaseMapTest
         public Process() { super(null); }
     }
     
-    public static abstract class Activity extends Base811 {
+    public abstract static class Activity extends Base811 {
         protected Activity parent;
         public Activity(Process owner, Activity parent) {
                 super(owner);

--- a/src/test/java/com/fasterxml/jackson/databind/ser/RawValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/RawValueTest.java
@@ -22,8 +22,8 @@ public class RawValueTest
      */
 
     /// Class for testing {@link JsonRawValue} annotations with getters returning String
-    @JsonPropertyOrder(alphabetic=true)
-    final static class ClassGetter<T>
+    @JsonPropertyOrder(alphabetic = true)
+    static final class ClassGetter<T>
     {
         protected final T _value;
     	

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestAnnotations.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestAnnotations.java
@@ -24,7 +24,7 @@ public class TestAnnotations
      */
 
     /// Class for testing {@link JsonProperty} annotations with getters
-    final static class SizeClassGetter
+    static final class SizeClassGetter
     {
         @JsonProperty public int size() { return 3; }
         @JsonProperty("length") public int foobar() { return -17; }
@@ -36,14 +36,14 @@ public class TestAnnotations
     }
 
     // And additional testing to cover [JACKSON-64]
-    final static class SizeClassGetter2
+    static final class SizeClassGetter2
     {
         // Should still be considered property "x"
         @JsonProperty protected int getX() { return 3; }
     }
 
     // and some support for testing [JACKSON-120]
-    final static class SizeClassGetter3
+    static final class SizeClassGetter3
     {
         // Should be considered property "y" even tho non-public
         @JsonSerialize protected int getY() { return 8; }
@@ -54,15 +54,15 @@ public class TestAnnotations
      * Class for testing {@link JsonSerializer} annotation
      * for class itself.
      */
-    @JsonSerialize(using=BogusSerializer.class)
-    final static class ClassSerializer {
+    @JsonSerialize(using = BogusSerializer.class)
+    static final class ClassSerializer {
     }
 
     /**
      * Class for testing an active {@link JsonSerialize#using} annotation
      * for a method
      */
-    final static class ClassMethodSerializer {
+    static final class ClassMethodSerializer {
         private int _x;
 
         public ClassMethodSerializer(int x) { _x = x; }
@@ -75,7 +75,7 @@ public class TestAnnotations
      * Class for testing an inactive (one that will not have any effect)
      * {@link JsonSerialize} annotation for a method
      */
-    final static class InactiveClassMethodSerializer {
+    static final class InactiveClassMethodSerializer {
         private int _x;
 
         public InactiveClassMethodSerializer(int x) { _x = x; }
@@ -135,7 +135,7 @@ public class TestAnnotations
     /**********************************************************
      */
 
-    public final static class BogusSerializer extends JsonSerializer<Object>
+    public static final class BogusSerializer extends JsonSerializer<Object>
     {
         @Override
         public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider)
@@ -145,7 +145,7 @@ public class TestAnnotations
         }
     }
 
-    private final static class StringSerializer extends JsonSerializer<Object>
+    private static final class StringSerializer extends JsonSerializer<Object>
     {
         @Override
         public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider)

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestAnyGetter.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestAnyGetter.java
@@ -13,7 +13,7 @@ public class TestAnyGetter extends BaseMapTest
 {
     static class Bean
     {
-        final static Map<String,Boolean> extra = new HashMap<String,Boolean>();
+        static final Map<String,Boolean> extra = new HashMap<String,Boolean>();
         static {
             extra.put("a", Boolean.TRUE);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestCollectionSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestCollectionSerialization.java
@@ -14,7 +14,7 @@ public class TestCollectionSerialization
     enum Key { A, B, C };
 
     // Field-based simple bean with a single property, "values"
-    final static class CollectionBean
+    static final class CollectionBean
     {
         @JsonProperty // not required
         public Collection<Object> values;
@@ -72,7 +72,7 @@ public class TestCollectionSerialization
     /**********************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public void testCollections() throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestConfig.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestConfig.java
@@ -22,11 +22,11 @@ public class TestConfig
     /**********************************************************
      */
 
+    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    @JsonSerialize(typing=JsonSerialize.Typing.STATIC)
-    final static class Config { }
+    static final class Config { }
 
-    final static class ConfigNone { }
+    static final class ConfigNone { }
 
     static class AnnoBean {
         public int getX() { return 1; }
@@ -48,7 +48,7 @@ public class TestConfig
     /**********************************************************
      */
 
-    final static ObjectMapper MAPPER = new ObjectMapper();
+    static final ObjectMapper MAPPER = new ObjectMapper();
 
     /* Test to verify that we don't overflow number of features; if we
      * hit the limit, need to change implementation -- this test just
@@ -224,7 +224,7 @@ public class TestConfig
         assertEquals(tz1, mapper.reader().getConfig().getTimeZone());
     }
     
-    private final static String getLF() {
+    private static final String getLF() {
         return System.getProperty("line.separator");
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestIterable.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestIterable.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class TestIterable extends BaseMapTest
 {
-    final static class IterableWrapper
+    static final class IterableWrapper
         implements Iterable<Integer>
     {
         List<Integer> _ints = new ArrayList<Integer>();
@@ -96,7 +96,7 @@ public class TestIterable extends BaseMapTest
     /**********************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     
     public void testIterator() throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestJsonValue.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestJsonValue.java
@@ -38,7 +38,7 @@ public class TestJsonValue
      * method. Difference is between Integer serialization, and
      * conversion to a Json String.
      */
-    final static class ToStringValueClass<T>
+    static final class ToStringValueClass<T>
         extends ValueClass<T>
     {
         public ToStringValueClass(T value) { super(value); }
@@ -49,7 +49,7 @@ public class TestJsonValue
         @JsonValue T value() { return super.value(); }
     }
 
-    final static class ToStringValueClass2
+    static final class ToStringValueClass2
         extends ValueClass<String>
     {
         public ToStringValueClass2(String value) { super(value); }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestMapSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestMapSerialization.java
@@ -129,7 +129,7 @@ public class TestMapSerialization extends BaseMapTest
     /**********************************************************
      */
 
-    final private ObjectMapper MAPPER = objectMapper();
+    private final ObjectMapper MAPPER = objectMapper();
 
     public void testUsingObjectWriter() throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestStatics.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestStatics.java
@@ -18,7 +18,7 @@ public class TestStatics
     /**********************************************************
      */
 
-    final static class FieldBean
+    static final class FieldBean
     {
         public int x = 1;
 
@@ -28,7 +28,7 @@ public class TestStatics
         @JsonProperty public static int z = 3;
     }
 
-    final static class GetterBean
+    static final class GetterBean
     {
         public int getX() { return 3; }
 

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestTreeSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestTreeSerialization.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.node.*;
 public class TestTreeSerialization
     extends BaseMapTest
 {
-    final static class Bean {
+    static final class Bean {
         public String getX() { return "y"; }
         public int getY() { return 13; }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestUnwrappedWithTypeInfo.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestUnwrappedWithTypeInfo.java
@@ -17,7 +17,8 @@ public class TestUnwrappedWithTypeInfo extends BaseMapTest
 	@JsonTypeName("OuterType")
 	static class Outer {
 
-		private @JsonProperty String p1;
+		@JsonProperty
+		private String p1;
 		public String getP1() { return p1; }
 		public void setP1(String p1) { this.p1 = p1; }
 
@@ -35,7 +36,8 @@ public class TestUnwrappedWithTypeInfo extends BaseMapTest
 	@JsonTypeName("InnerType")
 	static class Inner {
 
-		private @JsonProperty String p2;
+		@JsonProperty
+		private String p2;
 		public String getP2() { return p2; }
 		public void setP2(String p2) { this.p2 = p2; }
 

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestFormatForCollections.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestFormatForCollections.java
@@ -40,7 +40,7 @@ public class TestFormatForCollections extends BaseMapTest
     /**********************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();    
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
 
     // [Issue#40]

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestForwardReference.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestForwardReference.java
@@ -46,12 +46,12 @@ public class TestForwardReference extends BaseMapTest {
 		public String id;
 	}
 
-	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
-	@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 	@JsonSubTypes({
 			@JsonSubTypes.Type(value = ForwardReferenceClassOne.class, name = "One"),
 			@JsonSubTypes.Type(value = ForwardReferenceClassTwo.class, name = "Two")})
-	static abstract class ForwardReferenceClass
+	@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
+	abstract static class ForwardReferenceClass
 	{
 		public String id;
 		public void setId(String id) {

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArray.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArray.java
@@ -122,7 +122,7 @@ public class TestPOJOAsArray extends BaseMapTest
     /*****************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     
     /**
      * Test that verifies that property annotation works

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArrayAdvanced.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArrayAdvanced.java
@@ -62,7 +62,7 @@ public class TestPOJOAsArrayAdvanced extends BaseMapTest
     /*****************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public void testWithView() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArrayWithBuilder.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArrayWithBuilder.java
@@ -50,7 +50,7 @@ public class TestPOJOAsArrayWithBuilder extends BaseMapTest
     /*****************************************************
      */
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public void testSimpleBuilder() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestParentChildReferences.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestParentChildReferences.java
@@ -162,9 +162,9 @@ public class TestParentChildReferences
         public void setParent(Parent parent) { this.parent = parent; }
     }
 
-    @JsonTypeInfo(use=Id.NAME)
     @JsonSubTypes({@JsonSubTypes.Type(ConcreteNode.class)})
-    static abstract class AbstractNode
+    @JsonTypeInfo(use = Id.NAME)
+    abstract static class AbstractNode
     {
         public String id;
         

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrapped.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrapped.java
@@ -46,7 +46,7 @@ public class TestUnwrapped extends BaseMapTest
         }
     }
     
-    final static class Location {
+    static final class Location {
         public int x;
         public int y;
 

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestAnnotatedClass.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestAnnotatedClass.java
@@ -35,7 +35,7 @@ public class TestAnnotatedClass
         public int y() { return 3; }
     }
 
-    static abstract class GenericBase<T extends Number>
+    abstract static class GenericBase<T extends Number>
     {
         public abstract void setX(T value);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestGenericFieldInSubtype.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestGenericFieldInSubtype.java
@@ -38,7 +38,7 @@ class Result677<T> {
 abstract class BaseType<T> {
     public T value;
 
-    public final static class SubType<T extends Number> extends BaseType<T>
+    public static final class SubType<T extends Number> extends BaseType<T>
     {
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
@@ -42,10 +42,10 @@ public class TestTypeFactory
     static class MyStringXMap<V> extends HashMap<String,V> { }
 
     // And one more, now with obfuscated type names; essentially it's just Map<Int,Long>
-    static abstract class IntLongMap extends XLongMap<Integer> { }
+    abstract static class IntLongMap extends XLongMap<Integer> { }
     // trick here is that V now refers to key type, not value type
-    static abstract class XLongMap<V> extends XXMap<V,Long> { }
-    static abstract class XXMap<K,V> implements Map<K,V> { }
+    abstract static class XLongMap<V> extends XXMap<V,Long> { }
+    abstract static class XXMap<K,V> implements Map<K,V> { }
 
     static class SneakyBean {
         public IntLongMap intMap;
@@ -471,7 +471,7 @@ public class TestTypeFactory
         assertEquals(tf.constructType(long[].class), params[0]);
     }
 
-    static abstract class StringIntMapEntry implements Map.Entry<String,Integer> { }
+    abstract static class StringIntMapEntry implements Map.Entry<String,Integer> { }
     
     public void testMapEntryResolution()
     {

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactoryWithClassLoader.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactoryWithClassLoader.java
@@ -127,7 +127,7 @@ public void testUsesFallBackClassLoaderIfNoThreadClassLoaderAndNoWithClassLoader
 public static class AClass
 {
   private String _foo, _bar;
-  protected final static Class<?> thisClass = new Object() {
+  protected static final Class<?> thisClass = new Object() {
   }.getClass().getEnclosingClass();
 
   public AClass() { }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TypeAliasesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TypeAliasesTest.java
@@ -11,11 +11,11 @@ import com.fasterxml.jackson.databind.*;
 public class TypeAliasesTest
     extends BaseMapTest
 {
-    public static abstract class Base<T> {
+    public abstract static class Base<T> {
         public T inconsequential = null;
     }
 
-    public static abstract class BaseData<T> {
+    public abstract static class BaseData<T> {
         public T dataObj;
     }
    

--- a/src/test/java/com/fasterxml/jackson/databind/util/TestClassUtil.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/TestClassUtil.java
@@ -17,7 +17,7 @@ public class TestClassUtil
     /* Test classes and interfaces needed for testing class util
      * methods
      */
-    static abstract class BaseClass implements Comparable<BaseClass>,
+    abstract static class BaseClass implements Comparable<BaseClass>,
         BaseInt
     {
         BaseClass(String str) { }
@@ -37,13 +37,13 @@ public class TestClassUtil
         }
     }
 
-    static abstract class SubClass
+    abstract static class SubClass
         extends BaseClass
         implements SubInt {
         SubClass() { super("x"); }
     }
 
-    static abstract class ConcreteAndAbstract {
+    abstract static class ConcreteAndAbstract {
         public abstract void a();
         
         public void c() { }

--- a/src/test/java/perf/ManualReadPerfWithMedia.java
+++ b/src/test/java/perf/ManualReadPerfWithMedia.java
@@ -39,7 +39,7 @@ public class ManualReadPerfWithMedia extends ObjectReaderTestBase
                 m2, "JSON-as-Array", input, MediaItem.class);
     }
 
-    final static class NoFormatIntrospector extends JacksonAnnotationIntrospector
+    static final class NoFormatIntrospector extends JacksonAnnotationIntrospector
     {
         private static final long serialVersionUID = 1L;
         @Override

--- a/src/test/java/perf/ObjectReaderTestBase.java
+++ b/src/test/java/perf/ObjectReaderTestBase.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.*;
 
 abstract class ObjectReaderTestBase
 {
-    protected final static int WARMUP_ROUNDS = 5;
+    protected static final int WARMUP_ROUNDS = 5;
 
     protected String _desc1, _desc2;
     


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:ModifiersOrderCheck - Modifiers should be declared in the correct order
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:ModifiersOrderCheck
Please let me know if you have any questions.
Kirill Vlasov