### PR TITLE
Add a Deserialisation Feature to read null and missing fields as empty collections.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -439,14 +439,14 @@ public enum DeserializationFeature implements ConfigFeature
 
     /**
      * Feature that determines whether {@link ObjectReader} should
-     * try to deserialize missing or null fields into empty collections or arrays
+     * try to deserialize missing or null fields as empty containers (collections, arrays or maps)
      * of the appropriate type.
      *<p>
      * Feature is disabled by default.
      *
      * @since 2.8
      */
-    READ_NULL_AS_EMPTY_COLLECTION(false)
+    READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY(false)
     
     ;
 

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -434,7 +434,19 @@ public enum DeserializationFeature implements ConfigFeature
      * 
      * @since 2.1
      */
-    EAGER_DESERIALIZER_FETCH(true)
+    EAGER_DESERIALIZER_FETCH(true),
+
+
+    /**
+     * Feature that determines whether {@link ObjectReader} should
+     * try to deserialize missing or null fields into empty collections or arrays
+     * of the appropriate type.
+     *<p>
+     * Feature is disabled by default.
+     *
+     * @since 2.8
+     */
+    READ_NULL_AS_EMPTY_COLLECTION(false)
     
     ;
 

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -3786,7 +3786,7 @@ public class ObjectMapper
                 if (cfg.useRootWrapping()) {
                     result = _unwrapAndDeserialize(p, ctxt, cfg, valueType, deser);
                 } else {
-                    result = deser.deserialize(p, ctxt);
+                     result = deser.deserialize(p, ctxt);
                 }
                 ctxt.checkUnresolvedObjectId();
             }

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -355,7 +355,7 @@ public class ObjectReader
             t = p.nextToken();
             if (t == null) {
                 // Throw mapping exception, since it's failure to map, not an actual parsing problem
-                if (this._config.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                if (this._config.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
                     t = JsonToken.VALUE_NULL;
                 } else {
                     ctxt.reportMissingContent(null); // default msg is fine

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -355,7 +355,11 @@ public class ObjectReader
             t = p.nextToken();
             if (t == null) {
                 // Throw mapping exception, since it's failure to map, not an actual parsing problem
-                ctxt.reportMissingContent(null); // default msg is fine
+                if (this._config.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                    t = JsonToken.VALUE_NULL;
+                } else {
+                    ctxt.reportMissingContent(null); // default msg is fine
+                }
             }
         }
         return t;
@@ -527,8 +531,8 @@ public class ObjectReader
      */
 
     /**
-     * Convenience method to bind from {@link JsonPointer}.  
-     * {@link JsonPointerBasedFilter} is registered and will be used for parsing later. 
+     * Convenience method to bind from {@link JsonPointer}.
+     * {@link JsonPointerBasedFilter} is registered and will be used for parsing later.
      * @since 2.6
      */
     public ObjectReader at(final String value) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1165,7 +1165,8 @@ public abstract class BasicDeserializerFactory
                     //   most often it ought to be `Map` or `EnumMap`, but due to abstract
                     //   mapping it will more likely be concrete type like `HashMap`.
                     //   So, for time being, just pass `Map.class`
-                    MapDeserializer md = new MapDeserializer(type, inst, keyDes, contentDeser, contentTypeDeser);
+                    boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                    MapDeserializer md = new MapDeserializer(type, inst, keyDes, contentDeser, contentTypeDeser, readNullAsEmpty);
                     JsonIgnoreProperties.Value ignorals = config.getDefaultPropertyIgnorals(Map.class,
                             beanDesc.getClassInfo());
                     Set<String> ignored = (ignorals == null) ? null

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1165,7 +1165,7 @@ public abstract class BasicDeserializerFactory
                     //   most often it ought to be `Map` or `EnumMap`, but due to abstract
                     //   mapping it will more likely be concrete type like `HashMap`.
                     //   So, for time being, just pass `Map.class`
-                    boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                    boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask());
                     MapDeserializer md = new MapDeserializer(type, inst, keyDes, contentDeser, contentTypeDeser, readNullAsEmpty);
                     JsonIgnoreProperties.Value ignorals = config.getDefaultPropertyIgnorals(Map.class,
                             beanDesc.getClassInfo());

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -287,7 +287,7 @@ public class BeanDeserializer
             } while ((propName = p.nextFieldName()) != null);
         }
 
