### PR TITLE
Fix AtomicReferenceSerializer.isEmpty to prevent class cast exception.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AtomicReferenceSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AtomicReferenceSerializer.java
@@ -224,7 +224,7 @@ public class AtomicReferenceSerializer
         JsonSerializer<Object> ser = _valueSerializer;
         if (ser == null) {
             try {
-                ser = _findCachedSerializer(provider, value.getClass());
+                ser = _findCachedSerializer(provider, contents.getClass());
             } catch (JsonMappingException e) { // nasty but necessary
                 throw new RuntimeJsonMappingException(e);
             }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestJDKAtomicTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestJDKAtomicTypes.java
@@ -137,6 +137,46 @@ public class TestJDKAtomicTypes
                 mapper.writeValueAsString(new SimpleWrapper(null)));
     }
 
+    public void testSerPropInclusionAlways() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setPropertyInclusion(incl);
+        assertEquals(aposToQuotes("{'value':true}"),
+                mapper.writeValueAsString(new SimpleWrapper(Boolean.TRUE)));
+    }
+
+    public void testSerPropInclusionNonNull() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_NULL);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setPropertyInclusion(incl);
+        assertEquals(aposToQuotes("{'value':true}"),
+                mapper.writeValueAsString(new SimpleWrapper(Boolean.TRUE)));
+    }
+
+    public void testSerPropInclusionNonAbsent() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_ABSENT);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setPropertyInclusion(incl);
+        assertEquals(aposToQuotes("{'value':true}"),
+                mapper.writeValueAsString(new SimpleWrapper(Boolean.TRUE)));
+    }
+
+    public void testSerPropInclusionNonEmpty() throws Exception
+    {
+        JsonInclude.Value incl =
+                JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_EMPTY);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setPropertyInclusion(incl);
+        assertEquals(aposToQuotes("{'value':true}"),
+                mapper.writeValueAsString(new SimpleWrapper(Boolean.TRUE)));
+    }
+
     // [databind#340]
     public void testPolymorphicAtomicReference() throws Exception
     {


### PR DESCRIPTION
Similar to FasterXML/jackson-datatypes-collections#4, AtomicReferenceSerializer grabs the incorrect serializer for the content type when trying to determine if the reference is empty.