### PR TITLE
Add mutant factory method ObjectWriter#with(SerializationConfig)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -357,7 +357,18 @@ public class ObjectWriter
     /* Life-cycle, fluent factories, other
     /**********************************************************************
      */
-    
+
+    /**
+     * Mutant factory method that will construct a new instance that has
+     * specified underlying {@link SerializationConfig}.
+     *<p>
+     * NOTE: use of this method is not recommended, as there are many other
+     * re-configuration methods available.
+     */
+    public ObjectWriter with(SerializationConfig config) {
+        return _new(this, config);
+    }
+
     /**
      * Fluent factory method that will construct a new writer instance that will
      * use specified date format for serializing dates; or if null passed, one


### PR DESCRIPTION
I need to overwrite the TypeResolverBuilder for an edge case.
I just wanted to use an ObjectReader or ObjectWriter to avoid losing the global configuration. This works for the ObjectReader as well, but not for the ObjectWriter.

So I added the method `ObjectWriter#with(SerializationConfig)` in the same way as `ObjectReader#with(DeserializationConfig)`.