-        if (ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+        if (ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             Iterator<SettableBeanProperty> itr = _beanProperties.iterator();
             while (itr.hasNext()) {
                 SettableBeanProperty property = itr.next();

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -267,8 +267,10 @@ public class BeanDeserializer
         final Object bean = _valueInstantiator.createUsingDefault(ctxt);
         // [databind#631]: Assign current value, to be accessible by custom serializers
         p.setCurrentValue(bean);
+        Set<String> presentNames = new HashSet<String>();
         if (p.hasTokenId(JsonTokenId.ID_FIELD_NAME)) {
             String propName = p.getCurrentName();
+            presentNames.add(propName);
             do {
                 p.nextToken();
                 SettableBeanProperty prop = _beanProperties.find(propName);
@@ -284,6 +286,17 @@ public class BeanDeserializer
                 handleUnknownVanilla(p, ctxt, bean, propName);
             } while ((propName = p.nextFieldName()) != null);
         }
+
+        if (ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            Iterator<SettableBeanProperty> itr = _beanProperties.iterator();
+            while (itr.hasNext()) {
+                SettableBeanProperty property = itr.next();
+                if (!presentNames.contains(property._propName.getSimpleName())) {
+                    property.set(bean, property._valueDeserializer.getEmptyValue(ctxt));
+                }
+            }
+        }
+
         return bean;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ArrayBlockingQueueDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ArrayBlockingQueueDeserializer.java
@@ -39,10 +39,10 @@ public class ArrayBlockingQueueDeserializer
      protected ArrayBlockingQueueDeserializer(JavaType collectionType,
             JsonDeserializer<Object> valueDeser, TypeDeserializer valueTypeDeser,
             ValueInstantiator valueInstantiator,
-            JsonDeserializer<Object> delegateDeser, Boolean unwrapSingle)
+            JsonDeserializer<Object> delegateDeser, Boolean unwrapSingle, Boolean readNullAsArray)
     {
         super(collectionType, valueDeser, valueTypeDeser, valueInstantiator,
-                delegateDeser, unwrapSingle);
+                delegateDeser, unwrapSingle, readNullAsArray);
     }
 
     /**
@@ -59,7 +59,7 @@ public class ArrayBlockingQueueDeserializer
     @Override
     @SuppressWarnings("unchecked")
     protected ArrayBlockingQueueDeserializer withResolved(JsonDeserializer<?> dd,
-            JsonDeserializer<?> vd, TypeDeserializer vtd, Boolean unwrapSingle)
+            JsonDeserializer<?> vd, TypeDeserializer vtd, Boolean unwrapSingle, Boolean readNullAsArray)
     {
         if ((dd == _delegateDeserializer) && (vd == _valueDeserializer) && (vtd == _valueTypeDeserializer)
                 && (_unwrapSingle == unwrapSingle)) {
@@ -67,7 +67,7 @@ public class ArrayBlockingQueueDeserializer
         }
         return new ArrayBlockingQueueDeserializer(_collectionType,
                 (JsonDeserializer<Object>) vd, vtd,
-                _valueInstantiator, (JsonDeserializer<Object>) dd, unwrapSingle);
+                _valueInstantiator, (JsonDeserializer<Object>) dd, unwrapSingle, readNullAsArray);
                 
     }
 
@@ -135,4 +135,9 @@ public class ArrayBlockingQueueDeserializer
         // In future could check current token... for now this should be enough:
         return typeDeserializer.deserializeTypedFromArray(jp, ctxt);
     }
+
+    protected Collection<Object> createEmptyCollection(JsonParser parser, DeserializationContext ctxt) throws JsonMappingException {
+        return new ArrayBlockingQueue<>(1);
+    }
+
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -200,7 +200,7 @@ public class CollectionDeserializer
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
         Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
-                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask());
 
         // also, often value deserializer is resolved here:
         JsonDeserializer<?> valueDeser = _valueDeserializer;
@@ -444,7 +444,7 @@ public class CollectionDeserializer
     @Override
     public Collection<Object> getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyCollection(ctxt.getParser(), ctxt);
         } else {
             return super.getNullValue(ctxt);
@@ -454,7 +454,7 @@ public class CollectionDeserializer
     @Override
     public Collection<Object> getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyCollection(ctxt.getParser(), ctxt);
         } else {
             return super.getNullValue(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.impl.ReadableObjectId.Referring;
-import com.fasterxml.jackson.databind.deser.std.ContainerDeserializerBase;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 /**
@@ -64,6 +63,16 @@ public class CollectionDeserializer
      */
     protected final Boolean _unwrapSingle;
 
+
+    /**
+     * Specific override for this instance (from proper, or global per-type overrides)
+     * to indicate whether null and missing values may be interpreted as empty collections.
+     * If null, left to global defaults.
+     *
+     * @since 2.8
+     */
+    protected final Boolean _readNullAsEmpty;
+
     // NOTE: no PropertyBasedCreator, as JSON Arrays have no properties
 
     /*
@@ -80,7 +89,7 @@ public class CollectionDeserializer
             JsonDeserializer<Object> valueDeser,
             TypeDeserializer valueTypeDeser, ValueInstantiator valueInstantiator)
     {
-        this(collectionType, valueDeser, valueTypeDeser, valueInstantiator, null, null);
+        this(collectionType, valueDeser, valueTypeDeser, valueInstantiator, null, null, null);
     }
 
     /**
@@ -90,7 +99,8 @@ public class CollectionDeserializer
             JsonDeserializer<Object> valueDeser, TypeDeserializer valueTypeDeser,
             ValueInstantiator valueInstantiator,
             JsonDeserializer<Object> delegateDeser,
-            Boolean unwrapSingle)
+            Boolean unwrapSingle,
+            Boolean readNullAsEmpty)
     {
         super(collectionType);
         _collectionType = collectionType;
@@ -99,6 +109,7 @@ public class CollectionDeserializer
         _valueInstantiator = valueInstantiator;
         _delegateDeserializer = delegateDeser;
         _unwrapSingle = unwrapSingle;
+        _readNullAsEmpty = readNullAsEmpty;
     }
 
     /**
@@ -114,6 +125,7 @@ public class CollectionDeserializer
         _valueInstantiator = src._valueInstantiator;
         _delegateDeserializer = src._delegateDeserializer;
         _unwrapSingle = src._unwrapSingle;
+        _readNullAsEmpty = src._readNullAsEmpty;
     }
 
     /**
@@ -124,7 +136,7 @@ public class CollectionDeserializer
     @SuppressWarnings("unchecked")
     protected CollectionDeserializer withResolved(JsonDeserializer<?> dd,
             JsonDeserializer<?> vd, TypeDeserializer vtd,
-            Boolean unwrapSingle)
+            Boolean unwrapSingle, Boolean readNullAsEmpty)
     {
         if ((dd == _delegateDeserializer) && (vd == _valueDeserializer) && (vtd == _valueTypeDeserializer)
                 && (_unwrapSingle == unwrapSingle)) {
@@ -132,7 +144,7 @@ public class CollectionDeserializer
         }
         return new CollectionDeserializer(_collectionType,
                 (JsonDeserializer<Object>) vd, vtd,
-                _valueInstantiator, (JsonDeserializer<Object>) dd, unwrapSingle);
+                _valueInstantiator, (JsonDeserializer<Object>) dd, unwrapSingle, readNullAsEmpty);
     }
 
     /**
@@ -142,7 +154,7 @@ public class CollectionDeserializer
     protected CollectionDeserializer withResolved(JsonDeserializer<?> dd,
             JsonDeserializer<?> vd, TypeDeserializer vtd)
     {
-        return withResolved(dd, vd, vtd, _unwrapSingle);
+        return withResolved(dd, vd, vtd, _unwrapSingle, _readNullAsEmpty);
     }
 
     // Important: do NOT cache if polymorphic values
@@ -186,6 +198,10 @@ public class CollectionDeserializer
         //   comes down to "List vs Collection" I suppose... for now, pass Collection
         Boolean unwrapSingle = findFormatFeature(ctxt, property, Collection.class,
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
+        Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
+                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+
         // also, often value deserializer is resolved here:
         JsonDeserializer<?> valueDeser = _valueDeserializer;
         
@@ -202,7 +218,7 @@ public class CollectionDeserializer
         if (valueTypeDeser != null) {
             valueTypeDeser = valueTypeDeser.forProperty(property);
         }
-        return withResolved(delegateDeser, valueDeser, valueTypeDeser, unwrapSingle);
+        return withResolved(delegateDeser, valueDeser, valueTypeDeser, unwrapSingle, readNullAsEmpty);
     }
     
     /*
@@ -422,6 +438,42 @@ public class CollectionDeserializer
         @Override
         public void handleResolvedForwardReference(Object id, Object value) throws IOException {
             _parent.resolveForwardReference(id, value);
+        }
+    }
+
+    @Override
+    public Collection<Object> getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyCollection(ctxt.getParser(), ctxt);
+        } else {
+            return super.getNullValue(ctxt);
+        }
+    }
+
+    @Override
+    public Collection<Object> getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyCollection(ctxt.getParser(), ctxt);
+        } else {
+            return super.getNullValue(ctxt);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Collection<Object> createEmptyCollection(JsonParser parser, DeserializationContext ctxt) throws JsonMappingException {
+        try {
+            if (_valueInstantiator.canCreateUsingDefault()) {
+                return (Collection<Object>) _valueInstantiator.createUsingDefault(ctxt);
+            } else if (_valueInstantiator.canCreateUsingDelegate()) {
+                Object emptyValue = _delegateDeserializer.getEmptyValue(ctxt);
+                return (Collection<Object>) _valueInstantiator.createUsingDelegate(ctxt, emptyValue);
+            } else {
+                throw new JsonMappingException(parser, "Could not instantiate empty collection for type " + _collectionType.getRawClass().getSimpleName());
+            }
+        } catch (IOException ex) {
+            throw new JsonMappingException(parser, "Could not create collection of type " + _collectionType.getRawClass().getSimpleName(), ex);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -403,7 +403,7 @@ public class MapDeserializer
     @Override
     public Map<Object, Object> getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyCollection(ctxt.getParser(), ctxt);
         } else {
             return super.getNullValue(ctxt);
@@ -413,7 +413,7 @@ public class MapDeserializer
     @Override
     public Map<Object, Object> getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyCollection(ctxt.getParser(), ctxt);
         } else {
             return super.getNullValue(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -63,6 +63,15 @@ public class ObjectArrayDeserializer
      */
     protected final Boolean _unwrapSingle;
 
+    /**
+     * Specific override for this instance (from proper, or global per-type overrides)
+     * to indicate whether null and missing values may be interpreted as empty collections.
+     * If null, left to global defaults.
+     *
+     * @since 2.8
+     */
+    protected final Boolean _readNullAsEmpty;
+
     /*
     /**********************************************************
     /* Life-cycle
@@ -79,11 +88,12 @@ public class ObjectArrayDeserializer
         _elementDeserializer = elemDeser;
         _elementTypeDeserializer = elemTypeDeser;
         _unwrapSingle = null;
+        _readNullAsEmpty = null;
     }
 
     protected ObjectArrayDeserializer(ObjectArrayDeserializer base,
             JsonDeserializer<Object> elemDeser, TypeDeserializer elemTypeDeser,
-            Boolean unwrapSingle)
+            Boolean unwrapSingle, Boolean readNullAsEmpty)
     {
         super(base._arrayType);
         _arrayType = base._arrayType;
@@ -93,6 +103,7 @@ public class ObjectArrayDeserializer
         _elementDeserializer = elemDeser;
         _elementTypeDeserializer = elemTypeDeser;
         _unwrapSingle = unwrapSingle;
+        _readNullAsEmpty = readNullAsEmpty;
     }
     
     /**
@@ -101,7 +112,7 @@ public class ObjectArrayDeserializer
     public ObjectArrayDeserializer withDeserializer(TypeDeserializer elemTypeDeser,
             JsonDeserializer<?> elemDeser)
     {
-        return withResolved(elemTypeDeser, elemDeser, _unwrapSingle);
+        return withResolved(elemTypeDeser, elemDeser, _unwrapSingle, _readNullAsEmpty);
     }
 
     /**
@@ -109,15 +120,16 @@ public class ObjectArrayDeserializer
      */
     @SuppressWarnings("unchecked")
     public ObjectArrayDeserializer withResolved(TypeDeserializer elemTypeDeser,
-            JsonDeserializer<?> elemDeser, Boolean unwrapSingle)
+            JsonDeserializer<?> elemDeser, Boolean unwrapSingle, Boolean readNullAsEmpty)
     {
         if ((unwrapSingle == _unwrapSingle)
                 && (elemDeser == _elementDeserializer)
-                && (elemTypeDeser == _elementTypeDeserializer)) {
+                && (elemTypeDeser == _elementTypeDeserializer)
+                && (readNullAsEmpty == _readNullAsEmpty)) {
             return this;
         }
         return new ObjectArrayDeserializer(this,
-                (JsonDeserializer<Object>) elemDeser, elemTypeDeser, unwrapSingle);
+                (JsonDeserializer<Object>) elemDeser, elemTypeDeser, unwrapSingle, readNullAsEmpty);
     }
 
     @Override
