### PR TITLE
try/catch usage of sql classes in serializer static initializer to al…

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
@@ -84,13 +84,18 @@ public abstract class BasicSerializerFactory
         _concrete.put(Calendar.class.getName(), CalendarSerializer.instance);
         DateSerializer dateSer = DateSerializer.instance;
         _concrete.put(java.util.Date.class.getName(), dateSer);
-        // note: timestamps are very similar to java.util.Date, thus serialized as such
-        _concrete.put(java.sql.Timestamp.class.getName(), dateSer);
         
-        // leave some of less commonly used ones as lazy, no point in proactive construction
-        _concreteLazy.put(java.sql.Date.class.getName(), SqlDateSerializer.class);
-        _concreteLazy.put(java.sql.Time.class.getName(), SqlTimeSerializer.class);
-
+        try {
+            // note: timestamps are very similar to java.util.Date, thus serialized as such
+            _concrete.put(java.sql.Timestamp.class.getName(), dateSer);
+        
+            // leave some of less commonly used ones as lazy, no point in proactive construction
+            _concreteLazy.put(java.sql.Date.class.getName(), SqlDateSerializer.class);
+            _concreteLazy.put(java.sql.Time.class.getName(), SqlTimeSerializer.class);
+        } catch(NoClassDefFoundError e) {
+        	//java.sql is not standard in embedded compact configurations.
+        }
+        
         // And then other standard non-structured JDK types
         for (Map.Entry<Class<?>,Object> en : StdJdkSerializers.all()) {
             Object value = en.getValue();


### PR DESCRIPTION
…low it to be used in embedded compact1 configurations.

try/catch usage of sql classes in serializer static initializer to allow it to be used in embedded compact1 configurations.

The fix I made is quite simple but maybe you would prefer to have an externally specified factory that only instantiates a subset of the concrete type serializers. But that would require a substantial change since the existing serializers (BeanSerializerFactory/BasicSerializerFactory) do not allow much customization.