### PR TITLE
Replace "can not" by "cannot" in code

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -154,7 +154,7 @@ public abstract class DeserializationContext
             DeserializerCache cache)
     {
         if (df == null) {
-            throw new IllegalArgumentException("Can not pass null DeserializerFactory");
+            throw new IllegalArgumentException("Cannot pass null DeserializerFactory");
         }
         _factory = df;
         if (cache == null) {
@@ -377,7 +377,7 @@ public abstract class DeserializationContext
     {
         if (_injectableValues == null) {
             reportBadDefinition(ClassUtil.classOf(valueId), String.format(
-"No 'injectableValues' configured, can not inject value with id [%s]", valueId));
+"No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
         }
         return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance);
     }
@@ -1000,11 +1000,11 @@ public abstract class DeserializationContext
         //   exists), or input mismatch problem (otherwise) since none of existing creators
         //   match with token.
         if ((valueInst != null) && !valueInst.canInstantiate()) {
-            msg = String.format("Can not construct instance of %s (no Creators, like default construct, exist): %s",
+            msg = String.format("Cannot construct instance of %s (no Creators, like default construct, exist): %s",
                     ClassUtil.nameOf(instClass), msg);
             return reportBadDefinition(constructType(instClass), msg);
         }
-        msg = String.format("Can not construct instance of %s (although at least one Creator exists): %s",
+        msg = String.format("Cannot construct instance of %s (although at least one Creator exists): %s",
                 ClassUtil.nameOf(instClass), msg);
         return reportInputMismatch(instClass, msg);
     }
@@ -1109,7 +1109,7 @@ public abstract class DeserializationContext
                 msg = String.format("Unexpected end-of-input when binding data into %s",
                         _calcName(instClass));
             } else {
-                msg = String.format("Can not deserialize instance of %s out of %s token",
+                msg = String.format("Cannot deserialize instance of %s out of %s token",
                         _calcName(instClass), t);
             }
         }
@@ -1424,7 +1424,7 @@ public abstract class DeserializationContext
             return null;
         }
         JavaType type = constructType(deser.handledType());
-        String msg = String.format("Invalid configuration: values of type %s can not be merged", type);
+        String msg = String.format("Invalid configuration: values of type %s cannot be merged", type);
         throw InvalidDefinitionException.from(getParser(), msg, type);
     }
 