@@ -127,6 +139,8 @@ public class ObjectArrayDeserializer
         JsonDeserializer<?> deser = _elementDeserializer;
         Boolean unwrapSingle = findFormatFeature(ctxt, property, _arrayType.getRawClass(),
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
+                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
         // May have a content converter
         deser = findConvertingContentDeserializer(ctxt, property, deser);
         final JavaType vt = _arrayType.getContentType();
@@ -139,7 +153,7 @@ public class ObjectArrayDeserializer
         if (elemTypeDeser != null) {
             elemTypeDeser = elemTypeDeser.forProperty(property);
         }
-        return withResolved(elemTypeDeser, deser, unwrapSingle);
+        return withResolved(elemTypeDeser, deser, unwrapSingle, readNullAsEmpty);
     }
 
     @Override // since 2.5
@@ -295,5 +309,36 @@ public class ObjectArrayDeserializer
         result[0] = value;
         return result;
     }
+
+    @Override
+    public Object[] getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyArray();
+        } else {
+            return super.getNullValue(ctxt);
+        }
+
+    }
+
+    @Override
+    public Object[] getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyArray();
+        } else {
+            return super.getNullValue(ctxt);
+        }
+    }
+
+    private Object[] createEmptyArray() {
+        if (_untyped) {
+            return new Object[0];
+        } else {
+            return (Object[]) Array.newInstance(_elementClass, 0);
+        }
+    }
+
+
 }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -140,7 +140,7 @@ public class ObjectArrayDeserializer
         Boolean unwrapSingle = findFormatFeature(ctxt, property, _arrayType.getRawClass(),
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
-                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask());
         // May have a content converter
         deser = findConvertingContentDeserializer(ctxt, property, deser);
         final JavaType vt = _arrayType.getContentType();
