### PR TITLE
Fixed ArrayIndexOutOfBoundException for enum by index deser

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -136,7 +136,7 @@ public class EnumDeserializer
                         "not allowed to deserialize Enum value out of number: disable DeserializationConfig.DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS to allow"
                         );
             }
-            if (index >= 0 && index <= _enumsByIndex.length) {
+            if (index >= 0 && index < _enumsByIndex.length) {
                 return _enumsByIndex[index];
             }
             if ((_enumDefaultValue != null)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/EnumDeserializationTest.java
@@ -458,11 +458,35 @@ public class EnumDeserializationTest
         assertSame(EnumWithDefaultAnno.OTHER, myEnum);
     }
 
-    public void testEnumWithDefaultAnnotationUsingIndexes() throws Exception {
+    public void testEnumWithDefaultAnnotationUsingIndexInBound1() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
 
-        EnumWithDefaultAnno myEnum = mapper.readValue("9", EnumWithDefaultAnno.class);
+        EnumWithDefaultAnno myEnum = mapper.readValue("1", EnumWithDefaultAnno.class);
+        assertSame(EnumWithDefaultAnno.B, myEnum);
+    }
+
+    public void testEnumWithDefaultAnnotationUsingIndexInBound2() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumWithDefaultAnno myEnum = mapper.readValue("2", EnumWithDefaultAnno.class);
+        assertSame(EnumWithDefaultAnno.OTHER, myEnum);
+    }
+
+    public void testEnumWithDefaultAnnotationUsingIndexSameAsLength() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumWithDefaultAnno myEnum = mapper.readValue("3", EnumWithDefaultAnno.class);
+        assertSame(EnumWithDefaultAnno.OTHER, myEnum);
+    }
+
+    public void testEnumWithDefaultAnnotationUsingIndexOutOfBound() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumWithDefaultAnno myEnum = mapper.readValue("4", EnumWithDefaultAnno.class);
         assertSame(EnumWithDefaultAnno.OTHER, myEnum);
     }
 


### PR DESCRIPTION
You get index out of bound exception during deserialization of enum by index if you provide index equal to number of Enum elements. Even if `READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` is enabled.