@@ -1481,7 +1481,7 @@ public abstract class DeserializationContext
     public JsonMappingException weirdKeyException(Class<?> keyClass, String keyValue,
             String msg) {
         return InvalidFormatException.from(_parser,
-                String.format("Can not deserialize Map key of type %s from String %s: %s",
+                String.format("Cannot deserialize Map key of type %s from String %s: %s",
                         ClassUtil.nameOf(keyClass), _quotedString(keyValue), msg),
                 keyValue, keyClass);
     }
@@ -1502,7 +1502,7 @@ public abstract class DeserializationContext
     public JsonMappingException weirdStringException(String value, Class<?> instClass,
             String msg) {
         return InvalidFormatException.from(_parser,
-                String.format("Can not deserialize value of type %s from String %s: %s",
+                String.format("Cannot deserialize value of type %s from String %s: %s",
                         ClassUtil.nameOf(instClass), _quotedString(value), msg),
                 value, instClass);
     }
@@ -1517,7 +1517,7 @@ public abstract class DeserializationContext
     public JsonMappingException weirdNumberException(Number value, Class<?> instClass,
             String msg) {
         return InvalidFormatException.from(_parser,
-                String.format("Can not deserialize value of type %s from number %s: %s",
+                String.format("Cannot deserialize value of type %s from number %s: %s",
                         ClassUtil.nameOf(instClass), String.valueOf(value), msg),
                 value, instClass);
     }
@@ -1534,7 +1534,7 @@ public abstract class DeserializationContext
     public JsonMappingException instantiationException(Class<?> instClass, Throwable cause) {
         // Most likely problem with Creator definition, right?
         JavaType type = constructType(instClass);
-        String msg = String.format("Can not construct instance of %s, problem: %s",
+        String msg = String.format("Cannot construct instance of %s, problem: %s",
                 ClassUtil.nameOf(instClass), cause.getMessage());
         InvalidDefinitionException e = InvalidDefinitionException.from(_parser, msg, type);
         e.initCause(cause);
@@ -1553,7 +1553,7 @@ public abstract class DeserializationContext
     public JsonMappingException instantiationException(Class<?> instClass, String msg0) {
         // Most likely problem with Creator definition, right?
         JavaType type = constructType(instClass);
-        String msg = String.format("Can not construct instance of %s: %s",
+        String msg = String.format("Cannot construct instance of %s: %s",
                 ClassUtil.nameOf(instClass), msg0);
         return InvalidDefinitionException.from(_parser, msg, type);
     }
@@ -1681,7 +1681,7 @@ public abstract class DeserializationContext
     @Deprecated
     public JsonMappingException mappingException(Class<?> targetClass, JsonToken token) {
         return JsonMappingException.from(_parser,
-                String.format("Can not deserialize instance of %s out of %s token",
+                String.format("Cannot deserialize instance of %s out of %s token",
                         _calcName(targetClass), token));
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/JsonDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonDeserializer.java
@@ -128,7 +128,7 @@ public abstract class JsonDeserializer<T>
         if (ctxt.isEnabled(MapperFeature.IGNORE_MERGE_FOR_UNMERGEABLE)) {
             return deserialize(p, ctxt);
         }
-        throw new UnsupportedOperationException("Can not update object of type "
+        throw new UnsupportedOperationException("Cannot update object of type "
                 +intoValue.getClass().getName()+" (by deserializer of type "+getClass().getName()+")");
     }
 
@@ -362,7 +362,7 @@ public abstract class JsonDeserializer<T>
      */
     public SettableBeanProperty findBackReference(String refName)
     {
-        throw new IllegalArgumentException("Can not handle managed/back reference '"+refName
+        throw new IllegalArgumentException("Cannot handle managed/back reference '"+refName
                 +"': type: value deserializer of type "+getClass().getName()+" does not support them");
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
@@ -85,7 +85,7 @@ public class JsonMappingException
         public Reference(Object from, String fieldName) {
             _from = from;
             if (fieldName == null) {
-                throw new NullPointerException("Can not pass null fieldName");
+                throw new NullPointerException("Cannot pass null fieldName");
             }
             _fieldName = fieldName;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -881,7 +881,7 @@ public abstract class JsonNode
      */
     public JsonNode with(String propertyName) {
         throw new UnsupportedOperationException("JsonNode not of type ObjectNode (but "
-                +getClass().getName()+"), can not call with() on it");
+                +getClass().getName()+"), cannot call with() on it");
     }
 
     /**
@@ -894,7 +894,7 @@ public abstract class JsonNode
      */
     public JsonNode withArray(String propertyName) {
         throw new UnsupportedOperationException("JsonNode not of type ObjectNode (but "
-                +getClass().getName()+"), can not call withArray() on it");
+                +getClass().getName()+"), cannot call withArray() on it");
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -1519,7 +1519,7 @@ public class ObjectMapper
          *   use "As.EXTERNAL_PROPERTY", since that will not work (with 2.5+)
          */
         if (includeAs == JsonTypeInfo.As.EXTERNAL_PROPERTY) {
-            throw new IllegalArgumentException("Can not use includeAs of "+includeAs);
+            throw new IllegalArgumentException("Cannot use includeAs of "+includeAs);
         }
         
         TypeResolverBuilder<?> typer = new DefaultTypeResolverBuilder(applicability);
@@ -4157,7 +4157,7 @@ public class ObjectMapper
         deser = ctxt.findRootValueDeserializer(valueType);
         if (deser == null) { // can this happen?
             return ctxt.reportBadDefinition(valueType,
-                    "Can not find a deserializer for type "+valueType);
+                    "Cannot find a deserializer for type "+valueType);
         }
         _rootDeserializers.put(valueType, deser);
         return deser;
@@ -4170,7 +4170,7 @@ public class ObjectMapper
     {
         if (schema != null) {
             if (!_jsonFactory.canUseSchema(schema)) {
-                    throw new IllegalArgumentException("Can not use FormatSchema of type "+schema.getClass().getName()
+                    throw new IllegalArgumentException("Cannot use FormatSchema of type "+schema.getClass().getName()
                             +" for format "+_jsonFactory.getFormatName());
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -1781,7 +1781,7 @@ public class ObjectReader
         throws JsonProcessingException
     {
         // 17-Aug-2015, tatu: Unfortunately, no parser/generator available so:
-        throw new JsonParseException(null, "Can not detect format from input, does not look like any of detectable formats "
+        throw new JsonParseException(null, "Cannot detect format from input, does not look like any of detectable formats "
                 +detector.toString());
     }
 
@@ -1798,7 +1798,7 @@ public class ObjectReader
     {
         if (schema != null) {
             if (!_parserFactory.canUseSchema(schema)) {
-                    throw new IllegalArgumentException("Can not use FormatSchema of type "+schema.getClass().getName()
+                    throw new IllegalArgumentException("Cannot use FormatSchema of type "+schema.getClass().getName()
                             +" for format "+_parserFactory.getFormatName());
             }
         }
@@ -1824,7 +1824,7 @@ public class ObjectReader
     protected void _reportUndetectableSource(Object src) throws JsonProcessingException
     {
         // 17-Aug-2015, tatu: Unfortunately, no parser/generator available so:
-        throw new JsonParseException(null, "Can not use source of type "
+        throw new JsonParseException(null, "Cannot use source of type "
                 +src.getClass().getName()+" with format auto-detection: must be byte- not char-based");
     }
 
@@ -1858,7 +1858,7 @@ public class ObjectReader
         // Nope: need to ask provider to resolve it
         deser = ctxt.findRootValueDeserializer(t);
         if (deser == null) { // can this happen?
-            ctxt.reportBadDefinition(t, "Can not find a deserializer for type "+t);
+            ctxt.reportBadDefinition(t, "Cannot find a deserializer for type "+t);
         }
         _rootDeserializers.put(t, deser);
         return deser;
@@ -1876,7 +1876,7 @@ public class ObjectReader
             deser = ctxt.findRootValueDeserializer(JSON_NODE_TYPE);
             if (deser == null) { // can this happen?
                 ctxt.reportBadDefinition(JSON_NODE_TYPE,
-                        "Can not find a deserializer for type "+JSON_NODE_TYPE);
+                        "Cannot find a deserializer for type "+JSON_NODE_TYPE);
             }
             _rootDeserializers.put(JSON_NODE_TYPE, deser);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -1099,7 +1099,7 @@ public class ObjectWriter
     {
         if (schema != null) {
             if (!_generatorFactory.canUseSchema(schema)) {
-                    throw new IllegalArgumentException("Can not use FormatSchema of type "+schema.getClass().getName()
+                    throw new IllegalArgumentException("Cannot use FormatSchema of type "+schema.getClass().getName()
                             +" for format "+_generatorFactory.getFormatName());
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -272,7 +272,7 @@ public abstract class SerializerProvider
     public void setDefaultKeySerializer(JsonSerializer<Object> ks)
     {
         if (ks == null) {
-            throw new IllegalArgumentException("Can not pass null JsonSerializer");
+            throw new IllegalArgumentException("Cannot pass null JsonSerializer");
         }
         _keySerializer = ks;
     }
@@ -289,7 +289,7 @@ public abstract class SerializerProvider
     public void setNullValueSerializer(JsonSerializer<Object> nvs)
     {
         if (nvs == null) {
-            throw new IllegalArgumentException("Can not pass null JsonSerializer");
+            throw new IllegalArgumentException("Cannot pass null JsonSerializer");
         }
         _nullValueSerializer = nvs;
     }
@@ -306,7 +306,7 @@ public abstract class SerializerProvider
     public void setNullKeySerializer(JsonSerializer<Object> nks)
     {
         if (nks == null) {
-            throw new IllegalArgumentException("Can not pass null JsonSerializer");
+            throw new IllegalArgumentException("Cannot pass null JsonSerializer");
         }
         _nullKeySerializer = nks;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/DeserializerFactoryConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/DeserializerFactoryConfig.java
@@ -99,7 +99,7 @@ public class DeserializerFactoryConfig
     public DeserializerFactoryConfig withAdditionalDeserializers(Deserializers additional)
     {
         if (additional == null) {
-            throw new IllegalArgumentException("Can not pass null Deserializers");
+            throw new IllegalArgumentException("Cannot pass null Deserializers");
         }
         Deserializers[] all = ArrayBuilders.insertInListNoDup(_additionalDeserializers, additional);
         return new DeserializerFactoryConfig(all, _additionalKeyDeserializers, _modifiers,
@@ -115,7 +115,7 @@ public class DeserializerFactoryConfig
     public DeserializerFactoryConfig withAdditionalKeyDeserializers(KeyDeserializers additional)
     {
         if (additional == null) {
-            throw new IllegalArgumentException("Can not pass null KeyDeserializers");
+            throw new IllegalArgumentException("Cannot pass null KeyDeserializers");
         }
         KeyDeserializers[] all = ArrayBuilders.insertInListNoDup(_additionalKeyDeserializers, additional);
         return new DeserializerFactoryConfig(_additionalDeserializers, all, _modifiers,
@@ -131,7 +131,7 @@ public class DeserializerFactoryConfig
     public DeserializerFactoryConfig withDeserializerModifier(BeanDeserializerModifier modifier)
     {
         if (modifier == null) {
-            throw new IllegalArgumentException("Can not pass null modifier");
+            throw new IllegalArgumentException("Cannot pass null modifier");
         }
         BeanDeserializerModifier[] all = ArrayBuilders.insertInListNoDup(_modifiers, modifier);
         return new DeserializerFactoryConfig(_additionalDeserializers, _additionalKeyDeserializers, all,
@@ -148,7 +148,7 @@ public class DeserializerFactoryConfig
     public DeserializerFactoryConfig withAbstractTypeResolver(AbstractTypeResolver resolver)
     {
         if (resolver == null) {
-            throw new IllegalArgumentException("Can not pass null resolver");
+            throw new IllegalArgumentException("Cannot pass null resolver");
         }
         AbstractTypeResolver[] all = ArrayBuilders.insertInListNoDup(_abstractTypeResolvers, resolver);
         return new DeserializerFactoryConfig(_additionalDeserializers, _additionalKeyDeserializers, _modifiers,
@@ -168,7 +168,7 @@ public class DeserializerFactoryConfig
     public DeserializerFactoryConfig withValueInstantiators(ValueInstantiators instantiators) 
     {
         if (instantiators == null) {
-            throw new IllegalArgumentException("Can not pass null resolver");
+            throw new IllegalArgumentException("Cannot pass null resolver");
         }
         ValueInstantiators[] all = ArrayBuilders.insertInListNoDup(_valueInstantiators, instantiators);
         return new DeserializerFactoryConfig(_additionalDeserializers, _additionalKeyDeserializers, _modifiers,

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/SerializerFactoryConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/SerializerFactoryConfig.java
@@ -56,7 +56,7 @@ public final class SerializerFactoryConfig
     public SerializerFactoryConfig withAdditionalSerializers(Serializers additional)
     {
         if (additional == null) {
-            throw new IllegalArgumentException("Can not pass null Serializers");
+            throw new IllegalArgumentException("Cannot pass null Serializers");
         }
         Serializers[] all = ArrayBuilders.insertInListNoDup(_additionalSerializers, additional);
         return new SerializerFactoryConfig(all, _additionalKeySerializers, _modifiers);
@@ -65,7 +65,7 @@ public final class SerializerFactoryConfig
     public SerializerFactoryConfig withAdditionalKeySerializers(Serializers additional)
     {
         if (additional == null) {
-            throw new IllegalArgumentException("Can not pass null Serializers");
+            throw new IllegalArgumentException("Cannot pass null Serializers");
         }
         Serializers[] all = ArrayBuilders.insertInListNoDup(_additionalKeySerializers, additional);
         return new SerializerFactoryConfig(_additionalSerializers, all, _modifiers);
@@ -74,7 +74,7 @@ public final class SerializerFactoryConfig
     public SerializerFactoryConfig withSerializerModifier(BeanSerializerModifier modifier)
     {
         if (modifier == null) {
-            throw new IllegalArgumentException("Can not pass null modifier");
+            throw new IllegalArgumentException("Cannot pass null modifier");
         }
         BeanSerializerModifier[] modifiers = ArrayBuilders.insertInListNoDup(_modifiers, modifier);
         return new SerializerFactoryConfig(_additionalSerializers, _additionalKeySerializers, modifiers);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/AbstractDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/AbstractDeserializer.java
@@ -142,7 +142,7 @@ public class AbstractDeserializer
                         idProp = (_properties == null) ? null : _properties.get(propName.getSimpleName());
                         if (idProp == null) {
                             ctxt.reportBadDefinition(_baseType, String.format(
-                                    "Invalid Object Id definition for %s: can not find property with name '%s'",
+                                    "Invalid Object Id definition for %s: cannot find property with name '%s'",
                                     handledType().getName(), propName));
                         }
                         idType = idProp.getType();
@@ -150,7 +150,7 @@ public class AbstractDeserializer
 /*
                          ctxt.reportBadDefinition(_baseType, String.format(
 /
-"Invalid Object Id definition for abstract type %s: can not use `PropertyGenerator` on polymorphic types using property annotation",
+"Invalid Object Id definition for abstract type %s: cannot use `PropertyGenerator` on polymorphic types using property annotation",
 handledType().getName()));
 */
                     } else { // other types simpler

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -518,7 +518,7 @@ public abstract class BasicDeserializerFactory
                     /*
                     if ((ix == 0) && isNonStaticInnerClass) {
                         throw new IllegalArgumentException("Non-static inner classes like "
-                                +ctor.getDeclaringClass().getName()+" can not use @JsonCreator for constructors");
+                                +ctor.getDeclaringClass().getName()+" cannot use @JsonCreator for constructors");
                     }
                     */
                     throw new IllegalArgumentException("Argument #"+ix
@@ -809,7 +809,7 @@ public abstract class BasicDeserializerFactory
         throws JsonMappingException
     {
         ctxt.reportBadDefinition(beanDesc.getType(), String.format(
-                "Can not define Creator parameter %d as `@JsonUnwrapped`: combination not yet supported",
+                "Cannot define Creator parameter %d as `@JsonUnwrapped`: combination not yet supported",
                 param.getIndex()));
     }
 
@@ -1018,7 +1018,7 @@ public abstract class BasicDeserializerFactory
                 if (implType == null) {
                     // [databind#292]: Actually, may be fine, but only if polymorphich deser enabled
                     if (type.getTypeHandler() == null) {
-                        throw new IllegalArgumentException("Can not find a deserializer for non-concrete Collection type "+type);
+                        throw new IllegalArgumentException("Cannot find a deserializer for non-concrete Collection type "+type);
                     }
                     deser = AbstractDeserializer.constructForNonPOJO(beanDesc);
                 } else {
@@ -1140,7 +1140,7 @@ public abstract class BasicDeserializerFactory
                 }
                 Class<?> kt = keyType.getRawClass();
                 if (kt == null || !kt.isEnum()) {
-                    throw new IllegalArgumentException("Can not construct EnumMap; generic (key) type not available");
+                    throw new IllegalArgumentException("Cannot construct EnumMap; generic (key) type not available");
                 }
                 deser = new EnumMapDeserializer(type, inst, null,
                         contentDeser, contentTypeDeser, null);
@@ -1169,7 +1169,7 @@ public abstract class BasicDeserializerFactory
                     } else {
                         // [databind#292]: Actually, may be fine, but only if polymorphic deser enabled
                         if (type.getTypeHandler() == null) {
-                            throw new IllegalArgumentException("Can not find a deserializer for non-concrete Map type "+type);
+                            throw new IllegalArgumentException("Cannot find a deserializer for non-concrete Map type "+type);
                         }
                         deser = AbstractDeserializer.constructForNonPOJO(beanDesc);
                     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -775,7 +775,7 @@ public class BeanDeserializer
                         // !!! 08-Jul-2011, tatu: Could probably support; but for now
                         //   it's too complicated, so bail out
                         ctxt.reportInputMismatch(creatorProp,
-                                "Can not create polymorphic instances with unwrapped values");
+                                "Cannot create polymorphic instances with unwrapped values");
                         return null;
                     }
                     return _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
@@ -953,7 +953,7 @@ public class BeanDeserializer
                             // !!! 08-Jul-2011, tatu: Could theoretically support; but for now
                             //   it's too complicated, so bail out
                             return ctxt.reportBadDefinition(_beanType, String.format(
-                                    "Can not create polymorphic instances with external type ids (%s -> %s)",
+                                    "Cannot create polymorphic instances with external type ids (%s -> %s)",
                                     _beanType, bean.getClass()));
                         }
                         return ext.complete(p, ctxt, bean);
@@ -1034,7 +1034,7 @@ public class BeanDeserializer
         {
             if (_bean == null) {
                 _context.reportInputMismatch(_prop,
-"Can not resolve ObjectId forward reference using property '%s' (of type %s): Bean not yet resolved",
+"Cannot resolve ObjectId forward reference using property '%s' (of type %s): Bean not yet resolved",
 _prop.getName(), _prop.getDeclaringClass().getName());
         }
             _prop.set(_bean, value);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -684,7 +684,7 @@ public abstract class BeanDeserializerBase
                     idProp = findProperty(propName);
                     if (idProp == null) {
                         ctxt.reportBadDefinition(_beanType, String.format(
-                                "Invalid Object Id definition for %s: can not find property with name '%s'",
+                                "Invalid Object Id definition for %s: cannot find property with name '%s'",
                                 handledType().getName(), propName));
                     }
                     idType = idProp.getType();
@@ -764,7 +764,7 @@ public abstract class BeanDeserializerBase
         SettableBeanProperty backProp = valueDeser.findBackReference(refName);
         if (backProp == null) {
             ctxt.reportBadDefinition(_beanType, String.format(
-"Can not handle managed/back reference '%s': no back reference property found from type %s",
+"Cannot handle managed/back reference '%s': no back reference property found from type %s",
                     refName, prop.getType()));
         }
         // also: verify that type is compatible
@@ -773,7 +773,7 @@ public abstract class BeanDeserializerBase
         boolean isContainer = prop.getType().isContainerType();
         if (!backRefType.getRawClass().isAssignableFrom(referredType.getRawClass())) {
             ctxt.reportBadDefinition(_beanType, String.format(
-"Can not handle managed/back reference '%s': back reference type (%s) not compatible with managed type (%s)",
+"Cannot handle managed/back reference '%s': back reference type (%s) not compatible with managed type (%s)",
                     refName, backRefType.getRawClass().getName(),
                     referredType.getRawClass().getName()));
         }
@@ -812,7 +812,7 @@ public abstract class BeanDeserializerBase
                 //   of unwrapped values through creator properties, so fail fast
                 if (prop instanceof CreatorProperty) {
                     ctxt.reportBadDefinition(getValueType(), String.format(
-                            "Can not define Creator property \"%s\" as `@JsonUnwrapped`: combination not yet supported",
+                            "Cannot define Creator property \"%s\" as `@JsonUnwrapped`: combination not yet supported",
                             prop.getName()));
                 }
                 return unwrapper;
@@ -1273,7 +1273,7 @@ public abstract class BeanDeserializerBase
 "can only instantiate non-static inner class by using default, no-argument constructor");
         }
         return ctxt.handleMissingInstantiator(raw, getValueInstantiator(), p,
-                "can not deserialize from Object value (no delegate- or property-based Creator)");
+                "cannot deserialize from Object value (no delegate- or property-based Creator)");
     }
 
     protected abstract Object _deserializeUsingPropertyBased(final JsonParser p,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -369,7 +369,7 @@ public class BeanDeserializerFactory
             idProp = builder.findProperty(propName);
             if (idProp == null) {
                 throw new IllegalArgumentException("Invalid Object Id definition for "
-                        +beanDesc.getBeanClass().getName()+": can not find property with name '"+propName+"'");
+                        +beanDesc.getBeanClass().getName()+": cannot find property with name '"+propName+"'");
             }
             idType = idProp.getType();
             gen = new PropertyBasedObjectIdGenerator(objectIdInfo.getScope());
@@ -688,7 +688,7 @@ public class BeanDeserializerFactory
                     //    work through constructors; but let's at least indicate the issue for now
                     if (m instanceof AnnotatedParameter) {
                         ctxt.reportBadTypeDefinition(beanDesc,
-"Can not bind back reference using Creator parameter (reference '%s', parameter index #%d)",
+"Cannot bind back reference using Creator parameter (reference '%s', parameter index #%d)",
 name, ((AnnotatedParameter) m).getIndex());
                     }
                 }
@@ -889,17 +889,17 @@ name, ((AnnotatedParameter) m).getIndex());
     {
         String typeStr = ClassUtil.canBeABeanType(type);
         if (typeStr != null) {
-            throw new IllegalArgumentException("Can not deserialize Class "+type.getName()+" (of type "+typeStr+") as a Bean");
+            throw new IllegalArgumentException("Cannot deserialize Class "+type.getName()+" (of type "+typeStr+") as a Bean");
         }
         if (ClassUtil.isProxyType(type)) {
-            throw new IllegalArgumentException("Can not deserialize Proxy class "+type.getName()+" as a Bean");
+            throw new IllegalArgumentException("Cannot deserialize Proxy class "+type.getName()+" as a Bean");
         }
         /* also: can't deserialize some local classes: static are ok; in-method not;
          * other non-static inner classes are ok
          */
         typeStr = ClassUtil.isLocalType(type, true);
         if (typeStr != null) {
-            throw new IllegalArgumentException("Can not deserialize Class "+type.getName()+" (of type "+typeStr+") as a Bean");
+            throw new IllegalArgumentException("Cannot deserialize Class "+type.getName()+" (of type "+typeStr+") as a Bean");
         }
         return true;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -56,7 +56,7 @@ public class BuilderBasedDeserializer
         _buildMethod = builder.getBuildMethod();
         // 05-Mar-2012, tatu: Can not really make Object Ids work with builders, not yet anyway
         if (_objectIdReader != null) {
-            throw new IllegalArgumentException("Can not use Object Id with Builder-based deserialization (type "
+            throw new IllegalArgumentException("Cannot use Object Id with Builder-based deserialization (type "
                     +beanDesc.getType()+")");
         }
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
@@ -578,14 +578,14 @@ public final class DeserializerCache
         // Let's try to figure out the reason, to give better error messages
         Class<?> rawClass = type.getRawClass();
         if (!ClassUtil.isConcrete(rawClass)) {
-            return ctxt.reportBadDefinition(type, "Can not find a Value deserializer for abstract type "+type);
+            return ctxt.reportBadDefinition(type, "Cannot find a Value deserializer for abstract type "+type);
         }
-        return ctxt.reportBadDefinition(type, "Can not find a Value deserializer for type "+type);
+        return ctxt.reportBadDefinition(type, "Cannot find a Value deserializer for type "+type);
     }
 
     protected KeyDeserializer _handleUnknownKeyDeserializer(DeserializationContext ctxt, JavaType type)
         throws JsonMappingException
     {
-        return ctxt.reportBadDefinition(type, "Can not find a (Map) Key deserializer for type "+type);
+        return ctxt.reportBadDefinition(type, "Cannot find a (Map) Key deserializer for type "+type);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -537,7 +537,7 @@ public abstract class SettableBeanProperty
         // 20-Oct-2016, tatu: Also tricky -- for now, report an error
         if (_valueTypeDeserializer != null) {
             ctxt.reportBadDefinition(getType(),
-                    String.format("Can not merge polymorphic property '%s'",
+                    String.format("Cannot merge polymorphic property '%s'",
                             getName()));
 //            return _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
@@ -307,7 +307,7 @@ public class BeanAsArrayBuilderDeserializer
                          *   but make explicitly non-supported for now.
                          */
                         return ctxt.reportBadDefinition(_beanType, String.format(
-"Can not support implicit polymorphic deserialization for POJOs-as-Arrays style: nominal type %s, actual type %s",
+"Cannot support implicit polymorphic deserialization for POJOs-as-Arrays style: nominal type %s, actual type %s",
                                 _beanType.getRawClass().getName(), builder.getClass().getName()));
                     }
                 }
@@ -343,7 +343,7 @@ public class BeanAsArrayBuilderDeserializer
     {
         // Let's start with failure
         return ctxt.handleUnexpectedToken(handledType(), p.getCurrentToken(), p,
-                "Can not deserialize a POJO (of type %s) from non-Array representation (token: %s): "
+                "Cannot deserialize a POJO (of type %s) from non-Array representation (token: %s): "
                 +"type/property designed to be serialized as JSON Array",
                 _beanType.getRawClass().getName(),
                 p.getCurrentToken());

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
@@ -327,7 +327,7 @@ public class BeanAsArrayDeserializer
                          *   but make explicitly non-supported for now.
                          */
                         ctxt.reportBadDefinition(_beanType, String.format(
-                                "Can not support implicit polymorphic deserialization for POJOs-as-Arrays style: "
+                                "Cannot support implicit polymorphic deserialization for POJOs-as-Arrays style: "
                                 +"nominal type %s, actual type %s",
                                 _beanType.getRawClass().getName(), bean.getClass().getName()));
                     }
@@ -363,7 +363,7 @@ public class BeanAsArrayDeserializer
         throws IOException
     {
         return ctxt.handleUnexpectedToken(handledType(), p.getCurrentToken(), p,
-                "Can not deserialize a POJO (of type %s) from non-Array representation (token: %s): "
+                "Cannot deserialize a POJO (of type %s) from non-Array representation (token: %s): "
                 +"type/property designed to be serialized as JSON Array",
                 _beanType.getRawClass().getName(),
                 p.getCurrentToken());

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -471,7 +471,7 @@ public class BeanPropertyMap
     public SettableBeanProperty find(String key)
     {
         if (key == null) {
-            throw new IllegalArgumentException("Can not pass null property name");
+            throw new IllegalArgumentException("Cannot pass null property name");
         }
         if (_caseInsensitive) {
             key = key.toLowerCase();

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
@@ -98,7 +98,7 @@ public abstract class ContainerDeserializerBase<T>
         JsonDeserializer<Object> valueDeser = getContentDeserializer();
         if (valueDeser == null) {
             throw new IllegalArgumentException(String.format(
-                    "Can not handle managed/back reference '%s': type: container deserializer of type %s returned null for 'getContentDeserializer()'",
+                    "Cannot handle managed/back reference '%s': type: container deserializer of type %s returned null for 'getContentDeserializer()'",
                     refName, getClass().getName()));
         }
         return valueDeser.findBackReference(refName);
@@ -147,7 +147,7 @@ public abstract class ContainerDeserializerBase<T>
         if (vi == null || !vi.canCreateUsingDefault()) {
             JavaType type = getValueType();
             ctxt.reportBadDefinition(type,
-                    String.format("Can not create empty instance of %s, no default Creator", type));
+                    String.format("Cannot create empty instance of %s, no default Creator", type));
         }
         try {
             return vi.createUsingDefault(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapEntryDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapEntryDeserializer.java
@@ -179,7 +179,7 @@ public class MapEntryDeserializer
         if (t != JsonToken.FIELD_NAME) {
             if (t == JsonToken.END_OBJECT) {
                 return ctxt.reportInputMismatch(this,
-                        "Can not deserialize a Map.Entry out of empty JSON Object");
+                        "Cannot deserialize a Map.Entry out of empty JSON Object");
             }
             return (Map.Entry<Object,Object>) ctxt.handleUnexpectedToken(handledType(), p);
         }
@@ -227,7 +227,7 @@ public class MapEntryDeserializer
     public Map.Entry<Object,Object> deserialize(JsonParser p, DeserializationContext ctxt,
             Map.Entry<Object,Object> result) throws IOException
     {
-        throw new IllegalStateException("Can not update Map.Entry values");
+        throw new IllegalStateException("Cannot update Map.Entry values");
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
@@ -154,7 +154,7 @@ public class NumberDeserializers
             //    short-circuits `null` handling. Hence need this check as well.
             if (_primitive && ctxt.isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)) {
                 ctxt.reportInputMismatch(this,
-                        "Can not map `null` into type %s (set DeserializationConfig.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)",
+                        "Cannot map `null` into type %s (set DeserializationConfig.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)",
                         handledType().toString());
             }
             return _nullValue;
@@ -310,7 +310,7 @@ public class NumberDeserializers
                 // as per [JACKSON-804], allow range up to 255, inclusive
                 if (_byteOverflow(value)) {
                     return (Byte) ctxt.handleWeirdStringValue(_valueClass, text,
-                            "overflow, value can not be represented as 8-bit value");
+                            "overflow, value cannot be represented as 8-bit value");
                     // fall-through for deferred fails
                 }
                 return Byte.valueOf((byte) value);
@@ -382,7 +382,7 @@ public class NumberDeserializers
                 // So far so good: but does it fit?
                 if (_shortOverflow(value)) {
                     return (Short) ctxt.handleWeirdStringValue(_valueClass, text,
-                            "overflow, value can not be represented as 16-bit value");
+                            "overflow, value cannot be represented as 16-bit value");
                 }
                 return Short.valueOf((short) value);
             }
@@ -848,7 +848,7 @@ public class NumberDeserializers
             case JsonTokenId.ID_NUMBER_INT:
             case JsonTokenId.ID_NUMBER_FLOAT:
             case JsonTokenId.ID_STRING:
-                // can not point to type information: hence must be non-typed (int/double)
+                // cannot point to type information: hence must be non-typed (int/double)
                 return deserialize(p, ctxt);
             }
             return typeDeserializer.deserializeTypedFromScalar(p, ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
@@ -312,7 +312,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                     }
                     if (str.length() != 1) {
                         ctxt.reportInputMismatch(this,
-"Can not convert a JSON String of length %d into a char element of char array", str.length());
+"Cannot convert a JSON String of length %d into a char element of char array", str.length());
                     }
                     sb.append(str.charAt(0));
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDelegatingDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDelegatingDeserializer.java
@@ -220,7 +220,7 @@ public class StdDelegatingDeserializer<T>
         throws IOException
     {
         throw new UnsupportedOperationException(String.format
-                ("Can not update object of type %s (using deserializer for type %s)"
+                ("Cannot update object of type %s (using deserializer for type %s)"
                         +intoValue.getClass().getName(), _delegateType));
     }
     

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -206,7 +206,7 @@ public abstract class StdDeserializer<T>
         // So far so good: but does it fit?
         if (_byteOverflow(value)) {
             Number v = (Number) ctxt.handleWeirdStringValue(_valueClass, String.valueOf(value),
-                    "overflow, value can not be represented as 8-bit value");
+                    "overflow, value cannot be represented as 8-bit value");
             return _nonNullNumber(v).byteValue();
         }
         return (byte) value;
@@ -219,7 +219,7 @@ public abstract class StdDeserializer<T>
         // So far so good: but does it fit?
         if (_shortOverflow(value)) {
             Number v = (Number) ctxt.handleWeirdStringValue(_valueClass, String.valueOf(value),
-                    "overflow, value can not be represented as 16-bit value");
+                    "overflow, value cannot be represented as 16-bit value");
             return _nonNullNumber(v).shortValue();
         }
         return (short) value;
@@ -688,7 +688,7 @@ public abstract class StdDeserializer<T>
         //   either supporting nested arrays, or to cause infinite looping.
         if (p.hasToken(JsonToken.START_ARRAY)) {
             String msg = String.format(
-"Can not deserialize instance of %s out of %s token: nested Arrays not allowed with %s",
+"Cannot deserialize instance of %s out of %s token: nested Arrays not allowed with %s",
                     ClassUtil.nameOf(_valueClass), JsonToken.START_ARRAY,
                     "DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS");
             @SuppressWarnings("unchecked")
@@ -708,7 +708,7 @@ public abstract class StdDeserializer<T>
             String type) throws IOException
     {
         ctxt.reportInputMismatch(handledType(),
-                "Can not coerce a floating-point value ('%s') into %s (enable `DeserializationFeature.ACCEPT_FLOAT_AS_INT` to allow)",
+                "Cannot coerce a floating-point value ('%s') into %s (enable `DeserializationFeature.ACCEPT_FLOAT_AS_INT` to allow)",
                 p.getValueAsString(), type);
     }
 
@@ -800,7 +800,7 @@ public abstract class StdDeserializer<T>
     {
         if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)) {
             ctxt.reportInputMismatch(this,
-                    "Can not coerce `null` %s (disable `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES` to allow)",
+                    "Cannot coerce `null` %s (disable `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES` to allow)",
                     _coercedTypeDesc());
         }
     }
@@ -840,7 +840,7 @@ public abstract class StdDeserializer<T>
     {
         MapperFeature feat = MapperFeature.ALLOW_COERCION_OF_SCALARS;
         if (!ctxt.isEnabled(feat)) {
-            ctxt.reportInputMismatch(this, "Can not coerce String \"%s\" %s (enable `%s.%s` to allow)",
+            ctxt.reportInputMismatch(this, "Cannot coerce String \"%s\" %s (enable `%s.%s` to allow)",
                 str, _coercedTypeDesc(), feat.getClass().getSimpleName(), feat.name());
         }
     }
@@ -853,7 +853,7 @@ public abstract class StdDeserializer<T>
             // 31-Mar-2017, tatu: Since we don't know (or this deep, care) about exact type,
             //   access as a String: may require re-encoding by parser which should be fine
             String valueDesc = p.getText();
-            ctxt.reportInputMismatch(this, "Can not coerce Number (%s) %s (enable `%s.%s` to allow)",
+            ctxt.reportInputMismatch(this, "Cannot coerce Number (%s) %s (enable `%s.%s` to allow)",
                 valueDesc, _coercedTypeDesc(), feat.getClass().getSimpleName(), feat.name());
         }
     }
@@ -862,7 +862,7 @@ public abstract class StdDeserializer<T>
             String inputDesc) throws JsonMappingException
     {
         String enableDesc = state ? "enable" : "disable";
-        ctxt.reportInputMismatch(this, "Can not coerce %s to Null value %s (%s `%s.%s` to allow)",
+        ctxt.reportInputMismatch(this, "Cannot coerce %s to Null value %s (%s `%s.%s` to allow)",
             inputDesc, _coercedTypeDesc(), enableDesc, feature.getClass().getSimpleName(), feature.name());
     }
     
@@ -1082,7 +1082,7 @@ public abstract class StdDeserializer<T>
             return NullsFailProvider.constructForProperty(prop);
         }
         if (nulls == Nulls.AS_EMPTY) {
-            // can not deal with empty values if there is no value deserializer that
+            // cannot deal with empty values if there is no value deserializer that
             // can indicate what "empty value" is:
             if (valueDeser == null) {
                 return null;
@@ -1096,7 +1096,7 @@ public abstract class StdDeserializer<T>
                 if (!vi.canCreateUsingDefault()) {
                     final JavaType type = prop.getType();
                     ctxt.reportBadDefinition(type,
-                            String.format("Can not create empty instance of %s, no default Creator", type));
+                            String.format("Cannot create empty instance of %s, no default Creator", type));
                 }
             }
             // Second: can with pre-fetch value?
@@ -1135,7 +1135,7 @@ public abstract class StdDeserializer<T>
      * @param instanceOrClass Instance that is being populated by this
      *   deserializer, or if not known, Class that would be instantiated.
      *   If null, will assume type is what {@link #getValueClass} returns.
-     * @param propName Name of the property that can not be mapped
+     * @param propName Name of the property that cannot be mapped
      */
     protected void handleUnknownProperty(JsonParser p, DeserializationContext ctxt,
             Object instanceOrClass, String propName)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -157,7 +157,7 @@ public class StdKeyDeserializer extends KeyDeserializer
                 int value = _parseInt(key);
                 // allow range up to 255, inclusive (to support "unsigned" byte)
                 if (value < Byte.MIN_VALUE || value > 255) {
-                    return ctxt.handleWeirdKey(_keyClass, key, "overflow, value can not be represented as 8-bit value");
+                    return ctxt.handleWeirdKey(_keyClass, key, "overflow, value cannot be represented as 8-bit value");
                 }
                 return Byte.valueOf((byte) value);
             }
@@ -165,7 +165,7 @@ public class StdKeyDeserializer extends KeyDeserializer
             {
                 int value = _parseInt(key);
                 if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
-                    return ctxt.handleWeirdKey(_keyClass, key, "overflow, value can not be represented as 16-bit value");
+                    return ctxt.handleWeirdKey(_keyClass, key, "overflow, value cannot be represented as 16-bit value");
                     // fall-through and truncate if need be
                 }
                 return Short.valueOf((short) value);

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
@@ -36,7 +36,7 @@ public final class AnnotatedMethod
     {
         super(ctxt, classAnn, paramAnnotations);
         if (method == null) {
-            throw new IllegalArgumentException("Can not construct AnnotatedMethod with null Method");
+            throw new IllegalArgumentException("Cannot construct AnnotatedMethod with null Method");
         }
         _method = method;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -766,7 +766,7 @@ public class JacksonAnnotationIntrospector
                         type = type.withStaticTyping();
                     } else {
                         throw new JsonMappingException(null,
-                                String.format("Can not refine serialization type %s into %s; types not related",
+                                String.format("Cannot refine serialization type %s into %s; types not related",
                                         type, serClass.getName()));
                     }
                 } catch (IllegalArgumentException iae) {
@@ -801,7 +801,7 @@ public class JacksonAnnotationIntrospector
                             keyType = keyType.withStaticTyping();
                         } else {
                             throw new JsonMappingException(null,
-                                    String.format("Can not refine serialization key type %s into %s; types not related",
+                                    String.format("Cannot refine serialization key type %s into %s; types not related",
                                             keyType, keyClass.getName()));
                         }
                     } catch (IllegalArgumentException iae) {
@@ -837,7 +837,7 @@ public class JacksonAnnotationIntrospector
                            contentType = contentType.withStaticTyping();
                        } else {
                            throw new JsonMappingException(null,
-                                   String.format("Can not refine serialization content type %s into %s; types not related",
+                                   String.format("Cannot refine serialization content type %s into %s; types not related",
                                            contentType, contentClass.getName()));
                        }
                    } catch (IllegalArgumentException iae) { // shouldn't really happen

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -1285,7 +1285,7 @@ public class POJOPropertyBuilder
 
             if (explName) {
                 if (this.name == null) { // sanity check to catch internal problems
-                    throw new IllegalArgumentException("Can not pass true for 'explName' if name is null/empty");
+                    throw new IllegalArgumentException("Cannot pass true for 'explName' if name is null/empty");
                 }
                 // 03-Apr-2014, tatu: But how about name-space only override?
                 //   Probably should not be explicit? Or, need to merge somehow?

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/VirtualAnnotatedMember.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/VirtualAnnotatedMember.java
@@ -84,12 +84,12 @@ public class VirtualAnnotatedMember extends AnnotatedMember
 
     @Override
     public void setValue(Object pojo, Object value) throws IllegalArgumentException {
-        throw new IllegalArgumentException("Can not set virtual property '"+_name+"'");
+        throw new IllegalArgumentException("Cannot set virtual property '"+_name+"'");
     }
 
     @Override
     public Object getValue(Object pojo) throws IllegalArgumentException {
-        throw new IllegalArgumentException("Can not get virtual property '"+_name+"'");
+        throw new IllegalArgumentException("Cannot get virtual property '"+_name+"'");
     }
     
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -65,7 +65,7 @@ public class StdTypeResolverBuilder
     {
         // sanity checks
         if (idType == null) {
-            throw new IllegalArgumentException("idType can not be null");
+            throw new IllegalArgumentException("idType cannot be null");
         }
         _idType = idType;
         _customIdResolver = idRes;
@@ -168,7 +168,7 @@ public class StdTypeResolverBuilder
     @Override
     public StdTypeResolverBuilder inclusion(JsonTypeInfo.As includeAs) {
         if (includeAs == null) {
-            throw new IllegalArgumentException("includeAs can not be null");
+            throw new IllegalArgumentException("includeAs cannot be null");
         }
         _includeAs = includeAs;
         return this;
@@ -227,7 +227,7 @@ public class StdTypeResolverBuilder
     {
         // Custom id resolver?
         if (_customIdResolver != null) { return _customIdResolver; }
-        if (_idType == null) throw new IllegalStateException("Can not build, 'init()' not yet called");
+        if (_idType == null) throw new IllegalStateException("Cannot build, 'init()' not yet called");
         switch (_idType) {
         case CLASS:
             return new ClassNameIdResolver(baseType, config.getTypeFactory());

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeSerializerBase.java
@@ -52,7 +52,7 @@ public abstract class TypeSerializerBase extends TypeSerializer
     protected void handleMissingId(Object value) {
         /*
         String typeDesc = ClassUtil.classNameOf(value, "NULL");
-        throw new IllegalArgumentException("Can not resolve type id for "
+        throw new IllegalArgumentException("Cannot resolve type id for "
                 +typeDesc+" (using "+_idResolver.getClass().getName()+")");
                 */
     }

--- a/src/main/java/com/fasterxml/jackson/databind/module/SimpleAbstractTypeResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/module/SimpleAbstractTypeResolver.java
@@ -53,14 +53,14 @@ public class SimpleAbstractTypeResolver
     {
         // Sanity checks, just in case someone tries to force typing...
         if (superType == subType) {
-            throw new IllegalArgumentException("Can not add mapping from class to itself");
+            throw new IllegalArgumentException("Cannot add mapping from class to itself");
         }
         if (!superType.isAssignableFrom(subType)) {
-            throw new IllegalArgumentException("Can not add mapping from class "+superType.getName()
+            throw new IllegalArgumentException("Cannot add mapping from class "+superType.getName()
                     +" to "+subType.getName()+", as latter is not a subtype of former");
         }
         if (!Modifier.isAbstract(superType.getModifiers())) {
-            throw new IllegalArgumentException("Can not add mapping from class "+superType.getName()
+            throw new IllegalArgumentException("Cannot add mapping from class "+superType.getName()
                     +" since it is not abstract");
         }
         _mappings.put(new ClassKey(superType), subType);

--- a/src/main/java/com/fasterxml/jackson/databind/module/SimpleModule.java
+++ b/src/main/java/com/fasterxml/jackson/databind/module/SimpleModule.java
@@ -510,7 +510,7 @@ public class SimpleModule
     {
         if (thingy == null) {
             throw new IllegalArgumentException(String.format(
-                    "Can not pass `null` as %s", type));
+                    "Cannot pass `null` as %s", type));
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -69,7 +69,7 @@ public class TextNode
         } catch (IllegalArgumentException e) {
             throw InvalidFormatException.from(null,
                     String.format(
-"Can not access contents of TextNode as binary due to broken Base64 encoding: %s",
+"Cannot access contents of TextNode as binary due to broken Base64 encoding: %s",
 e.getMessage()),
                     str, byte[].class);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/node/TreeTraversingParser.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TreeTraversingParser.java
@@ -407,7 +407,7 @@ public class TreeTraversingParser extends ParserMinimalBase
         JsonNode n = currentNode();
         if (n == null || !n.isNumber()) {
             JsonToken t = (n == null) ? null : n.asToken();
-            throw _constructError("Current token ("+t+") not numeric, can not use numeric value accessors");
+            throw _constructError("Current token ("+t+") not numeric, cannot use numeric value accessors");
         }
         return n;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
@@ -392,7 +392,7 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
         // may need to disable check in future?
         if ((_serializer != null) && (_serializer != ser)) {
             throw new IllegalStateException(String.format(
-                    "Can not override _serializer: had a %s, trying to set to %s",
+                    "Cannot override _serializer: had a %s, trying to set to %s",
                     ClassUtil.classNameOf(_serializer), ClassUtil.classNameOf(ser)));
         }
         _serializer = ser;
@@ -405,7 +405,7 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
         // may need to disable check in future?
         if ((_nullSerializer != null) && (_nullSerializer != nullSer)) {
             throw new IllegalStateException(String.format(
-                    "Can not override _nullSerializer: had a %s, trying to set to %s",
+                    "Cannot override _nullSerializer: had a %s, trying to set to %s",
                     ClassUtil.classNameOf(_nullSerializer), ClassUtil.classNameOf(nullSer)));
         }
         _nullSerializer = nullSer;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
@@ -102,7 +102,7 @@ public class BeanSerializerFactory
          */
         if (getClass() != BeanSerializerFactory.class) {
             throw new IllegalStateException("Subtype of BeanSerializerFactory ("+getClass().getName()
-                    +") has not properly overridden method 'withAdditionalSerializers': can not instantiate subtype with "
+                    +") has not properly overridden method 'withAdditionalSerializers': cannot instantiate subtype with "
                     +"additional serializer definitions");
         }
         return new BeanSerializerFactory(config);
@@ -446,7 +446,7 @@ public class BeanSerializerFactory
         // 05-Jul-2012, tatu: ... but we should be able to just return "unknown type" serializer, right?
         if (beanDesc.getBeanClass() == Object.class) {
             return prov.getUnknownTypeSerializer(Object.class);
-//            throw new IllegalArgumentException("Can not create bean serializer for Object.class");
+//            throw new IllegalArgumentException("Cannot create bean serializer for Object.class");
         }
         final SerializationConfig config = prov.getConfig();
         BeanSerializerBuilder builder = constructBeanSerializerBuilder(beanDesc);
@@ -557,7 +557,7 @@ public class BeanSerializerFactory
             for (int i = 0, len = props.size() ;; ++i) {
                 if (i == len) {
                     throw new IllegalArgumentException("Invalid Object Id definition for "+beanDesc.getBeanClass().getName()
-                            +": can not find property with name '"+propName+"'");
+                            +": cannot find property with name '"+propName+"'");
                 }
                 BeanPropertyWriter prop = props.get(i);
                 if (propName.equals(prop.getName())) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -317,7 +317,7 @@ public class PropertyBuilder
                 // 06-Nov-2015, tatu: As per [databind#998], do not fail.
                 /*
                 Class<?> cls = _beanDesc.getClassInfo().getAnnotated();
-                throw new IllegalArgumentException("Class "+cls.getName()+" has no default constructor; can not instantiate default bean value to support 'properties=JsonSerialize.Inclusion.NON_DEFAULT' annotation");
+                throw new IllegalArgumentException("Class "+cls.getName()+" has no default constructor; cannot instantiate default bean value to support 'properties=JsonSerialize.Inclusion.NON_DEFAULT' annotation");
                  */
 
                 // And use a marker

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnwrappingBeanSerializer.java
@@ -127,7 +127,7 @@ public class UnwrappingBeanSerializer
     {
         if (provider.isEnabled(SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS)) {
             provider.reportBadDefinition(handledType(),
-                    "Unwrapped property requires use of type information: can not serialize without disabling `SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS`");
+                    "Unwrapped property requires use of type information: cannot serialize without disabling `SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS`");
         }
         gen.setCurrentValue(bean); // [databind#631]
         if (_objectIdWriter != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -491,7 +491,7 @@ public abstract class BeanSerializerBase
                     for (int i = 0, len = _props.length; ; ++i) {
                         if (i == len) {
                             provider.reportBadDefinition(_beanType, String.format(
-                                    "Invalid Object Id definition for %s: can not find property with name '%s'",
+                                    "Invalid Object Id definition for %s: cannot find property with name '%s'",
                                     handledType().getName(), propName));
                         }
                         BeanPropertyWriter prop = _props[i];

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/DateTimeSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/DateTimeSerializerBase.java
@@ -102,7 +102,7 @@ public abstract class DateTimeSerializerBase<T>
         //    So: require it be `SimpleDateFormat`; can't config other types
         if (!(df0 instanceof SimpleDateFormat)) {
             serializers.reportBadDefinition(handledType(), String.format(
-"Configured `DateFormat` (%s) not a `SimpleDateFormat`; can not configure `Locale` or `TimeZone`",
+"Configured `DateFormat` (%s) not a `SimpleDateFormat`; cannot configure `Locale` or `TimeZone`",
 df0.getClass().getName()));
         }
         SimpleDateFormat df = (SimpleDateFormat) df0;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
@@ -572,7 +572,7 @@ public class MapSerializer
             }
             try {
                 valueSer = _findSerializer(prov, elemValue);
-            } catch (JsonMappingException e) { // Ugh... can not just throw as-is, so...
+            } catch (JsonMappingException e) { // Ugh... cannot just throw as-is, so...
                 // 05-Nov-2015, tatu: For now, probably best not to assume empty then
                 return false;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -424,7 +424,7 @@ public abstract class StdSerializer<T>
         // Not ok to miss the provider, if a filter is declared to be needed.
         if (filters == null) {
             provider.reportBadDefinition(handledType(),
-                    "Can not resolve PropertyFilter with id '"+filterId+"'; no FilterProvider configured");
+                    "Cannot resolve PropertyFilter with id '"+filterId+"'; no FilterProvider configured");
         }
         // But whether unknown ids are ok just depends on filter provider; if we get null that's fine
         return filters.findPropertyFilter(filterId, valueToFilter);

--- a/src/main/java/com/fasterxml/jackson/databind/type/ArrayType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/ArrayType.java
@@ -125,7 +125,7 @@ public final class ArrayType
     }
 
     private JavaType _reportUnsupported() {
-        throw new UnsupportedOperationException("Can not narrow or widen array types");
+        throw new UnsupportedOperationException("Cannot narrow or widen array types");
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/type/CollectionLikeType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/CollectionLikeType.java
@@ -86,7 +86,7 @@ public class CollectionLikeType extends TypeBase
         if (baseType instanceof TypeBase) {
             return new CollectionLikeType((TypeBase) baseType, elementType);
         }
-        throw new IllegalArgumentException("Can not upgrade from an instance of "+baseType.getClass());
+        throw new IllegalArgumentException("Cannot upgrade from an instance of "+baseType.getClass());
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/type/MapLikeType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/MapLikeType.java
@@ -66,7 +66,7 @@ public class MapLikeType extends TypeBase {
             return new MapLikeType((TypeBase) baseType, keyT, valueT);
         }
         throw new IllegalArgumentException(
-                "Can not upgrade from an instance of " + baseType.getClass());
+                "Cannot upgrade from an instance of " + baseType.getClass());
     }
 
     @Deprecated

--- a/src/main/java/com/fasterxml/jackson/databind/type/ReferenceType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/ReferenceType.java
@@ -70,7 +70,7 @@ public class ReferenceType extends SimpleType
         if (baseType instanceof TypeBase) {
             return new ReferenceType((TypeBase) baseType, refdType);
         }
-        throw new IllegalArgumentException("Can not upgrade from an instance of "+baseType.getClass());
+        throw new IllegalArgumentException("Cannot upgrade from an instance of "+baseType.getClass());
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
@@ -104,14 +104,14 @@ public class SimpleType // note: until 2.6 was final
          * Map/Collection entries are constructed
          */
         if (Map.class.isAssignableFrom(cls)) {
-            throw new IllegalArgumentException("Can not construct SimpleType for a Map (class: "+cls.getName()+")");
+            throw new IllegalArgumentException("Cannot construct SimpleType for a Map (class: "+cls.getName()+")");
         }
         if (Collection.class.isAssignableFrom(cls)) {
-            throw new IllegalArgumentException("Can not construct SimpleType for a Collection (class: "+cls.getName()+")");
+            throw new IllegalArgumentException("Cannot construct SimpleType for a Collection (class: "+cls.getName()+")");
         }
         // ... and while we are at it, not array types either
         if (cls.isArray()) {
-            throw new IllegalArgumentException("Can not construct SimpleType for an array (class: "+cls.getName()+")");
+            throw new IllegalArgumentException("Cannot construct SimpleType for an array (class: "+cls.getName()+")");
         }
         TypeBindings b = TypeBindings.emptyBindings();
         return new SimpleType(cls, b,
@@ -162,13 +162,13 @@ public class SimpleType // note: until 2.6 was final
             }
         }
         // should not get here but...
-        throw new IllegalArgumentException("Internal error: Can not resolve sub-type for Class "+subclass.getName()+" to "
+        throw new IllegalArgumentException("Internal error: Cannot resolve sub-type for Class "+subclass.getName()+" to "
                 +_class.getName());
     }
     
     @Override
     public JavaType withContentType(JavaType contentType) {
-        throw new IllegalArgumentException("Simple types have no content types; can not call withContentType()");
+        throw new IllegalArgumentException("Simple types have no content types; cannot call withContentType()");
     }
     
     @Override
@@ -182,7 +182,7 @@ public class SimpleType // note: until 2.6 was final
     @Override
     public JavaType withContentTypeHandler(Object h) {
         // no content type, so:
-        throw new IllegalArgumentException("Simple types have no content types; can not call withContenTypeHandler()");
+        throw new IllegalArgumentException("Simple types have no content types; cannot call withContenTypeHandler()");
     }
 
     @Override
@@ -196,7 +196,7 @@ public class SimpleType // note: until 2.6 was final
     @Override
     public  SimpleType withContentValueHandler(Object h) {
         // no content type, so:
-        throw new IllegalArgumentException("Simple types have no content types; can not call withContenValueHandler()");
+        throw new IllegalArgumentException("Simple types have no content types; cannot call withContenValueHandler()");
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -110,7 +110,7 @@ public class TypeBindings
         }
         // Check here to give better error message
         if (names.length != types.length) {
-            throw new IllegalArgumentException("Can not create TypeBindings for class "+erasedType.getName()
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
                    +" with "+types.length+" type parameter"
                    +((types.length == 1) ? "" : "s")+": class expects "+names.length);
         }
@@ -123,7 +123,7 @@ public class TypeBindings
         TypeVariable<?>[] vars = TypeParamStash.paramsFor1(erasedType);
         int varLen = (vars == null) ? 0 : vars.length;
         if (varLen != 1) {
-            throw new IllegalArgumentException("Can not create TypeBindings for class "+erasedType.getName()
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
                     +" with 1 type parameter: class expects "+varLen);
         }
         return new TypeBindings(new String[] { vars[0].getName() },
@@ -136,7 +136,7 @@ public class TypeBindings
         TypeVariable<?>[] vars = TypeParamStash.paramsFor2(erasedType);
         int varLen = (vars == null) ? 0 : vars.length;
         if (varLen != 2) {
-            throw new IllegalArgumentException("Can not create TypeBindings for class "+erasedType.getName()
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
                     +" with 2 type parameters: class expects "+varLen);
         }
         return new TypeBindings(new String[] { vars[0].getName(), vars[1].getName() },
@@ -156,7 +156,7 @@ public class TypeBindings
             return EMPTY;
         }
         if (varLen != 1) {
-            throw new IllegalArgumentException("Can not create TypeBindings for class "+erasedType.getName()
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
                     +" with 1 type parameter: class expects "+varLen);
         }
         return new TypeBindings(new String[] { vars[0].getName() },
@@ -184,7 +184,7 @@ public class TypeBindings
         }
         // Check here to give better error message
         if (names.length != types.length) {
-            throw new IllegalArgumentException("Can not create TypeBindings for class "+erasedType.getName()
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
                    +" with "+types.length+" type parameter"
                    +((types.length == 1) ? "" : "s")+": class expects "+names.length);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1082,7 +1082,7 @@ public final class TypeFactory
                 vt = typeParams.get(1);
                 break;
             default:
-                throw new IllegalArgumentException("Strange Map type "+rawClass.getName()+": can not determine type parameters");
+                throw new IllegalArgumentException("Strange Map type "+rawClass.getName()+": cannot determine type parameters");
             }
         }
         return MapType.construct(rawClass, bindings, superClass, superInterfaces, kt, vt);
@@ -1099,7 +1099,7 @@ public final class TypeFactory
         } else if (typeParams.size() == 1) {
             ct = typeParams.get(0);
         } else {
-            throw new IllegalArgumentException("Strange Collection type "+rawClass.getName()+": can not determine type parameters");
+            throw new IllegalArgumentException("Strange Collection type "+rawClass.getName()+": cannot determine type parameters");
         }
         return CollectionType.construct(rawClass, bindings, superClass, superInterfaces, ct);
     }
@@ -1115,7 +1115,7 @@ public final class TypeFactory
         } else if (typeParams.size() == 1) {
             ct = typeParams.get(0);
         } else {
-            throw new IllegalArgumentException("Strange Reference type "+rawClass.getName()+": can not determine type parameters");
+            throw new IllegalArgumentException("Strange Reference type "+rawClass.getName()+": cannot determine type parameters");
         }
         return ReferenceType.construct(rawClass, bindings, superClass, superInterfaces, ct);
     }
@@ -1294,7 +1294,7 @@ public final class TypeFactory
                 superClass = null;
                 superInterfaces = _resolveSuperInterfaces(context, rawType, bindings);
             } else {
-                // Note: even Enums can implement interfaces, so can not drop those
+                // Note: even Enums can implement interfaces, so cannot drop those
                 superClass = _resolveSuperClass(context, rawType, bindings);
                 superInterfaces = _resolveSuperInterfaces(context, rawType, bindings);
             }

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeParser.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeParser.java
@@ -83,7 +83,7 @@ public class TypeParser
             return _factory.findClass(className);
         } catch (Exception e) {
             ClassUtil.throwIfRTE(e);
-            throw _problem(tokens, "Can not locate class '"+className+"', problem: "+e.getMessage());
+            throw _problem(tokens, "Cannot locate class '"+className+"', problem: "+e.getMessage());
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -570,7 +570,7 @@ public final class ClassUtil
             } else {
                 // Has to be public...
                 if (!Modifier.isPublic(ctor.getModifiers())) {
-                    throw new IllegalArgumentException("Default constructor for "+cls.getName()+" is not accessible (non-public?): not allowed to try modify access via Reflection: can not instantiate type");
+                    throw new IllegalArgumentException("Default constructor for "+cls.getName()+" is not accessible (non-public?): not allowed to try modify access via Reflection: cannot instantiate type");
                 }
             }
             return ctor;
@@ -862,7 +862,7 @@ public final class ClassUtil
             // Google App Engine); so let's only fail if we really needed it...
             if (!ao.isAccessible()) {
                 Class<?> declClass = member.getDeclaringClass();
-                throw new IllegalArgumentException("Can not access "+member+" (from class "+declClass.getName()+"; failed to set access: "+se.getMessage());
+                throw new IllegalArgumentException("Cannot access "+member+" (from class "+declClass.getName()+"; failed to set access: "+se.getMessage());
             }
         }
     }
@@ -1153,7 +1153,7 @@ public final class ClassUtil
             if (enumSetTypeField != null) {
                 return (Class<? extends Enum<?>>) get(set, enumSetTypeField);
             }
-            throw new IllegalStateException("Can not figure out type for EnumSet (odd JDK platform?)");
+            throw new IllegalStateException("Cannot figure out type for EnumSet (odd JDK platform?)");
         }
 
         @SuppressWarnings("unchecked")
@@ -1162,7 +1162,7 @@ public final class ClassUtil
             if (enumMapTypeField != null) {
                 return (Class<? extends Enum<?>>) get(set, enumMapTypeField);
             }
-            throw new IllegalStateException("Can not figure out type for EnumMap (odd JDK platform?)");
+            throw new IllegalStateException("Cannot figure out type for EnumMap (odd JDK platform?)");
         }
     	
         private Object get(Object bean, Field field)

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -46,7 +46,7 @@ public final class EnumValues
         Class<? extends Enum<?>> enumCls = ClassUtil.findEnumType(enumClass);
         Enum<?>[] enumValues = enumCls.getEnumConstants();
         if (enumValues == null) {
-            throw new IllegalArgumentException("Can not determine enum constants for Class "+enumClass.getName());
+            throw new IllegalArgumentException("Cannot determine enum constants for Class "+enumClass.getName());
         }
         String[] names = config.getAnnotationIntrospector().findEnumValues(enumCls, enumValues, new String[enumValues.length]);
         SerializableString[] textual = new SerializableString[enumValues.length];
@@ -72,7 +72,7 @@ public final class EnumValues
             }
             return new EnumValues(enumClass, textual);
         }
-        throw new IllegalArgumentException("Can not determine enum constants for Class "+enumClass.getName());
+        throw new IllegalArgumentException("Cannot determine enum constants for Class "+enumClass.getName());
     }
 
     public SerializableString serializedValueFor(Enum<?> key) {

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdConverter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdConverter.java
@@ -36,7 +36,7 @@ public abstract class StdConverter<IN,OUT>
         JavaType thisType = tf.constructType(getClass());
         JavaType convType = thisType.findSuperType(Converter.class);
         if (convType == null || convType.containedTypeCount() < 2) {
-            throw new IllegalStateException("Can not find OUT type parameter for Converter of type "+getClass().getName());
+            throw new IllegalStateException("Cannot find OUT type parameter for Converter of type "+getClass().getName());
         }
         return convType;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -290,7 +290,7 @@ public class StdDateFormat
         }
         sb.append('"');
         throw new ParseException
-            (String.format("Can not parse date \"%s\": not compatible with any of standard forms (%s)",
+            (String.format("Cannot parse date \"%s\": not compatible with any of standard forms (%s)",
                            dateStr, sb.toString()), pos.getErrorIndex());
     }
 
@@ -498,7 +498,7 @@ public class StdDateFormat
         try {
             return _parseAsISO8601(dateStr, pos);
         } catch (IllegalArgumentException e) {
-            throw new ParseException(String.format("Can not parse date \"%s\", problem: %s",
+            throw new ParseException(String.format("Cannot parse date \"%s\", problem: %s",
                     dateStr, e.getMessage()),
                     pos.getErrorIndex());
         }
@@ -591,7 +591,7 @@ public class StdDateFormat
                         break;
                     default:
                         throw new ParseException(String.format(
-"Can not parse date \"%s\": invalid fractional seconds '%s'; can use at most 3 digits",
+"Cannot parse date \"%s\": invalid fractional seconds '%s'; can use at most 3 digits",
                                        dateStr, m.group(1).substring(1)
                                        ),
                                 pos.getErrorIndex());
@@ -604,7 +604,7 @@ public class StdDateFormat
         }
 
         throw new ParseException
-        (String.format("Can not parse date \"%s\": while it seems to fit format '%s', parsing fails (leniency? %s)",
+        (String.format("Cannot parse date \"%s\": while it seems to fit format '%s', parsing fails (leniency? %s)",
                        dateStr, formatStr, _lenient),
            pos.getErrorIndex());
     }

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -435,7 +435,7 @@ public class TokenBuffer
                         gen.writeNumber((String) n);
                     } else {
                         throw new JsonGenerationException(String.format(
-                                "Unrecognized value type for VALUE_NUMBER_FLOAT: %s, can not serialize",
+                                "Unrecognized value type for VALUE_NUMBER_FLOAT: %s, cannot serialize",
                                 n.getClass().getName()), gen);
                     }
                 }
@@ -1649,7 +1649,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
                 // fall through to error case
             }
             if (_currToken != JsonToken.VALUE_STRING) {
-                throw _constructError("Current token ("+_currToken+") not VALUE_STRING (or VALUE_EMBEDDED_OBJECT with byte[]), can not access as binary");
+                throw _constructError("Current token ("+_currToken+") not VALUE_STRING (or VALUE_EMBEDDED_OBJECT with byte[]), cannot access as binary");
             }
             final String str = getText();
             if (str == null) {
@@ -1715,7 +1715,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         protected final void _checkIsNumber() throws JsonParseException
         {
             if (_currToken == null || !_currToken.isNumeric()) {
-                throw _constructError("Current token ("+_currToken+") not numeric, can not use numeric value accessors");
+                throw _constructError("Current token ("+_currToken+") not numeric, cannot use numeric value accessors");
             }
         }
 

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
@@ -321,7 +321,7 @@ public class ObjectReaderTest extends BaseMapTest
             
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not use FormatSchema");
+            verifyException(e, "Cannot use FormatSchema");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectWriterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectWriterTest.java
@@ -194,7 +194,7 @@ public class ObjectWriterTest
             newW = w.with(schema);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not use FormatSchema");
+            verifyException(e, "Cannot use FormatSchema");
         }
     }
 
@@ -294,7 +294,7 @@ public class ObjectWriterTest
                 .writeValueAsBytes("foo");
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not use FormatSchema");
+            verifyException(e, "Cannot use FormatSchema");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/convert/NumericConversionTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/NumericConversionTest.java
@@ -22,25 +22,25 @@ public class NumericConversionTest extends BaseMapTest
             R.forType(Integer.class).readValue("1.5");
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
         try {
             R.forType(Integer.TYPE).readValue("1.5");
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
         try {
             R.forType(IntWrapper.class).readValue("{\"i\":-2.25 }");
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
         try {
             R.forType(int[].class).readValue("[ 2.5 ]");
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
     }
 
@@ -58,27 +58,27 @@ public class NumericConversionTest extends BaseMapTest
             R.forType(Long.class).readValue("1.5");
             fail("Should not pass");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
 
         try {
             R.forType(Long.TYPE).readValue("1.5");
             fail("Should not pass");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
         
         try {
             R.forType(LongWrapper.class).readValue("{\"l\": 7.7 }");
             fail("Should not pass");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
         try {
             R.forType(long[].class).readValue("[ 2.5 ]");
             fail("Should not pass");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce a floating-point");
+            verifyException(e, "Cannot coerce a floating-point");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/convert/TestBeanConversions.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/TestBeanConversions.java
@@ -147,7 +147,7 @@ public class TestBeanConversions
         try {
             MAPPER.readValue("{\"boolProp\":\"foobar\"}", BooleanBean.class);
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize value of type boolean from String");
+            verifyException(e, "Cannot deserialize value of type boolean from String");
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestBeanDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestBeanDeserializer.java
@@ -251,7 +251,7 @@ public class TestBeanDeserializer extends BaseMapTest
             MAPPER.readValue("{ \"x\" : 3 }", Abstract.class);
             fail("Should fail on trying to deserialize abstract type");
         } catch (JsonProcessingException e) {
-            verifyException(e, "can not construct");
+            verifyException(e, "cannot construct");
         }
     }    
     public void testPropertyRemoval() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestCollectionDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestCollectionDeserialization.java
@@ -226,7 +226,7 @@ public class TestCollectionDeserialization
             MAPPER.readValue(OBJECTS_JSON, Key[].class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Cannot deserialize");
             List<JsonMappingException.Reference> refs = e.getPath();
             assertEquals(1, refs.size());
             assertEquals(1, refs.get(0).getIndex());
@@ -236,7 +236,7 @@ public class TestCollectionDeserialization
             MAPPER.readValue("[ \"xyz\", { } ]", String[].class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Cannot deserialize");
             List<JsonMappingException.Reference> refs = e.getPath();
             assertEquals(1, refs.size());
             assertEquals(1, refs.get(0).getIndex());
@@ -246,7 +246,7 @@ public class TestCollectionDeserialization
             MAPPER.readValue("{\"keys\":"+OBJECTS_JSON+"}", KeyListBean.class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Cannot deserialize");
             List<JsonMappingException.Reference> refs = e.getPath();
             assertEquals(2, refs.size());
             // Bean has no index, but has name:

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestCustomDeserializers.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestCustomDeserializers.java
@@ -277,7 +277,7 @@ public class TestCustomDeserializers
                         JsonDeserializer<?> d = new MyStringDeserializer(deserializer);
                         // just for test coverage purposes...
                         if (d.getDelegatee() != deserializer) {
-                            throw new Error("Can not access delegatee!");
+                            throw new Error("Cannot access delegatee!");
                         }
                         return d;
                     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/InnerClassCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/InnerClassCreatorTest.java
@@ -64,7 +64,7 @@ public class InnerClassCreatorTest extends BaseMapTest
             MAPPER.readValue(ser, Something1501.class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not construct instance");
+            verifyException(e, "Cannot construct instance");
             verifyException(e, "InnerSomething1501");
             verifyException(e, "can only instantiate non-static inner class by using default");
         }
@@ -77,7 +77,7 @@ public class InnerClassCreatorTest extends BaseMapTest
             MAPPER.readValue(ser, Something1502.class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not construct instance");
+            verifyException(e, "Cannot construct instance");
             verifyException(e, "InnerSomething1502");
             verifyException(e, "can only instantiate non-static inner class by using default");
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/TestValueInstantiator.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/TestValueInstantiator.java
@@ -589,7 +589,7 @@ public class TestValueInstantiator extends BaseMapTest
             MAPPER.readValue("{ }", MyBean.class);
             fail("Should not succeed");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not construct instance of");
+            verifyException(e, "Cannot construct instance of");
             verifyException(e, "no Creators");
             // as per [databind#1414], is definition problem
             assertEquals(InvalidDefinitionException.class, e.getClass());
@@ -604,7 +604,7 @@ public class TestValueInstantiator extends BaseMapTest
             MAPPER.readValue("\"foo\"", MyBean.class);
             fail("Should not succeed");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not construct instance of");
+            verifyException(e, "Cannot construct instance of");
             verifyException(e, "no String-argument constructor/factory");
             // as per [databind#1414], is definition problem
             assertEquals(InvalidDefinitionException.class, e.getClass());

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsGenericTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsGenericTest.java
@@ -56,7 +56,7 @@ public class NullConversionsGenericTest extends BaseMapTest
                     NoCtorWrapper.class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not create empty instance");
+            verifyException(e, "Cannot create empty instance");
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/Base64DecodingTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/Base64DecodingTest.java
@@ -43,7 +43,7 @@ public class Base64DecodingTest extends BaseMapTest
             /*byte[] b =*/ nodeValue.binaryValue();
             fail("Should not pass");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not access contents of TextNode as binary");
+            verifyException(e, "Cannot access contents of TextNode as binary");
             verifyException(e, "Illegal character '!'");
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/DateDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/DateDeserializationTest.java
@@ -617,7 +617,7 @@ public class DateDeserializationTest
             reader.readValue(input);
             fail("Did not throw exception when reading a value from a single value array with the UNWRAP_SINGLE_VALUE_ARRAYS feature disabled");
         } catch (MismatchedInputException exp) {
-            verifyException(exp, "Can not deserialize");
+            verifyException(exp, "Cannot deserialize");
             verifyException(exp, "out of START_ARRAY");
         }
 
@@ -655,7 +655,7 @@ public class DateDeserializationTest
             MAPPER.readValue(JSON, StrictCalendarBean.class);
             fail("Should not pass with invalid (with strict) date value");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not deserialize value of type java.util.Calendar");
+            verifyException(e, "Cannot deserialize value of type java.util.Calendar");
             verifyException(e, "from String \"2015-11-32\"");
             verifyException(e, "expected format");
         }
@@ -668,7 +668,7 @@ public class DateDeserializationTest
             mapper.readValue(quote("2015-11-32"), java.util.Date.class);
             fail("Should not pass with invalid (with strict) date value");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not deserialize value of type java.util.Date");
+            verifyException(e, "Cannot deserialize value of type java.util.Date");
             verifyException(e, "from String \"2015-11-32\"");
             verifyException(e, "expected format");
         }
@@ -686,7 +686,7 @@ public class DateDeserializationTest
             MAPPER.readValue(quote("foobar"), Date.class);
             fail("Should have failed with an exception");
         } catch (InvalidFormatException e) {
-            verifyException(e, "Can not deserialize value of type java.util.Date from String");
+            verifyException(e, "Cannot deserialize value of type java.util.Date from String");
             assertEquals("foobar", e.getValue());
             assertEquals(Date.class, e.getTargetType());
         } catch (Exception e) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDefaultReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDefaultReadTest.java
@@ -222,7 +222,7 @@ public class EnumDefaultReadTest extends BaseMapTest
             reader.forType(toValueType).readValue(quote(fromValue));
             fail("Deserialization should have failed");
         } catch (InvalidFormatException e) {
-            verifyException(e, "Can not deserialize value of type");
+            verifyException(e, "Cannot deserialize value of type");
             /* Expected. */
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumDeserializationTest.java
@@ -273,7 +273,7 @@ public class EnumDeserializationTest
             value = r.readValue("1");
             fail("Expected an error");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Cannot deserialize");
             verifyException(e, "not allowed to deserialize Enum value out of number: disable");
         }
 
@@ -282,7 +282,7 @@ public class EnumDeserializationTest
             value = r.readValue(quote("1"));
             fail("Expected an error");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Cannot deserialize");
             // 26-Jan-2017, tatu: as per [databind#1505], should fail bit differently
             verifyException(e, "value not one of declared Enum");
         }
@@ -366,7 +366,7 @@ public class EnumDeserializationTest
              MAPPER.readValue("{\"map\":{\"NO-SUCH-VALUE\":\"val\"}}", ClassWithEnumMapKey.class);
              fail("Expected an exception for bogus enum value...");
          } catch (JsonMappingException jex) {
-             verifyException(jex, "Can not deserialize Map key of type com.fasterxml.jackson.databind.deser");
+             verifyException(jex, "Cannot deserialize Map key of type com.fasterxml.jackson.databind.deser");
          }
     }
 
@@ -406,7 +406,7 @@ public class EnumDeserializationTest
             fail("Exception was not thrown on deserializing a single array element of type enum; instead got: "+v);
         } catch (JsonMappingException exp) {
             //exception as thrown correctly
-            verifyException(exp, "Can not deserialize");
+            verifyException(exp, "Cannot deserialize");
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKNumberDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKNumberDeserTest.java
@@ -128,7 +128,7 @@ public class JDKNumberDeserTest extends BaseMapTest
                 .readValue(NULL_JSON);
             fail("Should not have passed");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce String \"null\"");
+            verifyException(e, "Cannot coerce String \"null\"");
         }
 
         ObjectMapper noCoerceMapper = new ObjectMapper();
@@ -137,7 +137,7 @@ public class JDKNumberDeserTest extends BaseMapTest
             noCoerceMapper.readValue(NULL_JSON, Integer.TYPE);
             fail("Should not have passed");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce String \"null\"");
+            verifyException(e, "Cannot coerce String \"null\"");
         }
     }
     

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKScalarsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKScalarsTest.java
@@ -227,7 +227,7 @@ public class JDKScalarsTest
             mapper.readValue("{\"v\":null}", CharacterBean.class);
             fail("Attempting to deserialize a 'null' JSON reference into a 'char' property did not throw an exception");
         } catch (JsonMappingException e) {
-            verifyException(e, "can not map `null`");
+            verifyException(e, "cannot map `null`");
             //Exception thrown as required
         }
 
@@ -542,7 +542,7 @@ public class JDKScalarsTest
                 .readValue("\"\"");
             fail("Should not have passed");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce empty String");
+            verifyException(e, "Cannot coerce empty String");
         }
     }
 
@@ -662,7 +662,7 @@ public class JDKScalarsTest
             reader.readValue(aposToQuotes("{'"+propName+"':''}"));
             fail("Expected failure for boolean + empty String");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce empty String (\"\")");
+            verifyException(e, "Cannot coerce empty String (\"\")");
             verifyException(e, "to Null value");
         }
     }
@@ -713,38 +713,38 @@ public class JDKScalarsTest
             reader.readValue("{\"booleanValue\":null}");
             fail("Expected failure for boolean + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type boolean");
+            verifyException(e, "Cannot map `null` into type boolean");
         }
         // byte/char/short/int/long
         try {
             reader.readValue("{\"byteValue\":null}");
             fail("Expected failure for byte + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type byte");
+            verifyException(e, "Cannot map `null` into type byte");
         }
         try {
             reader.readValue("{\"charValue\":null}");
             fail("Expected failure for char + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type char");
+            verifyException(e, "Cannot map `null` into type char");
         }
         try {
             reader.readValue("{\"shortValue\":null}");
             fail("Expected failure for short + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type short");
+            verifyException(e, "Cannot map `null` into type short");
         }
         try {
             reader.readValue("{\"intValue\":null}");
             fail("Expected failure for int + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type int");
+            verifyException(e, "Cannot map `null` into type int");
         }
         try {
             reader.readValue("{\"longValue\":null}");
             fail("Expected failure for long + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type long");
+            verifyException(e, "Cannot map `null` into type long");
         }
 
         // float/double
@@ -752,13 +752,13 @@ public class JDKScalarsTest
             reader.readValue("{\"floatValue\":null}");
             fail("Expected failure for float + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type float");
+            verifyException(e, "Cannot map `null` into type float");
         }
         try {
             reader.readValue("{\"doubleValue\":null}");
             fail("Expected failure for double + null");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not map `null` into type double");
+            verifyException(e, "Cannot map `null` into type double");
         }
     }
 
@@ -795,7 +795,7 @@ public class JDKScalarsTest
             readerNoCoerce.readValue(JSON_WITH_NULL);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not coerce `null`");
+            verifyException(e, "Cannot coerce `null`");
             verifyException(e, "as content of type `"+SIMPLE_NAME+"`");
         }
         
@@ -808,7 +808,7 @@ public class JDKScalarsTest
                 readerNoCoerce.readValue(EMPTY_STRING_JSON);
                 fail("Should not pass");
             } catch (JsonMappingException e) {
-                verifyException(e, "Can not coerce empty String (\"\")");
+                verifyException(e, "Cannot coerce empty String (\"\")");
                 verifyException(e, "as content of type `"+SIMPLE_NAME+"`");
             }
         }
