### PR TITLE
Null-safe equality check

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/type/ResolvedRecursiveType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/ResolvedRecursiveType.java
@@ -99,7 +99,8 @@ public class ResolvedRecursiveType extends TypeBase
         if (o == this) return true;
         if (o == null) return false;
         if (o.getClass() != getClass()) return false;
-
-        return ((ResolvedRecursiveType) o).getSelfReferencedType().equals(getSelfReferencedType());
+        
+        ResolvedRecursiveType other = (ResolvedRecursiveType) o;
+        return getSelfReferencedType() != null && getSelfReferencedType().equals(other.getSelfReferencedType());
     }
 }


### PR DESCRIPTION
This equality check needs to be null-safe. It appears that getSelfReferencedType() may not be always non-null. Due to this, I have seen null pointer exceptions thrown from ResolvedRecursiveType.equals() . 

Here's one example where object of type ResolvedRecursiveType is created which could return null  for getSelfReferencedType() calls. :

```java
                // In TypeFactory.java
                // Self-reference: needs special handling, then...
                ResolvedRecursiveType selfRef = new ResolvedRecursiveType(rawType, EMPTY_BINDINGS);
                prev.addSelfReference(selfRef);
                return selfRef;
```

