### PR TITLE
Refactor StdDateFormat 

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -38,7 +38,6 @@ public class StdDateFormat
 
     /**
      * Same as 'regular' 8601 except misses timezone altogether.
-     * Used only for parsing/reading dates.
      *
      * @since 2.8.10
      */
@@ -605,7 +604,7 @@ public class StdDateFormat
     	
     	
     	//
-    	// -- SECONDS --
+    	// -- TIME fields --
     	// 
     	//  Things to handle:
     	//  - hours, minutes and seconds are optional. Add a default value so it can be 

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -608,7 +608,8 @@ public class StdDateFormat
     	// -- SECONDS --
     	// 
     	//  Things to handle:
-    	//  - add seconds if absent (they are optional but required by the DateFormat we gonna use)
+    	//  - hours, minutes and seconds are optional. Add a default value so it can be 
+    	//    accepted by SimpleDateFormat
     	
     	// Count how many ':' we have in the time part
     	int columnCount = 0;
@@ -619,7 +620,6 @@ public class StdDateFormat
     		}
     	}
     	
-    	// If not exactly 2 ':', then we are missing some optional time elements
     	if( columnCount < 2 ) { 
     		sb.insert(current, ":00");
     	}


### PR DESCRIPTION
This PR addresses issues highlighted in `DateDeserializationTest` test cases + https://github.com/FasterXML/jackson-databind/issues/1667 & https://github.com/FasterXML/jackson-databind/issues/1668

The original version had different code path to handle `+hhmm`, `+hh:mm`, `Z`  and _not TZ_ hence producing different and inconsistent results for edge cases (like missing digits or time field). 
This new version makes sure the sanitisation process is the same for all cases. For instance, if we detect a `Z` timezone indicator, it is replaced by `+0000` before going through the next steps.

I made sure this new version behaves the same as the original and accepts the same input. Of course it differs for cases that were "wrongly" accepted or refused... The test cases defined in `DateDeserilizationTest` were very helpful to detect changes in behavior...

Concerning ISO8601, this new version behaves like described by the following BNF:
```
   date-fullyear   = 4DIGIT
   date-month      = 1*2DIGIT
   date-mday       = 1*2DIGIT
   time-hour       = 1*2DIGIT
   time-minute     = 1*2DIGIT
   time-second     = 1*2DIGIT
   time-secfrac    = "." 1*DIGIT
   time-numoffset  = ("+" / "-") time-hour [[":"] time-minute]
   time-offset     = "Z" / time-numoffset

   partial-time    = time-hour [":" time-minute [":" time-second [time-secfrac]]]
   full-date       = date-fullyear "-" date-month "-" date-mday
   full-time       = partial-time time-offset

   date-time       = full-date "T" full-time
```

The parser accepts `date-time`, `full-date` and `partial-time` inputs.

**Optional Digits**
Month, days, hours, minutes and second can be expressed with 1 or 2 digits.

**Optional Fields**
As described in ISO8601, any number of values may be dropped from any of the date and time representations, but in the order from the least to the most significant. 
The parser supports optional hours, minutes and seconds. This means the following forms are now accepted whatever the timezone indicator.

- `2000-01-02T03:04:05`
- `2000-01-02T03:04`
- `2000-01-02T03`
- `2000-01-02`

The original version had support for optional seconds but only if a timezone was present (failed if no timezone).

**Fraction of Seconds vs. millis**
Cfr. https://github.com/FasterXML/jackson-databind/issues/1668

This new version dropped the _millis_ concept in favour of the more correct _fraction of seconds_. This means the following forms now produce the correct/expected result:

- `2000-01-02T03:04:05.1` --> 100 millis
- `2000-01-02T03:04:05.01` --> 10 millis
- `2000-01-02T03:04:05.001` --> 1 millis

If more than 3 digits after the dot:
- `2000-01-02T03:04:05.1234` --> 5 seconds + 0.1234 seconds

**Leniency**
Leniency is fully supported on all fields except the old "millis" as it is now interpreted as a faction of second. The original version had a hard limit of 2 digits on some fields that somehow reduced the leniency support.
Although not expressed in the BNF above (maybe I should write another for the lenient mode), the following is now accepted:

- `2000-01-32` --> equivalent to `2000-02-01`
- `2000-01-02T03:04:61` --> equivalent to `2000-01-02T03:05:01`

When Leniency is turned off, the parser throws a ParseException when the field is not within the accepted range.

**Others**
Some other "technical" changes:
- The error message did not refer to the input string but the version after sanitisation which is potentially different.
- I managed to refactor part of the code to reduce the amount and the depth of `if/then/else` conditions and make the code flow easier to follow.
- Code was duplicated in `parse(String)`and `parse(String, ParsePosition)` methods
- The error index in thrown`ParseException` did not take into account the current position set in the `ParsePosition`
- Compared to the previous version, a single `StringBuffer` is now used through out the sanitisation process reducing the String manipulation overhead

**WHAT NOW?**
I reviewed the existing test cases so they reflect the new behaviour. Diff against the previous version to see the impact...
I also discovered some of these tests are non-sense, some are now deprecated but some new may have to be written in the light of the proposed BNF. I have not done it yet so the only changes clearly highlight the diff between this version and the previous.

IMHO most of these tests should explicitly test `StdDateFormat` without Jackson and be hosted in a separated file. The stuff that involve Jackson - like timezone settings, annotations, etc - should be separated and could stay in the current test class.