@@ -843,7 +843,7 @@ public class JDKScalarsTest
             MAPPER.readerFor(cls).readValue(JSON);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Can not deserialize value of type "+SIMPLE_NAME+" from String \"foobar\"");
+            verifyException(e, "Cannot deserialize value of type "+SIMPLE_NAME+" from String \"foobar\"");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/merge/PropertyMergeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/merge/PropertyMergeTest.java
@@ -190,7 +190,7 @@ public class PropertyMergeTest extends BaseMapTest
                 .readValue("\"blob\"");
             fail("Should not pass");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Cannot deserialize");
             verifyException(e, "from non-Array representation");
         }
     }
@@ -223,7 +223,7 @@ public class PropertyMergeTest extends BaseMapTest
             mapper.readValue("{\"value\":3}", CantMergeInts.class);
             fail("Should not pass");
         } catch (InvalidDefinitionException e) {
-            verifyException(e, "can not be merged");
+            verifyException(e, "cannot be merged");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/exc/ExceptionSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/ExceptionSerializationTest.java
@@ -120,14 +120,14 @@ public class ExceptionSerializationTest
             MAPPER.readValue( "{ \"val\": \"foo\" }", NoSerdeConstructor.class );
             fail("Should not pass");
         } catch (JsonMappingException e0) {
-            verifyException(e0, "can not deserialize from Object");
+            verifyException(e0, "cannot deserialize from Object");
             e = e0;
         }
         // but should be able to serialize new exception we got
         String json = MAPPER.writeValueAsString(e);
         JsonNode root = MAPPER.readTree(json);
         String msg = root.path("message").asText();
