### PR TITLE
Allow `DeserializationProblemHandler` to respond to primitive types

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -854,7 +854,7 @@ public abstract class DeserializationContext
             Object key = h.value().handleWeirdKey(this, keyClass, keyValue, msg);
             if (key != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if ((key == null) || keyClass.isInstance(key)) {
+                if (isHandleSane(keyClass, key)) {
                     return key;
                 }
                 throw weirdStringException(keyValue, keyClass, String.format(
@@ -898,7 +898,7 @@ public abstract class DeserializationContext
             Object instance = h.value().handleWeirdStringValue(this, targetClass, value, msg);
             if (instance != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if ((instance == null) || targetClass.isInstance(instance)) {
+                if (isHandleSane(targetClass, instance)) {
                     return instance;
                 }
                 throw weirdStringException(value, targetClass, String.format(
@@ -941,7 +941,7 @@ public abstract class DeserializationContext
             Object key = h.value().handleWeirdNumberValue(this, targetClass, value, msg);
             if (key != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if ((key == null) || targetClass.isInstance(key)) {
+                if (isHandleSane(targetClass, key)) {
                     return key;
                 }
                 throw weirdNumberException(value, targetClass, _format(
@@ -964,7 +964,7 @@ public abstract class DeserializationContext
             Object goodValue = h.value().handleWeirdNativeValue(this, targetType, badValue, p);
             if (goodValue != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if ((goodValue == null) || raw.isInstance(goodValue)) {
+                if (isHandleSane(raw, goodValue)) {
                     return goodValue;
                 }
                 throw JsonMappingException.from(p, _format(
@@ -1008,7 +1008,7 @@ targetType, goodValue.getClass()));
                     instClass, valueInst, p, msg);
             if (instance != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if ((instance == null) || instClass.isInstance(instance)) {
+                if (isHandleSane(instClass, instance)) {
                     return instance;
                 }
                 reportBadDefinition(constructType(instClass), String.format(
@@ -1058,7 +1058,7 @@ targetType, goodValue.getClass()));
             Object instance = h.value().handleInstantiationProblem(this, instClass, argument, t);
             if (instance != DeserializationProblemHandler.NOT_HANDLED) {
                 // Sanity check for broken handlers, otherwise nasty to debug:
-                if ((instance == null) || instClass.isInstance(instance)) {
+                if (isHandleSane(instClass, instance)) {
                     return instance;
                 }
                 reportBadDefinition(constructType(instClass), String.format(
@@ -1117,7 +1117,7 @@ targetType, goodValue.getClass()));
             Object instance = h.value().handleUnexpectedToken(this,
                     instClass, t, p, msg);
             if (instance != DeserializationProblemHandler.NOT_HANDLED) {
-                if ((instance == null) || instClass.isInstance(instance)) {
+                if (isHandleSane(instClass, instance)) {
                     return instance;
                 }
                 reportBadDefinition(constructType(instClass), String.format(
@@ -1589,4 +1589,20 @@ trailingToken, ClassUtil.nameOf(targetType)
         _dateFormat = df = (DateFormat) df.clone();
         return df;
     }
+
+    private boolean isHandleSane(Class<?> targetClass, Object instance) {
+        return (instance == null) || targetClass.isInstance(instance) || isWrapper(targetClass, instance.getClass());
+    }
+
+    private boolean isWrapper(Class<?> targetClass, Class<?> instanceClass) {
+        return targetClass == Byte.TYPE && instanceClass == Byte.class
+                || targetClass == Short.TYPE && instanceClass == Short.class
+                || targetClass == Integer.TYPE && instanceClass == Integer.class
+                || targetClass == Long.TYPE && instanceClass == Long.class
+                || targetClass == Float.TYPE && instanceClass == Float.class
+                || targetClass == Double.TYPE && instanceClass == Double.class
+                || targetClass == Character.TYPE && instanceClass == Character.class
+                || targetClass == Boolean.TYPE && instanceClass == Boolean.class;
+    }
+
 }


### PR DESCRIPTION
When registering a DeserializationProblemHandler, one is allowed to override its methods to return a converted value. 

DeserializationContext has a sanity check in case the problem handler returns an Object that is not assignable to the property that is currently being parsed.

However for properties that rely on primitive types, this sanity check will always fail due to autoboxing. 

(As a side note: Some upper code swallows the generated exception by this check, so the user only sees the original problem that caused the Problem Handler to be invoked in the first place even though the sanity check builds and throws a proper exception) 

This PR add an extra comparison for primitive type (against their wrapped versions) while moving the sanity check into its own method.

Please let me know if I'm missing anything!
Thank you