### PR TITLE
Introduce config override for includeAsProperty (#1522)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/BeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/BeanProperty.java
@@ -279,7 +279,7 @@ public interface BeanProperty extends Named
         @Override
         public JsonInclude.Value findPropertyInclusion(MapperConfig<?> config, Class<?> baseType)
         {
-            JsonInclude.Value v0 = config.getDefaultPropertyInclusion(baseType);
+            JsonInclude.Value v0 = config.getDefaultPropertyInclusion(baseType, _type.getRawClass());
             AnnotationIntrospector intr = config.getAnnotationIntrospector();
             if ((intr == null) || (_member == null)) {
                 return v0;

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
@@ -798,6 +798,26 @@ public final class DeserializationConfig
 
     @Override
     public JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
+            Class<?> propertyType) {
+        ConfigOverride propertyTypeOverrides = findConfigOverride(propertyType);
+        if (propertyTypeOverrides != null) {
+            JsonInclude.Value v0 = propertyTypeOverrides.getIncludeAsProperty();
+            if (v0 != null) {
+                return v0;
+            }
+		}
+        ConfigOverride baseTypeOverrides = findConfigOverride(baseType);
+        if (baseTypeOverrides != null) {
+            JsonInclude.Value v1 = baseTypeOverrides.getInclude();
+            if (v1 != null) {
+                return v1;
+            }
+        }
+        return EMPTY_INCLUDE;
+    }
+
+    @Override
+    public JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
             JsonInclude.Value defaultIncl)
     {
         ConfigOverride overrides = findConfigOverride(baseType);
@@ -805,6 +825,26 @@ public final class DeserializationConfig
             JsonInclude.Value v = overrides.getInclude();
             if (v != null) {
                 return v;
+            }
+        }
+        return defaultIncl;
+    }
+
+    @Override
+    public JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
+            Class<?> propertyType, JsonInclude.Value defaultIncl) {
+        ConfigOverride propertyTypeOverrides = findConfigOverride(propertyType);
+        if (propertyTypeOverrides != null) {
+            JsonInclude.Value v0 = propertyTypeOverrides.getIncludeAsProperty();
+            if (v0 != null) {
+                return v0;
+            }
+		}
+        ConfigOverride baseTypeOverrides = findConfigOverride(baseType);
+        if (baseTypeOverrides != null) {
+            JsonInclude.Value v1 = baseTypeOverrides.getInclude();
+            if (v1 != null) {
+                return v1;
             }
         }
         return defaultIncl;

--- a/src/main/java/com/fasterxml/jackson/databind/SerializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationConfig.java
@@ -901,6 +901,26 @@ public final class SerializationConfig
 
     @Override
     public JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
+            Class<?> propertyType) {
+        ConfigOverride propertyTypeOverrides = findConfigOverride(propertyType);
+        if (propertyTypeOverrides != null) {
+            JsonInclude.Value v0 = propertyTypeOverrides.getIncludeAsProperty();
+            if (v0 != null) {
+                return v0;
+            }
+		}
+        ConfigOverride baseTypeOverrides = findConfigOverride(baseType);
+        if (baseTypeOverrides != null) {
+            JsonInclude.Value v1 = baseTypeOverrides.getInclude();
+            if (v1 != null) {
+                return v1;
+            }
+        }
+        return _serializationInclusion;
+    }
+
+    @Override
+    public JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
             JsonInclude.Value defaultIncl)
     {
         ConfigOverride overrides = findConfigOverride(baseType);
@@ -908,6 +928,26 @@ public final class SerializationConfig
             JsonInclude.Value v = overrides.getInclude();
             if (v != null) {
                 return v;
+            }
+        }
+        return defaultIncl;
+    }
+
+    @Override
+    public JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
+            Class<?> propertyType, JsonInclude.Value defaultIncl) {
+        ConfigOverride propertyTypeOverrides = findConfigOverride(propertyType);
+        if (propertyTypeOverrides != null) {
+            JsonInclude.Value v0 = propertyTypeOverrides.getIncludeAsProperty();
+            if (v0 != null) {
+                return v0;
+            }
+		}
+        ConfigOverride baseTypeOverrides = findConfigOverride(baseType);
+        if (baseTypeOverrides != null) {
+            JsonInclude.Value v1 = baseTypeOverrides.getInclude();
+            if (v1 != null) {
+                return v1;
             }
         }
         return defaultIncl;

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/ConfigOverride.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/ConfigOverride.java
@@ -26,6 +26,11 @@ public abstract class ConfigOverride
     protected JsonInclude.Value _include;
 
     /**
+     * Definitions of inclusion overrides for properties of configured type, if any.
+     */
+    protected JsonInclude.Value _includeAsProperty;
+
+    /**
      * Definitions of property ignoral (whether to serialize, deserialize
      * given logical property) overrides, if any.
      */
@@ -43,12 +48,14 @@ public abstract class ConfigOverride
     protected ConfigOverride(ConfigOverride src) {
         _format = src._format;
         _include = src._include;
+        _includeAsProperty = src._includeAsProperty;
         _ignorals = src._ignorals;
         _isIgnoredType = src._isIgnoredType;
     }
 
     public JsonFormat.Value getFormat() { return _format; }
     public JsonInclude.Value getInclude() { return _include; }
+    public JsonInclude.Value getIncludeAsProperty() { return _includeAsProperty; }
     public JsonIgnoreProperties.Value getIgnorals() { return _ignorals; }
 
     public Boolean getIsIgnoredType() {

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java
@@ -367,6 +367,18 @@ public abstract class MapperConfig<T extends MapperConfig<T>>
 
     /**
      * Accessor for default property inclusion to use for serialization,
+     * considering possible per-type override for given base type and
+	 * possible per-type override for given property type.<br>
+     * NOTE: if no override found, defaults to value returned by
+     * {@link #getDefaultPropertyInclusion()}.
+     *
+     * @since 2.8.8
+     */
+    public abstract JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
+            Class<?> propertyType);
+
+    /**
+     * Accessor for default property inclusion to use for serialization,
      * considering possible per-type override for given base type; but
      * if none found, returning given <code>defaultIncl</code>
      *
@@ -376,6 +388,19 @@ public abstract class MapperConfig<T extends MapperConfig<T>>
      */
     public abstract JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
             JsonInclude.Value defaultIncl);
