### PR TITLE
New deserialization feature USE_BIG_DECIMAL_FOR_INTS.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -43,6 +43,30 @@ public enum DeserializationFeature implements ConfigFeature
 
     /**
      * Feature that determines whether JSON integral (non-floating-point)
+     * numbers are to be deserialized into {@link java.math.BigDecimal}s
+     * if only generic type description (either {@link Object} or
+     * {@link Number}, or within untyped {@link java.util.Map}
+     * or {@link java.util.Collection} context) is available.
+     * If enabled such values will be deserialized as
+     * {@link java.math.BigDecimal}s;
+     * if disabled, will be deserialized as "smallest" available type,
+     * which is either {@link Integer}, {@link Long} or
+     * {@link java.math.BigInteger}, depending on number of digits.
+     * <p>
+     * Feature is disabled by default, meaning that "untyped" integral
+     * numbers will by default be deserialized using whatever
+     * is the most compact integral type, to optimize efficiency.
+     * <p>
+     * Using this feature and {@link #USE_BIG_DECIMAL_FOR_FLOATS}
+     * allows all numbers to be tested for equality without
+     * loss of precision.
+     *
+     * @since 2.9
+     */
+    USE_BIG_DECIMAL_FOR_INTS(false),
+
+    /**
+     * Feature that determines whether JSON integral (non-floating-point)
      * numbers are to be deserialized into {@link java.math.BigInteger}s
      * if only generic type description (either {@link Object} or
      * {@link Number}, or within untyped {@link java.util.Map}
@@ -52,6 +76,10 @@ public enum DeserializationFeature implements ConfigFeature
      * if disabled, will be deserialized as "smallest" available type,
      * which is either {@link Integer}, {@link Long} or
      * {@link java.math.BigInteger}, depending on number of digits.
+     * <p>
+     * Note: if {@link #USE_BIG_DECIMAL_FOR_INTS} is enabled, it has precedence
+     * over this setting, forcing use of {@link java.math.BigDecimal} for all
+     * integral values.
      * <p>
      * Feature is disabled by default, meaning that "untyped" integral
      * numbers will by default be deserialized using whatever
@@ -70,9 +98,10 @@ public enum DeserializationFeature implements ConfigFeature
      * In addition, if enabled, trying to bind values that do not fit in {@link java.lang.Long}
      * will throw a {@link com.fasterxml.jackson.core.JsonProcessingException}.
      *<p>
-     * Note: if {@link #USE_BIG_INTEGER_FOR_INTS} is enabled, it has precedence
-     * over this setting, forcing use of {@link java.math.BigInteger} for all
-     * integral values.
+     * Note: if {@link #USE_BIG_DECIMAL_FOR_INTS} or {@link #USE_BIG_INTEGER_FOR_INTS}
+     * is enabled, it has precedence over this setting, forcing use of
+     * {@link java.math.BigDecimal} or {@link java.math.BigInteger} (respectively)
+     * for all integral values.
      *<p>
      * Feature is disabled by default, meaning that "untyped" integral
      * numbers will by default be deserialized using {@link java.lang.Integer}

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2711,7 +2711,10 @@ public class ObjectMapper
         if (fromValue == null) return null;
         TokenBuffer buf = new TokenBuffer(this, false);
         if (isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-            buf = buf.forceUseOfBigDecimal(true);
+            buf = buf.forceUseOfBigDecimalFloats(true);
+        }
+        if (isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS)) {
+            buf = buf.forceUseOfBigDecimalInts(true);
         }
         JsonNode result;
         try {
@@ -3640,7 +3643,10 @@ public class ObjectMapper
         // Then use TokenBuffer, which is a JsonGenerator:
         TokenBuffer buf = new TokenBuffer(this, false);
         if (isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-            buf = buf.forceUseOfBigDecimal(true);
+            buf = buf.forceUseOfBigDecimalFloats(true);
+        }
+        if (isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS)) {
+            buf = buf.forceUseOfBigDecimalInts(true);
         }
         try {
             // inlined 'writeValue' with minor changes:

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -554,7 +554,9 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
         JsonParser.NumberType nt;
         int feats = ctxt.getDeserializationFeatures();
         if ((feats & F_MASK_INT_COERCIONS) != 0) {
-            if (DeserializationFeature.USE_BIG_INTEGER_FOR_INTS.enabledIn(feats)) {
+            if (DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS.enabledIn(feats)) {
+                nt = JsonParser.NumberType.BIG_DECIMAL;
+            } else if (DeserializationFeature.USE_BIG_INTEGER_FOR_INTS.enabledIn(feats)) {
                 nt = JsonParser.NumberType.BIG_INTEGER;
             } else if (DeserializationFeature.USE_LONG_FOR_INTS.enabledIn(feats)) {
                 nt = JsonParser.NumberType.LONG;
@@ -570,7 +572,10 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
         if (nt == JsonParser.NumberType.LONG) {
             return nodeFactory.numberNode(p.getLongValue());
         }
-        return nodeFactory.numberNode(p.getBigIntegerValue());
+        if (nt == JsonParser.NumberType.BIG_INTEGER) {
+            return nodeFactory.numberNode(p.getBigIntegerValue());
+        }
+        return nodeFactory.numberNode(p.getDecimalValue());
     }
 
     protected final JsonNode _fromFloat(JsonParser p, DeserializationContext ctxt,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
@@ -842,6 +842,9 @@ public class NumberDeserializers
                         }
                         return Double.valueOf(text);
                     }
+                    if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS)) {
+                        return new BigDecimal(text);
+                    }
                     if (ctxt.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)) {
                         return new BigInteger(text);
                     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -34,14 +34,16 @@ public abstract class StdDeserializer<T>
     private static final long serialVersionUID = 1L;
 
     /**
-     * Bitmask that covers {@link DeserializationFeature#USE_BIG_INTEGER_FOR_INTS}
+     * Bitmask that covers {@link DeserializationFeature#USE_BIG_DECIMAL_FOR_INTS},
+     * {@link DeserializationFeature#USE_BIG_INTEGER_FOR_INTS},
      * and {@link DeserializationFeature#USE_LONG_FOR_INTS}, used for more efficient
      * cheks when coercing integral values for untyped deserialization.
      *
      * @since 2.6
      */
     protected final static int F_MASK_INT_COERCIONS = 
