### PR TITLE
Timestamp deserialization error

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
@@ -310,7 +310,7 @@ public class DateDeserializers
             if (d == null){
                 return null;
             }else{
-                return new Timestamp(_parseDate(jp, ctxt).getTime());
+                return new Timestamp(d.getTime());
             }
         }
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
@@ -306,7 +306,12 @@ public class DateDeserializers
         @Override
         public java.sql.Timestamp deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException
         {
-            return new Timestamp(_parseDate(jp, ctxt).getTime());
+            Date d = _parseDate(jp, ctxt);
+            if (d == null){
+                return null;
+            }else{
+                return new Timestamp(_parseDate(jp, ctxt).getTime());
+            }
         }
     }
 }


### PR DESCRIPTION
When the Timestamp type is deserialization, if date is null, it will throw a NullException.