### PR TITLE
Fixes #1573

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -26,7 +26,7 @@ public class BuilderBasedDeserializer
     private static final long serialVersionUID = 1L;
 
     protected final AnnotatedMethod _buildMethod;
-	
+
     /*
     /**********************************************************
     /* Life-cycle, construction, initialization
@@ -66,7 +66,7 @@ public class BuilderBasedDeserializer
         super(src, ignoreAllUnknown);
         _buildMethod = src._buildMethod;
     }
-    
+
     protected BuilderBasedDeserializer(BuilderBasedDeserializer src, NameTransformer unwrapper) {
         super(src, unwrapper);
         _buildMethod = src._buildMethod;
@@ -86,7 +86,7 @@ public class BuilderBasedDeserializer
         super(src, props);
         _buildMethod = src._buildMethod;
     }
-    
+
     @Override
     public JsonDeserializer<Object> unwrappingDeserializer(NameTransformer unwrapper)
     {
@@ -117,13 +117,13 @@ public class BuilderBasedDeserializer
         SettableBeanProperty[] props = _beanProperties.getPropertiesInInsertionOrder();
         return new BeanAsArrayBuilderDeserializer(this, props, _buildMethod);
     }
-    
+
     /*
     /**********************************************************
     /* JsonDeserializer implementation
     /**********************************************************
      */
-    
+
     protected final Object finishBuild(DeserializationContext ctxt, Object builder)
             throws IOException
     {
@@ -137,7 +137,7 @@ public class BuilderBasedDeserializer
             return wrapInstantiationProblem(e, ctxt);
         }
     }
-    
+
     /**
      * Main deserialization method for bean-based objects (POJOs).
      */
@@ -146,7 +146,7 @@ public class BuilderBasedDeserializer
         throws IOException
     {
         JsonToken t = p.getCurrentToken();
-        
+
         // common case first:
         if (t == JsonToken.START_OBJECT) {
             t = p.nextToken();
@@ -197,7 +197,7 @@ public class BuilderBasedDeserializer
          */
         return finishBuild(ctxt, _deserialize(p, ctxt, builder));
     }
-    
+
     /*
     /**********************************************************
     /* Concrete deserialization methods
@@ -207,7 +207,7 @@ public class BuilderBasedDeserializer
     protected final Object _deserialize(JsonParser p,
             DeserializationContext ctxt, Object builder)
         throws IOException, JsonProcessingException
-    {        
+    {
         if (_injectables != null) {
             injectValues(ctxt, builder);
         }
@@ -233,7 +233,7 @@ public class BuilderBasedDeserializer
             // Skip field name:
             p.nextToken();
             SettableBeanProperty prop = _beanProperties.find(propName);
-            
+
             if (prop != null) { // normal case
                 try {
                     builder = prop.deserializeSetAndReturn(p, ctxt, builder);
@@ -246,7 +246,7 @@ public class BuilderBasedDeserializer
         }
         return builder;
     }
-    
+
     /**
      * Streamlined version that is only used when no "special"
      * features are enabled.
@@ -323,7 +323,7 @@ public class BuilderBasedDeserializer
      * Method called to deserialize bean using "property-based creator":
      * this means that a non-default constructor or factory method is
      * called, and then possibly other setters. The trick is that
-     * values for creator method need to be buffered, first; and 
+     * values for creator method need to be buffered, first; and
      * due to non-guaranteed ordering possibly some other properties
      * as well.
      */
@@ -332,7 +332,7 @@ public class BuilderBasedDeserializer
     protected final Object _deserializeUsingPropertyBased(final JsonParser p,
             final DeserializationContext ctxt)
         throws IOException, JsonProcessingException
-    { 
+    {
         final PropertyBasedCreator creator = _propertyBasedCreator;
         PropertyValueBuffer buffer = creator.startBuilding(p, ctxt, _objectIdReader);
 
@@ -414,13 +414,13 @@ public class BuilderBasedDeserializer
         }
         return bean;
     }
-    
+
     /*
     /**********************************************************
     /* Deserializing when we have to consider an active View
     /**********************************************************
      */
-    
+
     protected final Object deserializeWithView(JsonParser p, DeserializationContext ctxt,
             Object bean, Class<?> activeView)
         throws IOException, JsonProcessingException
@@ -447,7 +447,7 @@ public class BuilderBasedDeserializer
         }
         return bean;
     }
