### PR TITLE
Allow deserialization of unknown Enums using a predefined value

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -977,6 +977,17 @@ public abstract class AnnotationIntrospector
         return names;
     }
 
+    /**
+     * Finds the Enum value that should be considered the default value, if possible.
+     *
+     * @param enumCls The Enum class to scan for the default value.
+     * @return null if none found or it's not possible to determine one.
+     * @since 2.8
+     */
+    public Enum<?> findDefaultEnumValue(Class<Enum<?>> enumCls) {
+        return null;
+    }
+
     /*
     /**********************************************************
     /* Deserialization: general annotations

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -354,6 +354,18 @@ public enum DeserializationFeature implements ConfigFeature
     READ_UNKNOWN_ENUM_VALUES_AS_NULL(false),
 
     /**
+     * Feature that allows unknown Enum values to be ignored and a predefined value specified through
+     * {@link com.fasterxml.jackson.annotation.JsonEnumDefaultValue @JsonEnumDefaultValue} annotation.
+     * If disabled, unknown Enum values will throw exceptions.
+     * If enabled, but no predefined default Enum value is specified, an exception will be thrown as well.
+     *<p>
+     * Feature is disabled by default.
+     *
+     * @since 2.8
+     */
+    READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE(false),
+
+    /**
      * Feature that controls whether numeric timestamp values are expected
      * to be written using nanosecond timestamps (enabled) or not (disabled),
      * <b>if and only if</b> datatype supports such resolution.

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1917,11 +1917,11 @@ public abstract class BasicDeserializerFactory
             if (config.canOverrideAccessModifiers()) {
                 ClassUtil.checkAndFixAccess(accessor, config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
             }
-            return EnumResolver.constructUnsafeUsingMethod(enumClass, accessor);
+            return EnumResolver.constructUnsafeUsingMethod(enumClass, accessor, config.getAnnotationIntrospector());
         }
         // May need to use Enum.toString()
         if (config.isEnabled(DeserializationFeature.READ_ENUMS_USING_TO_STRING)) {
-            return EnumResolver.constructUnsafeUsingToString(enumClass);
+            return EnumResolver.constructUnsafeUsingToString(enumClass, config.getAnnotationIntrospector());
         }
         return EnumResolver.constructUnsafe(enumClass, config.getAnnotationIntrospector());
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -28,6 +28,7 @@ public class EnumDeserializer
      * @since 2.6
      */
     protected final CompactStringObjectMap _enumLookup;
