### PR TITLE
Fix unstable unit test for sql date serialization

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/SqlDateSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/SqlDateSerializationTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.ser.jdk;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.*;
 
@@ -84,9 +85,13 @@ public class SqlDateSerializationTest extends BaseMapTest
     
     public void testPatternWithSqlDate() throws Exception
     {
+        ObjectMapper mapper = new ObjectMapper();
+        // `java.sql.Date` applies system default zone (and not UTC)
+        mapper.setTimeZone(TimeZone.getDefault());
+
         Person i = new Person();
         i.dateOfBirth = java.sql.Date.valueOf("1980-04-14");
         assertEquals(aposToQuotes("{'dateOfBirth':'1980.04.14'}"),
-                MAPPER.writeValueAsString(i));
+                mapper.writeValueAsString(i));
     }
 }


### PR DESCRIPTION
While working on another pull request, one unit test always failed for me because it depends on the system default time zone.

If the system default time zone has a positive offset (e.g. `+1`) in comparison to UTC, the `java.sql.Date.valueOf("1980-04-14")` instance is being parsed as `"1980-04-13"` by an `ObjectMapper` with the default UTC time zone.