+
+    /**
+     * Accessor for default property inclusion to use for serialization,
+     * considering possible per-type override for given base type and
+	 * possible per-type override for given property type; but
+     * if none found, returning given <code>defaultIncl</code>
+     *
+     * @param defaultIncl Inclusion setting to return if no overrides found.
+     *
+     * @since 2.8.8
+     */
+    public abstract JsonInclude.Value getDefaultPropertyInclusion(Class<?> baseType,
+            Class<?> propertyType, JsonInclude.Value defaultIncl);
 
     /**
      * Accessor for default format settings to use for serialization (and, to a degree

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MutableConfigOverride.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MutableConfigOverride.java
@@ -39,6 +39,11 @@ public class MutableConfigOverride
         return this;
     }
 
+    public MutableConfigOverride setIncludeAsProperty(JsonInclude.Value v) {
+        _includeAsProperty = v;
+        return this;
+    }
+
     public MutableConfigOverride setIgnorals(JsonIgnoreProperties.Value v) {
         _ignorals = v;
         return this;

--- a/src/test/java/com/fasterxml/jackson/databind/filter/JsonIncludeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/filter/JsonIncludeTest.java
@@ -129,6 +129,32 @@ public class JsonIncludeTest
         public Map<String,String> map = Collections.emptyMap();
     }
 
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @JsonPropertyOrder({"num", "annotated", "plain"})
+    static class MixedTypeBean
+    {
+        @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+        public Integer num = null;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public String annotated = null;
+
+        public String plain = null;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"num", "annotated", "plain"})
+    static class MixedTypeNonNullBean
+    {
+        @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+        public Integer num = null;
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        public String annotated = null;
+
+        public String plain = null;
+    }
+
     // [databind#1351]
 
     static class Issue1351Bean
@@ -221,7 +247,7 @@ public class JsonIncludeTest
         String json = MAPPER.writeValueAsString(bean);
         assertEquals(aposToQuotes("{'x':1,'y':2}"), json);
     }
-    
+
     public void testMixedMethod() throws IOException
     {
         MixedBean bean = new MixedBean();
@@ -307,6 +333,54 @@ public class JsonIncludeTest
             .setInclude(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, null));
         assertEquals(aposToQuotes("{'map':{}}"),
                 mapper.writeValueAsString(empty));
+    }
+
+    public void testPropConfigOverrideForIncludeAsPropertyNonNull() throws Exception
+    {
+        // First, with defaults, all but NON_NULL annotated included
+        MixedTypeBean nullValues = new MixedTypeBean();
+        assertEquals(aposToQuotes("{'num':null,'plain':null}"),
+                MAPPER.writeValueAsString(nullValues));
+        ObjectMapper mapper;
+
+        // and then change inclusion as property criteria for either
+        mapper = new ObjectMapper();
+        mapper.configOverride(String.class)
+                .setIncludeAsProperty(JsonInclude.Value
+                        .construct(JsonInclude.Include.NON_NULL, null));
+        assertEquals("{\"num\":null}",
+                mapper.writeValueAsString(nullValues));
+
+        mapper = new ObjectMapper();
+        mapper.configOverride(Integer.class)
+                .setIncludeAsProperty(JsonInclude.Value
+                        .construct(JsonInclude.Include.NON_NULL, null));
+        assertEquals("{\"plain\":null}",
+                mapper.writeValueAsString(nullValues));
+    }
+
+    public void testPropConfigOverrideForIncludeAsPropertyAlways() throws Exception
+    {
+        // First, with defaults, only ALWAYS annotated included
+        MixedTypeNonNullBean nullValues = new MixedTypeNonNullBean();
+        assertEquals("{\"annotated\":null}",
+                MAPPER.writeValueAsString(nullValues));
+        ObjectMapper mapper;
+
+        // and then change inclusion as property criteria for either
+        mapper = new ObjectMapper();
+        mapper.configOverride(String.class)
+                .setIncludeAsProperty(JsonInclude.Value
+                        .construct(JsonInclude.Include.ALWAYS, null));
+        assertEquals(aposToQuotes("{'annotated':null,'plain':null}"),
+                mapper.writeValueAsString(nullValues));
+
+        mapper = new ObjectMapper();
+        mapper.configOverride(Integer.class)
+                .setIncludeAsProperty(JsonInclude.Value
+                        .construct(JsonInclude.Include.ALWAYS, null));
+        assertEquals(aposToQuotes("{'num':null,'annotated':null}"),
+                mapper.writeValueAsString(nullValues));
     }
 
     // [databind#1351], [databind#1417]


### PR DESCRIPTION
@cowtowncoder this is a proof-of-concept how I'd image the include override per property type to work.

Unfortunately, I cannot be sure to have covered all relevant places due to the existing complexity of the databind library. However I hope it is helpful.

Since I couldn't build the current master branch without further setup, I based this on the 2.8 branch.