### PR TITLE
Prune out empty JSON arrays in JsonNode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -282,8 +282,21 @@ public class ObjectNode
     public void serialize(JsonGenerator g, SerializerProvider provider)
         throws IOException
     {
+        SerializationConfig config = null;
+        if (provider != null) {
+        	config = provider.getConfig();
+        }
         g.writeStartObject(this);
         for (Map.Entry<String, JsonNode> en : _children.entrySet()) {
+
+            // check if WRITE_EMPTY_JSON_ARRAYS feature is disabled,
+            // if the feature is disabled, then should not write an empty array
+            // to the output, so continue to the next element in the iteration
+            if (config != null && !config.isEnabled(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS) && en.getValue() instanceof ArrayNode
+                    && ((ArrayNode) en.getValue()).size() == 0) {
+            	continue;
+            }
+            
             g.writeFieldName(en.getKey());
                 /* 17-Feb-2009, tatu: Can we trust that all nodes will always
                  *   extend BaseJsonNode? Or if not, at least implement
@@ -300,8 +313,21 @@ public class ObjectNode
             TypeSerializer typeSer)
         throws IOException
     {
+        SerializationConfig config = null;
+        if (provider != null) {
+        	config = provider.getConfig();
+        }
         typeSer.writeTypePrefixForObject(this, g);
         for (Map.Entry<String, JsonNode> en : _children.entrySet()) {
+
+            // check if WRITE_EMPTY_JSON_ARRAYS feature is disabled,
+            // if the feature is disabled, then should not write an empty array
+            // to the output, so continue to the next element in the iteration
+            if (!config.isEnabled(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS) && en.getValue() instanceof ArrayNode
+                    && ((ArrayNode) en.getValue()).size() == 0) {
+            	continue;
+            }
+            
             g.writeFieldName(en.getKey());
             ((BaseJsonNode) en.getValue()).serialize(g, provider);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultForArrays.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultForArrays.java
@@ -1,5 +1,10 @@
 package com.fasterxml.jackson.databind.jsontype;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
@@ -65,6 +70,24 @@ public class TestDefaultForArrays extends BaseMapTest
         assertEquals(1, result.length);
         Object ob = result[0];
         assertTrue(ob instanceof JsonNode);
+    }
+    
+    public void testNodeInEmptyArray() throws Exception {
+        Map<String, List<String>> outerMap = new HashMap<String, List<String>>();
+        outerMap.put("inner", new ArrayList<String>());
+        ObjectMapper m = new ObjectMapper().disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS);
+        JsonNode tree = m.convertValue(outerMap, JsonNode.class);
+        
+        String json = m.writeValueAsString(tree);
+        assertEquals("{}", json);
+        
+        JsonNode node = new ObjectMapper().readTree("{\"a\":[]}");
+        
+        m.enableDefaultTyping(DefaultTyping.JAVA_LANG_OBJECT);
+        Object[] obs = new Object[] { node };
+        json = m.writeValueAsString(obs);
+        Object[] result = m.readValue(json, Object[].class);
+        assertEquals("{}", result[0].toString());
     }
 
     // test for [JACKSON-845]


### PR DESCRIPTION
Fix #867 for Support SerializationFeature.WRITE_EMPTY_JSON_ARRAYS for JsonNode.
I have made the changes to remove the empty arrays in case the SerializationFeature.WRITE_EMPTY_JSON_ARRAYS is disabled.

Let me know if this is fine