-    
+
     /*
     /**********************************************************
     /* Handling for cases where we have "unwrapped" values
@@ -477,7 +477,7 @@ public class BuilderBasedDeserializer
         }
 
         final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
-        
+
         for (; p.getCurrentToken() != JsonToken.END_OBJECT; p.nextToken()) {
             String propName = p.getCurrentName();
             p.nextToken();
@@ -515,7 +515,7 @@ public class BuilderBasedDeserializer
         tokens.writeEndObject();
         _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
         return bean;
-    }    
+    }
 
     @SuppressWarnings("resource")
     protected Object deserializeWithUnwrapped(JsonParser p,
@@ -580,31 +580,7 @@ public class BuilderBasedDeserializer
             // creator property?
             SettableBeanProperty creatorProp = creator.findCreatorProperty(propName);
             if (creatorProp != null) {
-                // Last creator property to set?
-                if (buffer.assignParameter(creatorProp, creatorProp.deserialize(p, ctxt))) {
-                    t = p.nextToken(); // to move to following FIELD_NAME/END_OBJECT
-                    Object bean;
-                    try {
-                        bean = creator.build(ctxt, buffer);
-                    } catch (Exception e) {
-                        wrapAndThrow(e, _beanType.getRawClass(), propName, ctxt);
-                        continue; // never gets here
-                    }
-                    // if so, need to copy all remaining tokens into buffer
-                    while (t == JsonToken.FIELD_NAME) {
-                        p.nextToken(); // to skip name
-                        tokens.copyCurrentStructure(p);
-                        t = p.nextToken();
-                    }
-                    tokens.writeEndObject();
-                    if (bean.getClass() != _beanType.getRawClass()) {
-                        // !!! 08-Jul-2011, tatu: Could probably support; but for now
-                        //   it's too complicated, so bail out
-                        ctxt.reportMappingException("Can not create polymorphic instances with unwrapped values");
-                        return null;
-                    }
-                    return _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
-                }
+                buffer.assignParameter(creatorProp, creatorProp.deserialize(p, ctxt));
                 continue;
             }
             // Object Id property?
@@ -646,7 +622,7 @@ public class BuilderBasedDeserializer
     /* external type id
     /**********************************************************
      */
-    
+
     protected Object deserializeWithExternalTypeId(JsonParser p, DeserializationContext ctxt)
         throws IOException, JsonProcessingException
     {
@@ -699,15 +675,14 @@ public class BuilderBasedDeserializer
                 } catch (Exception e) {
                     wrapAndThrow(e, bean, propName, ctxt);
                 }
-                continue;
             } else {
                 // Unknown: let's call handler method
-                handleUnknownProperty(p, ctxt, bean, propName);         
+                handleUnknownProperty(p, ctxt, bean, propName);
             }
         }
         // and when we get this far, let's try finalizing the deal:
         return ext.complete(p, ctxt, bean);
-    }        
+    }
 
     protected Object deserializeUsingPropertyBasedWithExternalTypeId(JsonParser p,
     		DeserializationContext ctxt)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/builder/BuilderWithUnwrappedTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/builder/BuilderWithUnwrappedTest.java
