### PR TITLE
Don't re-use dynamic serializers for property-updating copy constructors

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/MapEntrySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/MapEntrySerializer.java
@@ -143,7 +143,7 @@ public class MapEntrySerializer
         _valueTypeSerializer = src._valueTypeSerializer;
         _keySerializer = (JsonSerializer<Object>) keySer;
         _valueSerializer = (JsonSerializer<Object>) valueSer;
-        _dynamicValueSerializers = src._dynamicValueSerializers;
+        _dynamicValueSerializers = PropertySerializerMap.emptyForProperties();
         _property = src._property;
         _suppressableValue = suppressableValue;
         _suppressNulls = suppressNulls;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -118,7 +118,7 @@ public abstract class AsArraySerializerBase<T>
         _valueTypeSerializer = vts;
         _property = property;
         _elementSerializer = (JsonSerializer<Object>) elementSerializer;
-        _dynamicSerializers = src._dynamicSerializers;
+        _dynamicSerializers = PropertySerializerMap.emptyForProperties();
         _unwrapSingle = unwrapSingle;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
@@ -196,7 +196,7 @@ public class MapSerializer
         _valueTypeSerializer = src._valueTypeSerializer;
         _keySerializer = (JsonSerializer<Object>) keySerializer;
         _valueSerializer = (JsonSerializer<Object>) valueSerializer;
-        _dynamicValueSerializers = src._dynamicValueSerializers;
+        _dynamicValueSerializers = PropertySerializerMap.emptyForProperties();
         _property = property;
         _filterId = src._filterId;
         _sortKeys = src._sortKeys;
@@ -236,7 +236,7 @@ public class MapSerializer
         _valueTypeSerializer = src._valueTypeSerializer;
         _keySerializer = src._keySerializer;
         _valueSerializer = src._valueSerializer;
-        _dynamicValueSerializers = src._dynamicValueSerializers;
+        _dynamicValueSerializers = PropertySerializerMap.emptyForProperties();
         _property = src._property;
         _filterId = filterId;
         _sortKeys = sortKeys;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ReferenceTypeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ReferenceTypeSerializer.java
@@ -116,7 +116,7 @@ public abstract class ReferenceTypeSerializer<T>
     {
         super(base);
         _referredType = base._referredType;
-        _dynamicSerializers = base._dynamicSerializers;
+        _dynamicSerializers = PropertySerializerMap.emptyForProperties();
         _property = property;
         _valueTypeSerializer = vts;
         _valueSerializer = (JsonSerializer<Object>) valueSer;


### PR DESCRIPTION
Reason: dynamic serializers may hold property name and therefore must be re-created when the property changes.
(backport of [3b1cf096779bf3756794d2e325088b73b9e66e1b](https://github.com/FasterXML/jackson-databind/commit/3b1cf096779bf3756794d2e325088b73b9e66e1b) from 3.0 branch)

Feel free to re-create this change yourself it you accept it, but signing the CLA can take a while. Our prioirty  is to have it in central with upcoming 2.10+ releases.