### PR TITLE
Issue #2178: Make SQL date serialisation test TZ safe

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/SqlDateSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/SqlDateSerializationTest.java
@@ -99,7 +99,9 @@ public class SqlDateSerializationTest extends BaseMapTest
     // [databind#2064]
     public void testSqlDateConfigOverride() throws Exception
     {
+        // `java.sql.Date` applies system default zone (and not UTC)
         final ObjectMapper mapper = jsonMapperBuilder()
+                .defaultTimeZone(TimeZone.getDefault())
                 .withConfigOverride(java.sql.Date.class,
                         o -> o.setFormat(JsonFormat.Value.forPattern("yyyy+MM+dd")))
                 .build();


### PR DESCRIPTION
SqlDateSerializationTest.testSqlDateConfigOverride was
sensitive to time zone becaus the mapper is using UTC
while SQL dates use system default time zone. The mapper
it uses simply needs to be set up with the system default
time zone a la the other tests in SqlDateSerializationTest.