### PR TITLE
Fix Javadoc of ArrayNode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ArrayNode.java
@@ -353,8 +353,8 @@ public class ArrayNode
      */
 
     /**
-     * Method that will construct an ArrayNode and add it as a
-     * field of this ObjectNode, replacing old value, if any.
+     * Method that will construct an ArrayNode and add it at the end
+     * of this array node.
      *
      * @return Newly constructed ArrayNode
      */


### PR DESCRIPTION
The current Javadoc of addArray() method of ArrayNode.java looks inappropriate. I think addArray() method adds a newly created ArrayNode at the end of a caller ArrayNode object as addObject() method does. 