### PR TITLE
Fix misleading javadoc for PascalCaseStrategy

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
@@ -422,7 +422,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     public static class LowerCaseWithUnderscoresStrategy extends SnakeCaseStrategy {}
 
     /**
-     * @deprecated In 2.7 use {@link SnakeCaseStrategy} instead
+     * @deprecated In 2.7 use {@link UpperCamelCaseStrategy} instead
      */
     @Deprecated
     public static class PascalCaseStrategy extends UpperCamelCaseStrategy {}


### PR DESCRIPTION
PascalCaseStrategy replacement is UpperCamelCaseStrategy, not SnakeCaseStrategy