### PR TITLE
Rewrite `BeanPropertyMap` to work with `FieldNameMatcher`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonDeserializer.java
@@ -169,7 +169,8 @@ public abstract class JsonDeserializer<T>
      * Default implementation just returns 'this'
      * indicating that no unwrapped variant exists
      */
-    public JsonDeserializer<T> unwrappingDeserializer(NameTransformer unwrapper) {
+    public JsonDeserializer<T> unwrappingDeserializer(DeserializationContext ctxt,
+            NameTransformer unwrapper) {
         return this;
     }
 
@@ -259,9 +260,8 @@ public abstract class JsonDeserializer<T>
      * Java null, but for some types (especially primitives) it may be
      * necessary to use non-null values.
      *<p>
-     * Since version 2.6 (in which the context argument was added), call is
-     * expected to be made each and every time a null token needs to
-     * be handled.
+     * Call is expected to be made each and every time a null token
+     * needs to be handled.
      *<p>
      * Default implementation simply returns null.
      */

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.util.InternCache;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.FullyNamed;
 
 /**
  * Simple value class used for containing names of properties as defined
  * by annotations (and possibly other configuration sources).
- * 
- * @since 2.1
  */
 public class PropertyName
-    implements java.io.Serializable
+    implements FullyNamed,
+        java.io.Serializable
 {
     private static final long serialVersionUID = 1L; // 2.5
 
@@ -52,8 +52,6 @@ public class PropertyName
      * NOTE: not defined as volatile to avoid performance problem with
      * concurrent access in multi-core environments; due to statelessness
      * of {@link SerializedString} at most leads to multiple instantiations.
-     * 
-     * @since 2.4
      */
     protected SerializableString _encodedSimple;
     
@@ -84,9 +82,6 @@ public class PropertyName
         return this;
     }
 
-    /**
-     * @since 2.6
-     */
     public static PropertyName construct(String simpleName)
     {
         if (simpleName == null || simpleName.length() == 0) {
@@ -150,6 +145,22 @@ public class PropertyName
     
     /*
     /**********************************************************
+    /* FullyNamed impl
+    /**********************************************************
+     */
+
+    @Override
+    public String getName() {
+        return _simpleName;
+    }
+
+    @Override
+    public PropertyName getFullName() {
+        return this;
+    }
+
+    /*
+    /**********************************************************
     /* Accessors
     /**********************************************************
      */
@@ -161,8 +172,6 @@ public class PropertyName
     /**
      * Accessor that may be used to get lazily-constructed efficient
      * representation of the simple name.
-     * 
-     * @since 2.4
      */
     public SerializableString simpleAsEncoded(MapperConfig<?> config) {
         SerializableString sstr = _encodedSimple;

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
@@ -34,7 +34,9 @@ public class PropertyName
      * commonly this value disables behavior for which name would be needed.
      */
     public final static PropertyName NO_NAME = new PropertyName(new String(_NO_NAME), null);
-    
+
+    private final static InternCache INTERNER = InternCache.instance;
+
     /**
      * Basic name of the property.
      */
@@ -87,7 +89,7 @@ public class PropertyName
         if (simpleName == null || simpleName.length() == 0) {
             return USE_DEFAULT;
         }
-        return new PropertyName(InternCache.instance.intern(simpleName), null);
+        return new PropertyName(INTERNER.intern(simpleName), null);
     }
 
     public static PropertyName construct(String simpleName, String ns)
@@ -98,7 +100,7 @@ public class PropertyName
         if (ns == null && simpleName.length() == 0) {
             return USE_DEFAULT;
         }
-        return new PropertyName(InternCache.instance.intern(simpleName), ns);
+        return new PropertyName(INTERNER.intern(simpleName), ns);
     }
 
     public PropertyName internSimpleName()

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -126,8 +126,7 @@ public class BeanDeserializer
 
     @Override
     protected BeanDeserializerBase asArrayDeserializer() {
-        SettableBeanProperty[] props = _beanProperties.getPropertiesInInsertionOrder();
-        return new BeanAsArrayDeserializer(this, props);
+        return new BeanAsArrayDeserializer(this, _beanProperties.getPrimaryProperties());
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -301,8 +301,7 @@ public class BeanDeserializer
      * features are enabled, and when current logical token
      * is {@link JsonToken#START_OBJECT} (or equivalent).
      */
-    private final Object _vanillaDeserialize(JsonParser p,
-            DeserializationContext ctxt)
+    private final Object _vanillaDeserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException
     {
         final Object bean = _valueInstantiator.createUsingDefault(ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -280,7 +280,6 @@ public class BeanDeserializer
             }
             ix = p.nextFieldName(_fieldMatcher);
         }
-        // Should we verify there's END_OBJECT there?
         if (ix != FieldNameMatcher.MATCH_END_OBJECT) {
             if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
                 return _vanillaDeserializeWithUnknown(p, ctxt, bean,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -868,7 +868,7 @@ public class BeanDeserializer
             }
             final String propName = p.currentName();
             p.nextToken();
-            if (_ignorableProps != null && _ignorableProps.contains(propName)) {
+            if ((_ignorableProps != null) && _ignorableProps.contains(propName)) {
                 handleIgnoredProperty(p, ctxt, bean, propName);
                 continue;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -276,19 +276,8 @@ public class BeanDeserializer
         // [databind#631]: Assign current value, to be accessible by custom serializers
         p.setCurrentValue(bean);
 
-        while (true) {
-            int ix = p.nextFieldName(_fieldMatcher);
-            if (ix < 0) {
-                if (ix == FieldNameMatcher.MATCH_END_OBJECT) {
-                    return bean;
-                }
-                if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
-                    p.nextToken();
-                    return _vanillaDeserializeWithUnknown(p, ctxt, bean,
-                            p.getCurrentName());
-                }
-                break;
-            }
+        int ix = p.nextFieldName(_fieldMatcher);
+        while (ix >= 0) {
             p.nextToken();
             SettableBeanProperty prop = _fieldsByIndex[ix];
             try {
@@ -299,14 +288,6 @@ public class BeanDeserializer
             // Elem #2
             ix = p.nextFieldName(_fieldMatcher);
             if (ix < 0) {
-                if (ix == FieldNameMatcher.MATCH_END_OBJECT) {
-                    return bean;
-                }
-                if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
-                    p.nextToken();
-                    return _vanillaDeserializeWithUnknown(p, ctxt, bean,
-                            p.getCurrentName());
-                }
                 break;
             }
             p.nextToken();
@@ -319,14 +300,6 @@ public class BeanDeserializer
             // Elem #3
             ix = p.nextFieldName(_fieldMatcher);
             if (ix < 0) {
-                if (ix == FieldNameMatcher.MATCH_END_OBJECT) {
-                    return bean;
-                }
-                if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
-                    p.nextToken();
-                    return _vanillaDeserializeWithUnknown(p, ctxt, bean,
-                            p.getCurrentName());
-                }
                 break;
             }
             p.nextToken();
@@ -339,14 +312,6 @@ public class BeanDeserializer
             // Elem #4
             ix = p.nextFieldName(_fieldMatcher);
             if (ix < 0) {
-                if (ix == FieldNameMatcher.MATCH_END_OBJECT) {
-                    return bean;
-                }
-                if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
-                    p.nextToken();
-                    return _vanillaDeserializeWithUnknown(p, ctxt, bean,
-                            p.getCurrentName());
-                }
                 break;
             }
             p.nextToken();
@@ -356,6 +321,15 @@ public class BeanDeserializer
             } catch (Exception e) {
                 wrapAndThrow(e, bean, prop.getName(), ctxt);
             }
+            ix = p.nextFieldName(_fieldMatcher);
+        }
+        if (ix != FieldNameMatcher.MATCH_END_OBJECT) {
+            if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
+                p.nextToken();
+                return _vanillaDeserializeWithUnknown(p, ctxt, bean,
+                        p.getCurrentName());
+            }
+            return ctxt.handleUnexpectedToken(handledType(), p);
         }
         return bean;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -290,7 +290,6 @@ public class BeanDeserializer
             } catch (Exception e) {
                 wrapAndThrow(e, bean, prop.getName(), ctxt);
             }
-/*
             // Elem #2
             ix = p.nextFieldName(_fieldMatcher);
             if (ix < 0) {
@@ -311,7 +310,46 @@ public class BeanDeserializer
             } catch (Exception e) {
                 wrapAndThrow(e, bean, prop.getName(), ctxt);
             }
-*/
+            // Elem #3
+            ix = p.nextFieldName(_fieldMatcher);
+            if (ix < 0) {
+                if (ix == FieldNameMatcher.MATCH_END_OBJECT) {
+                    return bean;
+                }
+                if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
+                    p.nextToken();
+                    return _vanillaDeserializeWithUnknown(p, ctxt, bean,
+                            p.getCurrentName());
+                }
+                break;
+            }
+            p.nextToken();
+            prop = _fieldsByIndex[ix];
+            try {
+                prop.deserializeAndSet(p, ctxt, bean);
+            } catch (Exception e) {
+                wrapAndThrow(e, bean, prop.getName(), ctxt);
+            }
+            // Elem #4
+            ix = p.nextFieldName(_fieldMatcher);
+            if (ix < 0) {
+                if (ix == FieldNameMatcher.MATCH_END_OBJECT) {
+                    return bean;
+                }
+                if (ix == FieldNameMatcher.MATCH_UNKNOWN_NAME) {
+                    p.nextToken();
+                    return _vanillaDeserializeWithUnknown(p, ctxt, bean,
+                            p.getCurrentName());
+                }
+                break;
+            }
+            p.nextToken();
+            prop = _fieldsByIndex[ix];
+            try {
+                prop.deserializeAndSet(p, ctxt, bean);
+            } catch (Exception e) {
+                wrapAndThrow(e, bean, prop.getName(), ctxt);
+            }
         }
         return bean;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -85,8 +85,9 @@ public class BeanDeserializer
     }
 
     protected BeanDeserializer(BeanDeserializer src,
-            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties) {
-        super(src, unwrapHandler, renamedProperties);
+            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties,
+            boolean ignoreAllUnknown) {
+        super(src, unwrapHandler, renamedProperties, ignoreAllUnknown);
         _fieldMatcher = _beanProperties.getFieldMatcher();
         _fieldsByIndex = _beanProperties.getFieldMatcherProperties();
     }