+    private final Enum<?> _enumDefaultValue;
 
     /**
      * @since 2.6
@@ -39,6 +40,7 @@ public class EnumDeserializer
         super(res.getEnumClass());
         _enumLookup = res.constructLookup();
         _enumsByIndex = res.getRawEnums();
+        _enumDefaultValue = res.getDefaultValue();
     }
 
     /**
@@ -97,6 +99,9 @@ public class EnumDeserializer
             if (index >= 0 && index <= _enumsByIndex.length) {
                 return _enumsByIndex[index];
             }
+            if (ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE) && _enumDefaultValue != null) {
+                return _enumDefaultValue;
+            }
             if (!ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)) {
                 throw ctxt.weirdNumberException(index, _enumClass(),
                         "index value outside legal index range [0.."+(_enumsByIndex.length-1)+"]");
@@ -130,6 +135,10 @@ public class EnumDeserializer
                     // fine, ignore, was not an integer
                 }
             }
+        }
+        if (ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+            && _enumDefaultValue != null) {
+            return _enumDefaultValue;
         }
         if (!ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)) {
             throw ctxt.weirdStringException(name, _enumClass(),

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -186,6 +186,20 @@ public class JacksonAnnotationIntrospector
         return names;
     }
 
+    /**
+     * Finds the Enum value that should be considered the default value, if possible.
+     * <p>
+     * This implementation relies on {@link JsonEnumDefaultValue} annotation to determine the default value if present.
+     *
+     * @param enumCls The Enum class to scan for the default value.
+     * @return null if none found or it's not possible to determine one.
+     * @since 2.8
+     */
+    @Override
+    public Enum<?> findDefaultEnumValue(Class<Enum<?>> enumCls) {
+        return ClassUtil.findFirstAnnotatedEnumValue(enumCls, JsonEnumDefaultValue.class);
+    }
+
     /*
     /**********************************************************
     /* General class annotations

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -842,6 +842,34 @@ public final class ClassUtil
         return (Class<? extends Enum<?>>) cls;
     }
 
+    /**
+     * A method that will look for the first Enum value annotated with the given Annotation.
+     * <p>
+     * If there's more than one value annotated, the first one found will be returned. Which one exactly is used is undetermined.
+     *
+     * @param enumClass The Enum class to scan for a value with the given annotation
+     * @param annotationClass The annotation to look for.
+     * @return the Enum value annotated with the given Annotation or {@code null} if none is found.
+     * @throws IllegalArgumentException if there's a reflection issue accessing the Enum
+     * @since 2.8
+     */
+    public static <T extends Annotation> Enum<?> findFirstAnnotatedEnumValue(Class<Enum<?>> enumClass, Class<T> annotationClass) {
+        Field[] fields = getDeclaredFields(enumClass);
+        for (Field field : fields) {
+            Annotation defaultValueAnnotation = field.getAnnotation(annotationClass);
+            if (defaultValueAnnotation != null && field.isEnumConstant()) {
+                try {
+                    Method valueOf = enumClass.getDeclaredMethod("valueOf", String.class);  // using `getMethod` causes IllegalAccessException
+                    valueOf.setAccessible(true);
+                    return enumClass.cast(valueOf.invoke(null, field.getName()));
+                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                    throw new IllegalArgumentException("Could not extract Enum annotated with " + annotationClass.getSimpleName(), e);
+                }
+            }
+        }
+        return null;
+    }
+
     /*
     /**********************************************************
     /* Jackson-specific stuff

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -51,7 +51,7 @@ public class EnumResolver implements java.io.Serializable
             map.put(name, enumValues[i]);
         }
 
-        Enum<?> defaultEnum = ClassUtil.findFirstAnnotatedEnumValue(enumCls, JsonEnumDefaultValue.class);
+        Enum<?> defaultEnum = ai.findDefaultEnumValue(enumCls);
 
         return new EnumResolver(enumCls, enumValues, map, defaultEnum);
     }
@@ -70,7 +70,7 @@ public class EnumResolver implements java.io.Serializable
             map.put(e.toString(), e);
         }
 
-        Enum<?> defaultEnum = ClassUtil.findFirstAnnotatedEnumValue(enumCls, JsonEnumDefaultValue.class);
+        Enum<?> defaultEnum = new JacksonAnnotationIntrospector().findDefaultEnumValue(enumCls);
         return new EnumResolver(enumCls, enumValues, map, defaultEnum);
     }    
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -1,8 +1,6 @@
 package com.fasterxml.jackson.databind.util;
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 import java.lang.reflect.Method;
 import java.util.*;
@@ -13,6 +11,8 @@ import java.util.*;
  */
 public class EnumResolver implements java.io.Serializable
 {
+    private static final AnnotationIntrospector defaultAnnotationInstrospector = null;
+
     private static final long serialVersionUID = 1L;
 
     protected final Class<Enum<?>> _enumClass;
@@ -57,10 +57,21 @@ public class EnumResolver implements java.io.Serializable
     }
 
     /**
+     * @deprecated Since 2.8, use {@link #constructUsingToString(Class, AnnotationIntrospector)} instead
+     */
+    @Deprecated
+    public static EnumResolver constructUsingToString(Class<Enum<?>> enumCls)
+    {
+        return constructUsingToString(enumCls, defaultAnnotationInstrospector);
+    }
+
+    /**
      * Factory method for constructing resolver that maps from Enum.toString() into
      * Enum value
+     *
+     * @since 2.8
      */