@@ -1,0 +1,246 @@
+package com.fasterxml.jackson.databind.deser.builder;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+public class BuilderWithUnwrappedTest extends BaseMapTest {
+    /*
+     *************************************
+     * Mock classes
+     *************************************
+     */
+
+    final static class Name {
+        private final String first;
+        private final String last;
+
+        @JsonCreator
+        Name(
+                @JsonProperty("first_name") String first,
+                @JsonProperty("last_name") String last
+        ) {
+            this.first = first;
+            this.last = last;
+        }
+
+        String getFirst() {
+            return first;
+        }
+
+        String getLast() {
+            return last;
+        }
+    }
+
+    @JsonDeserialize(builder = Person.Builder.class)
+    final static class Person {
+        private final long id;
+        private final Name name;
+        private final int age;
+        private final boolean alive;
+
+        private Person(Builder builder) {
+            id = builder.id;
+            name = builder.name;
+            age = builder.age;
+            alive = builder.alive;
+        }
+
+        long getId() {
+            return id;
+        }
+
+        Name getName() {
+            return name;
+        }
+
+        int getAge() {
+            return age;
+        }
+
+        boolean isAlive() {
+            return alive;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "set")
+        final static class Builder {
+            private final long id;
+            private Name name;
+            private int age;
+            private boolean alive;
+
+            Builder(@JsonProperty("person_id") long id) {
+                this.id = id;
+            }
+
+            @JsonUnwrapped
+            void setName(Name name) {
+                this.name = name;
+            }
+
+            @JsonProperty("years_old")
+            void setAge(int age) {
+                this.age = age;
+            }
+
+            @JsonProperty("living")
+            void setAlive(boolean alive) {
+                this.alive = alive;
+            }
+
+            Person build() {
+                return new Person(this);
+            }
+        }
+    }
+
+    @JsonDeserialize(builder = Animal.Builder.class)
+    final static class Animal {
+        private final long id;
+        private final Name name;
+        private final int age;
+        private final boolean alive;
+
+        private Animal(Builder builder) {
+            id = builder.id;
+            name = builder.name;
+            age = builder.age;
+            alive = builder.alive;
+        }
+
+        long getId() {
+            return id;
+        }
+
+        Name getName() {
+            return name;
+        }
+
+        int getAge() {
+            return age;
+        }
+
+        boolean isAlive() {
+            return alive;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "set")
+        final static class Builder {
+            private final long id;
+            private Name name;
+            private int age;
+            private final boolean alive;
+
+            Builder(
+                    @JsonProperty("animal_id") long id,
+                    @JsonProperty("living") boolean alive
+            ) {
+                this.id = id;
+                this.alive = alive;
+            }
+
+            @JsonUnwrapped
+            void setName(Name name) {
+                this.name = name;
+            }
+
+            @JsonProperty("years_old")
+            void setAge(int age) {
+                this.age = age;
+            }
+
+            Animal build() {
+                return new Animal(this);
+            }
+        }
+    }
+
+    /*
+     *************************************
+     * Unit tests
+     *************************************
+     */
+
+    public void testWithUnwrappedAndCreatorSingleParameterAtBeginning() throws Exception {
+        final String json = aposToQuotes("{'person_id':1234,'first_name':'John','last_name':'Doe','years_old':30,'living':true}");
+
+        final ObjectMapper mapper = new ObjectMapper();
+        Person person = mapper.readValue(json, Person.class);
+        assertEquals(1234, person.getId());
+        assertNotNull(person.getName());
+        assertEquals("John", person.getName().getFirst());
+        assertEquals("Doe", person.getName().getLast());
+        assertEquals(30, person.getAge());
+        assertEquals(true, person.isAlive());
+    }
+
+    public void testWithUnwrappedAndCreatorSingleParameterInMiddle() throws Exception {
+        final String json = aposToQuotes("{'first_name':'John','last_name':'Doe','person_id':1234,'years_old':30,'living':true}");
+
+        final ObjectMapper mapper = new ObjectMapper();
+        Person person = mapper.readValue(json, Person.class);
+        assertEquals(1234, person.getId());
+        assertNotNull(person.getName());
+        assertEquals("John", person.getName().getFirst());
+        assertEquals("Doe", person.getName().getLast());
+        assertEquals(30, person.getAge());
+        assertEquals(true, person.isAlive());
+    }
+
+    public void testWithUnwrappedAndCreatorSingleParameterAtEnd() throws Exception {
+        final String json = aposToQuotes("{'first_name':'John','last_name':'Doe','years_old':30,'living':true,'person_id':1234}");
+
+        final ObjectMapper mapper = new ObjectMapper();
+        Person person = mapper.readValue(json, Person.class);
+        assertEquals(1234, person.getId());
+        assertNotNull(person.getName());
+        assertEquals("John", person.getName().getFirst());
+        assertEquals("Doe", person.getName().getLast());
+        assertEquals(30, person.getAge());
+        assertEquals(true, person.isAlive());
+    }
+
+    public void testWithUnwrappedAndCreatorMultipleParametersAtBeginning() throws Exception {
+        final String json = aposToQuotes("{'animal_id':1234,'living':true,'first_name':'John','last_name':'Doe','years_old':30}");
+
+        final ObjectMapper mapper = new ObjectMapper();
+        Animal animal = mapper.readValue(json, Animal.class);
+        assertEquals(1234, animal.getId());
+        assertNotNull(animal.getName());
+        assertEquals("John", animal.getName().getFirst());
+        assertEquals("Doe", animal.getName().getLast());
+        assertEquals(30, animal.getAge());
+        assertEquals(true, animal.isAlive());
+    }
+
+    public void testWithUnwrappedAndCreatorMultipleParametersInMiddle() throws Exception {
+        final String json = aposToQuotes("{'first_name':'John','animal_id':1234,'last_name':'Doe','living':true,'years_old':30}");
+
+        final ObjectMapper mapper = new ObjectMapper();
+        Animal animal = mapper.readValue(json, Animal.class);
+        assertEquals(1234, animal.getId());
+        assertNotNull(animal.getName());
+        assertEquals("John", animal.getName().getFirst());
+        assertEquals("Doe", animal.getName().getLast());
+        assertEquals(30, animal.getAge());
+        assertEquals(true, animal.isAlive());
+    }
+
+    public void testWithUnwrappedAndCreatorMultipleParametersAtEnd() throws Exception {
+        final String json = aposToQuotes("{'first_name':'John','last_name':'Doe','years_old':30,'living':true,'animal_id':1234}");
+
+        final ObjectMapper mapper = new ObjectMapper();
+        Animal animal = mapper.readValue(json, Animal.class);
+        assertEquals(1234, animal.getId());
+        assertNotNull(animal.getName());
+        assertEquals("John", animal.getName().getFirst());
+        assertEquals("Doe", animal.getName().getLast());
+        assertEquals(30, animal.getAge());
+        assertEquals(true, animal.isAlive());
+    }
+}


### PR DESCRIPTION
Please excuse the trailing whitespace removal. My IDE likes to keep things tidy.

Essentially, the logic was cutting short the processing of settable properties. I deleted the code which caused the premature return, and now all settable properties are able to be processed appropriately with the object construction happening at the end of the function after the primary loop.