### PR TITLE
Redundant casts should not be used

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/FloatNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/FloatNode.java
@@ -73,7 +73,7 @@ public class FloatNode extends NumericNode
     public long longValue() { return (long) _value; }
 
     @Override
-    public float floatValue() { return (float) _value; }
+    public float floatValue() { return _value; }
     
     @Override
     public double doubleValue() { return _value; }

--- a/src/test/java/com/fasterxml/jackson/databind/convert/TestArrayConversions.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/TestArrayConversions.java
@@ -196,8 +196,8 @@ public class TestArrayConversions
         for (int i = 0; i < size; ++i) {
             Number n1 = (Number) Array.get(inputArray, i);
             Number n2 = (Number) Array.get(outputArray, i);
-            double value1 = ((Number) n1).longValue();
-            double value2 = ((Number) n2).longValue();
+            double value1 = n1.longValue();
+            double value2 = n2.longValue();
             assertEquals("Entry #"+i+"/"+size+" not equal", value1, value2);
         }        
     }
@@ -207,8 +207,8 @@ public class TestArrayConversions
         for (int i = 0; i < size; ++i) {
             Number n1 = (Number) Array.get(inputArray, i);
             Number n2 = (Number) Array.get(outputArray, i);
-            double value1 = ((Number) n1).doubleValue();
-            double value2 = ((Number) n2).doubleValue();
+            double value1 = n1.doubleValue();
+            double value2 = n2.doubleValue();
             assertEquals("Entry #"+i+"/"+size+" not equal", value1, value2);
         }        
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestGenericListSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestGenericListSerialization.java
@@ -63,7 +63,7 @@ public class TestGenericListSerialization
         
         JSONResponse<List<Parent>> out = mapper.readValue(json, 0, json.length, rootType);
 
-        List<Parent> deserializedContent = (List<Parent>) out.getResult();
+        List<Parent> deserializedContent = out.getResult();
 
         assertEquals(2, deserializedContent.size());
         assertTrue(deserializedContent.get(0) instanceof Parent);

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectId154.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectId154.java
@@ -37,7 +37,7 @@ public class TestObjectId154 extends BaseMapTest
 
         assertNotNull(first.next);
         assertTrue(first.next instanceof Foo);
-        Foo second = (Foo) first.next;
+        Foo second = first.next;
         assertNotNull(second.ref);
         assertSame(first, second.ref);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1905 - Redundant casts should not be used
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905
Please let me know if you have any questions.
Kirill Vlasov