### PR TITLE
Reintroduce Annotated.annotations() method as deprecated

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/Annotated.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/Annotated.java
@@ -76,6 +76,16 @@ public abstract class Annotated
      */
     public abstract Class<?> getRawType();
 
+    /**
+     * Accessor that can be used to iterate over all the annotations
+     * associated with annotated component.
+     *
+     * @since 2.3
+     * @deprecated Since 2.9 should instead use {@link #getAnnotated()}
+     */
+    @Deprecated
+    public abstract Iterable<Annotation> annotations();
+
     // Also: ensure we can use #equals, #hashCode
     
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedClass.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedClass.java
@@ -248,6 +248,18 @@ public final class AnnotatedClass
     }
 
     @Override
+    @Deprecated
+    public Iterable<Annotation> annotations() {
+        if (_classAnnotations instanceof AnnotationMap) {
+            return ((AnnotationMap) _classAnnotations).annotations();
+        } else if (_classAnnotations instanceof AnnotationCollector.OneAnnotation ||
+           _classAnnotations instanceof AnnotationCollector.TwoAnnotations) {
+            throw new UnsupportedOperationException("please use getAnnotations/ hasAnnotation to check for Annotations");
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
     public JavaType getType() {
         return _type;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMember.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMember.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.introspect;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
+import java.util.Collections;
 
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
@@ -101,6 +102,15 @@ public abstract class AnnotatedMember
             return false;
         }
         return _annotations.hasOneOf(annoClasses);
+    }
+
+    @Override
+    @Deprecated
+    public Iterable<Annotation> annotations() {
+        if (_annotations == null) {
+            return Collections.emptyList();
+        }
+        return _annotations.annotations();
     }
 
     /**


### PR DESCRIPTION
Please reintroduce the method as deprecated for 2.9.1 as discussed in https://github.com/FasterXML/jackson-databind/commit/bf451c0ecd5f68047ef85d9347d9ed92a840c7cf

Currently lots of people are in JAR hell, see comments in https://github.com/swagger-api/swagger-core/pull/2342