### PR TITLE
When applying type modifiers, don't ignore container types.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1112,11 +1112,8 @@ public final class TypeFactory
             // sanity check
             throw new IllegalArgumentException("Unrecognized Type: "+((type == null) ? "[null]" : type.toString()));
         }
-        /* Need to allow TypeModifiers to alter actual type; however,
-         * for now only call for simple types (i.e. not for arrays, map or collections).
-         * Can be changed in future it necessary
-         */
-        if (_modifiers != null && !resultType.isContainerType()) {
+        /* Need to allow TypeModifiers to alter actual type. */
+        if (_modifiers != null) {
             TypeBindings b = resultType.getBindings();
             if (b == null) {
                 b = EMPTY_BINDINGS;


### PR DESCRIPTION
jackson-module-scala relies on using type modifiers to find Maps/Seqs... etc. Maps are subtypes of Iterable[Tuple2[_,_]] which means that the CollectionLikeType is found before the MapLikeType and it is unable to be overwritten by a type modifier once the super types have been resolved.