### PR TITLE
Remove `getClass()` from `_valueType` argument for error reporting

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -177,7 +177,7 @@ class FactoryBasedEnumDeserializer
     	try {
     		return prop.deserialize(p, ctxt);
     	} catch (Exception e) {
-    		wrapAndThrow(e, _valueClass.getClass(), prop.getName(), ctxt);
+    		wrapAndThrow(e, _valueClass, prop.getName(), ctxt);
     		// never gets here, unless caller declines to throw an exception
     		return null;
     	}


### PR DESCRIPTION
From ErrorProne:
```
src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java:184: error: [GetClassOnClass] Calling getClass() on an object of type Class returns the Class object for java.lang.Class; you probably meant to operate on the object directly
                wrapAndThrow(e, _valueClass.getClass(), prop.getName(), ctxt);
                                                    ^
    (see http://errorprone.info/bugpattern/GetClassOnClass)
  Did you mean 'wrapAndThrow(e, _valueClass, prop.getName(), ctxt);' or 'wrapAndThrow(e, Class.class, prop.getName(), ctxt);'?
```