-        String MATCH = "can not construct instance";
+        String MATCH = "cannot construct instance";
         if (!msg.toLowerCase().contains(MATCH)) {
             fail("Exception should contain '"+MATCH+"', does not: '"+msg+"'");
         }

--- a/src/test/java/com/fasterxml/jackson/databind/interop/TestFormatDetection.java
+++ b/src/test/java/com/fasterxml/jackson/databind/interop/TestFormatDetection.java
@@ -80,7 +80,7 @@ public class TestFormatDetection extends BaseMapTest
             detecting.readValue(utf8Bytes("<POJO><x>1</x></POJO>"));
             fail("Should have failed");
         } catch (JsonProcessingException e) {
-            verifyException(e, "Can not detect format from input");
+            verifyException(e, "Cannot detect format from input");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultForObject.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestDefaultForObject.java
@@ -136,7 +136,7 @@ public class TestDefaultForObject
             fail("Should have failed");
         } catch (JsonMappingException e) {
             // let's use whatever is currently thrown exception... may change tho
-            verifyException(e, "can not construct");
+            verifyException(e, "cannot construct");
         }
         
         // and then that we will succeed with default type info
@@ -348,7 +348,7 @@ public class TestDefaultForObject
                     JsonTypeInfo.As.EXTERNAL_PROPERTY);
             fail("Should not have passed");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not use includeAs of EXTERNAL_PROPERTY");
