### PR TITLE
Added AtomicInteger and AtomicLong deserializers

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/AtomicIntegerDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/AtomicIntegerDeserializer.java
@@ -1,0 +1,17 @@
+package com.fasterxml.jackson.databind.deser.std;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AtomicIntegerDeserializer extends JsonDeserializer<AtomicInteger> {
+
+    private static final long serialVersionUID = -1L;
+
+    @Override
+    public AtomicInteger deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return new AtomicInteger(p.getIntValue());
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/AtomicLongDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/AtomicLongDeserializer.java
@@ -1,0 +1,17 @@
+package com.fasterxml.jackson.databind.deser.std;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AtomicLongDeserializer extends JsonDeserializer<AtomicLong> {
+
+    private static final long serialVersionUID = -1L;
+
+    @Override
+    public AtomicLong deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return new AtomicLong(p.getLongValue());
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java
@@ -5,6 +5,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Container class that contains serializers for JDK types that
@@ -39,8 +41,13 @@ public class JdkDeserializers
                 return new StackTraceElementDeserializer();
             }
             if (rawType == AtomicBoolean.class) {
-                // (note: AtomicInteger/Long work due to single-arg constructor. For now?
                 return new AtomicBooleanDeserializer();
+            }
+            if (rawType == AtomicInteger.class) {
+                return new AtomicIntegerDeserializer();
+            }
+            if (rawType == AtomicLong.class) {
+                return new AtomicLongDeserializer();
             }
             if (rawType == ByteBuffer.class) {
                 return new ByteBufferDeserializer();


### PR DESCRIPTION
[This comment](https://github.com/FasterXML/jackson-databind/blob/84eca86b624036d365c4c029a5175e7bf40a6f5a/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java#L42) no longer appears to hold given that I get the following during deserialization;
```
com.fasterxml.jackson.databind.JsonMappingException:
Can not construct instance of java.util.concurrent.atomic.AtomicInteger: 
     no int/Int-argument constructor/factory method to deserialize from Number value (1)
```
So I have added the necessary AtomicInteger and AtomicLong deserializers.