### PR TITLE
Fix #1533: Respect ACCEPT_EMPTY_STRING_AS_NULL_OBJECT for polymorphism.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
@@ -153,6 +153,13 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
         // or, something for which "as-property" won't work, changed into "wrapper-array" type:
         if (p.getCurrentToken() == JsonToken.START_ARRAY) {
             return super.deserializeTypedFromAny(p, ctxt);
+        } else if (p.getCurrentToken() == JsonToken.VALUE_STRING) {
+            if (ctxt.isEnabled(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)) {
+                String str = p.getText().trim();
+                if (str.isEmpty()) {
+                    return null;
+                }
+            }
         }
         ctxt.reportWrongTokenException(p, JsonToken.FIELD_NAME,
                 "missing property '"+_typePropertyName+"' that is to contain type id  (for class "+baseTypeName()+")");

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -129,6 +129,16 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         public BaseClass value;
     }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY,
+            property = "type")
+    static class AsProperty {
+
+    }
+
+    static class AsPropertyWrapper {
+        public AsProperty value;
+    }
+
     /*
     /**********************************************************
     /* Unit tests, deserialization
@@ -245,6 +255,24 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
                 BaseWrapper.class);
         assertNotNull(w);
         assertNull(w.value);
+    }
+
+    public void testWithoutEmptyStringAsNullObject1533() throws Exception
+    {
+    	ObjectMapper mapper = new ObjectMapper().disable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
+        try {
+            mapper.readValue("{ \"value\": \"\" }", AsPropertyWrapper.class);
+            fail("Expected " + JsonMappingException.class);
+        } catch (JsonMappingException e) {
+            // expected
+        }
+    }
+
+    public void testWithEmptyStringAsNullObject1533() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper().enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
+        AsPropertyWrapper wrapper = mapper.readValue("{ \"value\": \"\" }", AsPropertyWrapper.class);
+        assertNull(wrapper.value);
     }
 
     /*


### PR DESCRIPTION
Fix was copied straight from https://github.com/FasterXML/jackson-databind/blob/2.8/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java#L884:

```
} else if (t == JsonToken.VALUE_STRING) {
    if (ctxt.isEnabled(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)) {
        String str = p.getText().trim();
        if (str.isEmpty()) {
            return null;
        }
    }
}
```