### PR TITLE
[databind#1433] ObjectMapper.convertValue no longer shortcuts nulls.

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -348,9 +348,9 @@ public class ObjectMapperTest extends BaseMapTest
     // [databind#1433]
     public void testConvertValueNullPrimitive() throws Exception
     {
-    	assertEquals(Byte.valueOf((byte) 0), MAPPER.convertValue(null, Byte.TYPE));
-    	assertEquals(Short.valueOf((short) 0), MAPPER.convertValue(null, Short.TYPE));
-    	assertEquals(Integer.valueOf(0), MAPPER.convertValue(null, Integer.TYPE));
+        assertEquals(Byte.valueOf((byte) 0), MAPPER.convertValue(null, Byte.TYPE));
+        assertEquals(Short.valueOf((short) 0), MAPPER.convertValue(null, Short.TYPE));
+        assertEquals(Integer.valueOf(0), MAPPER.convertValue(null, Integer.TYPE));
         assertEquals(Long.valueOf(0L), MAPPER.convertValue(null, Long.TYPE));
         assertEquals(Float.valueOf(0f), MAPPER.convertValue(null, Float.TYPE));
         assertEquals(Double.valueOf(0d), MAPPER.convertValue(null, Double.TYPE));
@@ -360,9 +360,9 @@ public class ObjectMapperTest extends BaseMapTest
     // [databind#1433]
     public void testConvertValueNullBoxed() throws Exception
     {
-    	assertNull(MAPPER.convertValue(null, Byte.class));
-    	assertNull(MAPPER.convertValue(null, Short.class));
-    	assertNull(MAPPER.convertValue(null, Integer.class));
+        assertNull(MAPPER.convertValue(null, Byte.class));
+        assertNull(MAPPER.convertValue(null, Short.class));
+        assertNull(MAPPER.convertValue(null, Integer.class));
         assertNull(MAPPER.convertValue(null, Long.class));
         assertNull(MAPPER.convertValue(null, Float.class));
         assertNull(MAPPER.convertValue(null, Double.class));

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -344,4 +344,28 @@ public class ObjectMapperTest extends BaseMapTest
     {
         assertEquals(Integer.valueOf(0), MAPPER.convertValue(null, Integer.TYPE));
     }
+    
+    // [databind#1433]
+    public void testConvertValueNullPrimitive() throws Exception
+    {
+    	assertEquals(Byte.valueOf((byte) 0), MAPPER.convertValue(null, Byte.TYPE));
+    	assertEquals(Short.valueOf((short) 0), MAPPER.convertValue(null, Short.TYPE));
+    	assertEquals(Integer.valueOf(0), MAPPER.convertValue(null, Integer.TYPE));
+        assertEquals(Long.valueOf(0L), MAPPER.convertValue(null, Long.TYPE));
+        assertEquals(Float.valueOf(0f), MAPPER.convertValue(null, Float.TYPE));
+        assertEquals(Double.valueOf(0d), MAPPER.convertValue(null, Double.TYPE));
+        assertEquals(Character.valueOf('\0'), MAPPER.convertValue(null, Character.TYPE));
+    }
+    
+    // [databind#1433]
+    public void testConvertValueNullBoxed() throws Exception
+    {
+    	assertNull(MAPPER.convertValue(null, Byte.class));
+    	assertNull(MAPPER.convertValue(null, Short.class));
+    	assertNull(MAPPER.convertValue(null, Integer.class));
+        assertNull(MAPPER.convertValue(null, Long.class));
+        assertNull(MAPPER.convertValue(null, Float.class));
+        assertNull(MAPPER.convertValue(null, Double.class));
+        assertNull(MAPPER.convertValue(null, Character.class));
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -338,4 +338,10 @@ public class ObjectMapperTest extends BaseMapTest
                 .readTree(input);
         assertNotNull(n);
     }
+    
+    // [databind#1433]
+    public void testConvertValueNullPrimitive() throws Exception
+    {
+        assertEquals(Integer.valueOf(0), MAPPER.convertValue(null, Integer.TYPE));
+    }
 }


### PR DESCRIPTION
This allows primitive conversions to assume the default value.
It also allows deserializer getNullValue hooks to function as intended.
