### PR TITLE
Fix #1737 on 2.7

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -11,6 +11,7 @@ Project: jackson-databind
 #1628: Don't print to error stream about failure to load JDK 7 types
  (reported by Villane@github)
 #1680: Blacklist couple more types for deserialization
+#1737: Block more JDK types from polymorphic deserialization
 
 2.7.9.1 (18-Apr-2017)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -48,7 +48,7 @@ public class BeanDeserializerFactory
     static {
         Set<String> s = new HashSet<String>();
         // Courtesy of [https://github.com/kantega/notsoserial]:
-        // (and wrt [databind#1599]
+        // (and wrt [databind#1599])
         s.add("org.apache.commons.collections.functors.InvokerTransformer");
         s.add("org.apache.commons.collections.functors.InstantiateTransformer");
         s.add("org.apache.commons.collections4.functors.InvokerTransformer");
@@ -60,6 +60,15 @@ public class BeanDeserializerFactory
         s.add("org.apache.xalan.xsltc.trax.TemplatesImpl");
         // [databind#1680]: may or may not be problem, take no chance
         s.add("com.sun.rowset.JdbcRowSetImpl");
+        // [databind#1737]; JDK provided
+        s.add("java.util.logging.FileHandler");
+        s.add("java.rmi.server.UnicastRemoteObject");
+        // [databind#1737]; 3rd party
+        s.add("org.springframework.aop.support.AbstractBeanFactoryPointcutAdvisor");
+        s.add("org.springframework.beans.factory.config.PropertyPathFactoryBean");
+        s.add("com.mchange.v2.c3p0.JndiRefForwardingDataSource");
+        s.add("com.mchange.v2.c3p0.WrapperConnectionPoolDataSource");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.interop;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.*;
 
 /**
@@ -12,12 +13,29 @@ public class IllegalTypesCheckTest extends BaseMapTest
         public int id;
         public Object obj;
     }
+
+    static class PolyWrapper {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS,
+                include = JsonTypeInfo.As.WRAPPER_ARRAY)
+        public Object v;
+    }
     
-    public void testIssue1599() throws Exception
+    /*
+    /**********************************************************
+    /* Unit tests
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = objectMapper();
+    
+    // // // Tests for [databind#1599]
+
+    public void testXalanTypes1599() throws Exception
     {
+        final String clsName = "com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl";
         final String JSON = aposToQuotes(
  "{'id': 124,\n"
-+" 'obj':[ 'com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl',\n"
++" 'obj':[ '"+clsName+"',\n"
 +"  {\n"
 +"    'transletBytecodes' : [ 'AAIAZQ==' ],\n"
 +"    'transletName' : 'a.b',\n"
@@ -32,9 +50,75 @@ public class IllegalTypesCheckTest extends BaseMapTest
             mapper.readValue(JSON, Bean1599.class);
             fail("Should not pass");
         } catch (JsonMappingException e) {
-            verifyException(e, "Illegal type");
-            verifyException(e, "to deserialize");
-            verifyException(e, "prevented for security reasons");
+            _verifySecurityException(e, clsName);
+        }
+    }
+
+    // // // Tests for [databind#1737]
+
+    public void testJDKTypes1737() throws Exception
+    {
+        _testTypes1737(java.util.logging.FileHandler.class);
+        _testTypes1737(java.rmi.server.UnicastRemoteObject.class);
+    }
+
+    // 17-Aug-2017, tatu: Ideally would test handling of 3rd party types, too,
+    //    but would require adding dependencies. This may be practical when
+    //    checking done by module, but for now let's not do that for databind.
+
+    /*
+    public void testSpringTypes1737() throws Exception
+    {
+        _testTypes1737("org.springframework.aop.support.AbstractBeanFactoryPointcutAdvisor");
+        _testTypes1737("org.springframework.beans.factory.config.PropertyPathFactoryBean");
+    }
+
+    public void testC3P0Types1737() throws Exception
+    {
+        _testTypes1737("com.mchange.v2.c3p0.JndiRefForwardingDataSource");
+        _testTypes1737("com.mchange.v2.c3p0.WrapperConnectionPoolDataSource");
+    }
+    */
+
+    private void _testTypes1737(Class<?> nasty) throws Exception {
+        _testTypes1737(nasty.getName());
+    }
+
+    private void _testTypes1737(String clsName) throws Exception
+    {
+        // While usually exploited via default typing let's not require
+        // it here; mechanism still the same
+        String json = aposToQuotes(
+                "{'v':['"+clsName+"','/tmp/foobar.txt']}"
+                );
+        try {
+            MAPPER.readValue(json, PolyWrapper.class);
+            fail("Should not pass");
+        } catch (JsonMappingException e) {
+            _verifySecurityException(e, clsName);
+        }
+    }
+
+    protected void _verifySecurityException(Throwable t, String clsName) throws Exception
+    {
+        // 17-Aug-2017, tatu: Expected type more granular in 2.9 (over 2.8)
+        _verifyException(t, JsonMappingException.class,
+            "Illegal type",
+            "to deserialize",
+            "prevented for security reasons");
+        verifyException(t, clsName);
+    }
+
+    protected void _verifyException(Throwable t, Class<?> expExcType,
+            String... patterns) throws Exception
+    {
+        Class<?> actExc = t.getClass();
+        if (!expExcType.isAssignableFrom(actExc)) {
+            fail("Expected Exception of type '"+expExcType.getName()+"', got '"
+                    +actExc.getName()+"', message: "+t.getMessage());
+        }
+        for (String pattern : patterns) {
+            verifyException(t, pattern);
         }
     }
 }


### PR DESCRIPTION
I maintain a library that depends on jackson-databind 2.7.9.1 as we still want to keep JDK 6 support for a little while longer.

As #1737 fixes CVE 2017-15095 it would be great to apply this on 2.7 as well.