### PR TITLE
Fix #1604 for 2.8.11

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/type/NestedTypes1604Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/NestedTypes1604Test.java
@@ -1,0 +1,84 @@
+package com.fasterxml.jackson.databind.type;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.*;
+
+// for [databind#1604]
+public class NestedTypes1604Test extends BaseMapTest {
+    public static class Data<T> {
+        private T data;
+
+        public Data(T data) {
+            this.data = data;
+        }
+
+        public T getData() {
+            return data;
+        }
+
+        public static <T> Data<List<T>> of(List<T> data) {
+            return new DataList<>(data);
+        }
+    }
+
+    public static class DataList<T> extends Data<List<T>> {
+        public DataList(List<T> data) {
+            super(data);
+        }
+    }
+
+    public static class Inner {
+        private int index;
+
+        public Inner(int index) {
+            this.index = index;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+    }
+
+    public static class BadOuter {
+        private Data<List<Inner>> inner;
+
+        public BadOuter(Data<List<Inner>> inner) {
+            this.inner = inner;
+        }
+
+        public Data<List<Inner>> getInner() {
+            return inner;
+        }
+    }
+
+    public static class GoodOuter {
+        private DataList<Inner> inner;
+
+        public GoodOuter(DataList<Inner> inner) {
+            this.inner = inner;
+        }
+
+        public DataList<Inner> getInner() {
+            return inner;
+        }
+    }
+
+    public void testIssue1604() throws Exception {
+        final ObjectMapper objectMapper = objectMapper();
+        List<Inner> inners = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            inners.add(new Inner(i));
+        }
+        String expectedJson = aposToQuotes("{'inner':{'data':[{'index':0},{'index':1}]}}");
+        assertEquals(
+            expectedJson,
+            objectMapper.writeValueAsString(new GoodOuter(new DataList<>(inners)))
+        );
+        assertEquals(
+            expectedJson,
+            objectMapper.writeValueAsString(new BadOuter(Data.of(inners)))
+        );
+    }
+}


### PR DESCRIPTION
@cowtowncoder Here's my proposed fix for #1604.  I have, selfishly, targeted the 2.8 maintenance branch, hoping to get this into a 2.8.11 release (that appears to be the next 2.8.x version given the tag sequence).

The more I thought about this, the more I came to believe that your concern about loss of type binding information isn't warranted.  I say that b/c I think when sub-types constrain the type parameterization of their super-types _via_ their inheritance specification, the type information is intrinsic to the class itself, and generic type bindings aren't necessary to build full-fidelity serialization configuration.

I eliminated a bit of inlining for code clarity (the arg count 1 & 2 special branches to avoid the array allocation).  I was careful to adapt the new code to the `TypeBindings.create()` overloads' affinity towards arrays, so hopefully that offsets the hand-optimization removal ;) 

I moved the failing test you had already seeded in the 2.9 codebase over into the `type` package, updated it to assert the expected JSON, and adapted it to the 2.8.x `objectMapper()` accessor in the base test class.

Thoughts?  Any test cases missing?  