### PR TITLE
Fixes #1605: InetAddressSerializer discards IP address

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/InetAddressSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/InetAddressSerializer.java
@@ -20,16 +20,8 @@ public class InetAddressSerializer
     @Override
     public void serialize(InetAddress value, JsonGenerator jgen, SerializerProvider provider) throws IOException
     {
-        // Ok: get textual description; choose "more specific" part
-        String str = value.toString().trim();
-        int ix = str.indexOf('/');
-        if (ix >= 0) {
-            if (ix == 0) { // missing host name; use address
-                str = str.substring(1);
-            } else { // otherwise use name
-                str = str.substring(0, ix);
-            }
-        }
+        // [databind#1605] ignoring hostname; address is required to avoid DNS lookup upon deserialization
+        String str = value.getHostAddress();
         jgen.writeString(str);
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypesTest.java
@@ -156,6 +156,9 @@ public class JDKStringLikeTypesTest extends BaseMapTest
         InetAddress address = MAPPER.readValue(quote("127.0.0.1"), InetAddress.class);
         assertEquals("127.0.0.1", address.getHostAddress());
 
+        InetAddress ip6 = MAPPER.readValue(quote("::1"), InetAddress.class);
+        assertEquals("0:0:0:0:0:0:0:1", ip6.getHostAddress());
+
         // should we try resolving host names? That requires connectivity... 
         final String HOST = "google.com";
         address = MAPPER.readValue(quote(HOST), InetAddress.class);

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/TestJdkTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/TestJdkTypes.java
@@ -83,7 +83,12 @@ public class TestJdkTypes
     public void testInetAddress() throws IOException
     {
         assertEquals(quote("127.0.0.1"), MAPPER.writeValueAsString(InetAddress.getByName("127.0.0.1")));
-        assertEquals(quote("google.com"), MAPPER.writeValueAsString(InetAddress.getByName("google.com")));
+        assertEquals(
+                quote("13.107.21.100"),
+                MAPPER.writeValueAsString(InetAddress.getByAddress("google.com", new byte[] {13, 107, 21, 100})));
+        assertEquals(
+                quote("0:0:0:0:0:0:1:203"),
+                MAPPER.writeValueAsString(InetAddress.getByAddress(null, new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3})));
     }
 
     public void testInetSocketAddress() throws IOException


### PR DESCRIPTION
Always serializing the address, for now. Never just the hostname, since that triggers a DNS lookup upon deserialization.

The deserializer still accepts either address or hostname.