### PR TITLE
Fix problem #1112.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -928,7 +928,7 @@ public abstract class DeserializationContext
      */
     public JsonMappingException weirdKeyException(Class<?> keyClass, String keyValue, String msg) {
         return InvalidFormatException.from(_parser,
-                String.format("Can not construct Map key of type %s from String \"%s\": ",
+                String.format("Can not construct Map key of type %s from String \"%s\": %s",
                         keyClass.getName(), _desc(keyValue), msg),
                 keyValue, keyClass);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/ExceptionFromCustomEnumKeyDeserializerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/ExceptionFromCustomEnumKeyDeserializerTest.java
@@ -1,0 +1,105 @@
+/******************************************************************************
+ * * This data and information is proprietary to, and a valuable trade secret
+ * * of, Basis Technology Corp.  It is given in confidence by Basis Technology
+ * * and may only be used as permitted under the license agreement under which
+ * * it has been distributed, and in no other way.
+ * *
+ * * Copyright (c) 2015 Basis Technology Corporation All rights reserved.
+ * *
+ * * The technical data and information provided herein are provided with
+ * * `limited rights', and the computer software provided herein is provided
+ * * with `restricted rights' as those terms are defined in DAR and ASPR
+ * * 7-104.9(a).
+ ******************************************************************************/
+
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ExceptionFromCustomEnumKeyDeserializerTest {
+    public enum AnEnum {
+        ZERO,
+        ONE
+    }
+
+    public static class AnEnumDeserializer extends FromStringDeserializer<AnEnum> {
+
+        public AnEnumDeserializer() {
+            super(AnEnum.class);
+        }
+
+        //CHECKSTYLE:OFF
+        @Override
+        protected AnEnum _deserialize(String value, DeserializationContext ctxt) throws IOException {
+            try {
+                return AnEnum.valueOf(value);
+            } catch (IllegalArgumentException e) {
+                throw ctxt.weirdKeyException(AnEnum.class, value, "Undefined AnEnum code");
+            }
+        }
+    }
+
+    public static class AnEnumKeyDeserializer extends KeyDeserializer {
+
+        @Override
+        public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+            try {
+                return AnEnum.valueOf(key);
+            } catch (IllegalArgumentException e) {
+                throw ctxt.weirdKeyException(AnEnum.class, key, "Undefined AnEnum code");
+            }
+        }
+    }
+
+
+    @JsonDeserialize(using = AnEnumDeserializer.class, keyUsing = AnEnumKeyDeserializer.class)
+    public enum LanguageCodeMixin {
+    }
+
+    public static class EnumModule extends SimpleModule {
+
+        public void setupModule(SetupContext context) {
+            context.setMixInAnnotations(AnEnum.class, LanguageCodeMixin.class);
+        }
+
+        /**
+         * Register a Jackson module for Rosette's top-level enums an {@link ObjectMapper}.
+         * @param mapper the mapper.
+         * @return the same mapper, for convenience.
+         */
+        public static ObjectMapper setupObjectMapper(ObjectMapper mapper) {
+            final EnumModule module = new EnumModule();
+            mapper.registerModule(module);
+            return mapper;
+        }
+    }
+
+    @Test
+    public void lostMessage() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new EnumModule());
+        try {
+            objectMapper.readValue("{\"TWO\": \"dumpling\"}", new TypeReference<Map<AnEnum, String>>() {});
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Undefined AnEnum"));
+            return;
+        }
+        fail("No exception");
+    }
+}


### PR DESCRIPTION
This is a fix for an issue in which the detailed error message provided in an unhappy custom key deserializer is not retained in the message of the exception that is thrown.