### PR TITLE
While deserializing, @JsonBackReference property is always ignored since 2.9.0

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -197,7 +197,7 @@ public class BeanDeserializerBuilder
         _backRefProperties.put(referenceName, prop);
         // also: if we had property with same name, actually remove it
         if (_properties != null) {
-            _properties.remove(prop.getName());
+            _properties.remove(referenceName);
         }
         // ??? 23-Jul-2012, tatu: Should it be included in list of all properties?
         //   For now, won't add, since it is inferred, not explicit...

--- a/src/test/java/com/fasterxml/jackson/failing/BackReference1878Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/BackReference1878Test.java
@@ -1,0 +1,34 @@
+package com.fasterxml.jackson.failing;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Created on 09/01/18.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class BackReference1878Test extends BaseMapTest {
+
+    static class Child {
+        @JsonBackReference
+        public Parent b;
+    }
+
+    static class Parent {
+        @JsonManagedReference
+        public Child a;
+    }
+
+    private final ObjectMapper MAPPER = new ObjectMapper();
+
+    public void testChildDeserialization() throws Exception {
+        MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        Child child = MAPPER.readValue("{\"b\": {}}", Child.class);
+        assertNotNull(child.b);
+    }
+
+}


### PR DESCRIPTION
Fix #1878 
  