### PR TITLE
Implemented JsonNode#optional(...) methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -176,6 +176,33 @@ public abstract class JsonNode
     @Override
     public abstract JsonNode path(int index);
 
+    /**
+     * This method works similar to {@link #path(String)}, but
+     * instead of returning a "missing node" if the node is unavailable,
+     * it returns an optional that may contain the
+     * JsonNode at the given fieldName.
+     */
+    public Optional<JsonNode> optional(String fieldName) {
+        JsonNode path = path(fieldName);
+        if (path.isMissingNode()) {
+            return Optional.empty();
+        }
+        return Optional.of(path);
+    }
+
+    /**
+     * This method works similar to {@link #path(int)}, but
+     * instead of returning a "missing node" if the node is unavailable,
+     * it returns an optional that may contain the JsonNode at the given index.
+     */
+    public Optional<JsonNode> optional(int index) {
+        JsonNode path = path(index);
+        if (path.isMissingNode()) {
+            return Optional.empty();
+        }
+        return Optional.of(path);
+    }
+
     @Override
     public Iterator<String> fieldNames() {
         return ClassUtil.emptyIterator();


### PR DESCRIPTION
Closes https://github.com/FasterXML/jackson-databind/issues/2145, though it might be wanted to add the methods `#optional(String)` and `#optional(int)` to the TreeNode in jackson-core.
If that is the case, let me know, and I will open PRs in both repositories.
This implementation is very rudimentary and uses the `#path(...)` methods, while checking with `#isMissingNode()` whether an empty optional should be returned.