### PR TITLE
Replace "can not" by "cannot" in the source comments

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -572,7 +572,7 @@ public abstract class AnnotationIntrospector
      * it is "weak" and does not either proof that a property exists (for example,
      * if visibility is not high enough), or override explicit names.
      * In practice this method is used to introspect optional names for creator
-     * parameters (which may or may not be available and can not be detected
+     * parameters (which may or may not be available and cannot be detected
      * by standard databind); or to provide alternate name mangling for
      * fields, getters and/or setters.
      * 
@@ -605,7 +605,7 @@ public abstract class AnnotationIntrospector
      * Method called in cases where a class has two methods eligible to be used
      * for the same logical property, and default logic is not enough to figure
      * out clear precedence. Introspector may try to choose one to use; or, if
-     * unable, return `null` to indicate it can not resolve the problem.
+     * unable, return `null` to indicate it cannot resolve the problem.
      *
      * @since 2.7
      */

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -825,7 +825,7 @@ public abstract class DeserializationContext
 
     /**
      * Method that deserializers should call if they encounter a String value
-     * that can not be converted to expected key of a {@link java.util.Map}
+     * that cannot be converted to expected key of a {@link java.util.Map}
      * valued property.
      * Default implementation will try to call {@link DeserializationProblemHandler#handleWeirdNumberValue}
      * on configured handlers, if any, to allow for recovery; if recovery does not
@@ -868,7 +868,7 @@ public abstract class DeserializationContext
 
     /**
      * Method that deserializers should call if they encounter a String value
-     * that can not be converted to target property type, in cases where some
+     * that cannot be converted to target property type, in cases where some
      * String values could be acceptable (either with different settings,
      * or different value).
      * Default implementation will try to call {@link DeserializationProblemHandler#handleWeirdStringValue}
@@ -912,7 +912,7 @@ public abstract class DeserializationContext
 
     /**
      * Method that deserializers should call if they encounter a numeric value
-     * that can not be converted to target property type, in cases where some
+     * that cannot be converted to target property type, in cases where some
      * numeric values could be acceptable (either with different settings,
      * or different numeric value).
      * Default implementation will try to call {@link DeserializationProblemHandler#handleWeirdNumberValue}
@@ -1053,7 +1053,7 @@ public abstract class DeserializationContext
     /**
      * Method that deserializers should call if the first token of the value to
      * deserialize is of unexpected type (that is, type of token that deserializer
-     * can not handle). This could occur, for example, if a Number deserializer
+     * cannot handle). This could occur, for example, if a Number deserializer
      * encounter {@link JsonToken#START_ARRAY} instead of
      * {@link JsonToken#VALUE_NUMBER_INT} or {@link JsonToken#VALUE_NUMBER_FLOAT}.
      * 
@@ -1073,7 +1073,7 @@ public abstract class DeserializationContext
     /**
      * Method that deserializers should call if the first token of the value to
      * deserialize is of unexpected type (that is, type of token that deserializer
-     * can not handle). This could occur, for example, if a Number deserializer
+     * cannot handle). This could occur, for example, if a Number deserializer
      * encounter {@link JsonToken#START_ARRAY} instead of
      * {@link JsonToken#VALUE_NUMBER_INT} or {@link JsonToken#VALUE_NUMBER_FLOAT}.
      * 
@@ -1119,7 +1119,7 @@ public abstract class DeserializationContext
 
     /**
      * Method that deserializers should call if they encounter a type id
-     * (for polymorphic deserialization) that can not be resolved to an
+     * (for polymorphic deserialization) that cannot be resolved to an
      * actual type; usually since there is no mapping defined.
      * Default implementation will try to call {@link DeserializationProblemHandler#handleUnknownTypeId}
      * on configured handlers, if any, to allow for recovery; if recovery does not
@@ -1132,7 +1132,7 @@ public abstract class DeserializationContext
      *
      * @return {@link JavaType} that id resolves to
      *
-     * @throws IOException To indicate unrecoverable problem, if resolution can not
+     * @throws IOException To indicate unrecoverable problem, if resolution cannot
      *    be made to work
      *
      * @since 2.8

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -143,7 +143,7 @@ public enum DeserializationFeature implements ConfigFeature
     /**
      * Feature that determines what happens when type of a polymorphic
      * value (indicated for example by {@link com.fasterxml.jackson.annotation.JsonTypeInfo})
-     * can not be found (missing) or resolved (invalid class name, unmappable id);
+     * cannot be found (missing) or resolved (invalid class name, unmappable id);
      * if enabled, an exception ir thrown; if false, null value is used instead.
      *<p>
      * Feature is enabled by default so that exception is thrown for missing or invalid

--- a/src/main/java/com/fasterxml/jackson/databind/JsonDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonDeserializer.java
@@ -340,7 +340,7 @@ public abstract class JsonDeserializer<T>
      * serialization, and if so, should be able to resolve it to actual
      * Object instance to return as deserialized value.
      *<p>
-     * Default implementation returns null, as support can not be implemented
+     * Default implementation returns null, as support cannot be implemented
      * generically. Some standard deserializers (most notably
      * {@link com.fasterxml.jackson.databind.deser.BeanDeserializer})
      * do implement this feature, and may return reader instance, depending on exact

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -544,7 +544,7 @@ public abstract class JsonNode
      * and 1 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured types
+     * If representation cannot be converted to an int (including structured types
      * like Objects and Arrays),
      * default value of <b>0</b> will be returned; no exceptions are thrown.
      */
@@ -558,7 +558,7 @@ public abstract class JsonNode
      * and 1 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured types
+     * If representation cannot be converted to an int (including structured types
      * like Objects and Arrays),
      * specified <b>defaultValue</b> will be returned; no exceptions are thrown.
      */
@@ -572,7 +572,7 @@ public abstract class JsonNode
      * and 1 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an long (including structured types
+     * If representation cannot be converted to an long (including structured types
      * like Objects and Arrays),
      * default value of <b>0</b> will be returned; no exceptions are thrown.
      */
@@ -586,7 +586,7 @@ public abstract class JsonNode
      * and 1 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an long (including structured types
+     * If representation cannot be converted to an long (including structured types
      * like Objects and Arrays),
      * specified <b>defaultValue</b> will be returned; no exceptions are thrown.
      */
@@ -600,7 +600,7 @@ public abstract class JsonNode
      * and 1.0 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured types
+     * If representation cannot be converted to an int (including structured types
      * like Objects and Arrays),
      * default value of <b>0.0</b> will be returned; no exceptions are thrown.
      */
@@ -614,7 +614,7 @@ public abstract class JsonNode
      * and 1.0 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured types
+     * If representation cannot be converted to an int (including structured types
      * like Objects and Arrays),
      * specified <b>defaultValue</b> will be returned; no exceptions are thrown.
      */
@@ -628,7 +628,7 @@ public abstract class JsonNode
      * 0 maps to false
      * and Strings 'true' and 'false' map to corresponding values.
      *<p>
-     * If representation can not be converted to a boolean value (including structured types
+     * If representation cannot be converted to a boolean value (including structured types
      * like Objects and Arrays),
      * default value of <b>false</b> will be returned; no exceptions are thrown.
      */
@@ -642,7 +642,7 @@ public abstract class JsonNode
      * 0 maps to false
      * and Strings 'true' and 'false' map to corresponding values.
      *<p>
-     * If representation can not be converted to a boolean value (including structured types
+     * If representation cannot be converted to a boolean value (including structured types
      * like Objects and Arrays),
      * specified <b>defaultValue</b> will be returned; no exceptions are thrown.
      */

--- a/src/main/java/com/fasterxml/jackson/databind/JsonSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonSerializer.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.util.NameTransformer;
  * with null values -- caller <b>must</b> handle null values, usually
  * by calling {@link SerializerProvider#findNullValueSerializer} to obtain
  * serializer to use.
- * This also means that custom serializers can not be directly used to change
+ * This also means that custom serializers cannot be directly used to change
  * the output to produce when serializing null values.
  *<p>
  * If serializer is an aggregate one -- meaning it delegates handling of some

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -90,7 +90,7 @@ Simplest usage is of form:
  *  </li>
  * <li>If the specific kind of configurability is not available via {@link ObjectReader} and
  *   {@link ObjectWriter}, you may need to use multiple {@link ObjectMapper} instead (for example:
- *   you can not change mix-in annotations on-the-fly; or, set of custom (de)serializers).
+ *   you cannot change mix-in annotations on-the-fly; or, set of custom (de)serializers).
  *   To help with this usage, you may want to use method {@link #copy()} which creates a clone
  *   of the mapper with specific configuration, and allows configuration of the copied instance
  *   before it gets used. Note that {@link #copy} operation is as expensive as constructing
@@ -295,7 +295,7 @@ public class ObjectMapper
      * instances.
      */
     protected final static BaseSettings DEFAULT_BASE = new BaseSettings(
-            null, // can not share global ClassIntrospector any more (2.5+)
+            null, // cannot share global ClassIntrospector any more (2.5+)
             DEFAULT_ANNOTATION_INTROSPECTOR,
              null, TypeFactory.defaultInstance(),
             null, StdDateFormat.instance, null,
@@ -1097,7 +1097,7 @@ public class ObjectMapper
     /**
      * Accessor for the "blueprint" (or, factory) instance, from which instances
      * are created by calling {@link DefaultSerializerProvider#createInstance}.
-     * Note that returned instance can not be directly used as it is not properly
+     * Note that returned instance cannot be directly used as it is not properly
      * configured: to get a properly configured instance to call, use
      * {@link #getSerializerProviderInstance()} instead.
      */
@@ -2245,7 +2245,7 @@ public class ObjectMapper
      * Note: this method should NOT be used if the result type is a
      * container ({@link java.util.Collection} or {@link java.util.Map}.
      * The reason is that due to type erasure, key and value types
-     * can not be introspected when using this method.
+     * cannot be introspected when using this method.
      * 
      * @throws IOException if a low-level I/O problem (unexpected end-of-input,
      *   network error) occurs (passed through as-is without additional wrapping -- note
@@ -2681,7 +2681,7 @@ public class ObjectMapper
     /**
      *<p>
      * Note: return type is co-variant, as basic ObjectCodec
-     * abstraction can not refer to concrete node types (as it's
+     * abstraction cannot refer to concrete node types (as it's
      * part of core package, whereas impls are part of mapper
      * package)
      */
@@ -2693,7 +2693,7 @@ public class ObjectMapper
     /**
      *<p>
      * Note: return type is co-variant, as basic ObjectCodec
-     * abstraction can not refer to concrete node types (as it's
+     * abstraction cannot refer to concrete node types (as it's
      * part of core package, whereas impls are part of mapper
      * package)
      */
@@ -4061,7 +4061,7 @@ public class ObjectMapper
      * content for data binding.
      *
      * @return First token to be used for data binding after this call:
-     *  can never be null as exception will be thrown if parser can not
+     *  can never be null as exception will be thrown if parser cannot
      *  provide more tokens.
      *
      * @throws IOException if the underlying input source has problems during

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -112,7 +112,7 @@ public class ObjectReader
      * this value object will be updated instead.
      * Note that value can be of almost any type, except not
      * {@link com.fasterxml.jackson.databind.type.ArrayType}; array
-     * types can not be modified because array size is immutable.
+     * types cannot be modified because array size is immutable.
      */
     protected final Object _valueToUpdate;
 
@@ -134,7 +134,7 @@ public class ObjectReader
      * NOTE: If defined non-null, <code>readValue()</code> methods that take
      * {@link Reader} or {@link String} input <b>will fail with exception</b>,
      * because format-detection only works on byte-sources. Also, if format
-     * can not be detect reliably (as per detector settings),
+     * cannot be detect reliably (as per detector settings),
      * a {@link JsonParseException} will be thrown).
      * 
      * @since 2.1
@@ -807,7 +807,7 @@ public class ObjectReader
      * to construct appropriate {@link JsonParser} for actual parsing.
      *<p>
      * Note: since format detection only works with byte sources, it is possible to
-     * get a failure from some 'readValue()' methods. Also, if input can not be reliably
+     * get a failure from some 'readValue()' methods. Also, if input cannot be reliably
      * (enough) detected as one of specified types, an exception will be thrown.
      *<p>
      * Note: not all {@link JsonFactory} types can be passed: specifically, ones that
@@ -831,7 +831,7 @@ public class ObjectReader
      * {@link DataFormatReaders}.
      *<p>
      * NOTE: since format detection only works with byte sources, it is possible to
-     * get a failure from some 'readValue()' methods. Also, if input can not be reliably
+     * get a failure from some 'readValue()' methods. Also, if input cannot be reliably
      * (enough) detected as one of specified types, an exception will be thrown.
      * 
      * @param readers DataFormatReaders to use for detecting underlying format.

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -1322,7 +1322,7 @@ public class ObjectWriter
         private final JsonSerializer<Object> valueSerializer;
 
         /**
-         * When dealing with polymorphic types, we can not pre-fetch
+         * When dealing with polymorphic types, we cannot pre-fetch
          * serializer, but can pre-fetch {@link TypeSerializer}.
          */
         private final TypeSerializer typeSerializer;

--- a/src/main/java/com/fasterxml/jackson/databind/SequenceWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SequenceWriter.java
@@ -196,7 +196,7 @@ public class SequenceWriter
         return this;
     }
 
-    // NOTE: redundant wrt variant that takes Iterable, but can not remove or even
+    // NOTE: redundant wrt variant that takes Iterable, but cannot remove or even
     // deprecate due to backwards-compatibility needs
     public <C extends Collection<?>> SequenceWriter writeAll(C container) throws IOException {
         for (Object value : container) {

--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -275,7 +275,7 @@ public enum SerializationFeature implements ConfigFeature
      * Feature that determines whether Map entries with null values are
      * to be serialized (true) or not (false).
      *<p>
-     * NOTE: unlike other {@link SerializationFeature}s, this feature <b>can not</b> be
+     * NOTE: unlike other {@link SerializationFeature}s, this feature <b>cannot</b> be
      * dynamically changed on per-call basis, because its effect is considered during
      * construction of serializers and property handlers.
      *<p>
@@ -297,7 +297,7 @@ public enum SerializationFeature implements ConfigFeature
      * Note that this does not change behavior of {@link java.util.Map}s, or
      * "Collection-like" types.
      *<p>
-     * NOTE: unlike other {@link SerializationFeature}s, this feature <b>can not</b> be
+     * NOTE: unlike other {@link SerializationFeature}s, this feature <b>cannot</b> be
      * dynamically changed on per-call basis, because its effect is considered during
      * construction of serializers and property handlers.
      *<p>

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -837,7 +837,7 @@ public abstract class SerializerProvider
     /**
      * Method called to find a serializer to use for null values for given
      * declared type. Note that type is completely based on declared type,
-     * since nulls in Java have no type and thus runtime type can not be
+     * since nulls in Java have no type and thus runtime type cannot be
      * determined.
      * 
      * @since 2.0
@@ -867,7 +867,7 @@ public abstract class SerializerProvider
 
     /**
      * Method called to get the serializer to use if provider
-     * can not determine an actual type-specific serializer
+     * cannot determine an actual type-specific serializer
      * to use; typically when none of {@link SerializerFactory}
      * instances are able to construct a serializer.
      *<p>
@@ -1289,7 +1289,7 @@ public abstract class SerializerProvider
     /**
      * Method that will try to find a serializer, either from cache
      * or by constructing one; but will not return an "unknown" serializer
-     * if this can not be done but rather returns null.
+     * if this cannot be done but rather returns null.
      *
      * @return Serializer if one can be found, null if not.
      */

--- a/src/main/java/com/fasterxml/jackson/databind/annotation/JsonSerialize.java
+++ b/src/main/java/com/fasterxml/jackson/databind/annotation/JsonSerialize.java
@@ -130,7 +130,7 @@ public @interface JsonSerialize
     /**
      * Which helper object is to be used to convert type into something
      * that Jackson knows how to serialize; either because base type
-     * can not be serialized easily, or just to alter serialization.
+     * cannot be serialized easily, or just to alter serialization.
      *
      * @since 2.2
      */

--- a/src/main/java/com/fasterxml/jackson/databind/annotation/NoClass.java
+++ b/src/main/java/com/fasterxml/jackson/databind/annotation/NoClass.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.databind.annotation;
 
 /**
  * Marker class used with annotations to indicate "no class". This is
- * a silly but necessary work-around -- annotations can not take nulls
+ * a silly but necessary work-around -- annotations cannot take nulls
  * as either default or explicit values. Hence for class values we must
  * explicitly use a bogus placeholder to denote equivalent of
  * "no class" (for which 'null' is usually the natural choice).

--- a/src/main/java/com/fasterxml/jackson/databind/annotation/package-info.java
+++ b/src/main/java/com/fasterxml/jackson/databind/annotation/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Annotations that directly depend on classes in databinding bundle
- * (not just Jackson core) and can not be included
- * in Jackson core annotations package (because it can not have any
+ * (not just Jackson core) and cannot be included
+ * in Jackson core annotations package (because it cannot have any
  * external dependencies).
  */
 package com.fasterxml.jackson.databind.annotation;

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/ConfigFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/ConfigFeature.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.databind.cfg;
 /**
  * Interface that actual SerializationFeature enumerations used by
  * {@link MapperConfig} implementations must implement.
- * Necessary since enums can not be extended using normal
+ * Necessary since enums cannot be extended using normal
  * inheritance, but can implement interfaces
  */
 public interface ConfigFeature

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/ContextAttributes.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/ContextAttributes.java
@@ -69,7 +69,7 @@ public abstract class ContextAttributes
         protected final static Object NULL_SURROGATE = new Object();
         
         /**
-         * Shared attributes that we can not modify in-place.
+         * Shared attributes that we cannot modify in-place.
          */
         protected final Map<?,?> _shared;
 

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
@@ -50,7 +50,7 @@ public abstract class MapperConfigBase<CFG extends ConfigFeature,
 
     /**
      * Mix-in annotation mappings to use, if any: immutable,
-     * can not be changed once defined.
+     * cannot be changed once defined.
      * 
      * @since 2.6
      */

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -802,7 +802,7 @@ public abstract class BasicDeserializerFactory
         return false;
     }
 
-    // 01-Dec-2016, tatu: As per [databind#265] we can not yet support passing
+    // 01-Dec-2016, tatu: As per [databind#265] we cannot yet support passing
     //   of unwrapped values through creator properties, so fail fast
     protected void _reportUnwrappedCreatorProperty(DeserializationContext ctxt,
             BeanDescription beanDesc, AnnotatedParameter param)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -808,7 +808,7 @@ public abstract class BeanDeserializerBase
         if (am != null) {
             NameTransformer unwrapper = ctxt.getAnnotationIntrospector().findUnwrappingNameTransformer(am);
             if (unwrapper != null) {
-                // 01-Dec-2016, tatu: As per [databind#265] we can not yet support passing
+                // 01-Dec-2016, tatu: As per [databind#265] we cannot yet support passing
                 //   of unwrapped values through creator properties, so fail fast
                 if (prop instanceof CreatorProperty) {
                     ctxt.reportBadDefinition(getValueType(), String.format(
@@ -913,7 +913,7 @@ public abstract class BeanDeserializerBase
 
     @Override
     public AccessPattern getEmptyAccessPattern() {
-        // Empty values can not be shared
+        // Empty values cannot be shared
         return AccessPattern.DYNAMIC;
     }
     
@@ -1407,7 +1407,7 @@ public abstract class BeanDeserializerBase
 
     public Object deserializeFromArray(JsonParser p, DeserializationContext ctxt) throws IOException
     {
-        // note: can not call `_delegateDeserializer()` since order reversed here:
+        // note: cannot call `_delegateDeserializer()` since order reversed here:
         JsonDeserializer<Object> delegateDeser = _arrayDelegateDeserializer;
         // fallback to non-array delegate
         if ((delegateDeser != null) || ((delegateDeser = _delegateDeserializer) != null)) {
@@ -1528,7 +1528,7 @@ public abstract class BeanDeserializerBase
 
     /**
      * Method called when a JSON property is encountered that has not matching
-     * setter, any-setter or field, and thus can not be assigned.
+     * setter, any-setter or field, and thus cannot be assigned.
      */
     @Override
     protected void handleUnknownProperty(JsonParser p, DeserializationContext ctxt,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -558,7 +558,7 @@ public class BeanDeserializerFactory
                     } else if (!propDef.hasConstructorParameter()) {
                         PropertyMetadata md = propDef.getMetadata();
                         // 25-Oct-2016, tatu: If merging enabled, might not need setter.
-                        //   We can not quite support this with creator parameters; in theory
+                        //   We cannot quite support this with creator parameters; in theory
                         //   possibly, but right not not due to complexities of routing, so
                         //   just prevent
                         if (md.getMergeInfo() != null) {
@@ -879,7 +879,7 @@ name, ((AnnotatedParameter) m).getIndex());
 
     /**
      * Helper method used to skip processing for types that we know
-     * can not be (i.e. are never consider to be) beans: 
+     * cannot be (i.e. are never consider to be) beans: 
      * things like primitives, Arrays, Enums, and proxy types.
      *<p>
      * Note that usually we shouldn't really be getting these sort of

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -54,7 +54,7 @@ public class BuilderBasedDeserializer
                 ignorableProps, ignoreAllUnknown, hasViews);
         _targetType = targetType;
         _buildMethod = builder.getBuildMethod();
-        // 05-Mar-2012, tatu: Can not really make Object Ids work with builders, not yet anyway
+        // 05-Mar-2012, tatu: Cannot really make Object Ids work with builders, not yet anyway
         if (_objectIdReader != null) {
             throw new IllegalArgumentException("Can not use Object Id with Builder-based deserialization (type "
                     +beanDesc.getType()+")");
@@ -228,7 +228,7 @@ public class BuilderBasedDeserializer
     public Object deserialize(JsonParser p, DeserializationContext ctxt,
     		Object value) throws IOException
     {
-        // 26-Oct-2016, tatu: I can not see any of making this actually
+        // 26-Oct-2016, tatu: I cannot see any of making this actually
         //    work correctly, so let's indicate problem right away
         JavaType valueType = _targetType;
         // Did they try to give us builder?

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ContextualDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ContextualDeserializer.java
@@ -29,7 +29,7 @@ public interface ContextualDeserializer
      *    deserializers that may be needed by this deserializer
      * @param property Method, field or constructor parameter that represents the property
      *   (and is used to assign deserialized value).
-     *   Should be available; but there may be cases where caller can not provide it and
+     *   Should be available; but there may be cases where caller cannot provide it and
      *   null is passed instead (in which case impls usually pass 'this' deserializer as is)
      * 
      * @return Deserializer to use for deserializing values of specified property;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/CreatorProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/CreatorProperty.java
@@ -49,7 +49,7 @@ public class CreatorProperty
     protected final int _creatorIndex;
 
     /**
-     * In special cases, when implementing "updateValue", we can not use
+     * In special cases, when implementing "updateValue", we cannot use
      * constructors or factory methods, but have to fall back on using a
      * setter (or mutable field property). If so, this refers to that fallback
      * accessor.

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
@@ -38,7 +38,7 @@ public abstract class DefaultDeserializationContext
     /**
      * Constructor that will pass specified deserializer factory and
      * cache: cache may be null (in which case default implementation
-     * will be used), factory can not be null
+     * will be used), factory cannot be null
      */
     protected DefaultDeserializationContext(DeserializerFactory df, DeserializerCache cache) {
         super(df, cache);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializationProblemHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializationProblemHandler.java
@@ -75,7 +75,7 @@ public abstract class DeserializationProblemHandler
     }
 
     /**
-     * Method called when a property name from input can not be converted to a
+     * Method called when a property name from input cannot be converted to a
      * non-Java-String key type (passed as <code>rawKeyType</code>) due to format problem.
      * Handler may choose to do one of 3 things:
      *<ul>
@@ -108,7 +108,7 @@ public abstract class DeserializationProblemHandler
 
     /**
      * Method called when a String value
-     * can not be converted to a non-String value type due to specific problem
+     * cannot be converted to a non-String value type due to specific problem
      * (as opposed to String values never being usable).
      * Handler may choose to do one of 3 things:
      *<ul>
@@ -142,7 +142,7 @@ public abstract class DeserializationProblemHandler
 
     /**
      * Method called when a numeric value (integral or floating-point from input
-     * can not be converted to a non-numeric value type due to specific problem
+     * cannot be converted to a non-numeric value type due to specific problem
      * (as opposed to numeric values never being usable).
      * Handler may choose to do one of 3 things:
      *<ul>
@@ -177,7 +177,7 @@ public abstract class DeserializationProblemHandler
     /**
      * Method that deserializers should call if the first token of the value to
      * deserialize is of unexpected type (that is, type of token that deserializer
-     * can not handle). This could occur, for example, if a Number deserializer
+     * cannot handle). This could occur, for example, if a Number deserializer
      * encounter {@link JsonToken#START_ARRAY} instead of
      * {@link JsonToken#VALUE_NUMBER_INT} or {@link JsonToken#VALUE_NUMBER_FLOAT}.
      *<ul>

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -163,7 +163,7 @@ public class SettableAnyProperty
                 AnnotatedField field = (AnnotatedField) _setter;
                 Map<Object,Object> val = (Map<Object,Object>) field.getValue(instance);
                 /* 01-Jun-2016, tatu: At this point it is not quite clear what to do if
-                 *    field is `null` -- we can not necessarily count on zero-args
+                 *    field is `null` -- we cannot necessarily count on zero-args
                  *    constructor except for a small set of types, so for now just
                  *    ignore if null. May need to figure out something better in future.
                  */
@@ -172,7 +172,7 @@ public class SettableAnyProperty
                     val.put(propName, value);
                 }
             } else {
-                // note: can not use 'setValue()' due to taking 2 args
+                // note: cannot use 'setValue()' due to taking 2 args
                 ((AnnotatedMethod) _setter).callOnWith(instance, propName, value);
             }
         } catch (Exception e) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -85,7 +85,7 @@ public abstract class SettableBeanProperty
     /*
     /**********************************************************
     /* Configuration that is not yet immutable; generally assigned
-    /* during initialization process but can not be passed to
+    /* during initialization process but cannot be passed to
     /* constructor.
     /**********************************************************
      */
@@ -594,7 +594,7 @@ public abstract class SettableBeanProperty
     }
 
     // 10-Oct-2015, tatu: _Should_ be deprecated, too, but its remaining
-    //   callers can not actually provide a JsonParser
+    //   callers cannot actually provide a JsonParser
     protected void _throwAsIOE(Exception e, Object value) throws IOException {
         _throwAsIOE((JsonParser) null, e, value);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams;
  * is a scalar value (String, number, boolean).
  *<p>
  * Note that this type is not parameterized (even though it would seemingly
- * make sense), because such type information can not be use effectively
+ * make sense), because such type information cannot be use effectively
  * during runtime: access is always using either wildcard type, or just
  * basic {@link java.lang.Object}; and so adding type parameter seems
  * like unnecessary extra work.

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiators.java
@@ -26,7 +26,7 @@ public interface ValueInstantiators
      *   a custom instantiator already)
      *   
      * @return Instantiator to use; either <code>defaultInstantiator</code> that was passed,
-     *   or a custom variant; can not be null.
+     *   or a custom variant; cannot be null.
      */
     public ValueInstantiator findValueInstantiator(DeserializationConfig config,
             BeanDescription beanDesc, ValueInstantiator defaultInstantiator);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
@@ -15,7 +15,7 @@ public class BeanAsArrayBuilderDeserializer
     private static final long serialVersionUID = 1L;
 
     /**
-     * Deserializer we delegate operations that we can not handle.
+     * Deserializer we delegate operations that we cannot handle.
      */
     final protected BeanDeserializerBase _delegate;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
@@ -21,7 +21,7 @@ public class BeanAsArrayDeserializer
     private static final long serialVersionUID = 1L;
 
     /**
-     * Deserializer we delegate operations that we can not handle.
+     * Deserializer we delegate operations that we cannot handle.
      */
     protected final BeanDeserializerBase _delegate;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ArrayBlockingQueueDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ArrayBlockingQueueDeserializer.java
@@ -79,7 +79,7 @@ public class ArrayBlockingQueueDeserializer
     protected Collection<Object> createDefaultInstance(DeserializationContext ctxt)
         throws IOException
     {
-        // 07-Nov-2016, tatu: Important: can not create using default ctor (one
+        // 07-Nov-2016, tatu: Important: cannot create using default ctor (one
         //    does not exist); and also need to know exact size. Hence, return
         //    null from here
         return null;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -540,7 +540,7 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
             */
 
             
-            // These states can not be mapped; input stream is
+            // These states cannot be mapped; input stream is
             // off by an event or two
 
         //case END_OBJECT:

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdScalarDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdScalarDeserializer.java
@@ -39,7 +39,7 @@ public abstract class StdScalarDeserializer<T> extends StdDeserializer<T>
     }
 
     /**
-     * By default assumption is that scalar types can not be updated: many are immutable
+     * By default assumption is that scalar types cannot be updated: many are immutable
      * values (such as primitives and wrappers)
      */
     @Override // since 2.9

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
@@ -127,7 +127,7 @@ public class UntypedObjectDeserializer
 
     /**
      * We need to implement this method to properly find things to delegate
-     * to: it can not be done earlier since delegated deserializers almost
+     * to: it cannot be done earlier since delegated deserializers almost
      * certainly require access to this instance (at least "List" and "Map" ones)
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/fasterxml/jackson/databind/exc/IgnoredPropertyException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/IgnoredPropertyException.java
@@ -47,7 +47,7 @@ public class IgnoredPropertyException
      *    if available), or if not, type itself
      * @param propertyName Name of unrecognized property
      * @param propertyIds (optional, null if not available) Set of properties that
-     *    type would recognize, if completely known: null if set can not be determined.
+     *    type would recognize, if completely known: null if set cannot be determined.
      */
     public static IgnoredPropertyException from(JsonParser p,
             Object fromObjectOrClass, String propertyName,

--- a/src/main/java/com/fasterxml/jackson/databind/exc/UnrecognizedPropertyException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/UnrecognizedPropertyException.java
@@ -43,7 +43,7 @@ public class UnrecognizedPropertyException
      *    if available), or if not, type itself
      * @param propertyName Name of unrecognized property
      * @param propertyIds (optional, null if not available) Set of properties that
-     *    type would recognize, if completely known: null if set can not be determined.
+     *    type would recognize, if completely known: null if set cannot be determined.
      */
     public static UnrecognizedPropertyException from(JsonParser p,
             Object fromObjectOrClass, String propertyName,

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/Annotated.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/Annotated.java
@@ -59,7 +59,7 @@ public abstract class Annotated
     /**
      * JDK declared generic type of the annotated element; definition
      * of what exactly this means depends on sub-class. Note that such type
-     * can not be reliably resolved without {@link TypeResolutionContext}, and
+     * cannot be reliably resolved without {@link TypeResolutionContext}, and
      * as a result use of this method was deprecated in Jackson 2.7: see
      * {@link #getType} for replacement.
      *

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedField.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedField.java
@@ -18,7 +18,7 @@ public final class AnnotatedField
     /**
      * Actual {@link Field} used for access.
      *<p>
-     * Transient since it can not be persisted directly using
+     * Transient since it cannot be persisted directly using
      * JDK serialization
      */
     protected final transient Field _field;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedParameter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedParameter.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 /**
  * Object that represents method parameters, mostly so that associated
  * annotations can be processed conveniently. Note that many of accessors
- * can not return meaningful values since parameters do not have stand-alone
+ * cannot return meaningful values since parameters do not have stand-alone
  * JDK objects associated; so access should mostly be limited to checking
  * annotation values which are properly aggregated and included.
  */

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -179,7 +179,7 @@ public class JacksonAnnotationIntrospector
     public String findEnumValue(Enum<?> value)
     {
         // 11-Jun-2015, tatu: As per [databind#677], need to allow explicit naming.
-        //   Unfortunately can not quite use standard AnnotatedClass here (due to various
+        //   Unfortunately cannot quite use standard AnnotatedClass here (due to various
         //   reasons, including odd representation JVM uses); has to do for now
         try {
             // We know that values are actually static fields with matching name so:
@@ -1438,7 +1438,7 @@ public class JacksonAnnotationIntrospector
         // 08-Dec-2014, tatu: To deprecate `JsonTypeInfo.None` we need to use other placeholder(s);
         //   and since `java.util.Void` has other purpose (to indicate "deser as null"), we'll instead
         //   use `JsonTypeInfo.class` itself. But any annotation type will actually do, as they have no
-        //   valid use (can not instantiate as default)
+        //   valid use (cannot instantiate as default)
         if (defaultImpl != JsonTypeInfo.None.class && !defaultImpl.isAnnotation()) {
             b = b.defaultImpl(defaultImpl);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -488,7 +488,7 @@ public class POJOPropertiesCollector
         boolean expl = (pn != null && !pn.isEmpty());
         if (!expl) {
             if (impl.isEmpty()) {
-                // Important: if neither implicit nor explicit name, can not make use of
+                // Important: if neither implicit nor explicit name, cannot make use of
                 // this creator parameter -- may or may not be a problem, verified at a later point.
                 return;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/jsonschema/JsonSerializableSchema.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonschema/JsonSerializableSchema.java
@@ -25,7 +25,7 @@ public @interface JsonSerializableSchema
 {
     /**
      * Marker value used to indicate that property has "no value";
-     * needed because annotations can not have null as default
+     * needed because annotations cannot have null as default
      * value.
      */
     public final static String NO_VALUE = "##irrelevant";

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeDeserializer.java
@@ -66,7 +66,7 @@ public abstract class TypeDeserializer
     /**
      * Accessor for "default implementation" type; optionally defined
      * class to use in cases where type id is not
-     * accessible for some reason (either missing, or can not be
+     * accessible for some reason (either missing, or cannot be
      * resolved)
      */
     public abstract Class<?> getDefaultImpl();

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeResolverBuilder.java
@@ -135,7 +135,7 @@ public interface TypeResolverBuilder<T extends TypeResolverBuilder<T>>
 
     /**
      * Method for specifying default implementation to use if type id 
-     * is either not available, or can not be resolved.
+     * is either not available, or cannot be resolved.
      * 
      * @return Resulting builder instance (usually this builder,
      *   but may be a newly constructed instance for immutable builders}

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeSerializer.java
@@ -68,7 +68,7 @@ public abstract class TypeSerializer
      * Method called to write initial part of type information for given
      * value, when it will be output as scalar JSON value (not as JSON
      * Object or Array).
-     * This means that the context after call can not be that of JSON Object;
+     * This means that the context after call cannot be that of JSON Object;
      * it may be Array or root context.
      * 
      * @param value Value that will be serialized, for which type information is
@@ -165,7 +165,7 @@ public abstract class TypeSerializer
      * value, when it will be output as scalar JSON value (not as JSON
      * Object or Array),
      * using specified custom type id instead of calling {@link TypeIdResolver}.
-     * This means that the context after call can not be that of JSON Object;
+     * This means that the context after call cannot be that of JSON Object;
      * it may be Array or root context.
      * 
      * @param value Value that will be serialized, for which type information is

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsArrayTypeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsArrayTypeSerializer.java
@@ -35,7 +35,7 @@ public class AsArrayTypeSerializer extends TypeSerializerBase
     @Override
     public void writeTypePrefixForObject(Object value, JsonGenerator g) throws IOException {
         final String typeId = idFromValue(value);
-        // NOTE: can not always avoid writing type id, even if null
+        // NOTE: cannot always avoid writing type id, even if null
         if (g.canWriteTypeId()) {
             _writeTypeId(g, typeId);
         } else {
@@ -48,7 +48,7 @@ public class AsArrayTypeSerializer extends TypeSerializerBase
     @Override
     public void writeTypePrefixForObject(Object value, JsonGenerator g, Class<?> type) throws IOException {
         final String typeId = idFromValueAndType(value, type);
-        // NOTE: can not always avoid writing type id, even if null
+        // NOTE: cannot always avoid writing type id, even if null
         if (g.canWriteTypeId()) {
             _writeTypeId(g, typeId);
         } else {

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsExternalTypeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsExternalTypeSerializer.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
  * Type serializer that preferably embeds type information as an "external"
  * type property; embedded in enclosing JSON object.
  * Note that this serializer should only be used when value is being output
- * at JSON Object context; otherwise it can not work reliably, and will have
+ * at JSON Object context; otherwise it cannot work reliably, and will have
  * to revert operation similar to {@link AsPropertyTypeSerializer}.
  *<p>
  * Note that implementation of serialization is bit cumbersome as we must

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsWrapperTypeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsWrapperTypeSerializer.java
@@ -43,7 +43,7 @@ public class AsWrapperTypeSerializer extends TypeSerializerBase
             g.writeStartObject();
             // and then JSON Object start caller wants
 
-            // 28-Jan-2015, tatu: No really good answer here; can not really change
+            // 28-Jan-2015, tatu: No really good answer here; cannot really change
             //   structure, so change null to empty String...
             g.writeObjectFieldStart(_validTypeId(typeId));
         }
@@ -61,7 +61,7 @@ public class AsWrapperTypeSerializer extends TypeSerializerBase
             g.writeStartObject();
             // and then JSON Object start caller wants
 
-            // 28-Jan-2015, tatu: No really good answer here; can not really change
+            // 28-Jan-2015, tatu: No really good answer here; cannot really change
             //   structure, so change null to empty String...
             g.writeObjectFieldStart(_validTypeId(typeId));
         }

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolver.java
@@ -71,7 +71,7 @@ public class ClassNameIdResolver
         }
         String str = cls.getName();
         if (str.startsWith("java.util")) {
-            // 25-Jan-2009, tatu: There are some internal classes that we can not access as is.
+            // 25-Jan-2009, tatu: There are some internal classes that we cannot access as is.
             //     We need better mechanism; for now this has to do...
 
             // Enum sets and maps are problematic since we MUST know type of

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -127,7 +127,7 @@ public class StdTypeResolverBuilder
         } else {
             // 20-Mar-2016, tatu: It is important to do specialization go through
             //   TypeFactory to ensure proper resolution; with 2.7 and before, direct
-            //   call to JavaType was used, but that can not work reliably with 2.7
+            //   call to JavaType was used, but that cannot work reliably with 2.7
             // 20-Mar-2016, tatu: Can finally add a check for type compatibility BUT
             //   if so, need to add explicit checks for marker types. Not ideal, but
             //   seems like a reasonable compromise.

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeDeserializerBase.java
@@ -40,7 +40,7 @@ public abstract class TypeDeserializerBase
 
     /**
      * Type to use as the default implementation, if type id is
-     * missing or can not be resolved.
+     * missing or cannot be resolved.
      */
     protected final JavaType _defaultImpl;
 
@@ -172,7 +172,7 @@ public abstract class TypeDeserializerBase
                  *   we actually now need to explicitly narrow from base type (which may have parameterization)
                  *   using raw type.
                  *
-                 *   One complication, though; can not change 'type class' (simple type to container); otherwise
+                 *   One complication, though; cannot change 'type class' (simple type to container); otherwise
                  *   we may try to narrow a SimpleType (Object.class) into MapType (Map.class), losing actual
                  *   type in process (getting SimpleType of Map.class which will not work as expected)
                  */
@@ -263,7 +263,7 @@ public abstract class TypeDeserializerBase
     }
 
     /**
-     * Helper method called when given type id can not be resolved into 
+     * Helper method called when given type id cannot be resolved into 
      * concrete deserializer either directly (using given {@link  TypeIdResolver}),
      * or using default type.
      * Default implementation simply throws a {@link com.fasterxml.jackson.databind.JsonMappingException} to

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/package-info.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/package-info.java
@@ -2,7 +2,7 @@
  * Package that contains interfaces that define how to implement
  * functionality for dynamically resolving type during deserialization.
  * This is needed for complete handling of polymorphic types, where
- * actual type can not be determined statically (declared type is
+ * actual type cannot be determined statically (declared type is
  * a supertype of actual polymorphic serialized types).
  */
 package com.fasterxml.jackson.databind.jsontype;

--- a/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
@@ -61,7 +61,7 @@ public final class MissingNode
         /* Nothing to output... should we signal an error tho?
          * Chances are, this is an erroneous call. For now, let's
          * not do that; serialize as explicit null. Why? Because we
-         * can not just omit a value as JSON Object field name may have
+         * cannot just omit a value as JSON Object field name may have
          * been written out.
          */
         jg.writeNull();

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
@@ -549,7 +549,7 @@ public abstract class BasicSerializerFactory
         TypeSerializer elementTypeSerializer = createTypeSerializer(config,
                 elementType);
 
-        // if elements have type serializer, can not force static typing:
+        // if elements have type serializer, cannot force static typing:
         if (elementTypeSerializer != null) {
             staticTyping = false;
         }
@@ -975,7 +975,7 @@ public abstract class BasicSerializerFactory
         throws JsonMappingException
     {
         // 25-Jun-2015, tatu: Note that unlike with Collection(Like) and Map(Like) types, array
-        //   types can not be annotated (in theory I guess we could have mix-ins but... ?)
+        //   types cannot be annotated (in theory I guess we could have mix-ins but... ?)
         //   so we need not do primary annotation lookup here.
         //   So all we need is (1) Custom, (2) Default array serializers
         SerializationConfig config = prov.getConfig();
@@ -1129,7 +1129,7 @@ public abstract class BasicSerializerFactory
     protected boolean usesStaticTyping(SerializationConfig config,
             BeanDescription beanDesc, TypeSerializer typeSer)
     {
-        /* 16-Aug-2010, tatu: If there is a (value) type serializer, we can not force
+        /* 16-Aug-2010, tatu: If there is a (value) type serializer, we cannot force
          *    static typing; that would make it impossible to handle expected subtypes
          */
         if (typeSer != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
@@ -135,7 +135,7 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
      */
 
     /**
-     * Serializer to use for writing out the value: null if it can not be known
+     * Serializer to use for writing out the value: null if it cannot be known
      * statically; non-null if it can.
      */
     protected JsonSerializer<Object> _serializer;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java
@@ -112,7 +112,7 @@ public class BeanSerializer
     @Override
     protected BeanSerializerBase asArraySerializer()
     {
-        /* Can not:
+        /* Cannot:
          * 
          * - have Object Id (may be allowed in future)
          * - have "any getter"

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
@@ -616,7 +616,7 @@ public class BeanSerializerFactory
     
     /**
      * Helper method used to skip processing for types that we know
-     * can not be (i.e. are never consider to be) beans: 
+     * cannot be (i.e. are never consider to be) beans: 
      * things like primitives, Arrays, Enums, and proxy types.
      *<p>
      * Note that usually we shouldn't really be getting these sort of

--- a/src/main/java/com/fasterxml/jackson/databind/ser/ContextualSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/ContextualSerializer.java
@@ -27,7 +27,7 @@ public interface ContextualSerializer
      * @param prov Serializer provider to use for accessing config, other serializers
      * @param property Method or field that represents the property
      *   (and is used to access value to serialize).
-     *   Should be available; but there may be cases where caller can not provide it and
+     *   Should be available; but there may be cases where caller cannot provide it and
      *   null is passed instead (in which case impls usually pass 'this' serializer as is)
      * 
      * @return Serializer to use for serializing values of specified property;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -162,7 +162,7 @@ public class PropertyBuilder
             // First: case of class/type specifying it; try to find POJO property defaults
             Object defaultBean;
 
-            // 16-Oct-2016, tatu: Note: if we can not for some reason create "default instance",
+            // 16-Oct-2016, tatu: Note: if we cannot for some reason create "default instance",
             //    revert logic to the case of general/per-property handling, so both
             //    type-default AND null are to be excluded.
             //    (as per [databind#1417]

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/BeanAsArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/BeanAsArraySerializer.java
@@ -48,7 +48,7 @@ public class BeanAsArraySerializer
 
     /**
      * Serializer that would produce JSON Object version; used in
-     * cases where array output can not be used.
+     * cases where array output cannot be used.
      */
     protected final BeanSerializerBase _defaultSerializer;
     
@@ -209,7 +209,7 @@ public class BeanAsArraySerializer
                     prop.serializeAsElement(bean, gen, provider);
                 }
             }
-            // NOTE: any getters can not be supported either
+            // NOTE: any getters cannot be supported either
             //if (_anyGetterWriter != null) {
             //    _anyGetterWriter.getAndSerialize(bean, gen, provider);
             //}

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/IndexedListSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/IndexedListSerializer.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase;
 /**
  * This is an optimized serializer for Lists that can be efficiently
  * traversed by index (as opposed to others, such as {@link LinkedList}
- * that can not}.
+ * that cannot}.
  */
 @JacksonStdImpl
 public final class IndexedListSerializer

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/MapEntrySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/MapEntrySerializer.java
@@ -66,7 +66,7 @@ public class MapEntrySerializer
     protected final TypeSerializer _valueTypeSerializer;
 
     /**
-     * If value type can not be statically determined, mapping from
+     * If value type cannot be statically determined, mapping from
      * runtime value types to serializers are stored in this object.
      */
     protected PropertySerializerMap _dynamicValueSerializers;
@@ -314,7 +314,7 @@ public class MapEntrySerializer
             if (valueSer == null) {
                 try {
                     valueSer = _findAndAddDynamic(_dynamicValueSerializers, cc, prov);
-                } catch (JsonMappingException e) { // Ugh... can not just throw as-is, so...
+                } catch (JsonMappingException e) { // Ugh... cannot just throw as-is, so...
                     return false;
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/PropertySerializerMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/PropertySerializerMap.java
@@ -42,7 +42,7 @@ public abstract class PropertySerializerMap
 
     /**
      * Main lookup method. Takes a "raw" type since usage is always from
-     * place where parameterization is fixed such that there can not be
+     * place where parameterization is fixed such that there cannot be
      * type-parametric variations.
      */
     public abstract JsonSerializer<Object> serializerFor(Class<?> type);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanSerializer.java
@@ -87,7 +87,7 @@ public class UnwrappingBeanSerializer
     }
 
     /**
-     * JSON Array output can not be done if unwrapping operation is
+     * JSON Array output cannot be done if unwrapping operation is
      * requested; so implementation will simply return 'this'.
      */
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -56,7 +56,7 @@ public abstract class AsArraySerializerBase<T>
     protected final JsonSerializer<Object> _elementSerializer;
 
     /**
-     * If element type can not be statically determined, mapping from
+     * If element type cannot be statically determined, mapping from
      * runtime type to serializer is handled using this object
      */
     protected PropertySerializerMap _dynamicSerializers;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteArraySerializer.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * as numbers. Instead, we assume that it would make more sense to output content
  * as base64 encoded bytes (using default base64 encoding).
  *<p>
- * NOTE: since it is NOT serialized as an array, can not use AsArraySerializer as base
+ * NOTE: since it is NOT serialized as an array, cannot use AsArraySerializer as base
  *<p>
  * NOTE: since 2.6, has been a main-level class; earlier was embedded in
  * {@link StdArraySerializers}.

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
@@ -70,7 +70,7 @@ public class EnumSerializer
     public static EnumSerializer construct(Class<?> enumClass, SerializationConfig config,
             BeanDescription beanDesc, JsonFormat.Value format)
     {
-        /* 08-Apr-2015, tatu: As per [databind#749], we can not statically determine
+        /* 08-Apr-2015, tatu: As per [databind#749], we cannot statically determine
          *   between name() and toString(), need to construct `EnumValues` with names,
          *   handle toString() case dynamically (for example)
          */

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSetSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSetSerializer.java
@@ -77,7 +77,7 @@ public class EnumSetSerializer
          */
         for (Enum<?> en : value) {
             if (enumSer == null) {
-                /* 12-Jan-2010, tatu: Since enums can not be polymorphic, let's
+                /* 12-Jan-2010, tatu: Since enums cannot be polymorphic, let's
                  *   not bother with typed serializer variant here
                  */
                 enumSer = provider.findValueSerializer(en.getDeclaringClass(), _property);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
@@ -92,7 +92,7 @@ public class MapSerializer
     protected final TypeSerializer _valueTypeSerializer;
 
     /**
-     * If value type can not be statically determined, mapping from
+     * If value type cannot be statically determined, mapping from
      * runtime value types to serializers are stored in this object.
      */
     protected PropertySerializerMap _dynamicValueSerializers;
@@ -310,7 +310,7 @@ public class MapSerializer
         if (!staticValueType) {
             staticValueType = (valueType != null && valueType.isFinal());
         } else {
-            // also: Object.class can not be handled as static, ever
+            // also: Object.class cannot be handled as static, ever
             if (valueType.getRawClass() == Object.class) {
                 staticValueType = false;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NullSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NullSerializer.java
@@ -34,7 +34,7 @@ public class NullSerializer
      * Although this method should rarely get called, for convenience we should override
      * it, and handle it same way as "natural" types: by serializing exactly as is,
      * without type decorations. The most common possible use case is that of delegation
-     * by JSON filter; caller can not know what kind of serializer it gets handed.
+     * by JSON filter; caller cannot know what kind of serializer it gets handed.
      */
     @Override
     public void serializeWithType(Object value, JsonGenerator gen, SerializerProvider serializers,

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ObjectArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ObjectArraySerializer.java
@@ -48,7 +48,7 @@ public class ObjectArraySerializer
     protected JsonSerializer<Object> _elementSerializer;
 
     /**
-     * If element type can not be statically determined, mapping from
+     * If element type cannot be statically determined, mapping from
      * runtime type to serializer is handled using this object
      */
     protected PropertySerializerMap _dynamicSerializers;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/RawSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/RawSerializer.java
@@ -18,7 +18,7 @@ public class RawSerializer<T>
 {
     /**
      * Constructor takes in expected type of values; but since caller
-     * typically can not really provide actual type parameter, we will
+     * typically cannot really provide actual type parameter, we will
      * just take wild card and coerce type.
      */
     public RawSerializer(Class<?> cls) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ReferenceTypeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ReferenceTypeSerializer.java
@@ -57,7 +57,7 @@ public abstract class ReferenceTypeSerializer<T>
     protected final NameTransformer _unwrapper;
 
     /**
-     * If element type can not be statically determined, mapping from
+     * If element type cannot be statically determined, mapping from
      * runtime type to serializer is handled using this object
      */
     protected transient PropertySerializerMap _dynamicSerializers;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/SerializableSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/SerializableSerializer.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
  * Generic handler for types that implement {@link JsonSerializable}.
  *<p>
  * Note: given that this is used for anything that implements
- * interface, can not be checked for direct class equivalence.
+ * interface, cannot be checked for direct class equivalence.
  */
 @JacksonStdImpl
 @SuppressWarnings("serial")

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdArraySerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdArraySerializers.java
@@ -68,7 +68,7 @@ public class StdArraySerializers
         }
 
         // 01-Dec-2016, tatu: Only now realized that due strong typing of Java arrays,
-        //    we can not really ever have value type serializers
+        //    we cannot really ever have value type serializers
         @Override
         public final ContainerSerializer<?> _withValueTypeSerializer(TypeSerializer vts) {
             // throw exception or just do nothing?
@@ -255,7 +255,7 @@ public class StdArraySerializers
      * they are most likely to be textual data, and should be written as
      * Strings, not arrays of entries.
      *<p>
-     * NOTE: since it is NOT serialized as an array, can not use AsArraySerializer as base
+     * NOTE: since it is NOT serialized as an array, cannot use AsArraySerializer as base
      */
     @JacksonStdImpl
     public static class CharArraySerializer extends StdSerializer<char[]>

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdKeySerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdKeySerializers.java
@@ -30,7 +30,7 @@ public abstract class StdKeySerializers
             Class<?> rawKeyType, boolean useDefault)
     {
         // 24-Sep-2015, tatu: Important -- should ONLY consider types for which `@JsonValue`
-        //    can not be used, since caller has not yet checked for that annotation
+        //    cannot be used, since caller has not yet checked for that annotation
         //    This is why Enum types are not handled here quite yet
 
         // [databind#943: Use a dynamic key serializer if we are not given actual

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/TokenBufferSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/TokenBufferSerializer.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 
 /**
  * We also want to directly support serialization of {@link TokenBuffer};
- * and since it is part of core package, it can not implement
+ * and since it is part of core package, it cannot implement
  * {@link com.fasterxml.jackson.databind.JsonSerializable}
  * (which is only included in the mapper package)
  */

--- a/src/main/java/com/fasterxml/jackson/databind/type/ResolvedRecursiveType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/ResolvedRecursiveType.java
@@ -112,7 +112,7 @@ public class ResolvedRecursiveType extends TypeBase
         if (o == this) return true;
         if (o == null) return false;
         if (o.getClass() == getClass()) {
-            // 16-Jun-2017, tatu: as per [databind#1658], can not do recursive call since
+            // 16-Jun-2017, tatu: as per [databind#1658], cannot do recursive call since
             //    there is likely to be a cycle...
 
             // but... true or false?

--- a/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
@@ -127,7 +127,7 @@ public class SimpleType // note: until 2.6 was final
         }
         // Should we check that there is a sub-class relationship?
         // 15-Jan-2016, tatu: Almost yes, but there are some complications with
-        //    placeholder values (`Void`, `NoClass`), so can not quite do yet.
+        //    placeholder values (`Void`, `NoClass`), so cannot quite do yet.
         // TODO: fix in 2.9
         if (!_class.isAssignableFrom(subclass)) {
             /*

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeModifier.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeModifier.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.JavaType;
  * replace) basic type instance factory constructs.
  * This is typically needed to support creation of
  * {@link MapLikeType} and {@link CollectionLikeType} instances,
- * as those can not be constructed in generic fashion.
+ * as those cannot be constructed in generic fashion.
  */
 public abstract class TypeModifier
 {
@@ -29,7 +29,7 @@ public abstract class TypeModifier
      *   construct instance of primary type itself
      * 
      * @return Actual type instance to use; usually either <code>type</code> (as is or with
-     *    modifications), or a newly constructed type instance based on it. Can not be null.
+     *    modifications), or a newly constructed type instance based on it. Cannot be null.
      */
     public abstract JavaType modifyType(JavaType type, Type jdkType, TypeBindings context,
             TypeFactory typeFactory);

--- a/src/main/java/com/fasterxml/jackson/databind/util/Converter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/Converter.java
@@ -30,7 +30,7 @@ public interface Converter<IN,OUT>
      * Method that can be used to find out actual input (source) type; this
      * usually can be determined from type parameters, but may need
      * to be implemented differently from programmatically defined
-     * converters (which can not change static type parameter bindings).
+     * converters (which cannot change static type parameter bindings).
      * 
      * @since 2.2
      */
@@ -40,7 +40,7 @@ public interface Converter<IN,OUT>
      * Method that can be used to find out actual output (target) type; this
      * usually can be determined from type parameters, but may need
      * to be implemented differently from programmatically defined
-     * converters (which can not change static type parameter bindings).
+     * converters (which cannot change static type parameter bindings).
      * 
      * @since 2.2
      */

--- a/src/main/java/com/fasterxml/jackson/databind/util/NameTransformer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NameTransformer.java
@@ -108,7 +108,7 @@ public abstract class NameTransformer
 
     /**
      * Method called when reversal of transformation is needed; should return
-     * null if this is not possible, that is, given name can not have been
+     * null if this is not possible, that is, given name cannot have been
      * result of calling {@link #transform} of this object.
      */
     public abstract String reverse(String transformed);

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -89,7 +89,7 @@ public class StdDateFormat
 
     protected final static DateFormat DATE_FORMAT_ISO8601;
 
-    /* Let's construct "blueprint" date format instances: can not be used
+    /* Let's construct "blueprint" date format instances: cannot be used
      * as is, due to thread-safety issues, but can be used for constructing
      * actual instances more cheaply (avoids re-parsing).
      */
@@ -118,7 +118,7 @@ public class StdDateFormat
     /**
      * Explicit override for leniency, if specified.
      *<p>
-     * Can not be `final` because {@link #setLenient(boolean)} returns
+     * Cannot be `final` because {@link #setLenient(boolean)} returns
      * `void`.
      *
      * @since 2.7

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -40,7 +40,7 @@ public class TokenBuffer
     /**
      * Object codec to use for stream-based object
      * conversion through parser/generator interfaces. If null,
-     * such methods can not be used.
+     * such methods cannot be used.
      */
     protected ObjectCodec _objectCodec;
 
@@ -142,7 +142,7 @@ public class TokenBuffer
     /**
      * @param codec Object codec to use for stream-based object
      *   conversion through parser/generator interfaces. If null,
-     *   such methods can not be used.
+     *   such methods cannot be used.
      * @param hasNativeIds Whether resulting {@link JsonParser} (if created)
      *   is considered to support native type and object ids
      */
@@ -267,7 +267,7 @@ public class TokenBuffer
      *
      * @param codec Object codec to use for stream-based object
      *   conversion through parser/generator interfaces. If null,
-     *   such methods can not be used.
+     *   such methods cannot be used.
      * 
      * @return Parser that can be used for reading contents stored in this buffer
      */
@@ -336,9 +336,9 @@ public class TokenBuffer
      *<p>
      * Note: this method would be enough to implement
      * <code>JsonSerializer</code>  for <code>TokenBuffer</code> type;
-     * but we can not have upwards
+     * but we cannot have upwards
      * references (from core to mapper package); and as such we also
-     * can not take second argument.
+     * cannot take second argument.
      */
     public void serialize(JsonGenerator gen) throws IOException
     {
@@ -947,7 +947,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
 
     /**
      * Although we could support this method, it does not necessarily make
-     * sense: we can not make good use of streaming because buffer must
+     * sense: we cannot make good use of streaming because buffer must
      * hold all the data. Because of this, currently this will simply
      * throw {@link UnsupportedOperationException}
      */
@@ -1604,7 +1604,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
                 return (Number) value;
             }
             // Difficult to really support numbers-as-Strings; but let's try.
-            // NOTE: no access to DeserializationConfig, unfortunately, so can not
+            // NOTE: no access to DeserializationConfig, unfortunately, so cannot
             // try to determine Double/BigDecimal preference...
             if (value instanceof String) {
                 String str = (String) value;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/CreatorPropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/CreatorPropertiesTest.java
@@ -16,7 +16,7 @@ public class CreatorPropertiesTest extends BaseMapTest
 
         @ConstructorProperties({"x", "y"})
         // Same as above; use differing local parameter names so that parameter name
-        // introspection can not be used as the source of property names.
+        // introspection cannot be used as the source of property names.
         public Issue905Bean(int a, int b) {
             _x = a;
             _y = b;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/InnerClassCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/InnerClassCreatorTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.*;
 
 // For [databind#1501], [databind#1502], [databind#1503]; mostly to
 // test that for non-static inner classes constructors are ignored
-// and no Creators should be processed (since they can not be made
+// and no Creators should be processed (since they cannot be made
 // to work in standard way anyway).
 public class InnerClassCreatorTest extends BaseMapTest
 {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDeserializationTest.java
@@ -326,7 +326,7 @@ public class EnumDeserializationTest
 
     public void testAllowUnknownEnumValuesReadAsNull() throws Exception
     {
-        // can not use shared mapper when changing configs...
+        // cannot use shared mapper when changing configs...
         ObjectReader reader = MAPPER.reader(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
         assertNull(reader.forType(TestEnum.class).readValue("\"NO-SUCH-VALUE\""));
         assertNull(reader.forType(TestEnum.class).readValue(" 4343 "));
@@ -337,7 +337,7 @@ public class EnumDeserializationTest
     // [databind#1642]
     public void testAllowUnknownEnumValuesReadAsNullWithCreatorMethod() throws Exception
     {
-        // can not use shared mapper when changing configs...
+        // cannot use shared mapper when changing configs...
         ObjectReader reader = MAPPER.reader(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
         assertNull(reader.forType(StrictEnumCreator.class).readValue("\"NO-SUCH-VALUE\""));
         assertNull(reader.forType(StrictEnumCreator.class).readValue(" 4343 "));

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKScalarsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKScalarsTest.java
@@ -825,7 +825,7 @@ public class JDKScalarsTest
         _testInvalidStringCoercionFail(boolean[].class);
         _testInvalidStringCoercionFail(byte[].class);
 
-        // char[] is special, can not use generalized test here
+        // char[] is special, cannot use generalized test here
 //        _testInvalidStringCoercionFail(char[].class);
         _testInvalidStringCoercionFail(short[].class);
         _testInvalidStringCoercionFail(int[].class);

--- a/src/test/java/com/fasterxml/jackson/databind/exc/DeserExceptionTypeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/DeserExceptionTypeTest.java
@@ -20,7 +20,7 @@ public class DeserExceptionTypeTest
         public String propX;
     }
 
-    // Class that has no applicable creators and thus can not be instantiated;
+    // Class that has no applicable creators and thus cannot be instantiated;
     // definition problem
     static class NoCreatorsBean {
         public int x;

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestVisibleTypeId.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestVisibleTypeId.java
@@ -92,7 +92,7 @@ public class TestVisibleTypeId extends BaseMapTest
     static class ExternalIdBean2 {
         public int a = 2;
 
-        /* Type id property itself can not be external, as it is conceptually
+        /* Type id property itself cannot be external, as it is conceptually
          * part of the bean for which info is written:
          */
         @JsonTypeId

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
@@ -294,10 +294,10 @@ public class ExternalTypeIdTest extends BaseMapTest
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerSubtypes(ValueBean.class);
         // This may look odd, but one implementation nastiness is the fact
-        // that we can not properly serialize type id before the object,
+        // that we cannot properly serialize type id before the object,
         // because call is made after property name (for object) has already
         // been written out. So we'll write it after...
-        // Deserializer will work either way as it can not rely on ordering
+        // Deserializer will work either way as it cannot rely on ordering
         // anyway.
         assertEquals("{\"bean\":{\"value\":11},\"extType\":\"vbean\"}",
                 mapper.writeValueAsString(new ExternalBean(11)));

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestKeySerializers.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestKeySerializers.java
@@ -158,7 +158,7 @@ public class TestKeySerializers extends BaseMapTest
     // Test custom key serializer for enum
     public void testCustomForEnum() throws IOException
     {
-        // can not use shared mapper as we are registering a module
+        // cannot use shared mapper as we are registering a module
         final ObjectMapper mapper = new ObjectMapper();
         SimpleModule mod = new SimpleModule("test");
         mod.addKeySerializer(ABC.class, new ABCKeySerializer());

--- a/src/test/java/com/fasterxml/jackson/databind/type/RecursiveTypeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/RecursiveTypeTest.java
@@ -85,7 +85,7 @@ public class RecursiveTypeTest extends BaseMapTest
 
         assertNotNull(json);
 
-        // can not deserialize with current definition, however
+        // cannot deserialize with current definition, however
     }
 
     // for [databind#1301]


### PR DESCRIPTION
In the error messages, often "can not" is displayed.  Example: 

> no suitable constructor found, can not deserialize from Object value (missing default constructor or creator, or perhaps need to add/enable type information?)

"Can not" is spelled wrong here. Reason: The "not" does not form a part of another construction (such as "not only")

Both "cannot" and "can not" are acceptable spellings, but the first is much more usual. One would use can not when the ‘not’ forms part of another construction such as ‘not only’. For example:

> These green industries can not only create more jobs, but also promote sustainable development of the land.

Source: https://en.oxforddictionaries.com/usage/cannot-or-can-not

This PR fixes comments in the code.

