### PR TITLE
Remove incorrect fall-through comment

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
@@ -583,7 +583,6 @@ public class NumberDeserializers
                 } catch (IllegalArgumentException iae) { }
                 return (Long) ctxt.handleWeirdStringValue(_valueClass, text,
                         "not a valid Long value");
-                // fall-through
             case JsonTokenId.ID_NULL:
                 return (Long) _coerceNullToken(ctxt, _primitive);
             case JsonTokenId.ID_START_ARRAY:


### PR DESCRIPTION
Fall through will never happen since it's preceded by a return statement.