### PR TITLE
Possible fix for #1103

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.deser.std;
 
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.text.*;
@@ -233,6 +234,11 @@ public class DateDeserializers
                 throw ctxt.instantiationException(_calendarClass, e);
             }
         }
+
+        @Override
+        public Calendar deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+            return deserialize(jp, ctxt);
+        }
     }
 
     /**
@@ -260,6 +266,11 @@ public class DateDeserializers
         public java.util.Date deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             return _parseDate(jp, ctxt);
         }
+
+        @Override
+        public java.util.Date deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+            return deserialize(jp, ctxt);
+        }
     }
 
     /**
@@ -283,6 +294,11 @@ public class DateDeserializers
         public java.sql.Date deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             Date d = _parseDate(jp, ctxt);
             return (d == null) ? null : new java.sql.Date(d.getTime());
+        }
+
+        @Override
+        public java.sql.Date deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+            return deserialize(jp, ctxt);
         }
     }
 
@@ -309,6 +325,11 @@ public class DateDeserializers
         public java.sql.Timestamp deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException
         {
             return new Timestamp(_parseDate(jp, ctxt).getTime());
+        }
+
+        @Override
+        public java.sql.Timestamp deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+            return deserialize(jp, ctxt);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
@@ -237,7 +237,9 @@ public class DateDeserializers
 
         @Override
         public Calendar deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
-            return deserialize(jp, ctxt);
+            return jp.getCurrentToken() == JsonToken.START_ARRAY || jp.getCurrentToken() == JsonToken.START_OBJECT
+                   ? (Calendar) super.deserializeWithType(jp, ctxt, typeDeserializer)
+                   : deserialize(jp, ctxt);
         }
     }
 
@@ -269,7 +271,9 @@ public class DateDeserializers
 
         @Override
         public java.util.Date deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
-            return deserialize(jp, ctxt);
+            return jp.getCurrentToken() == JsonToken.START_ARRAY || jp.getCurrentToken() == JsonToken.START_OBJECT
+                   ? (Date) super.deserializeWithType(jp, ctxt, typeDeserializer)
+                   : deserialize(jp, ctxt);
         }
     }
 
@@ -298,7 +302,9 @@ public class DateDeserializers
 
         @Override
         public java.sql.Date deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
-            return deserialize(jp, ctxt);
+            return jp.getCurrentToken() == JsonToken.START_ARRAY || jp.getCurrentToken() == JsonToken.START_OBJECT
+                   ? (java.sql.Date) super.deserializeWithType(jp, ctxt, typeDeserializer)
+                   : deserialize(jp, ctxt);
         }
     }
 
@@ -329,7 +335,9 @@ public class DateDeserializers
 
         @Override
         public java.sql.Timestamp deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
-            return deserialize(jp, ctxt);
+            return jp.getCurrentToken() == JsonToken.START_ARRAY || jp.getCurrentToken() == JsonToken.START_OBJECT
+                   ? (Timestamp) super.deserializeWithType(jp, ctxt, typeDeserializer)
+                   : deserialize(jp, ctxt);
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue I ran into (#1103), but unfortunately breaks `TestTypedDeserialization.testIssue506WithDate` test, and I'm not quite sure how to fix it (it doesn't seem to be working properly anyway, as it writes type information using wrapper array and not as a `type2` property the `@JsonTypeInfo` annotation suggests).

I'm not quite sure what the Issue506 was (doesn't seem to be [this one](https://github.com/FasterXML/jackson-databind/issues/506)), so I have no idea where to look next.