### PR TITLE
Readded handleInstantiationProblem accepting a null object from a Des…

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -1036,7 +1036,7 @@ public abstract class DeserializationContext
             Object instance = h.value().handleInstantiationProblem(this, instClass, argument, t);
             if (instance != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if (instClass.isInstance(instance)) {
+                if ((instance == null) || instClass.isInstance(instance)) {
                     return instance;
                 }
                 reportBadDefinition(constructType(instClass), String.format(


### PR DESCRIPTION
…erializationProblemHandler

A null object will never be an instance of expected instClass when trying to handle a handleInstantiationProblem. This allows for null to be an acceptable handling of Instantiation.

Revert of small bug from [43fbd718a164be01cb414550050d8d0b9cf1479c](https://github.com/FasterXML/jackson-databind/commit/43fbd718a164be01cb414550050d8d0b9cf1479c)