### PR TITLE
Backporting #1899 (CVE) to 2.7.9(.5)

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -3,6 +3,10 @@ Project: jackson-databind
 ------------------------------------------------------------------------
 === Releases ===
 ------------------------------------------------------------------------
+2.7.9.5 (not yet released)
+
+#1899: Another two gadgets to exploit default typing issue in jackson-databind
+ (reported by OneSourceCat@github)
 
 2.7.9.4 (08-Jun-2018)
 

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
@@ -63,6 +63,9 @@ public class SubTypeValidator
         // [databind#2058]: Oracle JDBC driver, with jndi/ldap lookup
         s.add("oracle.jdbc.connector.OracleManagedConnectionFactory");
         s.add("oracle.jdbc.rowset.OracleJDBCRowSet");
+        // [databind#1899]: more 3rd party
+        s.add("org.hibernate.jmx.StatisticsService");
+        s.add("org.apache.ibatis.datasource.jndi.JndiDataSourceFactory");
 
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }


### PR DESCRIPTION
Backporting the fix for #1899 to 2.7. I have sent you the CLA to your E-Mail tsaloranta@gmail.com