### PR TITLE
added SET_PROPERTY_CREATOR_AS_DEFAULT MapperFeature

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.cfg.ConfigFeature;
 
@@ -213,6 +214,13 @@ public enum MapperFeature implements ConfigFeature
      */
     INFER_CREATOR_FROM_CONSTRUCTOR_PROPERTIES(true),
 
+    /**
+     * Feature that determines handling of creators.
+     * When enabled, in a case where JsonCreator mode can't be resolved it will be
+     * resolved as {@link JsonCreator.Mode.PROPERTIES} instead.
+     *
+     * @since 2.9
+     */
     SET_PROPERTY_CREATOR_AS_DEFAULT(false),
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -213,6 +213,8 @@ public enum MapperFeature implements ConfigFeature
      */
     INFER_CREATOR_FROM_CONSTRUCTOR_PROPERTIES(true),
 
+    SET_PROPERTY_CREATOR_AS_DEFAULT(false),
+
     /*
     /******************************************************
     /* Access modifier handling

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -1320,6 +1320,11 @@ public class JacksonAnnotationIntrospector
                 }
             }
         }
+
+        if(config.isEnabled(MapperFeature.SET_PROPERTY_CREATOR_AS_DEFAULT)) {
+            return JsonCreator.Mode.PROPERTIES;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Fixes #1631.
The tests for this are in the [parameter names module](https://github.com/FasterXML/jackson-modules-java8/pull/31).