### PR TITLE
Add Collector implementation for JsonNode streams

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/stream/JacksonCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/stream/JacksonCollector.java
@@ -1,0 +1,60 @@
+package com.fasterxml.jackson.databind.stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * Class that contains collector to work with lists of {@code JsonNode}
+ * in java 8 streams approach.
+ */
+public class JacksonCollector {
+
+    /**
+     * Builds {@code Collector} that is used to collect {@code JsonNode} objects into {@code ArrayNode}
+     *
+     * @return {@code Collector} implementation
+     */
+    public static Collector<JsonNode, ArrayNode, ArrayNode> toJsonList() {
+        return new JsonListCollector();
+    }
+
+    /**
+     * Default collector realization
+     */
+    private static class JsonListCollector implements Collector<JsonNode, ArrayNode, ArrayNode> {
+
+        @Override
+        public Supplier<ArrayNode> supplier() {
+            return new ObjectMapper()::createArrayNode;
+        }
+
+        @Override
+        public BiConsumer<ArrayNode, JsonNode> accumulator() {
+            return ArrayNode::add;
+        }
+
+        @Override
+        public BinaryOperator<ArrayNode> combiner() {
+            return ArrayNode::addAll;
+        }
+
+        @Override
+        public Function<ArrayNode, ArrayNode> finisher() {
+            return accumulator -> accumulator;
+        }
+
+        @Override
+        public Set<Characteristics> characteristics() {
+            return EnumSet.of(Characteristics.UNORDERED);
+        }
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/stream/package-info.java
+++ b/src/main/java/com/fasterxml/jackson/databind/stream/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Contains some helper classes that make integration with Java 8 Stream Api easier.
+ * For now, it contains collector implementation only, however, it will be improved and supplemented in future.
+ */
+package com.fasterxml.jackson.databind.stream;

--- a/src/test/java/com/fasterxml/jackson/databind/stream/StreamCollectorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/stream/StreamCollectorTest.java
@@ -15,6 +15,10 @@ public class StreamCollectorTest extends BaseMapTest {
                 .collect(JacksonCollector.toJsonList());
         assertNotNull(jsonArray);
         assertEquals(0, jsonArray.size());
+        assertEquals(
+                "[]",
+                jsonArray.toString()
+        );
     }
 
     public void testOneElementStream() throws JsonProcessingException {
@@ -23,12 +27,12 @@ public class StreamCollectorTest extends BaseMapTest {
                 objectMapper.valueToTree(new Point(1, 2))
         ).collect(JacksonCollector.toJsonList());
 
+        assertNotNull(jsonArray);
+        assertEquals(1, jsonArray.size());
         assertEquals(
                 "[{\"x\":1,\"y\":2}]",
                 jsonArray.toString()
         );
-        assertNotNull(jsonArray);
-        assertEquals(1, jsonArray.size());
     }
 
     public void testManyElementsStream() {
@@ -39,11 +43,11 @@ public class StreamCollectorTest extends BaseMapTest {
                 objectMapper.valueToTree(new Point(5, 6))
         ).collect(JacksonCollector.toJsonList());
 
+        assertNotNull(jsonArray);
+        assertEquals(3, jsonArray.size());
         assertEquals(
                 "[{\"x\":1,\"y\":2},{\"x\":3,\"y\":4},{\"x\":5,\"y\":6}]",
                 jsonArray.toString()
         );
-        assertNotNull(jsonArray);
-        assertEquals(3, jsonArray.size());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/stream/StreamCollectorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/stream/StreamCollectorTest.java
@@ -1,0 +1,49 @@
+package com.fasterxml.jackson.databind.stream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.util.stream.Stream;
+
+public class StreamCollectorTest extends BaseMapTest {
+
+    public void testEmpty() {
+        final ArrayNode jsonArray = Stream.<JsonNode>empty()
+                .collect(JacksonCollector.toJsonList());
+        assertNotNull(jsonArray);
+        assertEquals(0, jsonArray.size());
+    }
+
+    public void testOneElementStream() throws JsonProcessingException {
+        final ObjectMapper objectMapper = objectMapper();
+        final ArrayNode jsonArray = Stream.<JsonNode>of(
+                objectMapper.valueToTree(new Point(1, 2))
+        ).collect(JacksonCollector.toJsonList());
+
+        assertEquals(
+                "[{\"x\":1,\"y\":2}]",
+                jsonArray.toString()
+        );
+        assertNotNull(jsonArray);
+        assertEquals(1, jsonArray.size());
+    }
+
+    public void testManyElementsStream() {
+        final ObjectMapper objectMapper = objectMapper();
+        final ArrayNode jsonArray = Stream.<JsonNode>of(
+                objectMapper.valueToTree(new Point(1, 2)),
+                objectMapper.valueToTree(new Point(3, 4)),
+                objectMapper.valueToTree(new Point(5, 6))
+        ).collect(JacksonCollector.toJsonList());
+
+        assertEquals(
+                "[{\"x\":1,\"y\":2},{\"x\":3,\"y\":4},{\"x\":5,\"y\":6}]",
+                jsonArray.toString()
+        );
+        assertNotNull(jsonArray);
+        assertEquals(3, jsonArray.size());
+    }
+}


### PR DESCRIPTION
Collectors are useful in cases when we have arrays, collections or streams of JsonNode objects separated and we need to collect them to ArrayNode.
Example:
`final ArrayNode jsonArray = Stream.<JsonNode>of(
                node1,
                node2,
                node3
        ).collect(JacksonCollector.toJsonList());` 

where node1, node2 and node3 are instances of JsonNode class.
So, this collector can simplify code in such cases.

However, this features need java 8 or above version