@@ -313,7 +313,7 @@ public class ObjectArrayDeserializer
     @Override
     public Object[] getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyArray();
         } else {
             return super.getNullValue(ctxt);
@@ -324,7 +324,7 @@ public class ObjectArrayDeserializer
     @Override
     public Object[] getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyArray();
         } else {
             return super.getNullValue(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
@@ -1,14 +1,17 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.Base64Variants;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.util.ArrayBuilders;
+
+import java.io.IOException;
 
 /**
  * Container for deserializers used for instantiating "primitive arrays",
@@ -27,18 +30,30 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
      */
     protected final Boolean _unwrapSingle;
 
+    /**
+     * Specific override for this instance (from proper, or global per-type overrides)
+     * to indicate whether null and missing values may be interpreted as empty collections.
+     * If null, left to global defaults.
+     *
+     * @since 2.8
+     */
+    protected final Boolean _readNullAsEmpty;
+
+
     protected PrimitiveArrayDeserializers(Class<T> cls) {
         super(cls);
         _unwrapSingle = null;
+        _readNullAsEmpty = null;
     }
 
     /**
      * @since 2.7
      */
     protected PrimitiveArrayDeserializers(PrimitiveArrayDeserializers<?> base,
-            Boolean unwrapSingle) {
+                                          Boolean unwrapSingle, Boolean readNullAsEmpty) {
         super(base._valueClass);
         _unwrapSingle = unwrapSingle;
+        _readNullAsEmpty = readNullAsEmpty;
     }
     
     public static JsonDeserializer<?> forType(Class<?> rawType)
@@ -75,7 +90,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     /**
      * @since 2.7
      */
-    protected abstract PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle);
+    protected abstract PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty);
 
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
@@ -86,7 +101,10 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         if (unwrapSingle == _unwrapSingle) {
             return this;
         }
-        return withResolved(unwrapSingle);
+        Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
+                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+
+        return withResolved(unwrapSingle, readNullAsEmpty);
     }
 
     @Override
@@ -121,6 +139,30 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     protected abstract T handleSingleElementUnwrapped(JsonParser p,
             DeserializationContext ctxt) throws IOException;
 
+    @Override
+    public T getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyArray();
+        } else {
+            return super.getNullValue(ctxt);
+        }
+
+    }
+
+    @Override
+    public T getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyArray();
+        } else {
+            return super.getNullValue(ctxt);
+        }
+
+    }
+
+    protected abstract T createEmptyArray();
+
     /*
     /********************************************************
     /* Actual deserializers: efficient String[], char[] deserializers
@@ -134,12 +176,12 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         private static final long serialVersionUID = 1L;
 
         public CharDeser() { super(char[].class); }
-        protected CharDeser(CharDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected CharDeser(CharDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
             // 11-Dec-2015, tatu: Not sure how re-wrapping would work; omit
             return this;
         }
@@ -206,6 +248,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
             // not sure how this should work...
             return (char[]) ctxt.handleUnexpectedToken(_valueClass, p);
         }
+
+        @Override
+        protected char[] createEmptyArray() {
+            return new char[0];
+        }
     }
 
     /*
@@ -221,13 +268,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         private static final long serialVersionUID = 1L;
 
         public BooleanDeser() { super(boolean[].class); }
-        protected BooleanDeser(BooleanDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected BooleanDeser(BooleanDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new BooleanDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new BooleanDeser(this, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
@@ -262,6 +309,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                 DeserializationContext ctxt) throws IOException {
             return new boolean[] { _parseBooleanPrimitive(p, ctxt) };
         }
+
+        @Override
+        protected boolean[] createEmptyArray() {
+            return new boolean[0];
+        }
     }
 
     /**
@@ -275,13 +327,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         private static final long serialVersionUID = 1L;
 
         public ByteDeser() { super(byte[].class); }
-        protected ByteDeser(ByteDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected ByteDeser(ByteDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new ByteDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new ByteDeser(this, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
@@ -355,6 +407,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
             }
             return new byte[] { value };
         }
+
+        @Override
+        protected byte[] createEmptyArray() {
+            return new byte[0];
+        }
     }
 
     @JacksonStdImpl
@@ -364,13 +421,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         private static final long serialVersionUID = 1L;
 
         public ShortDeser() { super(short[].class); }
-        protected ShortDeser(ShortDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected ShortDeser(ShortDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new ShortDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new ShortDeser(this, unwrapSingle, readNullAsEmpty);
         }
         
         @Override
@@ -403,6 +460,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                 DeserializationContext ctxt) throws IOException {
             return new short[] { _parseShortPrimitive(p, ctxt) };
         }
+
+        @Override
+        protected short[] createEmptyArray() {
+            return new short[0];
+        }
     }
 
     @JacksonStdImpl
@@ -414,13 +476,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         public final static IntDeser instance = new IntDeser();
         
         public IntDeser() { super(int[].class); }
-        protected IntDeser(IntDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected IntDeser(IntDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new IntDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new IntDeser(this, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
@@ -454,6 +516,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                 DeserializationContext ctxt) throws IOException {
             return new int[] { _parseIntPrimitive(p, ctxt) };
         }
+
+        @Override
+        protected int[] createEmptyArray() {
+            return new int[0];
+        }
     }
 
     @JacksonStdImpl
@@ -465,13 +532,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         public final static LongDeser instance = new LongDeser();
 
         public LongDeser() { super(long[].class); }
-        protected LongDeser(LongDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected LongDeser(LongDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new LongDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new LongDeser(this, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
@@ -504,6 +571,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                 DeserializationContext ctxt) throws IOException {
             return new long[] { _parseLongPrimitive(p, ctxt) };
         }
+
+        @Override
+        protected long[] createEmptyArray() {
+            return new long[0];
+        }
     }
 
     @JacksonStdImpl
@@ -513,13 +585,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         private static final long serialVersionUID = 1L;
 
         public FloatDeser() { super(float[].class); }
-        protected FloatDeser(FloatDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected FloatDeser(FloatDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new FloatDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new FloatDeser(this, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
@@ -554,6 +626,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                 DeserializationContext ctxt) throws IOException {
             return new float[] { _parseFloatPrimitive(p, ctxt) };
         }
+
+        @Override
+        protected float[] createEmptyArray() {
+            return new float[0];
+        }
     }
 
     @JacksonStdImpl
@@ -563,13 +640,13 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         private static final long serialVersionUID = 1L;
         
         public DoubleDeser() { super(double[].class); }
-        protected DoubleDeser(DoubleDeser base, Boolean unwrapSingle) {
-            super(base, unwrapSingle);
+        protected DoubleDeser(DoubleDeser base, Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            super(base, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
-        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle) {
-            return new DoubleDeser(this, unwrapSingle);
+        protected PrimitiveArrayDeserializers<?> withResolved(Boolean unwrapSingle, Boolean readNullAsEmpty) {
+            return new DoubleDeser(this, unwrapSingle, readNullAsEmpty);
         }
 
         @Override
@@ -601,6 +678,11 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
         protected double[] handleSingleElementUnwrapped(JsonParser p,
                 DeserializationContext ctxt) throws IOException {
             return new double[] { _parseDoublePrimitive(p, ctxt) };
+        }
+
+        @Override
+        protected double[] createEmptyArray() {
+            return new double[0];
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
@@ -102,7 +102,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
             return this;
         }
         Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
-                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask());
 
         return withResolved(unwrapSingle, readNullAsEmpty);
     }
@@ -142,7 +142,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     @Override
     public T getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyArray();
         } else {
             return super.getNullValue(ctxt);
@@ -153,7 +153,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
     @Override
     public T getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyArray();
         } else {
             return super.getNullValue(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.databind.deser.std;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
@@ -80,7 +79,7 @@ public final class StringArrayDeserializer
         Boolean unwrapSingle = findFormatFeature(ctxt, property, String[].class,
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
-                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask());
         // Ok ok: if all we got is the default String deserializer, can just forget about it
         if ((deser != null) && isDefaultDeserializer(deser)) {
             deser = null;
@@ -204,7 +203,7 @@ public final class StringArrayDeserializer
     @Override
     public String[] getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyArray();
         } else {
             return super.getNullValue(ctxt);
@@ -215,7 +214,7 @@ public final class StringArrayDeserializer
     @Override
     public String[] getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyArray();
         } else {
             return super.getNullValue(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -55,7 +55,16 @@ public final class StringCollectionDeserializer
      * @since 2.7
      */
     protected final Boolean _unwrapSingle;
