### PR TITLE
Escape JSONP breaking characters

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/JSONPObject.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/JSONPObject.java
@@ -66,6 +66,8 @@ public class JSONPObject
     public void serialize(JsonGenerator jgen, SerializerProvider provider)
             throws IOException, JsonProcessingException
     {
+        // Escape line-separator characters that break JSONP
+        jgen.setCharacterEscapes(JsonpCharacterEscapes.instance());
         // First, wrapping:
         jgen.writeRaw(_function);
         jgen.writeRaw('(');

--- a/src/main/java/com/fasterxml/jackson/databind/util/JSONPObject.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/JSONPObject.java
@@ -76,19 +76,22 @@ public class JSONPObject
             jgen.setCharacterEscapes(JsonpCharacterEscapes.instance());
         }
 
-        // First, wrapping:
-        jgen.writeRaw(_function);
-        jgen.writeRaw('(');
-        if (_value == null) {
-            provider.defaultSerializeNull(jgen);
-        } else if (_serializationType != null) {
-            provider.findTypedValueSerializer(_serializationType, true, null).serialize(_value, jgen, provider);
-        } else {
-            Class<?> cls = _value.getClass();
-            provider.findTypedValueSerializer(cls, true, null).serialize(_value, jgen, provider);
+        try {
+            // First, wrapping:
+            jgen.writeRaw(_function);
+            jgen.writeRaw('(');
+            if (_value == null) {
+                provider.defaultSerializeNull(jgen);
+            } else if (_serializationType != null) {
+                provider.findTypedValueSerializer(_serializationType, true, null).serialize(_value, jgen, provider);
+            } else {
+                Class<?> cls = _value.getClass();
+                provider.findTypedValueSerializer(cls, true, null).serialize(_value, jgen, provider);
+            }
+            jgen.writeRaw(')');
+        } finally {
+            jgen.setCharacterEscapes(currentCharacterEscapes);
         }
-        jgen.writeRaw(')');
-        jgen.setCharacterEscapes(currentCharacterEscapes);
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/util/JSONPObjectTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/JSONPObjectTest.java
@@ -10,6 +10,10 @@ public class JSONPObjectTest extends BaseMapTest {
   private final String CALLBACK = "callback";
   private final ObjectMapper MAPPER = new ObjectMapper();
 
+  /**
+   * Unit tests for checking that JSONP breaking characters U+2028 and U+2029 are escaped when creating a {@link JSONPObject}.
+   */
+
   public void testU2028Escaped() throws IOException {
     String containsU2028 = String.format("This string contains %c char", '\u2028');
     JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2028);

--- a/src/test/java/com/fasterxml/jackson/databind/util/JSONPObjectTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/JSONPObjectTest.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.databind.util;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JSONPObjectTest extends BaseMapTest {
+
+  private final String CALLBACK = "callback";
+  private final ObjectMapper MAPPER = new ObjectMapper();
+
+  public void testU2028Escaped() throws IOException {
+    String containsU2028 = String.format("This string contains %c char", '\u2028');
+    JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2028);
+    String valueAsString = MAPPER.writeValueAsString(jsonpObject);
+    assertFalse(valueAsString.contains("\u2028"));
+  }
+
+  public void testU2029Escaped() throws IOException {
+    String containsU2029 = String.format("This string contains %c char", '\u2029');
+    JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2029);
+    String valueAsString = MAPPER.writeValueAsString(jsonpObject);
+    assertFalse(valueAsString.contains("\u2029"));
+  }
+
+  public void testU2030NotEscaped() throws IOException {
+    String containsU2030 = String.format("This string contains %c char", '\u2030');
+    JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2030);
+    String valueAsString = MAPPER.writeValueAsString(jsonpObject);
+    assertTrue(valueAsString.contains("\u2030"));
+  }
+}


### PR DESCRIPTION
This is a follow-up to this PR: https://github.com/FasterXML/jackson-core/pull/136 from @malaporte.
I ran into the same problem that malaporte had years ago, where the JSONP API response would cause an `Uncaught SyntaxError: Invalid or unexpected token` when the response contains the characters `U+2028` and/or `U+2029`. It took me quite a bit of time to find the `JsonpCharacterEscapes` class that he added whose purpose is just to escape those two characters. 

I thought it would be nice to incorporate it in the `JSONPObject` class, since its purpose is just to create a JSONP object.

This is a small change that should make life easier for anyone who is using `JSONPObject`. Please let me know if you have any questions or would like me to make changes. 