@@ -138,7 +139,7 @@ public class BeanDeserializer
             }
             // and handle direct unwrapping as well:
             return new BeanDeserializer(this, uwHandler,
-                    _beanProperties.renameAll(ctxt, transformer));
+                    _beanProperties.renameAll(ctxt, transformer), true);
         } finally { _currentlyTransforming = null; }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -155,7 +155,6 @@ public class BeanDeserializer
 
     @Override
     protected void initFieldMatcher(DeserializationContext ctxt) {
-        _beanProperties.init();
         _fieldMatcher = _beanProperties.constructMatcher(ctxt.getParserFactory());
         _fieldsByIndex = _beanProperties.getPropertiesWithAliases();
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -236,7 +236,7 @@ public class BeanDeserializer
         }
         do {
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
 
             if (prop != null) { // normal case
                 try {
@@ -369,9 +369,9 @@ public class BeanDeserializer
             String propName = p.getCurrentName();
             do { // minor unrolling here (by-2), less likely on critical path
                 p.nextToken();
-                SettableBeanProperty prop = _beanProperties.find(propName);
+                SettableBeanProperty prop;
                 
-                if ((prop = _beanProperties.find(propName)) == null) {
+                if ((prop = _findProperty(propName)) == null) {
                     handleUnknownVanilla(p, ctxt, bean, propName);
                 } else {
                     try {
@@ -383,7 +383,7 @@ public class BeanDeserializer
 
                 if ((propName = p.nextFieldName()) == null) break;
                 p.nextToken();
-                if ((prop = _beanProperties.find(propName)) == null) {
+                if ((prop = _findProperty(propName)) == null) {
                     handleUnknownVanilla(p, ctxt, bean, propName);
                 } else {
                     try {
@@ -403,7 +403,7 @@ public class BeanDeserializer
         handleUnknownVanilla(p, ctxt, bean, propName);
         while ((propName = p.nextFieldName()) != null) {
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop == null) {
                 handleUnknownVanilla(p, ctxt, bean, propName);
                 continue;
@@ -482,7 +482,7 @@ public class BeanDeserializer
             String propName = p.getCurrentName();
             do {
                 p.nextToken();
-                SettableBeanProperty prop = _beanProperties.find(propName);
+                SettableBeanProperty prop = _findProperty(propName);
                 if (prop != null) { // normal case
                     try {
                         prop.deserializeAndSet(p, ctxt, bean);
@@ -562,7 +562,7 @@ public class BeanDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) {
                 try {
                     buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
@@ -694,7 +694,7 @@ public class BeanDeserializer
             do {
                 p.nextToken();
                 // TODO: 06-Jan-2015, tatu: try streamlining call sequences here as well
-                SettableBeanProperty prop = _beanProperties.find(propName);
+                SettableBeanProperty prop = _findProperty(propName);
                 if (prop != null) {
                     if (!prop.visibleInView(activeView)) {
                         p.skipChildren();
@@ -748,7 +748,7 @@ public class BeanDeserializer
 
         for (; propName != null; propName = p.nextFieldName()) {
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) { // normal case
                 if ((activeView != null) && !prop.visibleInView(activeView)) {
                     p.skipChildren();
@@ -805,7 +805,7 @@ public class BeanDeserializer
         final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
         for (; t == JsonToken.FIELD_NAME; t = p.nextToken()) {
             String propName = p.getCurrentName();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             p.nextToken();
             if (prop != null) { // normal case
                 if (activeView != null && !prop.visibleInView(activeView)) {
@@ -905,7 +905,7 @@ public class BeanDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) {
                 buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
                 continue;
@@ -985,7 +985,7 @@ public class BeanDeserializer
         for (JsonToken t = p.currentToken(); t == JsonToken.FIELD_NAME; t = p.nextToken()) {
             String propName = p.getCurrentName();
             t = p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) { // normal case
                 // [JACKSON-831]: may have property AND be used as external type id:
                 if (t.isScalarValue()) {
@@ -1083,7 +1083,7 @@ public class BeanDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) {
                 buffer.bufferProperty(prop, prop.deserialize(p, ctxt));
                 continue;
@@ -1112,11 +1112,14 @@ public class BeanDeserializer
         }
     }
 
+    // @since 3.0
+    protected final SettableBeanProperty _findProperty(String propName) {
+        return _beanProperties.find(propName);
+    }
+    
     /**
      * Helper method for getting a lazily construct exception to be reported
      * to {@link DeserializationContext#handleInstantiationProblem(Class, Object, Throwable)}.
-     *
-     * @since 2.8
      */
     protected Exception _creatorReturnedNullException() {
         if (_nullFromCreator == null) {
@@ -1125,9 +1128,6 @@ public class BeanDeserializer
         return _nullFromCreator;
     }
 
-    /**
-     * @since 2.8
-     */
     static class BeanReferring extends Referring
     {
         private final DeserializationContext _context;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -595,8 +595,9 @@ public class BeanDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _findProperty(propName);
-            if (prop != null) {
+            int ix = _fieldMatcher.matchAnyName(propName);
+            if (ix >= 0) {
+                SettableBeanProperty prop = _fieldsByIndex[ix];
                 try {
                     buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
                 } catch (UnresolvedForwardReference reference) {
@@ -941,8 +942,9 @@ public class BeanDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _findProperty(propName);
-            if (prop != null) {
+            int ix = _fieldMatcher.matchAnyName(propName);
+            if (ix >= 0) {
+                SettableBeanProperty prop = _fieldsByIndex[ix];
                 buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
                 continue;
             }
@@ -1126,8 +1128,9 @@ public class BeanDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _findProperty(propName);
-            if (prop != null) {
+            int ix = _fieldMatcher.matchAnyName(propName);
+            if (ix >= 0) {
+                SettableBeanProperty prop = _fieldsByIndex[ix];
                 buffer.bufferProperty(prop, prop.deserialize(p, ctxt));
                 continue;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -1047,7 +1047,7 @@ public class BeanDeserializer
                 try {
                     prop.deserializeAndSet(p, ctxt, bean);
                 } catch (Exception e) {
-                    wrapAndThrow(e, bean, p.currentName(), ctxt);
+                    wrapAndThrow(e, bean, prop.getName(), ctxt);
                 }
                 continue;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -571,7 +571,7 @@ public abstract class BeanDeserializerBase
     protected void _replaceProperty(BeanPropertyMap props, SettableBeanProperty[] creatorProps,
             SettableBeanProperty origProp, SettableBeanProperty newProp)
     {
-        props.replace(newProp);
+        props.replace(origProp, newProp);
         // [databind#795]: Make sure PropertyBasedCreator's properties stay in sync
         if (creatorProps != null) {
             // 18-May-2015, tatu: _Should_ start with consistent set. But can we really

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -953,7 +953,7 @@ public abstract class BeanDeserializerBase
     }
     
     public boolean hasProperty(String propertyName) {
-        return _beanProperties.findPrimaryDefinition(propertyName) != null;
+        return _beanProperties.findDefinition(propertyName) != null;
     }
 
     public boolean hasViews() {
@@ -1021,7 +1021,7 @@ public abstract class BeanDeserializerBase
     protected SettableBeanProperty findProperty(String propertyName)
     {
         SettableBeanProperty prop = (_beanProperties == null) ?
-                null : _beanProperties.findPrimaryDefinition(propertyName);
+                null : _beanProperties.findDefinition(propertyName);
         if (_neitherNull(prop, _propertyBasedCreator)) {
             prop = _propertyBasedCreator.findCreatorProperty(propertyName);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -485,7 +485,7 @@ public abstract class BeanDeserializerBase
                     // 12-Dec-2014, tatu: As per [databind#647], we will have problems if
                     //    the original property is left in place. So let's remove it now.
                     // 25-Mar-2017, tatu: Wonder if this could be problematic wrt creators?
-                    //    (that is, should be remove it from creator too)
+                    //    (that is, should we remove it from creator too)
                     _beanProperties.remove(prop);
                     continue;
                 }
@@ -746,8 +746,9 @@ public abstract class BeanDeserializerBase
 
     // @since 3.0
     protected void initFieldMatcher(DeserializationContext ctxt) {
+        _beanProperties.init();
         _fieldMatcher = _beanProperties.constructMatcher(ctxt.getParserFactory());
-        _fieldsByIndex = _beanProperties.getPropertiesInInsertionOrder();
+        _fieldsByIndex = _beanProperties.getPropertiesWithAliases();
     }
 
     /**
@@ -962,7 +963,7 @@ public abstract class BeanDeserializerBase
     }
     
     public boolean hasProperty(String propertyName) {
-        return _beanProperties.find(propertyName) != null;
+        return _beanProperties.findPrimaryDefinition(propertyName) != null;
     }
 
     public boolean hasViews() {
@@ -1030,7 +1031,7 @@ public abstract class BeanDeserializerBase
     protected SettableBeanProperty findProperty(String propertyName)
     {
         SettableBeanProperty prop = (_beanProperties == null) ?
-                null : _beanProperties.find(propertyName);
+                null : _beanProperties.findPrimaryDefinition(propertyName);
         if (_neitherNull(prop, _propertyBasedCreator)) {
             prop = _propertyBasedCreator.findCreatorProperty(propertyName);
         }
@@ -1048,7 +1049,7 @@ public abstract class BeanDeserializerBase
     public SettableBeanProperty findProperty(int propertyIndex)
     {
         SettableBeanProperty prop = (_beanProperties == null) ?
-                null : _beanProperties.find(propertyIndex);
+                null : _beanProperties.findDefinition(propertyIndex);
         if (_neitherNull(prop, _propertyBasedCreator)) {
             prop = _propertyBasedCreator.findCreatorProperty(propertyIndex);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -300,7 +300,7 @@ public abstract class BeanDeserializerBase
         _vanillaProcessing = false;
     }
 
-    public BeanDeserializerBase(BeanDeserializerBase src, ObjectIdReader oir)
+    protected BeanDeserializerBase(BeanDeserializerBase src, ObjectIdReader oir)
     {
         super(src._beanType);
         _beanType = src._beanType;
@@ -327,10 +327,9 @@ public abstract class BeanDeserializerBase
             _beanProperties = src._beanProperties;
             _vanillaProcessing = src._vanillaProcessing;
         } else {
-            /* 18-Nov-2012, tatu: May or may not have annotations for id property;
-             *   but no easy access. But hard to see id property being optional,
-             *   so let's consider required at this point.
-             */
+            // 18-Nov-2012, tatu: May or may not have annotations for id property;
+            //   but no easy access. But hard to see id property being optional,
+            //   so let's consider required at this point.
             ObjectIdValueProperty idProp = new ObjectIdValueProperty(oir, PropertyMetadata.STD_REQUIRED);
             _beanProperties = src._beanProperties.withProperty(idProp);
             _vanillaProcessing = false;
@@ -453,7 +452,9 @@ public abstract class BeanDeserializerBase
                     deser = ctxt.findNonContextualValueDeserializer(prop.getType());
                 }
                 SettableBeanProperty newProp = prop.withValueDeserializer(deser);
-                _replaceProperty(_beanProperties, creatorProps, prop, newProp);
+                if (prop != newProp) {
+                    _replaceProperty(_beanProperties, creatorProps, prop, newProp);
+                }
             }
         }
 
@@ -1088,11 +1089,13 @@ public abstract class BeanDeserializerBase
      * @param original Property to replace
      * @param replacement Property to replace it with
      */
+    /*
     public void replaceProperty(SettableBeanProperty original,
             SettableBeanProperty replacement)
     {
         _beanProperties.replace(replacement);
     }
+    */
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1515,7 +1515,7 @@ public abstract class BeanDeserializerBase
             Object bean, String propName)
         throws IOException
     {
-        if (_ignorableProps != null && _ignorableProps.contains(propName)) {
+        if ((_ignorableProps != null) && _ignorableProps.contains(propName)) {
             handleIgnoredProperty(p, ctxt, bean, propName);
         } else if (_anySetter != null) {
             try {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1026,7 +1026,7 @@ public abstract class BeanDeserializerBase
      * has one. Name used is the external name, i.e. name used
      * in external data representation (JSON).
      */
-    public SettableBeanProperty findProperty(String propertyName)
+    protected SettableBeanProperty findProperty(String propertyName)
     {
         SettableBeanProperty prop = (_beanProperties == null) ?
                 null : _beanProperties.find(propertyName);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -267,7 +267,8 @@ public abstract class BeanDeserializerBase
      * invoked and lookup indices need to be updated.
      */
     protected BeanDeserializerBase(BeanDeserializerBase src,
-            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties)
+            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties,
+            boolean ignoreAllUnknown)
     {
         super(src._beanType);
 
@@ -279,7 +280,7 @@ public abstract class BeanDeserializerBase
 
         _backRefs = src._backRefs;
         _ignorableProps = src._ignorableProps;
-        _ignoreAllUnknown = (unwrapHandler != null) || src._ignoreAllUnknown;
+        _ignoreAllUnknown = ignoreAllUnknown;
         _anySetter = src._anySetter;
         _injectables = src._injectables;
         _objectIdReader = src._objectIdReader;
@@ -969,6 +970,14 @@ public abstract class BeanDeserializerBase
         for (SettableBeanProperty prop : _beanProperties) {
             names.add(prop.getName());
         }
+        // 22-Nov-2017, tatu: Won't quite work yet...
+        /*
+        if (_unwrappedPropertyHandler != null) {
+            for (SettableBeanProperty prop : _unwrappedPropertyHandler.getHandledProperties()) {
+                names.add(prop.getName());
+            }
+        }
+        */
         return names;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
-
+import com.fasterxml.jackson.core.sym.FieldNameMatcher;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.impl.*;
 import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer;
@@ -638,6 +638,12 @@ public abstract class BeanDeserializerBase
         }
         return null;
     }
+
+    // @since 3.0
+    protected FieldNameMatcher _fieldMatcher;
+
+    // @since 3.0
+    protected SettableBeanProperty[] _fieldsByIndex;
     
     /**
      * Although most of post-processing is done in resolve(), we only get
@@ -733,7 +739,14 @@ public abstract class BeanDeserializerBase
         if (shape == JsonFormat.Shape.ARRAY) {
             contextual = contextual.asArrayDeserializer();
         }
+        contextual.initFieldMatcher(ctxt);
         return contextual;
+    }
+
+    // @since 3.0
+    protected void initFieldMatcher(DeserializationContext ctxt) {
+        _fieldMatcher = _beanProperties.constructMatcher(ctxt.getParserFactory());
+        _fieldsByIndex = _beanProperties.getPropertiesInInsertionOrder();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -348,7 +348,6 @@ public class BeanDeserializerBuilder
         BeanPropertyMap propertyMap = BeanPropertyMap.construct(props,
                 _config.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES),
                 _collectAliases(props));
-        propertyMap.assignIndexes();
 
         // view processing must be enabled if:
         // (a) fields are not included by default (when deserializing with view), OR
@@ -421,7 +420,6 @@ public class BeanDeserializerBuilder
         BeanPropertyMap propertyMap = BeanPropertyMap.construct(props,
                 _config.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES),
                 _collectAliases(props));
-        propertyMap.assignIndexes();
 
         boolean anyViews = !_config.isEnabled(MapperFeature.DEFAULT_VIEW_INCLUSION);
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -503,12 +503,14 @@ public class BeanDeserializerBuilder
         return result;
     }
     
-    protected Map<String,List<PropertyName>> _collectAliases(Collection<SettableBeanProperty> props)
+    protected PropertyName[][] _collectAliases(Collection<SettableBeanProperty> props)
     {
-        Map<String,List<PropertyName>> mapping = null;
+        PropertyName[][] result = null;
         AnnotationIntrospector intr = _config.getAnnotationIntrospector();
         if (intr != null) {
+            int i = -1;
             for (SettableBeanProperty prop : props) {
+                ++i;
                 AnnotatedMember member = prop.getMember();
                 if (member == null) {
                     continue;
@@ -517,15 +519,12 @@ public class BeanDeserializerBuilder
                 if ((aliases == null) || aliases.isEmpty()) {
                     continue;
                 }
-                if (mapping == null) {
-                    mapping = new HashMap<>();
+                if (result == null) {
+                    result = new PropertyName[props.size()][];
                 }
-                mapping.put(prop.getName(), aliases);
+                result[i] = aliases.toArray(new PropertyName[aliases.size()]);
             }
         }
-        if (mapping == null) {
-            return Collections.emptyMap();
-        }
-        return mapping;
+        return result;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -421,10 +421,8 @@ public class BeanDeserializerFactory
             SettableBeanProperty prop = constructSettableProperty(ctxt, beanDesc, propDef,
                     am.getParameterType(0));
             if (prop != null) {
-                /* 21-Aug-2011, tatus: We may actually have found 'cause' property
-                 *   to set... but let's replace it just in case,
-                 *   otherwise can end up with odd errors.
-                 */
+                // 21-Aug-2011, tatus: We may actually have found 'cause' property to set...
+                //    but let's replace it just in case, otherwise can end up with odd errors.
                 builder.addOrReplaceProperty(prop, true);
             }
         }
@@ -433,9 +431,7 @@ public class BeanDeserializerFactory
         builder.addIgnorable("localizedMessage");
         // Java 7 also added "getSuppressed", skip if we have such data:
         builder.addIgnorable("suppressed");
-        /* As well as "message": it will be passed via constructor,
-         * as there's no 'setMessage()' method
-        */
+        // As well as "message": it will be passed via constructor as there's no 'setMessage()' method
         builder.addIgnorable("message");
 
         // update builder now that all information is in?

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -126,8 +126,9 @@ public class BuilderBasedDeserializer
 
     @Override
     protected BeanDeserializerBase asArrayDeserializer() {
-        SettableBeanProperty[] props = _beanProperties.getPropertiesInInsertionOrder();
-        return new BeanAsArrayBuilderDeserializer(this, _targetType, props, _buildMethod);
+        return new BeanAsArrayBuilderDeserializer(this, _targetType,
+                _beanProperties.getPrimaryProperties(), 
+                _buildMethod);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -134,7 +134,6 @@ public class BuilderBasedDeserializer
 
     @Override
     protected void initFieldMatcher(DeserializationContext ctxt) {
-        _beanProperties.init();
         _fieldMatcher = _beanProperties.constructMatcher(ctxt.getParserFactory());
         _fieldsByIndex = _beanProperties.getPropertiesWithAliases();
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.*;
 
 import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.sym.FieldNameMatcher;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.impl.*;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
@@ -130,6 +131,19 @@ public class BuilderBasedDeserializer
                 _beanProperties.getPrimaryProperties(), 
                 _buildMethod);
     }
+
+    @Override
+    protected void initFieldMatcher(DeserializationContext ctxt) {
+        _beanProperties.init();
+        _fieldMatcher = _beanProperties.constructMatcher(ctxt.getParserFactory());
+        _fieldsByIndex = _beanProperties.getPropertiesWithAliases();
+    }
+
+    // @since 3.0
+    protected FieldNameMatcher _fieldMatcher;
+
+    // @since 3.0
+    protected SettableBeanProperty[] _fieldsByIndex;
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -246,7 +246,7 @@ public class BuilderBasedDeserializer
             String propName = p.getCurrentName();
             // Skip field name:
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) { // normal case
                 try {
                     bean = prop.deserializeSetAndReturn(p, ctxt, bean);
@@ -291,7 +291,7 @@ public class BuilderBasedDeserializer
             String propName = p.getCurrentName();
             // Skip field name:
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) { // normal case
                 try {
                     bean = prop.deserializeSetAndReturn(p, ctxt, bean);
@@ -366,7 +366,7 @@ public class BuilderBasedDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) {
                 buffer.bufferProperty(prop, prop.deserialize(p, ctxt));
                 continue;
@@ -441,7 +441,7 @@ public class BuilderBasedDeserializer
             String propName = p.getCurrentName();
             // Skip field name:
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             
             if (prop != null) { // normal case
                 try {
@@ -471,7 +471,7 @@ public class BuilderBasedDeserializer
             String propName = p.getCurrentName();
             // Skip field name:
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) {
                 if (!prop.visibleInView(activeView)) {
                     p.skipChildren();
@@ -522,7 +522,7 @@ public class BuilderBasedDeserializer
         for (; p.currentToken() != JsonToken.END_OBJECT; p.nextToken()) {
             String propName = p.getCurrentName();
             p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) { // normal case
                 if (activeView != null && !prop.visibleInView(activeView)) {
                     p.skipChildren();
@@ -597,7 +597,7 @@ public class BuilderBasedDeserializer
                 continue;
             }
             // regular property? needs buffering
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) {
                 buffer.bufferProperty(prop, prop.deserialize(p, ctxt));
                 continue;
@@ -631,7 +631,7 @@ public class BuilderBasedDeserializer
         final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
         for (JsonToken t = p.currentToken(); t == JsonToken.FIELD_NAME; t = p.nextToken()) {
             String propName = p.getCurrentName();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             p.nextToken();
             if (prop != null) { // normal case
                 if (activeView != null && !prop.visibleInView(activeView)) {
@@ -687,7 +687,7 @@ public class BuilderBasedDeserializer
         for (JsonToken t = p.currentToken(); t == JsonToken.FIELD_NAME; t = p.nextToken()) {
             String propName = p.getCurrentName();
             t = p.nextToken();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             if (prop != null) { // normal case
                 // May have property AND be used as external type id:
                 if (t.isScalarValue()) {
@@ -739,5 +739,10 @@ public class BuilderBasedDeserializer
         return ctxt.reportBadDefinition(t, String.format(
                 "Deserialization (of %s) with Builder, External type id, @JsonCreator not yet implemented",
                 t));
+    }
+
+    // @since 3.0
+    private final SettableBeanProperty _findProperty(String propName) {
+        return _beanProperties.find(propName);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BuilderBasedDeserializer.java
@@ -91,8 +91,9 @@ public class BuilderBasedDeserializer
     }
 
     protected BuilderBasedDeserializer(BuilderBasedDeserializer src,
-            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties) {
-        super(src, unwrapHandler, renamedProperties);
+            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties,
+            boolean ignoreAllUnknown) {
+        super(src, unwrapHandler, renamedProperties, ignoreAllUnknown);
         _buildMethod = src._buildMethod;
         _targetType = src._targetType;
         _fieldMatcher = _beanProperties.getFieldMatcher();
@@ -148,7 +149,7 @@ public class BuilderBasedDeserializer
             }
             // and handle direct unwrapping as well:
             BeanPropertyMap props = _beanProperties.renameAll(ctxt, transformer);
-            return new BuilderBasedDeserializer(this, uwHandler, props);
+            return new BuilderBasedDeserializer(this, uwHandler, props, true);
         } finally { _currentlyTransforming = null; }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -273,12 +273,15 @@ public abstract class SettableBeanProperty
      */
     public abstract SettableBeanProperty withName(PropertyName newName);
 
-    /**
-     * @since 2.3
-     */
     public SettableBeanProperty withSimpleName(String simpleName) {
-        PropertyName n = (_propName == null)
-                ? new PropertyName(simpleName) : _propName.withSimpleName(simpleName);
+        PropertyName n;
+
+        if (_propName == null) {
+            n = new PropertyName(simpleName);
+        } else {
+            n = _propName.withSimpleName(simpleName);
+        }
+        n = n.internSimpleName();
         return (n == _propName) ? this : withName(n);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -311,7 +311,9 @@ public abstract class SettableBeanProperty
      */
     public void assignIndex(int index) {
         if (_propertyIndex != -1) {
-            throw new IllegalStateException("Property '"+getName()+"' already had index ("+_propertyIndex+"), trying to assign "+index);
+            if (_propertyIndex != index) {
+                throw new IllegalStateException("Property '"+getName()+"' already had index ("+_propertyIndex+"), trying to assign "+index);
+            }
         }
         _propertyIndex = index;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -70,8 +70,6 @@ public abstract class SettableBeanProperty
      * Entity used for possible translation from `null` into non-null
      * value of type of this property.
      * Often same as <code>_valueDeserializer</code>, but not always.
-     *
-     * @since 2.9
      */
     protected final NullValueProvider _nullProvider;
 
@@ -161,8 +159,6 @@ public abstract class SettableBeanProperty
 
     /**
      * Constructor only used by {@link com.fasterxml.jackson.databind.deser.impl.ObjectIdValueProperty}.
-     * 
-     * @since 2.3
      */
     protected SettableBeanProperty(PropertyName propName, JavaType type, 
             PropertyMetadata metadata, JsonDeserializer<Object> valueDeser)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
@@ -218,8 +218,6 @@ public abstract class ValueInstantiator
      * {@link PropertyValueBuffer#getParameter(SettableBeanProperty)} to safely
      * read the present properties only, and to have some other behavior for the
      * missing properties.
-     * 
-     * @since 2.8
      */
     public Object createFromObjectWith(DeserializationContext ctxt,
             SettableBeanProperty[] props, PropertyValueBuffer buffer)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
@@ -56,13 +56,12 @@ public class BeanAsArrayBuilderDeserializer
     }
     
     @Override
-    public JsonDeserializer<Object> unwrappingDeserializer(NameTransformer unwrapper)
+    public JsonDeserializer<Object> unwrappingDeserializer(DeserializationContext ctxt,
+            NameTransformer unwrapper)
     {
-        /* We can't do much about this; could either replace _delegate
-         * with unwrapping instance, or just replace this one. Latter seems
-         * more sensible.
-         */
-        return _delegate.unwrappingDeserializer(unwrapper);
+        // We can't do much about this; could either replace _delegate with unwrapping instance,
+        // or just replace this one. Latter seems more sensible.
+        return _delegate.unwrappingDeserializer(ctxt, unwrapper);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayBuilderDeserializer.java
@@ -29,8 +29,6 @@ public class BeanAsArrayBuilderDeserializer
     /**
      * Type that the builder will produce, target type; as opposed to
      * `handledType()` which refers to Builder class.
-     *
-     * @since 2.9
      */
     protected final JavaType _targetType;
 
@@ -44,8 +42,6 @@ public class BeanAsArrayBuilderDeserializer
      * Main constructor used both for creating new instances (by
      * {@link BeanDeserializer#asArrayDeserializer}) and for
      * creating copies with different delegate.
-     *
-     * @since 2.9
      */
     public BeanAsArrayBuilderDeserializer(BeanDeserializerBase delegate,
             JavaType targetType,
@@ -91,6 +87,9 @@ public class BeanAsArrayBuilderDeserializer
     protected BeanDeserializerBase asArrayDeserializer() {
         return this;
     }
+
+    @Override
+    protected void initFieldMatcher(DeserializationContext ctxt) { }
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
@@ -50,10 +50,8 @@ public class BeanAsArrayDeserializer
     @Override
     public JsonDeserializer<Object> unwrappingDeserializer(NameTransformer unwrapper)
     {
-        /* We can't do much about this; could either replace _delegate
-         * with unwrapping instance, or just replace this one. Latter seems
-         * more sensible.
-         */
+        // We can't do much about this; could either replace _delegate with unwrapping
+        // instance, or just replace this one. Latter seems more sensible.
         return _delegate.unwrappingDeserializer(unwrapper);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
@@ -48,11 +48,12 @@ public class BeanAsArrayDeserializer
     }
     
     @Override
-    public JsonDeserializer<Object> unwrappingDeserializer(NameTransformer unwrapper)
+    public JsonDeserializer<Object> unwrappingDeserializer(DeserializationContext ctxt,
+            NameTransformer unwrapper)
     {
         // We can't do much about this; could either replace _delegate with unwrapping
         // instance, or just replace this one. Latter seems more sensible.
-        return _delegate.unwrappingDeserializer(unwrapper);
+        return _delegate.unwrappingDeserializer(ctxt, unwrapper);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanAsArrayDeserializer.java
@@ -78,6 +78,9 @@ public class BeanAsArrayDeserializer
         return this;
     }
 
+    @Override
+    protected void initFieldMatcher(DeserializationContext ctxt) { }
+    
     /*
     /**********************************************************
     /* JsonDeserializer implementation

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -104,7 +104,7 @@ public class BeanPropertyMap
         final int hashSize = findSize(_size);
         _hashMask = hashSize-1;
 
-        // and allocate enough to contain primary/secondary, expand for spillovers as need be
+        // and allocate enough to contain primary/secondary, expand for spill-overs as need be
         int alloc = (hashSize + (hashSize>>1)) * 2;
         Object[] hashed = new Object[alloc];
         int spillCount = 0;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import com.fasterxml.jackson.core.TokenStreamFactory;
 import com.fasterxml.jackson.core.sym.FieldNameMatcher;
+import com.fasterxml.jackson.core.util.Named;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
@@ -358,8 +359,13 @@ public class BeanPropertyMap
     public FieldNameMatcher constructMatcher(TokenStreamFactory tsf)
     {
         // !!! 11-Nov-2017, tatu: Add aliases
-        return tsf.constructFieldNameMatcher(Arrays.asList(_propsInOrder),
-                _propsInOrder.length, _caseInsensitive);
+
+        List<Named> names = Arrays.asList(_propsInOrder);
+        // `true` -> yes, they are intern()ed alright
+        if (_caseInsensitive) {
+            return tsf.constructCIFieldNameMatcher(names, true);
+        }
+        return tsf.constructFieldNameMatcher(names, true);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -184,7 +184,7 @@ public class BeanPropertyMap
         int spillCount = 0;
 
         for (SettableBeanProperty prop : props) {
-            String key = getPropertyName(prop);
+            String key = _propertyName(prop);
             int slot = key.hashCode() & _hashMask;
             int ix = (slot<<1);
 
@@ -357,13 +357,13 @@ public class BeanPropertyMap
      */
     public void remove(SettableBeanProperty propToRm)
     {
-        final String key = getPropertyName(propToRm);
+        final String key = _propertyName(propToRm);
         ArrayList<SettableBeanProperty> props = new ArrayList<SettableBeanProperty>(_size);
         boolean found = false;
         for (SettableBeanProperty prop : _propsInOrder) {
             if (!found) {
                 // Important: make sure to lower-case name to match as necessary
-                String match = getPropertyName(prop);
+                String match = _propertyName(prop);
                 if (found = match.equals(key)) {
                     continue;
                 }
@@ -442,11 +442,7 @@ public class BeanPropertyMap
      */
     @Override
     public Iterator<SettableBeanProperty> iterator() {
-        return _properties().iterator();
-    }
-
-    private List<SettableBeanProperty> _properties() {
-        return Arrays.asList(_propsInOrder);
+        return Arrays.asList(_propsInOrder).iterator();
     }
 
     /**
@@ -457,15 +453,6 @@ public class BeanPropertyMap
      */
     public SettableBeanProperty[] getPrimaryProperties() {
         return _propsInOrder;
-    }
-
-    // Confining this case insensitivity to this function (and the find method) in case we want to
-    // apply a particular locale to the lower case function.  For now, using the default.
-    protected final String getPropertyName(SettableBeanProperty prop) {
-        if (_caseInsensitive) {
-            return prop.getName().toLowerCase();
-        }
-        return prop.getName();
     }
 
     /*
@@ -591,6 +578,15 @@ public class BeanPropertyMap
             }
         }
         return null;
+    }
+
+    // Confining this case insensitivity to this function (and the find method) in case we want to
+    // apply a particular locale to the lower case function.  For now, using the default.
+    protected final String _propertyName(SettableBeanProperty prop) {
+        if (_caseInsensitive) {
+            return prop.getName().toLowerCase();
+        }
+        return prop.getName();
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -248,11 +248,10 @@ public class BeanPropertyMap
             SettableBeanProperty prop = _propsInOrder[i];
             
             // What to do with holes? For now, retain
-            if (prop == null) {
-                newProps.add(prop);
-                continue;
+            if (prop != null) {
+                prop = _rename(prop, transformer);
             }
-            newProps.add(_rename(prop, transformer));
+            newProps.add(prop);
         }
         // 26-Feb-2017, tatu: Probably SHOULD handle renaming wrt Aliases?
         // NOTE: do NOT try reassigning indexes of properties; number doesn't change

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -1,18 +1,12 @@
 package com.fasterxml.jackson.databind.deser.impl;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.core.TokenStreamFactory;
+import com.fasterxml.jackson.core.sym.FieldNameMatcher;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
-import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.databind.util.NameTransformer;
 
 /**
@@ -353,6 +347,19 @@ public class BeanPropertyMap
             throw new NoSuchElementException("No entry '"+propToRm.getName()+"' found, can't remove");
         }
         init(props);
+    }
+
+    /*
+    /**********************************************************
+    /* Factory method(s) for helpers
+    /**********************************************************
+     */
+
+    public FieldNameMatcher constructMatcher(TokenStreamFactory tsf)
+    {
+        // !!! 11-Nov-2017, tatu: Add aliases
+        return tsf.constructFieldNameMatcher(Arrays.asList(_propsInOrder),
+                _propsInOrder.length, _caseInsensitive);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -430,9 +430,6 @@ public class ExternalTypeHandler
         private final TypeDeserializer _typeDeserializer;
         private final String _typePropertyName;
 
-        /**
-         * @since 2.8
-         */
         private SettableBeanProperty _typeProperty;
 
         public ExtTypedProperty(SettableBeanProperty property, TypeDeserializer typeDeser)
@@ -476,9 +473,6 @@ public class ExternalTypeHandler
             return _property;
         }
 
-        /**
-         * @since 2.8
-         */
         public SettableBeanProperty getTypeProperty() {
             return _typeProperty;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -411,7 +411,7 @@ public class ExternalTypeHandler
             for (int i = 0; i < len; ++i) {
                 ExtTypedProperty extProp = _properties.get(i);
                 String typePropId = extProp.getTypePropertyName();
-                SettableBeanProperty typeProp = otherProps.findPrimaryDefinition(typePropId);
+                SettableBeanProperty typeProp = otherProps.findDefinition(typePropId);
                 if (typeProp != null) {
                     extProp.linkTypeProperty(typeProp);
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -403,8 +403,6 @@ public class ExternalTypeHandler
          * Method called after all external properties have been assigned, to further
          * link property with polymorphic value with possible property for type id
          * itself. This is needed to support type ids as Creator properties.
-         *
-         * @since 2.8
          */
         public ExternalTypeHandler build(BeanPropertyMap otherProps) {
             // 21-Jun-2016, tatu: as per [databind#999], may need to link type id property also
@@ -413,7 +411,7 @@ public class ExternalTypeHandler
             for (int i = 0; i < len; ++i) {
                 ExtTypedProperty extProp = _properties.get(i);
                 String typePropId = extProp.getTypePropertyName();
-                SettableBeanProperty typeProp = otherProps.find(typePropId);
+                SettableBeanProperty typeProp = otherProps.findPrimaryDefinition(typePropId);
                 if (typeProp != null) {
                     extProp.linkTypeProperty(typeProp);
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyBasedCreator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyBasedCreator.java
@@ -39,10 +39,9 @@ public final class PropertyBasedCreator
     protected final HashMap<String, SettableBeanProperty> _propertyLookup;
 
     /**
-     * Array that contains properties that expect value to inject, if any;
-     * null if no injectable values are expected.
+     * Array that contains properties that match creator properties
      */
-    protected final SettableBeanProperty[] _allProperties;
+    protected final SettableBeanProperty[] _propertiesInOrder;
 
     /*
     /**********************************************************
@@ -64,7 +63,6 @@ public final class PropertyBasedCreator
         }
         final int len = creatorProps.length;
         _propertyCount = len;
-        _allProperties = new SettableBeanProperty[len];
 
         // 26-Feb-2017, tatu: Let's start by aliases, so that there is no
         //    possibility of accidental override of primary names
@@ -79,9 +77,10 @@ public final class PropertyBasedCreator
                 }
             }
         }
+        _propertiesInOrder = new SettableBeanProperty[len];
         for (int i = 0; i < len; ++i) {
             SettableBeanProperty prop = creatorProps[i];
-            _allProperties[i] = prop;
+            _propertiesInOrder[i] = prop;
             _propertyLookup.put(prop.getName(), prop);
         }
     }
@@ -163,8 +162,6 @@ public final class PropertyBasedCreator
 
     /**
      * Method called when starting to build a bean instance.
-     * 
-     * @since 2.1 (added ObjectIdReader parameter -- existed in previous versions without)
      */
     public PropertyValueBuffer startBuilding(JsonParser p, DeserializationContext ctxt,
             ObjectIdReader oir) {
@@ -174,7 +171,7 @@ public final class PropertyBasedCreator
     public Object build(DeserializationContext ctxt, PropertyValueBuffer buffer) throws IOException
     {
         Object bean = _valueInstantiator.createFromObjectWith(ctxt,
-                _allProperties, buffer);
+                _propertiesInOrder, buffer);
         // returning null isn't quite legal, but let's let caller deal with that
         if (bean != null) {
             // Object Id to handle?

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
@@ -54,6 +54,12 @@ public class UnwrappedPropertyHandler
         return new UnwrappedPropertyHandler(newProps);
     }
 
+    /*
+    public List<SettableBeanProperty> getHandledProperties() {
+        return Collections.unmodifiableList(_properties);
+    }
+    */
+
     @SuppressWarnings("resource")
     public Object processUnwrapped(JsonParser originalParser, DeserializationContext ctxt,
             Object bean, TokenBuffer buffered)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.*;
 
 import com.fasterxml.jackson.core.*;
+
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
@@ -21,7 +22,7 @@ public class UnwrappedPropertyHandler
 
     public UnwrappedPropertyHandler()  {
         _properties = new ArrayList<SettableBeanProperty>();
-   }
+    }
     protected UnwrappedPropertyHandler(List<SettableBeanProperty> props)  {
         _properties = props;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.*;
 
 import com.fasterxml.jackson.core.*;
-
+import com.fasterxml.jackson.core.util.InternCache;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
@@ -23,6 +23,7 @@ public class UnwrappedPropertyHandler
     public UnwrappedPropertyHandler()  {
         _properties = new ArrayList<SettableBeanProperty>();
     }
+
     protected UnwrappedPropertyHandler(List<SettableBeanProperty> props)  {
         _properties = props;
     }
@@ -31,17 +32,19 @@ public class UnwrappedPropertyHandler
         _properties.add(property);
     }
 
-    public UnwrappedPropertyHandler renameAll(NameTransformer transformer)
+    public UnwrappedPropertyHandler renameAll(DeserializationContext ctxt,
+            NameTransformer transformer)
     {
         ArrayList<SettableBeanProperty> newProps = new ArrayList<SettableBeanProperty>(_properties.size());
         for (SettableBeanProperty prop : _properties) {
             String newName = transformer.transform(prop.getName());
+            newName = InternCache.instance.intern(newName);
             prop = prop.withSimpleName(newName);
             JsonDeserializer<?> deser = prop.getValueDeserializer();
             if (deser != null) {
                 @SuppressWarnings("unchecked")
                 JsonDeserializer<Object> newDeser = (JsonDeserializer<Object>)
-                    deser.unwrappingDeserializer(transformer);
+                    deser.unwrappingDeserializer(ctxt, transformer);
                 if (newDeser != deser) {
                     prop = prop.withValueDeserializer(newDeser);
                 }
@@ -50,7 +53,7 @@ public class UnwrappedPropertyHandler
         }
         return new UnwrappedPropertyHandler(newProps);
     }
-    
+
     @SuppressWarnings("resource")
     public Object processUnwrapped(JsonParser originalParser, DeserializationContext ctxt,
             Object bean, TokenBuffer buffered)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -1137,9 +1137,8 @@ public abstract class StdDeserializer<T>
         if (ctxt.handleUnknownProperty(p, this, instanceOrClass, propName)) {
             return;
         }
-        /* But if we do get this far, need to skip whatever value we
-         * are pointing to now (although handler is likely to have done that already)
-         */
+        // But if we do get this far, need to skip whatever value we
+        // are pointing to now (although handler is likely to have done that already)
         p.skipChildren();
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -38,8 +38,9 @@ public class ThrowableDeserializer
      * Alternative constructor used when creating "unwrapping" deserializers
      */
     protected ThrowableDeserializer(BeanDeserializer src,
-            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties) {
-        super(src, unwrapHandler, renamedProperties);
+            UnwrappedPropertyHandler unwrapHandler, BeanPropertyMap renamedProperties,
+            boolean ignoreAllUnknown) {
+        super(src, unwrapHandler, renamedProperties, ignoreAllUnknown);
     }
 
     @Override
@@ -58,7 +59,7 @@ public class ThrowableDeserializer
         }
         // and handle direct unwrapping as well:
         return new ThrowableDeserializer(this, uwHandler,
-                _beanProperties.renameAll(ctxt, transformer));
+                _beanProperties.renameAll(ctxt, transformer), true);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -86,7 +86,7 @@ public class ThrowableDeserializer
 
         for (; p.currentToken() != JsonToken.END_OBJECT; p.nextToken()) {
             String propName = p.getCurrentName();
-            SettableBeanProperty prop = _beanProperties.find(propName);
+            SettableBeanProperty prop = _findProperty(propName);
             p.nextToken(); // to point to field value
 
             if (prop != null) { // normal case

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1378,7 +1378,8 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         public int nextFieldName(FieldNameMatcher matcher) throws IOException {
             String str = nextFieldName();
             if (str != null) {
-                return matcher.matchName(str);
+                // 15-Nov-2017, tatu: Can not assume name given is intern()ed
+                return matcher.matchAnyName(str);
             }
             if (hasToken(JsonToken.END_OBJECT)) {
                 return FieldNameMatcher.MATCH_END_OBJECT;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMapTest.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.misc;
+package com.fasterxml.jackson.databind.deser.impl;
 
 import java.util.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMapTest.java
@@ -32,7 +32,7 @@ public class BeanPropertyMapTest extends BaseMapTest
         props.add(new ObjectIdValueProperty(new MyObjectIdReader("pk"), md));
         props.add(new ObjectIdValueProperty(new MyObjectIdReader("firstName"), md));
         BeanPropertyMap propMap = new BeanPropertyMap(false, props,
-                new HashMap<String,List<PropertyName>>(), true);
+                null, true);
         propMap = propMap.withProperty(new ObjectIdValueProperty(new MyObjectIdReader("@id"), md));
         assertNotNull(propMap);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMapTest.java
@@ -32,7 +32,7 @@ public class BeanPropertyMapTest extends BaseMapTest
         props.add(new ObjectIdValueProperty(new MyObjectIdReader("pk"), md));
         props.add(new ObjectIdValueProperty(new MyObjectIdReader("firstName"), md));
         BeanPropertyMap propMap = new BeanPropertyMap(false, props,
-                new HashMap<String,List<PropertyName>>());
+                new HashMap<String,List<PropertyName>>(), true);
         propMap = propMap.withProperty(new ObjectIdValueProperty(new MyObjectIdReader("@id"), md));
         assertNotNull(propMap);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithPrefix.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithPrefix.java
@@ -170,7 +170,7 @@ public class TestUnwrappedWithPrefix extends BaseMapTest
     /**********************************************************
      */
 
-    public void testPrefixedUnwrapping() throws Exception
+    public void testPrefixedUnwrapDeserialize() throws Exception
     {
         PrefixUnwrap bean = MAPPER.readValue("{\"name\":\"Axel\",\"_x\":4,\"_y\":7}", PrefixUnwrap.class);
         assertNotNull(bean);
@@ -180,7 +180,7 @@ public class TestUnwrappedWithPrefix extends BaseMapTest
         assertEquals(7, bean.location.y);
     }
     
-    public void testDeepPrefixedUnwrappingDeserialize() throws Exception
+    public void testDeepPrefixedUnwrapDeserialize() throws Exception
     {
         DeepPrefixUnwrap bean = MAPPER.readValue("{\"u.name\":\"Bubba\",\"u._x\":2,\"u._y\":3}",
                 DeepPrefixUnwrap.class);


### PR DESCRIPTION
Major refactoring to allow more efficient matching of incoming field names to actual `SettableBeanProperty` representation: potentially coalescing 2 lookups (format -> String; String -> property object) into just one.