+            verifyException(e, "Cannot use includeAs of EXTERNAL_PROPERTY");
         }
     }
     

--- a/src/test/java/com/fasterxml/jackson/databind/misc/AccessFixTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/misc/AccessFixTest.java
@@ -14,7 +14,7 @@ public class AccessFixTest extends BaseMapTest
         @Override
         public void checkPermission(Permission perm) throws SecurityException {
             if ("suppressAccessChecks".equals(perm.getName())) {
-                throw new SecurityException("Can not force permission: "+perm);
+                throw new SecurityException("Cannot force permission: "+perm);
             }
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleArgCheckTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleArgCheckTest.java
@@ -25,14 +25,14 @@ public class SimpleModuleArgCheckTest extends BaseMapTest
             mod.addDeserializer(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as deserializer");
+            verifyException(e, "Cannot pass `null` as deserializer");
         }
 
         try {
             mod.addKeyDeserializer(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as key deserializer");
+            verifyException(e, "Cannot pass `null` as key deserializer");
         }
     }
 
@@ -51,21 +51,21 @@ public class SimpleModuleArgCheckTest extends BaseMapTest
             mod.addSerializer(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as serializer");
+            verifyException(e, "Cannot pass `null` as serializer");
         }
 
         try {
             mod.addSerializer((JsonSerializer<?>) null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as serializer");
+            verifyException(e, "Cannot pass `null` as serializer");
         }
         
         try {
             mod.addKeySerializer(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as key serializer");
+            verifyException(e, "Cannot pass `null` as key serializer");
         }
     }
 
@@ -87,13 +87,13 @@ public class SimpleModuleArgCheckTest extends BaseMapTest
             mod.addAbstractTypeMapping(null, String.class);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as abstract type to map");
+            verifyException(e, "Cannot pass `null` as abstract type to map");
         }
         try {
             mod.addAbstractTypeMapping(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as concrete type to map to");
+            verifyException(e, "Cannot pass `null` as concrete type to map to");
         }
     }
 
@@ -105,14 +105,14 @@ public class SimpleModuleArgCheckTest extends BaseMapTest
             mod.registerSubtypes(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as subtype to register");
+            verifyException(e, "Cannot pass `null` as subtype to register");
         }
 
         try {
             mod.registerSubtypes(new NamedType(Integer.class), (NamedType) null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as subtype to register");
+            verifyException(e, "Cannot pass `null` as subtype to register");
         }
     }
 
@@ -124,13 +124,13 @@ public class SimpleModuleArgCheckTest extends BaseMapTest
             mod.addValueInstantiator(null, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as class to register value instantiator for");
+            verifyException(e, "Cannot pass `null` as class to register value instantiator for");
         }
         try {
             mod.addValueInstantiator(CharSequence.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as value instantiator");
+            verifyException(e, "Cannot pass `null` as value instantiator");
         }
     }
 
@@ -142,13 +142,13 @@ public class SimpleModuleArgCheckTest extends BaseMapTest
             mod.setMixInAnnotation(null, String.class);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as target type");
+            verifyException(e, "Cannot pass `null` as target type");
         }
         try {
             mod.setMixInAnnotation(String.class, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not pass `null` as mixin class");
+            verifyException(e, "Cannot pass `null` as mixin class");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleTest.java
@@ -205,7 +205,7 @@ public class SimpleModuleTest extends BaseMapTest
             mapper.readValue("{\"str\":\"ab\",\"num\":2}", CustomBean.class);
             fail("Should have caused an exception");
         } catch (IOException e) {
-            verifyException(e, "Can not construct");
+            verifyException(e, "Cannot construct");
             verifyException(e, "no creators");
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/PolymorphicWithObjectId1551Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/PolymorphicWithObjectId1551Test.java
@@ -71,7 +71,7 @@ public class PolymorphicWithObjectId1551Test extends BaseMapTest
             // on serialization, reported for different type
             assertEquals(Car.class, e.getType().getRawClass());
             verifyException(e, "Invalid Object Id definition");
-            verifyException(e, "can not find property with name 'bogus'");
+            verifyException(e, "cannot find property with name 'bogus'");
         }
 
         // and same for deser
@@ -85,7 +85,7 @@ public class PolymorphicWithObjectId1551Test extends BaseMapTest
         } catch (InvalidDefinitionException e) {
             assertEquals(Vehicle.class, e.getType().getRawClass());
             verifyException(e, "Invalid Object Id definition");
-            verifyException(e, "can not find property with name 'bogus'");
+            verifyException(e, "cannot find property with name 'bogus'");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdSerialization.java
@@ -331,7 +331,7 @@ public class TestObjectIdSerialization extends BaseMapTest
             MAPPER.writeValueAsString(new Broken());
             fail("Should have thrown an exception");
         } catch (JsonMappingException e) {
-            verifyException(e, "can not find property with name 'id'");
+            verifyException(e, "cannot find property with name 'id'");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/TestJsonFilter.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/TestJsonFilter.java
@@ -146,7 +146,7 @@ public class TestJsonFilter extends BaseMapTest
             MAPPER.writeValueAsString(new Bean());
             fail("Should have failed without configured filter");
         } catch (JsonMappingException e) { // should be resolved to a MappingException (internally may be something else)
-            verifyException(e, "Can not resolve PropertyFilter with id 'RootFilter'");
+            verifyException(e, "Cannot resolve PropertyFilter with id 'RootFilter'");
         }
         
         // but when changing behavior, should work difference