-            DeserializationFeature.USE_BIG_INTEGER_FOR_INTS.getMask()
+            DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS.getMask()
+            | DeserializationFeature.USE_BIG_INTEGER_FOR_INTS.getMask()
             | DeserializationFeature.USE_LONG_FOR_INTS.getMask();
     
     /**
@@ -641,6 +643,9 @@ public abstract class StdDeserializer<T>
     protected Object _coerceIntegral(JsonParser p, DeserializationContext ctxt) throws IOException
     {
         int feats = ctxt.getDeserializationFeatures();
+        if (DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS.enabledIn(feats)) {
+            return p.getDecimalValue();
+        }
         if (DeserializationFeature.USE_BIG_INTEGER_FOR_INTS.enabledIn(feats)) {
             return p.getBigIntegerValue();
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
@@ -556,6 +556,9 @@ public class UntypedObjectDeserializer
                 return p.getText();
 
             case JsonTokenId.ID_NUMBER_INT:
+                if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS)) {
+                    return p.getDecimalValue();
+                }
                 if (ctxt.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)) {
                     return p.getBigIntegerValue();
                 }

--- a/src/test/java/com/fasterxml/jackson/databind/cfg/DeserializationConfigTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/cfg/DeserializationConfigTest.java
@@ -24,6 +24,7 @@ public class DeserializationConfigTest extends BaseMapTest
         assertTrue(cfg.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS));
 
         assertFalse(cfg.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS));
+        assertFalse(cfg.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS));
         assertFalse(cfg.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS));
 
         assertTrue(cfg.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKNumberDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKNumberDeserTest.java
@@ -159,7 +159,36 @@ public class JDKNumberDeserTest extends BaseMapTest
         assertEquals(biggie, result);
     }
 
-    public void testIntTypeOverride() throws Exception
+    public void testBigDecIntTypeOverride() throws Exception
+    {
+        ObjectReader r = MAPPER.reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_INTS);
+
+        BigDecimal exp = BigDecimal.valueOf(123L);
+
+        // first test as any Number
+        Number result = r.forType(Number.class).readValue(" 123 ");
+        assertEquals(BigDecimal.class, result.getClass());
+        assertEquals(exp, result);
+
+        // then as any Object
+        /*Object value =*/ r.forType(Object.class).readValue("123");
+        assertEquals(BigDecimal.class, result.getClass());
+        assertEquals(exp, result);
+
+        // and as JsonNode
+        JsonNode node = r.readTree("  123");
+        assertTrue(node.isBigDecimal());
+        assertEquals(123, node.asInt());
+
+        r = MAPPER.reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+
+        // test integral and decimal for equality
+        JsonNode decNode = r.readTree("1.23E2");
+        assertTrue(decNode.isBigDecimal());
+        assertEquals(node, decNode);
+    }
+
+    public void testBigIntTypeOverride() throws Exception
     {
         /* Slight twist; as per [JACKSON-100], can also request binding
          * to BigInteger even if value would fit in Integer
@@ -182,6 +211,13 @@ public class JDKNumberDeserTest extends BaseMapTest
         JsonNode node = r.readTree("  123");
         assertTrue(node.isBigInteger());
         assertEquals(123, node.asInt());
+
+        r = MAPPER.reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+
+        // test integral and decimal for equality
+        JsonNode decNode = r.readTree("1.23E2");
+        assertTrue(decNode.isBigDecimal());
+        assertFalse(node.equals(decNode));
     }
 
     public void testDoubleAsNumber() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/node/NumberNodesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NumberNodesTest.java
@@ -326,6 +326,7 @@ public class NumberNodesTest extends NodeTestBase
         BigIntegerNode n = BigIntegerNode.valueOf(BigInteger.ONE);
         assertStandardEquals(n);
         assertTrue(n.equals(new BigIntegerNode(BigInteger.ONE)));
+        assertFalse(n.equals(new DecimalNode(BigDecimal.ONE)));
         assertEquals(JsonToken.VALUE_NUMBER_INT, n.asToken());
         assertEquals(JsonParser.NumberType.BIG_INTEGER, n.numberType());
         assertTrue(n.isNumber());


### PR DESCRIPTION
When used together with USE_BIG_DECIMAL_FOR_FLOATS, this feature allows JSON floating point numbers and JSON integral numbers to be tested for equality without loss of precision.

USE_BIG_DECIMAL_FOR_INTS takes precedence over USE_BIG_INTEGER_FOR_INTS just as USE_BIG_INTEGER_FOR_INTS takes precedence over USE_LONG_FOR_INTS.

Closes #1561.