### PR TITLE
ClassNameIdResolver doesn't handle resolve Collections$SingletonMap & Collections$SingletonSet

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolver.java
@@ -61,7 +61,7 @@ public class ClassNameIdResolver
     /**********************************************************
      */
 
-    protected final String _idFrom(Object value, Class<?> cls, TypeFactory typeFactory)
+    protected String _idFrom(Object value, Class<?> cls, TypeFactory typeFactory)
     {
         // Need to ensure that "enum subtypes" work too
         if (Enum.class.isAssignableFrom(cls)) {
@@ -87,16 +87,18 @@ public class ClassNameIdResolver
                 // not optimal: but EnumMap is not a customizable type so this is sort of ok
                 str = typeFactory.constructMapType(EnumMap.class, enumClass, valueClass).toCanonical();
             } else {
-                String end = str.substring(9);
-                if ((end.startsWith(".Arrays$") || end.startsWith(".Collections$"))
-                       && str.indexOf("List") >= 0) {
-                    /* 17-Feb-2010, tatus: Another such case: result of
-                     *    Arrays.asList() is named like so in Sun JDK...
-                     *   Let's just plain old ArrayList in its place
-                     * NOTE: chances are there are plenty of similar cases
-                     * for other wrappers... (immutable, singleton, synced etc)
-                     */
+                /* 17-Feb-2010, tatus: Another such case: result of
+                 *    Arrays.asList() is named like so in Sun JDK...
+                 *   Let's just plain old ArrayList in its place
+                 * NOTE: chances are there are plenty of similar cases
+                 * for other wrappers... (immutable, singleton, synced etc)
+                 */
+                if (isJavaUtilCollectionClass(str, "List")) {
                     str = "java.util.ArrayList";
+                }else if(isJavaUtilCollectionClass(str, "Map")){
+                    str = "java.util.HashMap";
+                }else if(isJavaUtilCollectionClass(str, "Set")){
+                    str = "java.util.HashSet";
                 }
             }
         } else if (str.indexOf('$') >= 0) {
@@ -127,5 +129,10 @@ public class ClassNameIdResolver
     @Override
     public String getDescForKnownTypeIds() {
         return "class name used as type id";
+    }
+    
+    private static boolean isJavaUtilCollectionClass(String clazzName, String type){
+        String end = clazzName.substring(9);
+        return (end.startsWith(".Collections$") || end.startsWith(".Arrays$")) && clazzName.indexOf(type) > 0;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolverTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolverTest.java
@@ -1,0 +1,74 @@
+package com.fasterxml.jackson.databind.jsontype.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import com.fasterxml.jackson.databind.JavaType;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(TypeFactory.class)
+public class ClassNameIdResolverTest {
+
+    @Mock
+    private JavaType javaType;
+    
+    @Mock
+    private TypeFactory typeFactory;
+    
+    
+    private ClassNameIdResolver classNameIdResolver;
+    
+    @Before
+    public void setup(){
+        this.classNameIdResolver = new ClassNameIdResolver(javaType, typeFactory);
+    }
+    
+    @Test
+    public void testIdFromValue_shouldUseJavaUtilHashMapForSingletonMap(){
+        Map<String, String> utilMap = Collections.singletonMap("ANY_KEY", "ANY_VALUE");
+        
+        String clazz = classNameIdResolver.idFromValue( utilMap );
+        
+        assertEquals(clazz, "java.util.HashMap");
+    }
+    
+    @Test
+    public void testIdFromValue_shouldUseJavaUtilHashSetForSingletonSet(){
+        Set<String> utilSet = Collections.singleton("ANY_VALUE");
+        
+        String clazz = classNameIdResolver.idFromValue( utilSet );
+        
+        assertEquals(clazz, "java.util.HashSet");
+    }
+    
+    @Test
+    public void testIdFromValue_shouldUseJavaUtilArrayListSetForSingletonSet(){
+        List<String> utilList = Collections.singletonList("ANY_VALUE");
+        
+        String clazz = classNameIdResolver.idFromValue( utilList );
+        
+        assertEquals(clazz, "java.util.ArrayList");
+    }
+    
+    @Test
+    public void testIdFromValue_shouldUseJavaUtilArrayListSetForArraysList(){
+        List<String> utilList = Arrays.asList("ANY_VALUE");
+        
+        String clazz = classNameIdResolver.idFromValue( utilList );
+        
+        assertEquals(clazz, "java.util.ArrayList");
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolverTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/impl/ClassNameIdResolverTest.java
@@ -38,33 +38,33 @@ public class ClassNameIdResolverTest {
     
     @Test
     public void testIdFromValue_shouldUseJavaUtilHashMapForSingletonMap(){
-        Map<String, String> utilMap = Collections.singletonMap("ANY_KEY", "ANY_VALUE");
+        Map<String, String> singletonMap = Collections.singletonMap("ANY_KEY", "ANY_VALUE");
         
-        String clazz = classNameIdResolver.idFromValue( utilMap );
+        String clazz = classNameIdResolver.idFromValue( singletonMap );
         
         assertEquals(clazz, "java.util.HashMap");
     }
     
     @Test
     public void testIdFromValue_shouldUseJavaUtilHashSetForSingletonSet(){
-        Set<String> utilSet = Collections.singleton("ANY_VALUE");
+        Set<String> singletonSet = Collections.singleton("ANY_VALUE");
         
-        String clazz = classNameIdResolver.idFromValue( utilSet );
+        String clazz = classNameIdResolver.idFromValue( singletonSet );
         
         assertEquals(clazz, "java.util.HashSet");
     }
     
     @Test
-    public void testIdFromValue_shouldUseJavaUtilArrayListSetForSingletonSet(){
-        List<String> utilList = Collections.singletonList("ANY_VALUE");
+    public void testIdFromValue_shouldUseJavaUtilArrayListForSingletonList(){
+        List<String> singletonList = Collections.singletonList("ANY_VALUE");
         
-        String clazz = classNameIdResolver.idFromValue( utilList );
+        String clazz = classNameIdResolver.idFromValue( singletonList );
         
         assertEquals(clazz, "java.util.ArrayList");
     }
     
     @Test
-    public void testIdFromValue_shouldUseJavaUtilArrayListSetForArraysList(){
+    public void testIdFromValue_shouldUseJavaUtilArrayListForArrays$List(){
         List<String> utilList = Arrays.asList("ANY_VALUE");
         
         String clazz = classNameIdResolver.idFromValue( utilList );


### PR DESCRIPTION
The current implementation of `ClassNameIdResolver` doesn't handle `java.util.Collections$SingletonMap` neither `java.util.Collections$SingletonSet` due to this deserialization of these classes fails with an error _Cannot construct instance of `java.util.Collections$SingletonMap` (no Creators, like default construct, exist)_

This is due to that an object is serialized as:

```
{"@class":"java.util.Collections$SingletonMap","x":"Y"}
```
This pull request added support for 

- `java.util.Collections$SingletonSet`
- `java.util.Collections$SingletonMap`

`java.util.Collections$SingletonList` was already supported. Also not quite sure why was used *protected final* modifier  `protected final String _idFrom(..)` I would keep an option to override this method otherwise is quite difficult fix/adapt a behavior of this class.  