-    
+
+    /**
+     * Specific override for this instance (from proper, or global per-type overrides)
+     * to indicate whether null and missing values may be interpreted as empty collections.
+     * If null, left to global defaults.
+     *
+     * @since 2.8
+     */
+    protected final Boolean _readNullAsEmpty;
+
     // NOTE: no PropertyBasedCreator, as JSON Arrays have no properties
 
     /*
@@ -67,13 +76,13 @@ public final class StringCollectionDeserializer
     public StringCollectionDeserializer(JavaType collectionType,
             JsonDeserializer<?> valueDeser, ValueInstantiator valueInstantiator)
     {
-        this(collectionType, valueInstantiator, null, valueDeser, null);
+        this(collectionType, valueInstantiator, null, valueDeser, null, null);
     }
 
     @SuppressWarnings("unchecked")
     protected StringCollectionDeserializer(JavaType collectionType,
             ValueInstantiator valueInstantiator, JsonDeserializer<?> delegateDeser,
-            JsonDeserializer<?> valueDeser, Boolean unwrapSingle)
+            JsonDeserializer<?> valueDeser, Boolean unwrapSingle, Boolean readNullAsEmpty)
     {
         super(collectionType);
         _collectionType = collectionType;
@@ -81,17 +90,20 @@ public final class StringCollectionDeserializer
         _valueInstantiator = valueInstantiator;
         _delegateDeserializer = (JsonDeserializer<Object>) delegateDeser;
         _unwrapSingle = unwrapSingle;
+        _readNullAsEmpty = readNullAsEmpty;
     }
 
     protected StringCollectionDeserializer withResolved(JsonDeserializer<?> delegateDeser,
-            JsonDeserializer<?> valueDeser, Boolean unwrapSingle)
+            JsonDeserializer<?> valueDeser, Boolean unwrapSingle, Boolean readNullAsEmpty)
     {
         if ((_unwrapSingle == unwrapSingle)
-                && (_valueDeserializer == valueDeser) && (_delegateDeserializer == delegateDeser)) {
+                && (_valueDeserializer == valueDeser)
+                && (_delegateDeserializer == delegateDeser)
+                && (_readNullAsEmpty == readNullAsEmpty)) {
             return this;
         }
         return new StringCollectionDeserializer(_collectionType,
-                _valueInstantiator, delegateDeser, valueDeser, unwrapSingle);
+                _valueInstantiator, delegateDeser, valueDeser, unwrapSingle, readNullAsEmpty);
     }
 
     @Override // since 2.5
@@ -137,7 +149,12 @@ public final class StringCollectionDeserializer
         if (isDefaultDeserializer(valueDeser)) {
             valueDeser = null;
         }
-        return withResolved(delegate, valueDeser, unwrapSingle);
+
+        Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
+                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+
+
+        return withResolved(delegate, valueDeser, unwrapSingle, readNullAsEmpty);
     }
     
     /*
@@ -242,6 +259,36 @@ public final class StringCollectionDeserializer
     public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
         // In future could check current token... for now this should be enough:
         return typeDeserializer.deserializeTypedFromArray(p, ctxt);
+    }
+
+
+    @Override
+    public Collection<String> getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyCollection(ctxt.getParser(), ctxt);
+        } else {
+            return super.getNullValue(ctxt);
+        }
+    }
+
+    @Override
+    public Collection<String> getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (_readNullAsEmpty == Boolean.TRUE ||
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+            return createEmptyCollection(ctxt.getParser(), ctxt);
+        } else {
+            return super.getNullValue(ctxt);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Collection<String> createEmptyCollection(JsonParser parser, DeserializationContext ctxt) throws JsonMappingException {
+        try {
+            return (Collection<String>) _valueInstantiator.createUsingDefault(ctxt);
+        } catch (IOException ex) {
+            throw new JsonMappingException(parser, "Could not create collection of type " + _collectionType.getRawClass().getSimpleName(), ex);
+        }
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -151,7 +151,7 @@ public final class StringCollectionDeserializer
         }
 
         Boolean readNullAsEmpty = ctxt.hasDeserializationFeatures(
-                DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask());
+                DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask());
 
 
         return withResolved(delegate, valueDeser, unwrapSingle, readNullAsEmpty);
@@ -265,7 +265,7 @@ public final class StringCollectionDeserializer
     @Override
     public Collection<String> getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyCollection(ctxt.getParser(), ctxt);
         } else {
             return super.getNullValue(ctxt);
@@ -275,7 +275,7 @@ public final class StringCollectionDeserializer
     @Override
     public Collection<String> getEmptyValue(DeserializationContext ctxt) throws JsonMappingException {
         if (_readNullAsEmpty == Boolean.TRUE ||
-                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION.getMask())) {
+                ctxt.hasDeserializationFeatures(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY.getMask())) {
             return createEmptyCollection(ctxt.getParser(), ctxt);
         } else {
             return super.getNullValue(ctxt);

--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -59,7 +59,7 @@ public abstract class BaseMapTest
         public DoubleWrapper() { }
         public DoubleWrapper(double value) { d = value; }
     }
-    
+
     /**
      * Simple wrapper around String type, usually to test value
      * conversions or wrapping
@@ -89,6 +89,9 @@ public abstract class BaseMapTest
     {
         public List<T> list;
 
+        public ListWrapper() {
+        }
+
         public ListWrapper(@SuppressWarnings("unchecked") T... values) {
             list = new ArrayList<T>();
             for (T value : values) {
@@ -101,11 +104,14 @@ public abstract class BaseMapTest
     {
         public Map<K,V> map;
 
+        public MapWrapper() {
+        }
+
         public MapWrapper(Map<K,V> m) {
             map = m;
         }
     }
-    
+
     protected static class ArrayWrapper<T>
     {
         public T[] array;
@@ -114,7 +120,7 @@ public abstract class BaseMapTest
             array = v;
         }
     }
-    
+
     /**
      * Enumeration type with sub-classes per value.
      */
