### PR TITLE
Use key type factory methods ahead of ctors

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -52,15 +52,7 @@ public class StdKeyDeserializers
         // We don't need full deserialization information, just need to know creators.
         BeanDescription beanDesc = ctxt.introspect(type);
 
-        // Ok, so: can we find T(String) constructor?
-        Constructor<?> ctor = beanDesc.findSingleArgConstructor(String.class);
-        if (ctor != null) {
-            if (ctxt.canOverrideAccessModifiers()) {
-                ClassUtil.checkAndFixAccess(ctor, ctxt.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
-            }
-            return new StdKeyDeserializer.StringCtorKeyDeserializer(ctor);
-        }
-        /* or if not, "static T valueOf(String)" (or equivalent marked
+        /* Ok, so: can we find "static T valueOf(String)" (or equivalent marked
          * with @JsonCreator annotation?)
          */
         Method m = beanDesc.findFactoryMethod(String.class);
@@ -70,6 +62,16 @@ public class StdKeyDeserializers
             }
             return new StdKeyDeserializer.StringFactoryKeyDeserializer(m);
         }
+
+        // or if not, a T(String) constructor?
+        Constructor<?> ctor = beanDesc.findSingleArgConstructor(String.class);
+        if (ctor != null) {
+            if (ctxt.canOverrideAccessModifiers()) {
+                ClassUtil.checkAndFixAccess(ctor, ctxt.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
+            }
+            return new StdKeyDeserializer.StringCtorKeyDeserializer(ctor);
+        }
+
         // nope, no such luck...
         return null;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestGenericMapDeser.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestGenericMapDeser.java
@@ -71,7 +71,28 @@ public class TestGenericMapDeser
             return new KeyTypeFactory(str, true);
         }
     }
-    
+
+    static class KeyTypeFactoryPrecedence  {
+        protected String value;
+        public KeyTypeFactoryPrecedence(String v) {
+            this(v, false);
+        }
+
+        private KeyTypeFactoryPrecedence(String v, boolean factory) {
+            if (factory) {
+                value = "factory:" + v;
+            }
+            else {
+                value = "ctor:" + v;
+            }
+        }
+
+        @JsonCreator
+        public static KeyTypeFactoryPrecedence create(String str) {
+            return new KeyTypeFactoryPrecedence(str, true);
+        }
+    }
+
     /*
     /**********************************************************
     /* Test methods for sub-classing
@@ -165,6 +186,20 @@ public class TestGenericMapDeser
         Object key = entry.getKey();
         assertEquals(KeyTypeFactory.class, key.getClass());
         assertEquals("a", ((KeyTypeFactory) key).value);
+    }
+
+
+    public void testKeyViaFactoryPrecedenceOverConstructor() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<KeyTypeFactoryPrecedence,Integer> map = mapper.readValue("{\"a\":123}",
+                TypeFactory.defaultInstance().constructMapType(HashMap.class, KeyTypeFactoryPrecedence.class, Integer.class));
+        assertEquals(1, map.size());
+        Map.Entry<?,?> entry = map.entrySet().iterator().next();
+        assertEquals(Integer.valueOf(123), entry.getValue());
+        Object key = entry.getKey();
+        assertEquals(KeyTypeFactoryPrecedence.class, key.getClass());
+        assertEquals("factory:a", ((KeyTypeFactoryPrecedence) key).value);
     }
 
 }


### PR DESCRIPTION
Fixes #2158

Simply swaps the order factory method and String
constructors are searched for in the key type.
Factory methods are now preferred.