### PR TITLE
Fix Empty String deserialized as null

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringDeserializer.java
@@ -28,7 +28,8 @@ public final class StringDeserializer extends StdScalarDeserializer<String>
     public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException
     {
         if (p.hasToken(JsonToken.VALUE_STRING)) {
-            return p.getText();
+            String tokenValue = p.getText();
+            return (tokenValue.length == 0 && ctxt.isEnabled(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)) ? null : tokenValue;
         }
         JsonToken t = p.getCurrentToken();
         // [databind#381]


### PR DESCRIPTION
As title says.

I detected that by enabling empty strings deserialization to null on ObjectMapper Config

`mapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);`

That it was being ignored.

I believe that this will fix this issue