### PR TITLE
Fixed #1324, remove inefficient boolean parsing with BigInteger

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -229,9 +229,7 @@ public abstract class StdDeserializer<T>
         if (str.trim().length() == 0) {
             return (Boolean) getEmptyValue(ctxt);
         }
-
-        char c = str.charAt(0);
-        return c == '0' ? Boolean.FALSE : Boolean.TRUE;
+        return (str.charAt(0) == '0') ? Boolean.FALSE : Boolean.TRUE;
     }
 
     protected Byte _parseByte(JsonParser p, DeserializationContext ctxt) throws IOException {


### PR DESCRIPTION
Removed inefficient boolean parsing in StdDeserializer when provided value is too large