-    public static EnumResolver constructUsingToString(Class<Enum<?>> enumCls)
+    public static EnumResolver constructUsingToString(Class<Enum<?>> enumCls, AnnotationIntrospector ai)
     {
         Enum<?>[] enumValues = enumCls.getEnumConstants();
         HashMap<String, Enum<?>> map = new HashMap<String, Enum<?>>();
@@ -70,12 +81,22 @@ public class EnumResolver implements java.io.Serializable
             map.put(e.toString(), e);
         }
 
-        Enum<?> defaultEnum = new JacksonAnnotationIntrospector().findDefaultEnumValue(enumCls);
+        Enum<?> defaultEnum = ai.findDefaultEnumValue(enumCls);
         return new EnumResolver(enumCls, enumValues, map, defaultEnum);
-    }    
+    }
 
-    public static EnumResolver constructUsingMethod(Class<Enum<?>> enumCls,
-            Method accessor)
+    /**
+     * @deprecated Since 2.8, use {@link #constructUsingMethod(Class, Method, AnnotationIntrospector)} instead
+     */
+    @Deprecated
+    public static EnumResolver constructUsingMethod(Class<Enum<?>> enumCls, Method accessor) {
+        return constructUsingMethod(enumCls, accessor, defaultAnnotationInstrospector);
+    }
+
+    /**
+     * @since 2.8
+     */
+    public static EnumResolver constructUsingMethod(Class<Enum<?>> enumCls, Method accessor, AnnotationIntrospector ai)
     {
         Enum<?>[] enumValues = enumCls.getEnumConstants();
         HashMap<String, Enum<?>> map = new HashMap<String, Enum<?>>();
@@ -92,7 +113,7 @@ public class EnumResolver implements java.io.Serializable
             }
         }
 
-        Enum<?> defaultEnum = ClassUtil.findFirstAnnotatedEnumValue(enumCls, JsonEnumDefaultValue.class);
+        Enum<?> defaultEnum = (ai != null) ? ai.findDefaultEnumValue(enumCls) : null;
         return new EnumResolver(enumCls, enumValues, map, defaultEnum);
     }    
 
@@ -111,27 +132,48 @@ public class EnumResolver implements java.io.Serializable
     }
 
     /**
+     * @deprecated Since 2.8, use {@link #constructUnsafeUsingToString(Class, AnnotationIntrospector)} instead
+     */
+    @Deprecated
+    public static EnumResolver constructUnsafeUsingToString(Class<?> rawEnumCls)
+    {
+        return constructUnsafeUsingToString(rawEnumCls, defaultAnnotationInstrospector);
+    }
+
+    /**
      * Method that needs to be used instead of {@link #constructUsingToString}
      * if static type of enum is not known.
+     *
+     * @since 2.8
      */
     @SuppressWarnings({ "unchecked" })
