### PR TITLE
NullPointerException in JsonNodeDeserializer.java

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -222,6 +222,9 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
         for (; key != null; key = p.nextFieldName()) {
             JsonNode value;
             JsonToken t = p.nextToken();
+            if (t == null) {
+                throw new JsonParseException(p, "end-of-input while reading object.");
+            }
             switch (t.id()) {
             case JsonTokenId.ID_START_OBJECT:
                 value = deserializeObject(p, ctxt, nodeFactory);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestEndOfInputObjectMapper1260.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestEndOfInputObjectMapper1260.java
@@ -1,0 +1,28 @@
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestEndOfInputObjectMapper1260 {
+  @Test
+  public void testErrorHandling() throws IOException {
+    JsonParser parser = new JsonFactory().createParser("{\"A\":{\"B\":\n\n.");
+    parser.setCodec(new ObjectMapper());
+    try {
+      parser.readValueAsTree();
+    }
+    catch(JsonParseException e) {
+      // Intentional: Unexpected character ('.' (code 46)):
+    }
+    try {
+      parser.readValueAsTree();
+    }
+    catch(IOException e) {
+      // An IO error would be expected here, but 2.7.4 had a NPE here.
+    }
+  }
+}


### PR DESCRIPTION
At end-of-input (badly formed input), `t` can be `null` here in some rare conditions.
Maybe throw an `IOException` instead?

Here is the backtrace with version 2.7.4 from Mavencentral:
```
Caused by: java.lang.NullPointerException
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:222)
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeAny(JsonNodeDeserializer.java:309)
	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:73)
	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:15)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:3779)
	at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:2158)
	at com.fasterxml.jackson.core.JsonParser.readValueAsTree(JsonParser.java:1564)
```

I will also add a unit test, which indicates that this may need to be fixed earlier, probably in `ObjectMapper.readTree`.