### PR TITLE
Problem with handling of multi-argument creator with Enums

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -158,9 +158,7 @@ class FactoryBasedEnumDeserializer
     
             SettableBeanProperty creatorProp = creator.findCreatorProperty(propName);
             if (creatorProp != null) {
-                if (buffer.assignParameter(creatorProp, _deserializeWithErrorWrapping(p, ctxt, creatorProp))) {
-                    p.nextToken(); // to move to next field name
-                }
+                buffer.assignParameter(creatorProp, _deserializeWithErrorWrapping(p, ctxt, creatorProp));
                 continue;
             }
             if (buffer.readIdProperty(propName)) {

--- a/src/test/java/com/fasterxml/jackson/databind/creators/EnumCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/creators/EnumCreatorTest.java
@@ -275,6 +275,12 @@ public class EnumCreatorTest extends BaseMapTest
     {
         Enum929 v = MAPPER.readValue("{\"id\":3,\"name\":\"B\"}", Enum929.class);
         assertEquals(Enum929.B, v);
+        EnumSet<Enum929> valueEnumSet = MAPPER.readValue("[{\"id\":3,\"name\":\"B\"}, {\"id\":3,\"name\":\"A\"}]",
+                new TypeReference<EnumSet<Enum929>>() {});
+        assertTrue(valueEnumSet.contains(v));
+        List<Enum929> valueList = MAPPER.readValue("[{\"id\":3,\"name\":\"B\"}, {\"id\":3,\"name\":\"A\"}, {\"id\":3,\"name\":\"B\"}]",
+                new TypeReference<List<Enum929>>() {});
+        assertTrue(valueList.contains(v));
     }
     
     // for [databind#960]


### PR DESCRIPTION
Fix error (#1272) in multi-arg enum creator, when create it in List or Set.

Error example:

```java
    static enum Enum929
    {
        A, B, C;

        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
        static Enum929 forValues(@JsonProperty("id") int intProp,
                                 @JsonProperty("name") String name)
        {
            return Enum929.valueOf(name);
        }
    }
```
```java
EnumSet<Enum929> valueEnumSet = MAPPER.readValue("[{\"id\":3,\"name\":\"B\"}, {\"id\":3,\"name\":\"A\"}]", new TypeReference<EnumSet<Enum929>>() {});
```
Throw error:
```
com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.fasterxml.jackson.databind.creators.EnumCreatorTest$Enum929, problem: wrong number of arguments
 at [Source: [{"id":3,"name":"B"}, {"id":3,"name":"A"}]; line: 1, column: 24] (through reference chain: java.util.RegularEnumSet[1])

	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:268)
	at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:1441)
	at com.fasterxml.jackson.databind.DeserializationContext.handleInstantiationProblem(DeserializationContext.java:1055)
	at com.fasterxml.jackson.databind.deser.std.FactoryBasedEnumDeserializer.deserialize(FactoryBasedEnumDeserializer.java:136)
	at com.fasterxml.jackson.databind.deser.std.EnumSetDeserializer.deserialize(EnumSetDeserializer.java:142)
	at com.fasterxml.jackson.databind.deser.std.EnumSetDeserializer.deserialize(EnumSetDeserializer.java:18)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3787)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2850)
	at com.fasterxml.jackson.databind.creators.EnumCreatorTest.testMultiArgEnumCreator(EnumCreatorTest.java:276)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:42)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:262)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:84)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: java.lang.IllegalArgumentException: wrong number of arguments
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.fasterxml.jackson.databind.introspect.AnnotatedMethod.callOnWith(AnnotatedMethod.java:130)
	at com.fasterxml.jackson.databind.deser.std.FactoryBasedEnumDeserializer.deserialize(FactoryBasedEnumDeserializer.java:133)
	... 28 more
```