--- a/src/test/java/com/fasterxml/jackson/databind/struct/ScalarCoercionTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/ScalarCoercionTest.java
@@ -92,7 +92,7 @@ public class ScalarCoercionTest extends BaseMapTest
             NOT_COERCING_MAPPER.readerFor(type).readValue("\"\"");
             fail("Should have failed for "+type);
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce empty String");
+            verifyException(e, "Cannot coerce empty String");
             verifyException(e, "Null value for");
         }
     }
@@ -187,7 +187,7 @@ public class ScalarCoercionTest extends BaseMapTest
                 .readValue(input);
             fail("Should not have allowed coercion");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Can not coerce ");
+            verifyException(e, "Cannot coerce ");
             verifyException(e, " for type `");
             verifyException(e, "enable `MapperFeature.ALLOW_COERCION_OF_SCALARS` to allow");
         }

--- a/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayScalarsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayScalarsTest.java
@@ -256,7 +256,7 @@ public class UnwrapSingleArrayScalarsTest extends BaseMapTest
             mapper.readValue("[\""+value+"\"]", String.class);
             fail("Exception not thrown when attempting to unwrap a single value 'String' array into a simple String");
         } catch (MismatchedInputException exp) {
-            verifyException(exp, "Can not deserialize");
+            verifyException(exp, "Cannot deserialize");
             verifyException(exp, "out of START_ARRAY");
         }
         
