### PR TITLE
Fix for #1154

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/DateTimeSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/DateTimeSerializerBase.java
@@ -59,14 +59,15 @@ public abstract class DateTimeSerializerBase<T>
                     return withFormat(Boolean.TRUE, null);
                 }
 
-                if (format.getShape() == JsonFormat.Shape.STRING) {
+                if (format.getShape() == JsonFormat.Shape.STRING || format.hasPattern()
+                                || format.hasLocale() || format.hasTimeZone()) {
                     TimeZone tz = format.getTimeZone();
                     final String pattern = format.hasPattern()
-                                           ? format.getPattern()
-                                           : StdDateFormat.DATE_FORMAT_STR_ISO8601;
+                                    ? format.getPattern()
+                                    : StdDateFormat.DATE_FORMAT_STR_ISO8601;
                     final Locale loc = format.hasLocale()
-                                       ? format.getLocale()
-                                       : serializers.getLocale();
+                                    ? format.getLocale()
+                                    : serializers.getLocale();
                     SimpleDateFormat df = new SimpleDateFormat(pattern, loc);
                     if (tz == null) {
                         tz = serializers.getTimeZone();

--- a/src/test/java/com/fasterxml/jackson/databind/ser/DateSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/DateSerializationTest.java
@@ -64,6 +64,35 @@ public class DateSerializationTest
         }
     }
 
+    static class DateAsDefaultBean {
+        public Date date;
+        public DateAsDefaultBean(long l) { date = new java.util.Date(l); }
+    }
+    
+    static class DateAsDefaultBeanWithEmptyJsonFormat {
+        @JsonFormat
+        public Date date;
+        public DateAsDefaultBeanWithEmptyJsonFormat(long l) { date = new java.util.Date(l); }
+    }
+
+    static class DateAsDefaultBeanWithPattern {
+        @JsonFormat(pattern="yyyy-MM-dd")
+        public Date date;
+        public DateAsDefaultBeanWithPattern(long l) { date = new java.util.Date(l); }
+    }
+
+    static class DateAsDefaultBeanWithLocale {
+        @JsonFormat(locale = "fr")
+        public Date date;
+        public DateAsDefaultBeanWithLocale(long l) { date = new java.util.Date(l); }
+    }
+
+    static class DateAsDefaultBeanWithTimezone {
+        @JsonFormat(timezone="CET")
+        public Date date;
+        public DateAsDefaultBeanWithTimezone(long l) { date = new java.util.Date(l); }
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -228,6 +257,54 @@ public class DateSerializationTest
         w = w.with(TimeZone.getTimeZone("EST"));
         json = w.writeValueAsString(new Date(0));
         assertEquals(quote("1969-12-31/19:00 EST"), json);
+    }
+
+    /**
+     * Test to ensure that the default shape is correctly inferred as string or numeric,
+     * when this shape is not explicitly set with a <code>@JsonFormat</code> annotation
+     */
+    public void testDateDefaultShape() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        // No @JsonFormat => default to user config
+        mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String json = mapper.writeValueAsString(new DateAsDefaultBean(0L));
+        assertEquals(aposToQuotes("{'date':0}"), json);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBean(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01T00:00:00.000+0000'}"), json);
+
+        // Empty @JsonFormat => default to user config
+        mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithEmptyJsonFormat(0L));
+        assertEquals(aposToQuotes("{'date':0}"), json);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithEmptyJsonFormat(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01T00:00:00.000+0000'}"), json);
+
+        // @JsonFormat with Shape.ANY and pattern => STRING shape, regardless of user config
+        mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithPattern(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01'}"), json);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithPattern(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01'}"), json);
+
+        // @JsonFormat with Shape.ANY and locale => STRING shape, regardless of user config
+        mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithLocale(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01T00:00:00.000+0000'}"), json);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithLocale(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01T00:00:00.000+0000'}"), json);
+
+        // @JsonFormat with Shape.ANY and timezone => STRING shape, regardless of user config
+        mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithTimezone(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01T01:00:00.000+0100'}"), json);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        json = mapper.writeValueAsString(new DateAsDefaultBeanWithTimezone(0L));
+        assertEquals(aposToQuotes("{'date':'1970-01-01T01:00:00.000+0100'}"), json);
     }
 }
 


### PR DESCRIPTION
Fix for #1154. Partially rolls back to pre-#1111 behavior.
We just make sure that the STRING shape is chosen when Shape.ANY (the default) is set on the annotation, but some other annotation attribute was also set (pattern, locale or timezone).
This way of fixing the issue has the added benefit of respecting the user config regarding the default serialization of ~~strings~~ dates when @JsonFormat(shape = Shape.ANY) is set on a property.