### PR TITLE
Explicitly pass null on invoke calls  with no arguments

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -173,7 +173,7 @@ public class BuilderBasedDeserializer
             return builder;
         }
         try {
-            return _buildMethod.getMember().invoke(builder);
+            return _buildMethod.getMember().invoke(builder, (Object[]) null);
         } catch (Exception e) {
             return wrapInstantiationProblem(e, ctxt);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
@@ -114,7 +114,7 @@ public class BeanAsArrayBuilderDeserializer
         throws IOException
     {
         try {
-            return _buildMethod.getMember().invoke(builder);
+            return _buildMethod.getMember().invoke(builder, (Object[]) null);
         } catch (Exception e) {
             return wrapInstantiationProblem(e, ctxt);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/SetterlessProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/SetterlessProperty.java
@@ -110,7 +110,7 @@ public final class SetterlessProperty
         // Ok: then, need to fetch Collection/Map to modify:
         Object toModify;
         try {
-            toModify = _getter.invoke(instance);
+            toModify = _getter.invoke(instance, (Object[]) null);
         } catch (Exception e) {
             _throwAsIOE(p, e);
             return; // never gets here

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
@@ -123,7 +123,7 @@ public final class AnnotatedMethod
     }
 
     public final Object callOn(Object pojo) throws Exception {
-        return _method.invoke(pojo);
+        return _method.invoke(pojo, (Object[]) null);
     }
 
     public final Object callOnWith(Object pojo, Object... args) throws Exception {
@@ -191,7 +191,7 @@ public final class AnnotatedMethod
     public Object getValue(Object pojo) throws IllegalArgumentException
     {
         try {
-            return _method.invoke(pojo);
+            return _method.invoke(pojo, (Object[]) null);
         } catch (IllegalAccessException e) {
             throw new IllegalArgumentException("Failed to getValue() with method "
                     +getFullName()+": "+e.getMessage(), e);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
@@ -680,7 +680,7 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
             SerializerProvider prov) throws Exception {
         // inlined 'get()'
         final Object value = (_accessorMethod == null) ? _field.get(bean)
-                : _accessorMethod.invoke(bean);
+                : _accessorMethod.invoke(bean, (Object[]) null);
 
         // Null handling is bit different, check that first
         if (value == null) {
@@ -752,7 +752,7 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
             SerializerProvider prov) throws Exception {
         // inlined 'get()'
         final Object value = (_accessorMethod == null) ? _field.get(bean)
-                : _accessorMethod.invoke(bean);
+                : _accessorMethod.invoke(bean, (Object[]) null);
         if (value == null) { // nulls need specialized handling
             if (_nullSerializer != null) {
                 _nullSerializer.serialize(null, gen, prov);
@@ -908,7 +908,7 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
      */
     public final Object get(Object bean) throws Exception {
         return (_accessorMethod == null) ? _field.get(bean) : _accessorMethod
-                .invoke(bean);
+                .invoke(bean, (Object[]) null);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -102,7 +102,7 @@ public class EnumResolver implements java.io.Serializable
         for (int i = enumValues.length; --i >= 0; ) {
             Enum<?> en = enumValues[i];
             try {
-                Object o = accessor.invoke(en);
+                Object o = accessor.invoke(en, (Object[]) null);
                 if (o != null) {
                     map.put(o.toString(), en);
                 }


### PR DESCRIPTION
Java will complete no-args varargs calls with a new empty array. 
Avoid this by sending a null.