### PR TITLE
Use generic type when obtaining type hint

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
@@ -276,7 +276,7 @@ public class JsonValueSerializer
                     typeHint = _property.getType();
                 }
                 if (typeHint == null) {
-                    typeHint = visitor.getProvider().constructType(_handledType);
+                    typeHint = visitor.getProvider().constructType(_accessorMethod.getGenericReturnType());
                 }
             }
             ser = visitor.getProvider().findTypedValueSerializer(typeHint, false, _property);


### PR DESCRIPTION
This fixes the failing test I added in FasterXML/jackson-module-jsonSchema#100. I don't know if it's the right thing to do, but the generic information from a `@JsonValue` return type was being lost.