### PR TITLE
Adding int support back for Enum, was available in 2.7.x

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -111,6 +111,8 @@ class FactoryBasedEnumDeserializer
             //the below case handles it.
             if (curr == JsonToken.VALUE_STRING || curr == JsonToken.FIELD_NAME) {
                 value = p.getText();
+            } else if (curr == JsonToken.VALUE_NUMBER_INT) {
+                value = p.getIntValue();
             } else if ((_creatorProps != null) && p.isExpectedStartObjectToken()) {
                 if (_propCreator == null) {
                     _propCreator = PropertyBasedCreator.construct(ctxt, _valueInstantiator, _creatorProps,


### PR DESCRIPTION
While upgrading our code from 2.7 to 2.9 the deserializing of Enum's with `@JsonValue` and `@JsonCreator` is not working anymore.

Probally also fixes issue #1850 