-    public static EnumResolver constructUnsafeUsingToString(Class<?> rawEnumCls)
-    {            
+    public static EnumResolver constructUnsafeUsingToString(Class<?> rawEnumCls, AnnotationIntrospector ai)
+    {
         // oh so wrong... not much that can be done tho
         Class<Enum<?>> enumCls = (Class<Enum<?>>) rawEnumCls;
-        return constructUsingToString(enumCls);
+        return constructUsingToString(enumCls, ai);
+    }
+
+    /**
+     * @deprecated Since 2.8, use {@link #constructUnsafeUsingMethod(Class, Method, AnnotationIntrospector)} instead.
+     */
+    @Deprecated
+    public static EnumResolver constructUnsafeUsingMethod(Class<?> rawEnumCls, Method accessor) {
+        return constructUnsafeUsingMethod(rawEnumCls, accessor, defaultAnnotationInstrospector);
     }
 
     /**
      * Method used when actual String serialization is indicated using @JsonValue
      * on a method.
+     *
+     * @since 2.8
      */
     @SuppressWarnings({ "unchecked" })
-    public static EnumResolver constructUnsafeUsingMethod(Class<?> rawEnumCls, Method accessor)
+    public static EnumResolver constructUnsafeUsingMethod(Class<?> rawEnumCls, Method accessor, AnnotationIntrospector ai)
     {            
         // wrong as ever but:
         Class<Enum<?>> enumCls = (Class<Enum<?>>) rawEnumCls;
-        return constructUsingMethod(enumCls, accessor);
+        return constructUsingMethod(enumCls, accessor, ai);
     }
 
     public CompactStringObjectMap constructLookup() {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEnumDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEnumDeserialization.java
@@ -167,6 +167,27 @@ public class TestEnumDeserialization
         ;
     }
 
+    static enum EnumWithDefaultAnno {
+        A, B,
+
+        @JsonEnumDefaultValue
+        OTHER;
+    }
+
+    static enum EnumWithDefaultAnnoAndConstructor {
+        A, B,
+
+        @JsonEnumDefaultValue
+        OTHER;
+
+        @JsonCreator public static EnumWithDefaultAnnoAndConstructor fromId(String value) {
+            for (EnumWithDefaultAnnoAndConstructor e: values()) {
+                if (e.name().toLowerCase().equals(value)) return e;
+            }
+            return null;
+        }
+    }
+
     /*
     /**********************************************************
     /* Tests
@@ -480,5 +501,29 @@ public class TestEnumDeserialization
         assertEquals(2, result.length);
         assertSame(EnumWithPropertyAnno.B, result[0]);
         assertSame(EnumWithPropertyAnno.A, result[1]);
+    }
+
+    public void testEnumWithDefaultAnnotation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumWithDefaultAnno myEnum = mapper.readValue("\"foo\"", EnumWithDefaultAnno.class);
+        assertSame(EnumWithDefaultAnno.OTHER, myEnum);
+    }
+
+    public void testEnumWithDefaultAnnotationUsingIndexes() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumWithDefaultAnno myEnum = mapper.readValue("9", EnumWithDefaultAnno.class);
+        assertSame(EnumWithDefaultAnno.OTHER, myEnum);
+    }
+
+    public void testEnumWithDefaultAnnotationWithConstructor() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumWithDefaultAnnoAndConstructor myEnum = mapper.readValue("\"foo\"", EnumWithDefaultAnnoAndConstructor.class);
+        assertNull("When using a constructor, the default value annotation shouldn't be used.", myEnum);
     }
 }


### PR DESCRIPTION
## Use case:

When using Jackson to deserialize a json payload coming from a 3rd party provider, it's common not to have the entire list of enum values required to support proper Enum deserialization. Jackson already offers a way to deserialize unknown values as `null`, nevertheless, it can be more useful to be able to deserialize them into a pre-determined value (perhaps named "UNKNOWN") to avoid NPEs or other issues.

The current way to achieve this desired effect is to have a custom deserializer or a `@JsonCreator` constructor. This approach, while effective, is also somewhat cumbersome since we lose the ability to rely on other annotations like `@JsonProperty` or `@JsonValue` to serialize and deserialize values.

## Proposal 

Through the creation of a new Jackson annotation `@JsonEnumDefaultValue`, developers should be able to annotate a specific enum that they wish to use as default. This annotation, along with a new DeserializationFeature toggle, should make it easy to accomplish the desired effect.

## Complimentary Jackson annotation:
```
/**
 * Marker annotation that can be used to define a default value
 * used when trying to deserialize unknown Enum values.
 * <p>
 * This annotation is only applicable when the
 * {@link com.fasterxml.jackson.databind.DeserializationFeature#READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE}
 * deserialization feature is enabled.
 * <p>
 * If the more than one enum value is marked with this annotation,
 * the first one to be detected will be used. Which one exactly is undetermined.
 */
@Target(ElementType.FIELD)
@Retention(RetentionPolicy.RUNTIME)
@JacksonAnnotation
public @interface JsonEnumDefaultValue
{
}
```

## Open questions:

* Build-related: how do you handle compilation dependencies across jackson projects? 
* Is there a way to avoid the introspection penalty incurred in EnumResolver from scanning for the new annotation if the feature toggle is disabled?
* What's the right way to deal with logging? I see code where the default Java logging is used, but other places where it's not and just comments mentioning logging. 