@@ -137,7 +143,7 @@ public abstract class BaseMapTest
             x = x0;
             y = y0;
         }
-    
+
         @Override
         public boolean equals(Object o) {
             if (!(o instanceof Point)) {
@@ -188,7 +194,7 @@ public abstract class BaseMapTest
     /* Construction
     /**********************************************************
      */
-    
+
     protected BaseMapTest() { super(); }
 
     /*
@@ -205,7 +211,7 @@ public abstract class BaseMapTest
         }
         return SHARED_MAPPER;
     }
-    
+
     protected ObjectWriter objectWriter() {
         return objectMapper().writer();
     }
@@ -213,7 +219,7 @@ public abstract class BaseMapTest
     protected ObjectReader objectReader() {
         return objectMapper().reader();
     }
-    
+
     protected ObjectReader objectReader(Class<?> cls) {
         return objectMapper().readerFor(cls);
     }
@@ -262,7 +268,7 @@ public abstract class BaseMapTest
         String str = m.writeValueAsString(value);
         return (Map<String,Object>) m.readValue(str, Map.class);
     }
-    
+
     protected String serializeAsString(ObjectMapper m, Object value)
         throws IOException
     {
@@ -296,7 +302,7 @@ public abstract class BaseMapTest
     /* Helper methods, deserialization
     /**********************************************************
      */
-    
+
     protected <T> T readAndMapFromString(String input, Class<T> cls)
         throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyArrayDeserialization.java
@@ -34,7 +34,7 @@ public class TestEmptyArrayDeserialization
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        MAPPER.configure(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION, true);
+        MAPPER.configure(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY, true);
     }
 
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyArrayDeserialization.java
@@ -1,0 +1,104 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This unit test suite tries to verify that the "Native" java type
+ * mapper can properly re-construct Java array objects from Json arrays.
+ */
+public class TestEmptyArrayDeserialization
+        extends BaseMapTest {
+
+    private static final String EMPTY_OBJECT = "{}";
+
+
+    private static class ObjectArrayWrapper {
+        public Object[] wrapped;
+    }
+
+    private static class StringArrayWrapper {
+        public String[] wrapped;
+    }
+
+    private static class HiddenBinaryBean890 {
+        @JsonDeserialize(as = byte[].class)
+        public Object someBytes;
+    }
+
+    private final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        MAPPER.configure(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION, true);
+    }
+
+
+    public void testNullArray() throws Exception {
+        Object[] result = MAPPER.readValue("null", new TypeReference<Object[]>() {});
+
+        assertNotNull(result);
+        assertTrue(result.length == 0);
+    }
+
+    public void testNullStringArray() throws Exception {
+        String[] result = MAPPER.readValue("null", new TypeReference<String[]>() {});
+
+        assertNotNull(result);
+        assertTrue(result.length == 0);
+    }
+
+    public void testEmptyBeanArray() throws Exception {
+        ObjectArrayWrapper result = MAPPER.readValue(EMPTY_OBJECT, new TypeReference<ObjectArrayWrapper>() {});
+
+        assertNotNull(result.wrapped);
+        assertTrue(result.wrapped.length == 0);
+    }
+
+    public void testEmptyBeanStringArray() throws Exception {
+        StringArrayWrapper result = MAPPER.readValue(EMPTY_OBJECT, new TypeReference<StringArrayWrapper>() {});
+
+        assertNotNull(result.wrapped);
+        assertTrue(result.wrapped.length == 0);
+    }
+
+    public void testNullBeanArray() throws Exception {
+        String JSON = "{\"wrapped\": null}";
+
+        ObjectArrayWrapper result = MAPPER.readValue(JSON, new TypeReference<ObjectArrayWrapper>() {
+        });
+
+        assertNotNull(result.wrapped);
+        assertTrue(result.wrapped.length == 0);
+    }
+
+    /*
+    /**********************************************************
+    /* And special cases for byte array (base64 encoded)
+    /**********************************************************
+     */
+
+    // for [databind#890]
+    public void testEmptyByteArrayTypeOverride890() throws Exception {
+        HiddenBinaryBean890 result = MAPPER.readValue(
+                EMPTY_OBJECT, HiddenBinaryBean890.class);
+        assertNotNull(result);
+        assertNotNull(result.someBytes);
+        assertEquals(byte[].class, result.someBytes.getClass());
+        assertTrue(((byte[]) result.someBytes).length == 0);
+    }
+
+    // for [databind#890]
+    public void testNullByteArrayTypeOverride890() throws Exception {
+        HiddenBinaryBean890 result = MAPPER.readValue(
+                "{\"someBytes\": null}", HiddenBinaryBean890.class);
+        assertNotNull(result);
+        assertNotNull(result.someBytes);
+        assertEquals(byte[].class, result.someBytes.getClass());
+        assertTrue(((byte[]) result.someBytes).length == 0);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyCollectionDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyCollectionDeserialization.java
@@ -102,6 +102,13 @@ public class TestEmptyCollectionDeserialization
         assertTrue(result.isEmpty());
     }
 
+    public void testListFromEmpty() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        List<?> result = r.forType(List.class).readValue("");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
     public void testEmptyListWrapper() throws Exception {
         String JSON = EMPTY_OBJECT;
 
@@ -131,6 +138,13 @@ public class TestEmptyCollectionDeserialization
         assertTrue(result.isEmpty());
     }
 
+    public void testSetFromEmpty() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        Set<?> result = r.forType(Set.class).readValue("");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
     public void testEmptySetWrapper() throws Exception {
         String JSON = EMPTY_OBJECT;
 
@@ -154,6 +168,13 @@ public class TestEmptyCollectionDeserialization
     public void testMapFromNull() throws Exception {
         ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
         Map<?, ?> result = r.forType(Map.class).readValue("null");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testMapFromEmpty() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        Map<?, ?> result = r.forType(Map.class).readValue("");
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
@@ -189,6 +210,13 @@ public class TestEmptyCollectionDeserialization
     public void testIterableFromNull() throws Exception {
         ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
         Iterable<?> result = r.forType(Iterable.class).readValue("null");
+        assertNotNull(result);
+        assertFalse(result.iterator().hasNext());
+    }
+
+    public void testIterableFromEmpty() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        Iterable<?> result = r.forType(Iterable.class).readValue("");
         assertNotNull(result);
         assertFalse(result.iterator().hasNext());
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyCollectionDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyCollectionDeserialization.java
@@ -92,18 +92,18 @@ public class TestEmptyCollectionDeserialization
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        MAPPER.configure(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION, true);
+        MAPPER.configure(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY, true);
     }
 
     public void testListFromNull() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         List<?> result = r.forType(List.class).readValue("null");
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     public void testListFromEmpty() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         List<?> result = r.forType(List.class).readValue("");
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -132,14 +132,14 @@ public class TestEmptyCollectionDeserialization
     }
 
     public void testSetFromNull() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         Set<?> result = r.forType(Set.class).readValue("null");
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     public void testSetFromEmpty() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         Set<?> result = r.forType(Set.class).readValue("");
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -166,14 +166,14 @@ public class TestEmptyCollectionDeserialization
     }
 
     public void testMapFromNull() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         Map<?, ?> result = r.forType(Map.class).readValue("null");
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     public void testMapFromEmpty() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         Map<?, ?> result = r.forType(Map.class).readValue("");
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -208,14 +208,14 @@ public class TestEmptyCollectionDeserialization
     }
 
     public void testIterableFromNull() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         Iterable<?> result = r.forType(Iterable.class).readValue("null");
         assertNotNull(result);
         assertFalse(result.iterator().hasNext());
     }
 
     public void testIterableFromEmpty() throws Exception {
-        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_OR_MISSING_CONTAINER_AS_EMPTY);
         Iterable<?> result = r.forType(Iterable.class).readValue("");
         assertNotNull(result);
         assertFalse(result.iterator().hasNext());

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyCollectionDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEmptyCollectionDeserialization.java
@@ -1,0 +1,244 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
+
+@SuppressWarnings("serial")
+public class TestEmptyCollectionDeserialization
+        extends BaseMapTest {
+
+    private static final String EMPTY_OBJECT = "{}";
+
+    static class XBean {
+        public int x;
+
+        public XBean() {
+        }
+
+        public XBean(int x) {
+            this.x = x;
+        }
+    }
+
+    // [Issue#199]
+    static class ListAsIterable {
+        public Iterable<String> values;
+    }
+
+    static class ListAsIterableX {
+        public Iterable<XBean> nums;
+    }
+
+    // [Issue#828]
+    @JsonDeserialize(using = SomeObjectDeserializer.class)
+    static class SomeObject {
+    }
+
+    static class SomeObjectDeserializer extends StdDeserializer<SomeObject> {
+        public SomeObjectDeserializer() {
+            super(SomeObject.class);
+        }
+
+        @Override
+        public SomeObject deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            throw new RuntimeException("I want to catch this exception");
+        }
+    }
+
+    private static class SetWrapper<T> {
+        public Set<T> set;
+
+        public SetWrapper() {
+        }
+
+        public SetWrapper(@SuppressWarnings("unchecked") T... values) {
+            set = new HashSet<T>();
+            Collections.addAll(set, values);
+        }
+    }
+
+    private static class ArrayBlockingQueueWrapper<T> {
+        public ArrayBlockingQueue<T> queue;
+
+        public ArrayBlockingQueueWrapper() {
+
+        }
+
+        public ArrayBlockingQueueWrapper(@SuppressWarnings("unchecked") T... values) {
+            queue = new ArrayBlockingQueue<T>(values.length + 1);
+            Collections.addAll(queue, values);
+        }
+
+
+    }
+
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final static ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MAPPER.configure(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION, true);
+    }
+
+    public void testListFromNull() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        List<?> result = r.forType(List.class).readValue("null");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testEmptyListWrapper() throws Exception {
+        String JSON = EMPTY_OBJECT;
+
+        ListWrapper<Object> result = MAPPER.readValue(JSON, new TypeReference<ListWrapper<Object>>() {});
+        assertNotNull(result);
+
+        assertNotNull(result.list);
+
+        assertTrue(result.list.isEmpty());
+    }
+
+    public void testNullListWrapper() throws Exception {
+        String JSON = "{\"list\": null}";
+
+        ListWrapper<Object> result = MAPPER.readValue(JSON, new TypeReference<ListWrapper<Object>>() {});
+        assertNotNull(result);
+
+        assertNotNull(result.list);
+
+        assertTrue(result.list.isEmpty());
+    }
+
+    public void testSetFromNull() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        Set<?> result = r.forType(Set.class).readValue("null");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testEmptySetWrapper() throws Exception {
+        String JSON = EMPTY_OBJECT;
+
+        SetWrapper<Object> result = MAPPER.readValue(JSON, new TypeReference<SetWrapper<Object>>() {});
+        assertNotNull(result);
+
+        assertNotNull(result.set);
+        assertTrue(result.set.isEmpty());
+    }
+
+    public void testNullSetWrapper() throws Exception {
+        String JSON = "{\"set\": null}";
+
+        SetWrapper<Object> result = MAPPER.readValue(JSON, new TypeReference<SetWrapper<Object>>() {});
+        assertNotNull(result);
+
+        assertNotNull(result.set);
+        assertTrue(result.set.isEmpty());
+    }
+
+    public void testMapFromNull() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        Map<?, ?> result = r.forType(Map.class).readValue("null");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testEmptyMapWrapper() throws Exception {
+        String JSON = EMPTY_OBJECT;
+
+        MapWrapper<Integer, Object> result = MAPPER.readValue(JSON, new TypeReference<MapWrapper<Integer, Object>>() {});
+        assertNotNull(result);
+
+        assertNotNull(result.map);
+        assertTrue(result.map.isEmpty());
+    }
+
+    public void testNullMapWrapper() throws Exception {
+        String JSON = "{\"map\": null}";
+
+        MapWrapper<Integer, Object> result = MAPPER.readValue(JSON, new TypeReference<MapWrapper<Integer, Object>>() {});
+        assertNotNull(result);
+
+        assertNotNull(result.map);
+        assertTrue(result.map.isEmpty());
+    }
+
+    // [databind#161]
+    public void testArrayBlockingQueueWrapper() throws Exception {
+        ArrayBlockingQueueWrapper<?> q = MAPPER.readValue(EMPTY_OBJECT, ArrayBlockingQueueWrapper.class);
+        assertNotNull(q);
+        assertNotNull(q.queue);
+        assertTrue(q.queue.isEmpty());
+    }
+
+    public void testIterableFromNull() throws Exception {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.READ_NULL_AS_EMPTY_COLLECTION);
+        Iterable<?> result = r.forType(Iterable.class).readValue("null");
+        assertNotNull(result);
+        assertFalse(result.iterator().hasNext());
+    }
+
+    // [databind#199]
+    public void testIterableWrapperWithStrings() throws Exception {
+        String JSON = EMPTY_OBJECT;
+        ListAsIterable w = MAPPER.readValue(JSON, ListAsIterable.class);
+        assertNotNull(w);
+        assertNotNull(w.values);
+        Iterator<String> it = w.values.iterator();
+        assertFalse(it.hasNext());
+    }
+
+    // [databind#199]
+    public void testIterableWrapperWithNullString() throws Exception {
+        String JSON = "{\"values\": null}";
+        ListAsIterable w = MAPPER.readValue(JSON, ListAsIterable.class);
+        assertNotNull(w);
+        assertNotNull(w.values);
+        Iterator<String> it = w.values.iterator();
+        assertFalse(it.hasNext());
+    }
+
+    public void testEmptyIterableWithBeans() throws Exception {
+        String JSON = EMPTY_OBJECT;
+        ListAsIterableX w = MAPPER.readValue(JSON, ListAsIterableX.class);
+        assertNotNull(w);
+        assertNotNull(w.nums);
+        Iterator<XBean> it = w.nums.iterator();
+        assertFalse(it.hasNext());
+    }
+
+    public void testNullIterableWithBeans() throws Exception {
+        String JSON = "{\"nums\": null}";
+        ListAsIterableX w = MAPPER.readValue(JSON, ListAsIterableX.class);
+        assertNotNull(w);
+        assertNotNull(w.nums);
+        Iterator<XBean> it = w.nums.iterator();
+        assertFalse(it.hasNext());
+    }
+
+    // And then a round-trip test for empty collections
+    public void testRoundtrippingCollections() throws Exception {
+        final TypeReference<?> listWrapperType = new TypeReference<ListWrapper<Object>>() {};
+
+        String json = MAPPER.writeValueAsString(new ListWrapper());
+        ListWrapper<Object> result = MAPPER.readValue(json, listWrapperType);
+        assertNotNull(result);
+        assertNotNull(result.list);
+        assertTrue(result.list.isEmpty());
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestJsonSerialize2.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestJsonSerialize2.java
@@ -181,7 +181,7 @@ public class TestJsonSerialize2
         ObjectMapper defMapper = MAPPER;
         ObjectMapper inclMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
-        ListWrapper<String> list = new ListWrapper<String>();
+        ListWrapper<String> list = new ListWrapper<String>(new String[0]);
         assertEquals("{\"list\":[]}", defMapper.writeValueAsString(list));
         assertEquals("{}", inclMapper.writeValueAsString(list));
         assertEquals("{}", inclMapper.writeValueAsString(new ListWrapper<String>()));


### PR DESCRIPTION
Here's a basic approach - feels a bit blunt-force, but it seems to get the job done.

I'm afraid I don't understand contextual deserializers at all. There seems to be a problem where removing the check for the feature in BeanDeserializer#290 breaks a number of the contextual tests. The check gets them passing again, but it would be good to validate it with someone who better understood what was going on with that.

Should I add some user documentation? If so, where?

As discussed here: https://github.com/FasterXML/jackson-module-scala/pull/257 