@@ -284,7 +284,7 @@ public class UnwrapSingleArrayScalarsTest extends BaseMapTest
             mapper.readValue("[" + value.toString() + "]", BigDecimal.class);
             fail("Exception was not thrown when attempting to read a single value array of BigDecimal when UNWRAP_SINGLE_VALUE_ARRAYS feature is disabled");
         } catch (MismatchedInputException exp) {
-            verifyException(exp, "Can not deserialize");
+            verifyException(exp, "Cannot deserialize");
             verifyException(exp, "out of START_ARRAY");
         }
         
@@ -313,7 +313,7 @@ public class UnwrapSingleArrayScalarsTest extends BaseMapTest
             mapper.readValue("[" + value.toString() + "]", BigInteger.class);
             fail("Exception was not thrown when attempting to read a single value array of BigInteger when UNWRAP_SINGLE_VALUE_ARRAYS feature is disabled");
         } catch (MismatchedInputException exp) {
-            verifyException(exp, "Can not deserialize");
+            verifyException(exp, "Cannot deserialize");
             verifyException(exp, "out of START_ARRAY");
         }
         

--- a/src/test/java/com/fasterxml/jackson/databind/struct/UnwrappedCreatorParam265Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/UnwrappedCreatorParam265Test.java
@@ -78,7 +78,7 @@ public class UnwrappedCreatorParam265Test extends BaseMapTest
             /*JPersonWithoutName result =*/ mapper.readValue(json, JPersonWithoutName.class);
             fail("Should not pass");
         } catch (InvalidDefinitionException e) {
-            verifyException(e, "Can not define Creator parameter");
+            verifyException(e, "Cannot define Creator parameter");
             verifyException(e, "@JsonUnwrapped");
         }
     }
