### PR TITLE
JsonSerializer#serialize throws useless JsonProcessingException

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonSerializer.java
@@ -120,7 +120,7 @@ public abstract class JsonSerializer<T>
      *   serializing Objects value contains, if any.
      */
     public abstract void serialize(T value, JsonGenerator gen, SerializerProvider serializers)
-        throws IOException, JsonProcessingException;
+        throws IOException;
 
     /**
      * Method that can be called to ask implementation to serialize


### PR DESCRIPTION
Having "JsonProcessingException" in the throws list of JsonSerializer#serialize is useless because IOException (a superclass of JsonProcessingException) is also declared.

@see JsonSerializable#serialize