### PR TITLE
Allow for-each loops with object nodes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -183,6 +183,11 @@ public abstract class JsonNode
         return ClassUtil.emptyIterator();
     }
 
+    @Override
+    public Set<String> fieldNamesSet() {
+        return Collections.emptySet();
+    }
+
     /**
      * Method for locating node specified by given JSON pointer instances.
      * Method will never return null; if no matching node exists, 
@@ -768,6 +773,14 @@ public abstract class JsonNode
      */
     public Iterator<Map.Entry<String, JsonNode>> fields() {
         return ClassUtil.emptyIterator();
+    }
+
+    /**
+     * @return Set that can be used to traverse all key/value pairs for
+     *   object nodes; empty set (no contents) for other types
+     */
+    public Set<Map.Entry<String, JsonNode>> fields() {
+        return Collections.emptySet();
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -779,7 +779,7 @@ public abstract class JsonNode
      * @return Set that can be used to traverse all key/value pairs for
      *   object nodes; empty set (no contents) for other types
      */
-    public Set<Map.Entry<String, JsonNode>> fields() {
+    public Set<Map.Entry<String, JsonNode>> fieldSet() {
         return Collections.emptySet();
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -103,6 +103,11 @@ public class ObjectNode
     }
 
     @Override
+    public Set<String> fieldNamesSet() {
+        return _children.keySet();
+    }
+
+    @Override
     public JsonNode path(int index) {
         return MissingNode.getInstance();
     }
@@ -124,6 +129,15 @@ public class ObjectNode
     @Override
     public Iterator<Map.Entry<String, JsonNode>> fields() {
         return _children.entrySet().iterator();
+    }
+
+    /**
+     * Method to use for accessing all fields (with both names
+     * and values) of this JSON Object.
+     */
+    @Override
+    public Set<Map.Entry<String, JsonNode>> fieldSet() {
+        return _children.entrySet();
     }
 
     @Override


### PR DESCRIPTION
This change allows using the much more elegant for-each constructs:
```
for(Map.Entry<String, JsonNode> enry : objectNode.fieldSet())
```
and
```
for(String field : objectNode.fieldNamesSet())
```
in addition to the current iterator-based access, which is more code intensive:
```
Iterator<String> fieldNameIterator = objectNode.fieldNames();
while(fieldNameIterator.hasNext()) {
  String fieldName = fieldNameIterator.next();
}
```
and
```
Iterator<Map.Entry<String, JsonNode>> entryIterator = objectNode.fields();
while(entryIterator.hasNext()) {
  Map.Entry<String, JsonNode> entry = entryIterator.next();
}
```

IMPORTANT: This also needs an addition to TreeNode in jackson-core, to add this interface method:
```
    /**
     * Method for accessing names of all fields for this node, iff
     * this node is an Object node. Number of field names accessible
     * will be {@link #size}.
     */
    Set<String> fieldNamesSet();
```
or the `@Override` needs to be removed from this method in `JsonNode`.

In my opinion (you may want to consider this for version 3?), the `Iterator` based methods should be replaced with `Iterable` methods completely. I.e. if API breaking changes are acceptable, I would make `fields()` return an `Iterable<Map.Entry<String, JsonNode>>` rather than an iterator, as `.fieldNames().iterator()` is exactly equivalent; and `fieldNames()` return `Iterable<String>` rather than an iterator for the same reason. Java allows foreach loops for `Iterable`, but not for `Iterator`.