### PR TITLE
Two branches in the same conditional structure should not have exactly the same implementation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -305,11 +305,10 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
         switch (p.getCurrentTokenId()) {
         case JsonTokenId.ID_START_OBJECT:
         case JsonTokenId.ID_END_OBJECT: // for empty JSON Objects we may point to this
+        case JsonTokenId.ID_FIELD_NAME:
             return deserializeObject(p, ctxt, nodeFactory);
         case JsonTokenId.ID_START_ARRAY:
             return deserializeArray(p, ctxt, nodeFactory);
-        case JsonTokenId.ID_FIELD_NAME:
-            return deserializeObject(p, ctxt, nodeFactory);
         case JsonTokenId.ID_EMBEDDED_OBJECT:
             return _fromEmbedded(p, ctxt, nodeFactory);
         case JsonTokenId.ID_STRING:

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
@@ -71,7 +71,7 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
         JsonToken t = p.getCurrentToken();
         if (t == JsonToken.START_OBJECT) {
             t = p.nextToken();
-        } else if (t == JsonToken.START_ARRAY) {
+        } else if (t == JsonToken.START_ARRAY || t != JsonToken.FIELD_NAME) {
             /* This is most likely due to the fact that not all Java types are
              * serialized as JSON Objects; so if "as-property" inclusion is requested,
              * serialization of things like Lists must be instead handled as if
@@ -79,8 +79,6 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
              * But this can also be due to some custom handling: so, if "defaultImpl"
              * is defined, it will be asked to handle this case.
              */
-            return _deserializeTypedUsingDefaultImpl(p, ctxt, null);
-        } else if (t != JsonToken.FIELD_NAME) {
             return _deserializeTypedUsingDefaultImpl(p, ctxt, null);
         }
         // Ok, let's try to find the property. But first, need token buffer...

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializer.java
@@ -49,15 +49,13 @@ public class NumberSerializer
         /* These shouldn't match (as there are more specific ones),
          * but just to be sure:
          */
-        } else if (value instanceof Integer) {
-            g.writeNumber(value.intValue());
         } else if (value instanceof Long) {
             g.writeNumber(value.longValue());
         } else if (value instanceof Double) {
             g.writeNumber(value.doubleValue());
         } else if (value instanceof Float) {
             g.writeNumber(value.floatValue());
-        } else if ((value instanceof Byte) || (value instanceof Short)) {
+        } else if (value instanceof Integer || value instanceof Byte || value instanceof Short) {
             g.writeNumber(value.intValue()); // doesn't need to be cast to smaller numbers
         } else {
             // We'll have to use fallback "untyped" number write method

--- a/src/test/java/com/fasterxml/jackson/databind/TestObjectMapperBeanSerializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/TestObjectMapperBeanSerializer.java
@@ -39,10 +39,7 @@ public class TestObjectMapperBeanSerializer
             String name = jp.getCurrentName();
             JsonToken t = jp.nextToken();
 
-            if (name.equals("uri")) {
-                assertToken(JsonToken.VALUE_STRING, t);
-                assertEquals(FixtureObjectBase.VALUE_URSTR, getAndVerifyText(jp));
-            } else if (name.equals("url")) {
+            if (name.equals("uri") || name.equals("url")) {
                 assertToken(JsonToken.VALUE_STRING, t);
                 assertEquals(FixtureObjectBase.VALUE_URSTR, getAndVerifyText(jp));
             } else if (name.equals("testNull")) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1871 - Two branches in the same conditional structure should not have exactly the same implementation
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1871
Please let me know if you have any questions.
Kirill Vlasov