### PR TITLE
Problem with Object id handling, explicit `null` token

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
@@ -55,7 +55,7 @@ public final class StringDeserializer extends StdScalarDeserializer<String>
         }
         // allow coercions for other scalar types
         String text = p.getValueAsString();
-        // According to [databind#742], we shouldn't throw an exception if the value of the property is null
+        // According to [databind#742], StringDeserializer shouldn't throw an exception if the value of the property is null
         if (text != null || JsonToken.VALUE_NULL.equals(p.getCurrentToken())) {
             return text;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
@@ -55,7 +55,8 @@ public final class StringDeserializer extends StdScalarDeserializer<String>
         }
         // allow coercions for other scalar types
         String text = p.getValueAsString();
-        if (text != null) {
+        // According to [databind#742], we shouldn't throw an exception if the value of the property is null
+        if (text != null || JsonToken.VALUE_NULL.equals(p.getCurrentToken())) {
             return text;
         }
         throw ctxt.mappingException(_valueClass, p.getCurrentToken());

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdDeserialization.java
@@ -466,4 +466,31 @@ public class TestObjectIdDeserialization extends BaseMapTest
         assertNotNull(value);
         assertEquals(3, value.value);
     }
+
+    //for databind#1150
+    @JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property="id")
+    static class IdentifiableStringId
+    {
+        public String id;
+        public int value;
+
+        public Identifiable next;
+
+        public IdentifiableStringId() { this(0); }
+        public IdentifiableStringId(int v) {
+            value = v;
+        }
+    }
+
+    public void testNullStringPropertyId() throws Exception
+    {
+
+
+        IdentifiableStringId value = MAPPER.readValue
+                (aposToQuotes("{'value':3, 'next':null, 'id':null}"), IdentifiableStringId.class);
+        assertNotNull(value);
+        assertEquals(3, value.value);
+    }
+
+
 }


### PR DESCRIPTION
According to #742, it shouldn't throw an exception if the value of the property is null