### PR TITLE
@JsonAnySetter on field annotation for Map

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/BeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/BeanDescription.java
@@ -165,6 +165,16 @@ public abstract class BeanDescription
      */
     public abstract AnnotatedMethod findAnySetter();
 
+	/**
+	 * Method used to locate the field of the class that implements
+	 * {@link com.fasterxml.jackson.annotation.JsonAnySetter} If no such method
+	 * exists null is returned. If more than one are found, an exception is
+	 * thrown.
+	 * 
+	 * @since 2.8
+	 */
+	public abstract AnnotatedMember findAnySetterField();
+
     /**
      * Method for locating the getter method that is annotated with
      * {@link com.fasterxml.jackson.annotation.JsonValue} annotation,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -1,10 +1,14 @@
 package com.fasterxml.jackson.databind.deser;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.impl.ReadableObjectId.Referring;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
@@ -30,8 +34,8 @@ public class SettableAnyProperty
     /**
      * Annotated variant is needed for JDK serialization only
      */
-    final protected AnnotatedMethod _setter;
-
+    final protected AnnotatedMember _setter;
+    
     protected final JavaType _type;
 
     protected JsonDeserializer<Object> _valueDeserializer;
@@ -44,7 +48,7 @@ public class SettableAnyProperty
     /**********************************************************
      */
 
-    public SettableAnyProperty(BeanProperty property, AnnotatedMethod setter, JavaType type,
+    public SettableAnyProperty(BeanProperty property, AnnotatedMember setter, JavaType type,
             JsonDeserializer<Object> valueDeser, TypeDeserializer typeDeser)
     {
         _property = property;
@@ -53,7 +57,7 @@ public class SettableAnyProperty
         _valueDeserializer = valueDeser;
         _valueTypeDeserializer = typeDeser;
     }
-
+    
     public SettableAnyProperty withValueDeserializer(JsonDeserializer<Object> deser) {
         return new SettableAnyProperty(_property, _setter, _type,
                 deser, _valueTypeDeserializer);
@@ -138,11 +142,29 @@ public class SettableAnyProperty
         return _valueDeserializer.deserialize(p, ctxt);
     }
 
+    @SuppressWarnings("unchecked")
     public void set(Object instance, String propName, Object value) throws IOException
     {
         try {
-            // note: can not use 'setValue()' due to taking 2 args
-            _setter.getAnnotated().invoke(instance, propName, value);
+			// note: can not use 'setValue()' due to taking 2 args
+			if (_setter instanceof AnnotatedMethod) {
+				((AnnotatedMethod) _setter).getAnnotated().invoke(instance, propName, value);
+			}
+			// if annotation in the field (only map is supported now)
+			else if (_setter instanceof AnnotatedField) {
+				AnnotatedField field = ((AnnotatedField) _setter);
+
+				// get the field value..
+				Object val = field.getValue(instance);
+				
+				if (val != null) {
+					// add the property key and value
+					((Map) val).put(propName, value);
+
+					// set the value back to the field
+					field.setValue(instance, val);
+				}
+			}
         } catch (Exception e) {
             _throwAsIOE(e, propName, value);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
@@ -418,6 +418,22 @@ public class BasicBeanDescription extends BeanDescription
         }
         return anyGetter;
     }
+    
+	public AnnotatedMember findAnySetterField() throws IllegalArgumentException {
+		AnnotatedMember anySetter = (_propCollector == null) ? null : _propCollector.getAnySetterField();
+		if (anySetter != null) {
+			/*
+			 * For now let's require a Map; in future can add support for other
+			 * types like perhaps Iterable<Map.Entry>?
+			 */
+			Class<?> type = anySetter.getRawType();
+			if (!Map.class.isAssignableFrom(type)) {
+				throw new IllegalArgumentException("Invalid 'any-setter' annotation on field " + anySetter.getName()
+				        + "(): type is not instance of java.util.Map");
+			}
+		}
+		return anySetter;
+	}
 
     @Override
     public Map<String,AnnotatedMember> findBackReferenceProperties()

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestAnyProperties.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestAnyProperties.java
@@ -135,6 +135,33 @@ public class TestAnyProperties
         }
     }
     
+	static class JsonAnySetterOnMap {
+		public int id;
+
+		@JsonAnySetter
+		protected HashMap<String, String> other = new HashMap<String, String>();
+
+		@JsonAnyGetter
+		public Map<String, String> any() {
+			return other;
+		}
+
+	}
+
+	static class JsonAnySetterOnNullMap {
+		public int id;
+
+		@JsonAnySetter
+		protected HashMap<String, String> other;
+
+		@JsonAnyGetter
+		public Map<String, String> any() {
+			return other;
+		}
+
+	}
+
+    
     /*
     /**********************************************************
     /* Test methods
@@ -223,6 +250,21 @@ public class TestAnyProperties
         assertTrue(ob instanceof Impl);
         assertEquals("xyz", ((Impl) ob).value);
     }
+    
+	public void testJsonAnySetterOnMap() throws Exception {
+		JsonAnySetterOnMap result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
+		        JsonAnySetterOnMap.class);
+		assertEquals(2, result.id);
+		assertEquals("Joe", result.other.get("name"));
+		assertEquals("New Jersey", result.other.get("city"));
+	}
+
+	public void testJsonAnySetterOnNullMap() throws Exception {
+		JsonAnySetterOnNullMap result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
+		        JsonAnySetterOnNullMap.class);
+		assertEquals(2, result.id);
+		assertNull(result.other);
+	}
     
     /*
     /**********************************************************


### PR DESCRIPTION
Supporting  #1047 @JsonAnySetter annotation on java.util.Map field. 

The build might fail for this PR since the @JsonAnySetter annotation is not enabled for the field in
jackson-annotations.
If the code changes are fine, then I will send a separate PR for  @JsonAnySetter changes.

@cowtowncoder Let me know if the code changes are fine.