### PR TITLE
Return `ObjectNode` from `ObjectNode` set-methods in order to allow better chaining

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -354,7 +354,7 @@ public class ObjectNode
      *
      * @since 2.1
      */
-    public JsonNode set(String fieldName, JsonNode value)
+    public ObjectNode set(String fieldName, JsonNode value)
     {
         if (value == null) {
             value = nullNode();
@@ -373,7 +373,7 @@ public class ObjectNode
      *
      * @since 2.1
      */
-    public JsonNode setAll(Map<String,? extends JsonNode> properties)
+    public ObjectNode setAll(Map<String,? extends JsonNode> properties)
     {
         for (Map.Entry<String,? extends JsonNode> en : properties.entrySet()) {
             JsonNode n = en.getValue();
@@ -395,7 +395,7 @@ public class ObjectNode
      *
      * @since 2.1
      */
-    public JsonNode setAll(ObjectNode other)
+    public ObjectNode setAll(ObjectNode other)
     {
         _children.putAll(other._children);
         return this;


### PR DESCRIPTION
A minor improvement for the API: When returning ObjectNode instead of JsonNode one can chain after calling `set` and `setAll` (with no downside that's obvious for me).

Without this, it's necessary to cast the resulting `JsonNode` to `ObjectNode` (which always works).

Greetings!