@@ -94,7 +94,7 @@ public class UnwrappedCreatorParam265Test extends BaseMapTest
             /*JPersonWithName result =*/ mapper.readValue(json, JPersonWithName.class);
             fail("Should not pass");
         } catch (InvalidDefinitionException e) {
-            verifyException(e, "Can not define Creator property \"address\"");
+            verifyException(e, "Cannot define Creator property \"address\"");
             verifyException(e, "@JsonUnwrapped");
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
@@ -83,7 +83,7 @@ public class TestTypeBindings
             TypeBindings.create(AbstractType.class, unknown);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not create TypeBindings");
+            verifyException(e, "Cannot create TypeBindings");
             verifyException(e, "class expects 2");
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
@@ -192,14 +192,14 @@ public class TestTypeFactory
             // Maps must take 2 type parameters, not just one
             tf.constructParametrizedType(Map.class, Map.class, strC);
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not create TypeBindings for class java.util.Map");
+            verifyException(e, "Cannot create TypeBindings for class java.util.Map");
         }
 
         try {
             // Type only accepts one type param
             tf.constructParametrizedType(SingleArgGeneric.class, SingleArgGeneric.class, strC, strC);
         } catch (IllegalArgumentException e) {
-            verifyException(e, "Can not create TypeBindings for class ");
+            verifyException(e, "Cannot create TypeBindings for class ");
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/util/TestStdDateFormat.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/TestStdDateFormat.java
@@ -122,7 +122,7 @@ public class TestStdDateFormat
             f.parse("2015-11-32");
             fail("Should not pass");
         } catch (ParseException e) {
-            verifyException(e, "can not parse date");
+            verifyException(e, "Cannot parse date");
         }
 
         // ... yet, with lenient, do allow
@@ -136,7 +136,7 @@ public class TestStdDateFormat
         try {
             std.parse("foobar");
         } catch (java.text.ParseException e) {
-            verifyException(e, "Can not parse");
+            verifyException(e, "Cannot parse");
         }
     }
 }


### PR DESCRIPTION
Follow up to #1681.

In the error messages, often "can not" is displayed.  Example: 

> no suitable constructor found, can not deserialize from Object value (missing default constructor or creator, or perhaps need to add/enable type information?)

"Can not" is spelled wrong here. Reason: The "not" does not form a part of another construction (such as "not only")

Both "cannot" and "can not" are acceptable spellings, but the first is much more usual. One would use can not when the ‘not’ forms part of another construction such as ‘not only’. For example:

> These green industries can not only create more jobs, but also promote sustainable development of the land.

Source: https://en.oxforddictionaries.com/usage/cannot-or-can-not

This PR fixes in the code.