### PR TITLE
Automatically ignore cyclic references

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -33,6 +33,13 @@ public enum SerializationFeature implements ConfigFeature
      * Feature is disabled by default.
      */
     WRAP_ROOT_VALUE(false),
+    
+    /**
+     * Feature that allows automatically ignoring cyclic references.
+     * 
+     * Feature is disabled by default.
+     */
+    IGNORE_CYCLIC_REFERENCES(false),
 
     /**
      * Feature that allows enabling (or disabling) indentation


### PR DESCRIPTION
The feature allows jackson to automatically detect cyclic references between the objects that are being serialized, and ignore these cyclic references. The feature is deactivated by default.

This would solve #2099