### PR TITLE
Update SettableAnyProperty to use ValueDeserializer's NullValue

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -130,7 +130,7 @@ public class SettableAnyProperty
     {
         JsonToken t = jp.getCurrentToken();
         if (t == JsonToken.VALUE_NULL) {
-            return null;
+            return _valueDeserializer.getNullValue(ctxt);
         }
         if (_valueTypeDeserializer != null) {
             return _valueDeserializer.deserializeWithType(jp, ctxt, _valueTypeDeserializer);


### PR DESCRIPTION
Believe this is the appropriate fix for #1228  

similar implementation as in [SettableBeanProperty](https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.6.6/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java#L510-L521)