### PR TITLE
Support READ_UNKNOWN_ENUM_VALUES_AS_NULL with @JsonCreator

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -134,6 +134,12 @@ class FactoryBasedEnumDeserializer
             return _factory.callOnWith(_valueClass, value);
         } catch (Exception e) {
             Throwable t = ClassUtil.throwRootCauseIfIOE(e);
+
+            if (ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL) &&
+                    t instanceof IllegalArgumentException) {
+                return null;
+            }
+
             return ctxt.handleInstantiationProblem(_valueClass, value, t);
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDeserializationTest.java
@@ -116,6 +116,17 @@ public class EnumDeserializationTest
         }
     }
 
+    static enum StrictEnumCreator {
+        A, B;
+
+        @JsonCreator public static StrictEnumCreator fromId(String value) {
+            for (StrictEnumCreator e: values()) {
+                if (e.name().toLowerCase().equals(value)) return e;
+            }
+            throw new IllegalArgumentException(value);
+        }
+    }
+
     // // 
     
     public enum AnEnum {
@@ -319,6 +330,16 @@ public class EnumDeserializationTest
         ObjectReader reader = MAPPER.reader(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
         assertNull(reader.forType(TestEnum.class).readValue("\"NO-SUCH-VALUE\""));
         assertNull(reader.forType(TestEnum.class).readValue(" 4343 "));
+    }
+
+    // Ability to ignore unknown Enum values:
+
+    public void testAllowUnknownEnumValuesReadAsNullWithCreatorMethod() throws Exception
+    {
+        // can not use shared mapper when changing configs...
+        ObjectReader reader = MAPPER.reader(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+        assertNull(reader.forType(StrictEnumCreator.class).readValue("\"NO-SUCH-VALUE\""));
+        assertNull(reader.forType(StrictEnumCreator.class).readValue(" 4343 "));
     }
 
     public void testAllowUnknownEnumValuesForEnumSets() throws Exception


### PR DESCRIPTION
The deserialization feature READ_UNKNOWN_ENUM_VALUES_AS_NULL allows enum values that are not recognised to take a null value when parsed. Before this commit, this deserialization feature did not work whenever an enum had a method marked `@JsonCreator`, and the enum creator method itself had
to choose null in the case of unknown input.

With this change, if an enum creator method throws an IllegalArgumentException then this is considered to be an unknown value and (if READ_UNKNOWN_ENUM_VALUES_AS_NULL is active) then null will be
used.