### PR TITLE
Parsing objects with specified type which does not inherit default type.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
@@ -730,4 +730,8 @@ public final class DeserializationConfig
         }
         return b.buildTypeDeserializer(this, baseType, subtypes);
     }
+
+    public ClassIntrospector.MixInResolver getMixIns() {
+        return _mixIns;
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationConfig.java
@@ -730,8 +730,4 @@ public final class DeserializationConfig
         }
         return b.buildTypeDeserializer(this, baseType, subtypes);
     }
-
-    public ClassIntrospector.MixInResolver getMixIns() {
-        return _mixIns;
-    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -129,6 +129,8 @@ public class StdTypeResolverBuilder
             //   seems like a reasonable compromise.
             if (_defaultImpl == Void.class) {
                 defaultImpl = config.getTypeFactory().constructType(_defaultImpl);
+            } else if (!baseType.getRawClass().isAssignableFrom(_defaultImpl)) {
+                defaultImpl = null;
             } else {
                 defaultImpl = config.getTypeFactory()
                     .constructSpecializedType(baseType, _defaultImpl);

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -175,7 +175,7 @@ public class StdTypeResolverBuilder
         JavaType defaultType = config.getTypeFactory().constructType(_defaultImpl);
         for (JavaType current = defaultType; current != null; current = current.getSuperClass())
         {
-            AnnotatedClass annotatedClass = AnnotatedClassResolver.resolve(config, current, config.getMixIns());
+            AnnotatedClass annotatedClass = AnnotatedClassResolver.resolve(config, current, config);
             if (annotatedClass.hasAnnotation(JsonTypeInfo.class)) {
                 JsonTypeInfo typeInfo = annotatedClass.getAnnotation(JsonTypeInfo.class);
                 if (typeInfo.defaultImpl() == null || !typeInfo.defaultImpl().equals(_defaultImpl)) {

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -184,7 +184,7 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         assertEquals("i", ((BaseWithDefaultOthers) value).fields.get("impl"));
     }
 
-    public void testBaseWithDefaultOtherAsImpl() throws Exception {
+    public void testBaseWithDefaultOtherAsOthers() throws Exception {
         BaseWithDefaultOthers value = MAPPER.readerFor(BaseWithDefaultOthers.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
         assertTrue(value instanceof BaseWithDefaultOthers);
         assertEquals("b", ((BaseWithDefaultOthers) value).base);
@@ -229,54 +229,57 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         assertEquals("ii", value.get(1).impl);
     }
 
+    public void testDeserializationCachingOtherFirst() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertParsingDefaultAsBase(mapper);
+        assertParsingImplAsBase(mapper);
+        assertParsingImplAsImpl(mapper);
+        assertErrorParsingDefaultAsImpl(mapper);
+    }
+
     public void testDeserializationCachingBaseFirst() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
-        BaseWithDefault valueBase = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
-        assertTrue(valueBase instanceof BaseWithDefaultOthers);
-        assertEquals("b", ((BaseWithDefaultOthers) valueBase).base);
-        assertEquals("other", ((BaseWithDefaultOthers) valueBase).type);
-        assertEquals(1, ((BaseWithDefaultOthers) valueBase).fields.size());
-        assertEquals("i", ((BaseWithDefaultOthers) valueBase).fields.get("impl"));
-
-        BaseWithDefault valueBaseImpl = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
-        assertTrue(valueBaseImpl instanceof BaseWithDefaultImpl);
-        assertEquals("b", ((BaseWithDefaultImpl) valueBaseImpl).base);
-        assertEquals("i", ((BaseWithDefaultImpl) valueBaseImpl).impl);
-
-        BaseWithDefaultImpl valueImpl = mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
-        assertTrue(valueImpl instanceof BaseWithDefaultImpl);
-        assertEquals("b", ((BaseWithDefaultImpl) valueImpl).base);
-        assertEquals("i", ((BaseWithDefaultImpl) valueImpl).impl);
-
-        try {
-            mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
-            fail("Should not parse class with incorrect type");
-        } catch (InvalidTypeIdException e) {
-            verifyException(e, "Could not resolve type id 'other' as a subtype");
-        }
+        assertParsingImplAsBase(mapper);
+        assertParsingDefaultAsBase(mapper);
+        assertParsingImplAsImpl(mapper);
+        assertErrorParsingDefaultAsImpl(mapper);
     }
 
     public void testDeserializationCachingImplFirst() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
-        BaseWithDefaultImpl valueImpl = mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
-        assertTrue(valueImpl instanceof BaseWithDefaultImpl);
-        assertEquals("b", ((BaseWithDefaultImpl) valueImpl).base);
-        assertEquals("i", ((BaseWithDefaultImpl) valueImpl).impl);
+        assertParsingImplAsImpl(mapper);
+        assertParsingImplAsBase(mapper);
+        assertParsingDefaultAsBase(mapper);
+        assertErrorParsingDefaultAsImpl(mapper);
+    }
 
+    private void assertParsingImplAsBase(ObjectMapper mapper) throws java.io.IOException {
         BaseWithDefault valueBaseImpl = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
         assertTrue(valueBaseImpl instanceof BaseWithDefaultImpl);
         assertEquals("b", ((BaseWithDefaultImpl) valueBaseImpl).base);
         assertEquals("i", ((BaseWithDefaultImpl) valueBaseImpl).impl);
+    }
 
+    private void assertParsingImplAsImpl(ObjectMapper mapper) throws java.io.IOException {
+        BaseWithDefaultImpl valueImpl = mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueImpl instanceof BaseWithDefaultImpl);
+        assertEquals("b", ((BaseWithDefaultImpl) valueImpl).base);
+        assertEquals("i", ((BaseWithDefaultImpl) valueImpl).impl);
+    }
+
+    private void assertParsingDefaultAsBase(ObjectMapper mapper) throws java.io.IOException {
         BaseWithDefault valueBase = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
         assertTrue(valueBase instanceof BaseWithDefaultOthers);
         assertEquals("b", ((BaseWithDefaultOthers) valueBase).base);
         assertEquals("other", ((BaseWithDefaultOthers) valueBase).type);
         assertEquals(1, ((BaseWithDefaultOthers) valueBase).fields.size());
         assertEquals("i", ((BaseWithDefaultOthers) valueBase).fields.get("impl"));
+    }
 
+    private void assertErrorParsingDefaultAsImpl(ObjectMapper mapper) throws java.io.IOException {
         try {
             mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
             fail("Should not parse class with incorrect type");

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -63,6 +63,15 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         }
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = BaseWithIncorrectDefaultOthers.class)
+    @JsonSubTypes(value = {@JsonSubTypes.Type(name = "impl", value = BaseWithIncorrectDefaultImpl.class)})
+    public static abstract class BaseWithIncorrectDefault {}
+
+    public static class BaseWithIncorrectDefaultImpl extends BaseWithIncorrectDefault {}
+
+    public static class BaseWithIncorrectDefaultOthers {} // No extends BaseWithIncorrectDefault here
+
     /**
      * Also another variant to verify that from 2.5 on, can use non-deprecated
      * value for the same.
@@ -254,6 +263,24 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         assertParsingImplAsBase(mapper);
         assertParsingDefaultAsBase(mapper);
         assertErrorParsingDefaultAsImpl(mapper);
+    }
+
+    public void testBaseWithIncorrectDefaultAsBase() throws Exception {
+        try {
+            MAPPER.readerFor(BaseWithIncorrectDefault.class).readValue("{\"type\": \"impl\"}");
+            fail("Should not parse class with incorrect default implementation");
+        } catch (IllegalArgumentException e) {
+            verifyException(e, "not subtype of");
+        }
+    }
+
+    public void testBaseWithIncorrectDefaultAsImpl() throws Exception {
+        try {
+            MAPPER.readerFor(BaseWithIncorrectDefaultImpl.class).readValue("{\"type\": \"impl\"}");
+            fail("Should not parse class with incorrect default implementation");
+        } catch (IllegalArgumentException e) {
+            verifyException(e, "not subtype of");
+        }
     }
 
     private void assertParsingImplAsBase(ObjectMapper mapper) throws java.io.IOException {

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -229,6 +229,62 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         assertEquals("ii", value.get(1).impl);
     }
 
+    public void testDeserializationCachingBaseFirst() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        BaseWithDefault valueBase = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueBase instanceof BaseWithDefaultOthers);
+        assertEquals("b", ((BaseWithDefaultOthers) valueBase).base);
+        assertEquals("other", ((BaseWithDefaultOthers) valueBase).type);
+        assertEquals(1, ((BaseWithDefaultOthers) valueBase).fields.size());
+        assertEquals("i", ((BaseWithDefaultOthers) valueBase).fields.get("impl"));
+
+        BaseWithDefault valueBaseImpl = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueBaseImpl instanceof BaseWithDefaultImpl);
+        assertEquals("b", ((BaseWithDefaultImpl) valueBaseImpl).base);
+        assertEquals("i", ((BaseWithDefaultImpl) valueBaseImpl).impl);
+
+        BaseWithDefaultImpl valueImpl = mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueImpl instanceof BaseWithDefaultImpl);
+        assertEquals("b", ((BaseWithDefaultImpl) valueImpl).base);
+        assertEquals("i", ((BaseWithDefaultImpl) valueImpl).impl);
+
+        try {
+            mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
+            fail("Should not parse class with incorrect type");
+        } catch (InvalidTypeIdException e) {
+            verifyException(e, "Could not resolve type id 'other' as a subtype");
+        }
+    }
+
+    public void testDeserializationCachingImplFirst() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        BaseWithDefaultImpl valueImpl = mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueImpl instanceof BaseWithDefaultImpl);
+        assertEquals("b", ((BaseWithDefaultImpl) valueImpl).base);
+        assertEquals("i", ((BaseWithDefaultImpl) valueImpl).impl);
+
+        BaseWithDefault valueBaseImpl = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"impl\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueBaseImpl instanceof BaseWithDefaultImpl);
+        assertEquals("b", ((BaseWithDefaultImpl) valueBaseImpl).base);
+        assertEquals("i", ((BaseWithDefaultImpl) valueBaseImpl).impl);
+
+        BaseWithDefault valueBase = mapper.readerFor(BaseWithDefault.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
+        assertTrue(valueBase instanceof BaseWithDefaultOthers);
+        assertEquals("b", ((BaseWithDefaultOthers) valueBase).base);
+        assertEquals("other", ((BaseWithDefaultOthers) valueBase).type);
+        assertEquals(1, ((BaseWithDefaultOthers) valueBase).fields.size());
+        assertEquals("i", ((BaseWithDefaultOthers) valueBase).fields.get("impl"));
+
+        try {
+            mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"type\": \"other\", \"base\": \"b\", \"impl\": \"i\"}");
+            fail("Should not parse class with incorrect type");
+        } catch (InvalidTypeIdException e) {
+            verifyException(e, "Could not resolve type id 'other' as a subtype");
+        }
+    }
+
 //    // Seems not to be a bug, however it might be a useful feature to strictly specify deserializing type.
 //    public void testBaseWithDefaultAsImplNoTypeInJson() throws Exception {
 //        // Class is specified, there is only one implementation.

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -71,7 +71,12 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
     public static class BaseWithIncorrectDefaultImpl extends BaseWithIncorrectDefault {}
 
     public static class BaseWithIncorrectDefaultOthers {} // No extends BaseWithIncorrectDefault here
-
+    
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+    @JsonSubTypes(value = {})
+    public static class NoInheritanceMixIn {}
+    
     /**
      * Also another variant to verify that from 2.5 on, can use non-deprecated
      * value for the same.
@@ -315,13 +320,13 @@ public class TestPolymorphicWithDefaultImpl extends BaseMapTest
         }
     }
 
-//    // Seems not to be a bug, however it might be a useful feature to strictly specify deserializing type.
-//    public void testBaseWithDefaultAsImplNoTypeInJson() throws Exception {
-//        // Class is specified, there is only one implementation.
-//        BaseWithDefaultImpl value = MAPPER.readerFor(BaseWithDefaultImpl.class).readValue("{\"base\": \"b\", \"impl\": \"i\"}");
-//        assertEquals("b", value.base);
-//        assertEquals("i", value.impl);
-//    }
+    public void testBaseWithDefaultAsImplNoTypeInJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(BaseWithDefaultImpl.class, NoInheritanceMixIn.class);
+        BaseWithDefaultImpl value = mapper.readerFor(BaseWithDefaultImpl.class).readValue("{\"base\": \"b\", \"impl\": \"i\"}");
+        assertEquals("b", value.base);
+        assertEquals("i", value.impl);
+    }
 
     public void testDeserializationWithObject() throws Exception
     {


### PR DESCRIPTION
Tests which originally fails:
testBaseWithDefaultAsImpl()
testDeserializationListOfImpl()

Comment in StdTypeResolverBuilder in lines 127-129 is not clear enough. If there are some use cases I don't know, you can point me and I'll try to write tests and fix.