### PR TITLE
fix ObjectMapper: Bind types to TypeReference<> parameter

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2759,8 +2759,8 @@ public class ObjectMapper
      * @throws JsonMappingException if the input JSON structure does not match structure
      *   expected for result type (or has other mismatch issues)
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(File src, TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(File src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueTypeRef));
@@ -2816,8 +2816,8 @@ public class ObjectMapper
      * @throws JsonMappingException if the input JSON structure does not match structure
      *   expected for result type (or has other mismatch issues)
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(URL src, TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(URL src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueTypeRef));
@@ -2861,8 +2861,8 @@ public class ObjectMapper
      * @throws JsonMappingException if the input JSON structure does not match structure
      *   expected for result type (or has other mismatch issues)
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(String content, TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(String content, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(content), _typeFactory.constructType(valueTypeRef));
@@ -2894,8 +2894,8 @@ public class ObjectMapper
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueType));
     } 
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(Reader src, TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(Reader src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueTypeRef));
@@ -2915,8 +2915,8 @@ public class ObjectMapper
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueType));
     } 
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(InputStream src, TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(InputStream src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueTypeRef));
@@ -2944,16 +2944,15 @@ public class ObjectMapper
         return (T) _readMapAndClose(_jsonFactory.createParser(src, offset, len), _typeFactory.constructType(valueType));
     } 
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(byte[] src, TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(byte[] src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(src), _typeFactory.constructType(valueTypeRef));
     } 
     
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(byte[] src, int offset, int len,
-                           TypeReference valueTypeRef)
+    @SuppressWarnings({ "unchecked" })
+    public <T> T readValue(byte[] src, int offset, int len, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         return (T) _readMapAndClose(_jsonFactory.createParser(src, offset, len), _typeFactory.constructType(valueTypeRef));

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestCollectionDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestCollectionDeserialization.java
@@ -288,7 +288,7 @@ public class TestCollectionDeserialization
     // And then a round-trip test for singleton collections
     public void testSingletonCollections() throws Exception
     {
-        final TypeReference<?> xbeanListType = new TypeReference<List<XBean>>() { };
+        final TypeReference<List<XBean>> xbeanListType = new TypeReference<List<XBean>>() { };
 
         String json = MAPPER.writeValueAsString(Collections.singleton(new XBean(3)));
         Collection<XBean> result = MAPPER.readValue(json, xbeanListType);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestMapDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestMapDeserialization.java
@@ -245,15 +245,15 @@ public class TestMapDeserialization
     {
         // to get typing, must use type reference
         String JSON = "{ \"1\" : true, \"-1\" : false }";
-        Map<String,Integer> result = MAPPER.readValue
+        Map<Integer, Boolean> result = MAPPER.readValue
             (JSON, new TypeReference<HashMap<Integer,Boolean>>() { });
 
         assertNotNull(result);
         assertEquals(HashMap.class, result.getClass());
         assertEquals(2, result.size());
 
-        assertEquals(Boolean.TRUE, result.get(Integer.valueOf(1)));
-        assertEquals(Boolean.FALSE, result.get(Integer.valueOf(-1)));
+        assertEquals(Boolean.TRUE, result.get(1));
+        assertEquals(Boolean.FALSE, result.get(-1));
         assertNull(result.get("foobar"));
         assertNull(result.get(0));
     }
@@ -262,7 +262,7 @@ public class TestMapDeserialization
     {
         // to get typing, must use type reference
         String JSON = "{ \"a\" : \"b\" }";
-        Map<String,Integer> result = MAPPER.readValue
+        Map<String, String> result = MAPPER.readValue
             (JSON, new TypeReference<TreeMap<String,String>>() { });
 
         assertNotNull(result);
@@ -286,8 +286,8 @@ public class TestMapDeserialization
         String JSON = "{ \"a\" : 1, \"b\" : 2, \"c\" : -99 }";
         Map<String,Integer> result = MAPPER.readValue
             (JSON, new TypeReference<Map<String,Integer>>() { });
+
         assertNotNull(result);
-        assertTrue(result instanceof Map<?,?>);
         assertEquals(3, result.size());
 
         assertEquals(Integer.valueOf(-99), result.get("c"));
@@ -355,11 +355,11 @@ public class TestMapDeserialization
         String JSON = "{ \"KEY2\" : \"WHATEVER\" }";
 
         // to get typing, must use type reference
-        Map<Enum<?>,Enum<?>> result = MAPPER.readValue
+        Map<Key, Key> result = MAPPER.readValue
             (JSON, new TypeReference<Map<Key,Key>>() { });
 
         assertNotNull(result);
-        assertTrue(result instanceof Map<?,?>);
+        assertTrue(true);
         assertEquals(1, result.size());
 
         assertEquals(Key.WHATEVER, result.get(Key.KEY2));

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapRelatedTypesDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapRelatedTypesDeserTest.java
@@ -71,7 +71,8 @@ public class MapRelatedTypesDeserTest
     // JDK singletonMap
     public void testSingletonMapRoundtrip() throws Exception
     {
-        final TypeReference<?> type = new TypeReference<Map<String,IntWrapper>>() { };
+        final TypeReference<Map<String,IntWrapper>> type =
+            new TypeReference<Map<String,IntWrapper>>() { };
 
         String json = MAPPER.writeValueAsString(Collections.singletonMap("value", new IntWrapper(5)));
         Map<String,IntWrapper> result = MAPPER.readValue(json, type);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedContainerSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedContainerSerialization.java
@@ -138,7 +138,7 @@ public class TestTypedContainerSerialization
             List<Issue508A> l2 = new ArrayList<Issue508A>();
             l2.add(new Issue508A());
             l.add(l2);
-            TypeReference<?> typeRef = new TypeReference<List<List<Issue508A>>>() {};
+            TypeReference<List<List<Issue508A>>> typeRef = new TypeReference<List<List<Issue508A>>>() {};
             String json = mapper.writerFor(typeRef).writeValueAsString(l);
 
             List<?> output = mapper.readValue(json, typeRef);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeId999Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeId999Test.java
@@ -39,7 +39,7 @@ public class ExternalTypeId999Test extends BaseMapTest
 
     public void testExternalTypeId() throws Exception
     {
-        TypeReference<?> type = new TypeReference<Message<FooPayload>>() { };
+        TypeReference<Message<FooPayload>> type = new TypeReference<Message<FooPayload>>() { };
 
         Message<?> msg = MAPPER.readValue(aposToQuotes("{ 'type':'foo', 'payload': {} }"), type);
         assertNotNull(msg);


### PR DESCRIPTION
Previously functions making use of types passed via `TypeReference<T>`
did not bind return values explicitly to the referenced type.

This changes the signatures of those functions to make use of the
referenced type.

This will cause compile-time errors in code that "worked" before, such as:

```
Long l = mapper.readValue(someString, new TypeReference<String>(){});
```

Which should fail as `String` cannot safely be cast to `Long`.

---

I stumbled upon this problem earlier today and talked to a few friends to figure out if there was a reason why this was not done, and why in fact the warning that catches this (`rawtypes`) was explicitly supressed. We didn't come up with anything so I'm assuming it is a bug and submitting this PR to fix it.

If there _is_ in fact a reason for this behaviour I'd appreciate an explanation.

Cheers!
