### PR TITLE
JPMS Strictly Named

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Databind jar is also a functional OSGi bundle, with proper import/export declara
 
 -----
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.databind```
+
+-----
+
 # Use It!
 
 More comprehensive documentation can be found from [Jackson-docs](../../../jackson-docs) repository; as well as from [Wiki](../../wiki) of this project.

--- a/pom.xml
+++ b/pom.xml
@@ -25,21 +25,6 @@
   </scm>
 
   <properties>
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-            and new language features (diamond pattern) may be used.
-            JDK classes are still loaded dynamically since there isn't much downside
-            (small number of types); this allows use on JDK 6 platforms still (including
-            Android)
-         -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
-
     <!-- Can not use default, since group id != Java package name here -->
     <osgi.export>com.fasterxml.jackson.databind.*;version=${project.version}</osgi.export>
     <!-- but imports should work fine with defaults -->
@@ -158,6 +143,30 @@
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
       </plugin>
+
+         <plugin>
+             <groupId>org.moditect</groupId>
+             <artifactId>moditect-maven-plugin</artifactId>
+             <version>1.0.0.Beta1</version>
+             <executions>
+                 <execution>
+                     <id>add-module-infos</id>
+                     <phase>package</phase>
+                     <goals>
+                         <goal>add-module-info</goal>
+                     </goals>
+                     <configuration>
+                         <overwriteExistingFiles>true</overwriteExistingFiles>
+                         <module>
+                             <moduleInfoFile>
+                                 src/moditect/module-info.java
+                             </moduleInfoFile>
+                         </module>
+                     </configuration>
+                 </execution>
+             </executions>
+         </plugin>
+
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,20 @@
   </scm>
 
   <properties>
-    <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-    <javac.src.version>1.7</javac.src.version>
-    <javac.target.version>1.7</javac.target.version>
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+            and new language features (diamond pattern) may be used.
+            JDK classes are still loaded dynamically since there isn't much downside
+            (small number of types); this allows use on JDK 6 platforms still (including
+            Android)
+         -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
 
     <!-- Can not use default, since group id != Java package name here -->
     <osgi.export>com.fasterxml.jackson.databind.*;version=${project.version}</osgi.export>

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7SupportImpl.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7SupportImpl.java
@@ -1,9 +1,5 @@
 package com.fasterxml.jackson.databind.ext;
 
-import java.beans.ConstructorProperties;
-import java.beans.Transient;
-import java.nio.file.Path;
-
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.PropertyName;
@@ -11,8 +7,14 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
 import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams;
 
+import java.beans.ConstructorProperties;
+import java.beans.Transient;
+import java.nio.file.Path;
+
 /**
  * @since 2.8
+ *
+ * TODO Move this into a Java 7 Module
  */
 public class Java7SupportImpl extends Java7Support
 {

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -37,6 +37,4 @@ module com.fasterxml.jackson.databind {
 	requires static java.sql;
 	//TODThe JDK 7 Impl, Think about getting rid of this
 	requires static java.desktop;
-
-	provides ObjectCodec with com.fasterxml.jackson.databind.ObjectMapper;
 }

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,0 +1,40 @@
+import com.fasterxml.jackson.core.ObjectCodec;
+
+module com.fasterxml.jackson.databind {
+	uses java.nio.file.spi.FileSystemProvider;
+	exports com.fasterxml.jackson.databind;
+	exports com.fasterxml.jackson.databind.annotation;
+
+	exports com.fasterxml.jackson.databind.ser.std;
+	exports com.fasterxml.jackson.databind.deser.std;
+
+
+	exports com.fasterxml.jackson.databind.module to com.fasterxml.jackson.module.paranamer;
+	exports com.fasterxml.jackson.databind.introspect  to com.fasterxml.jackson.module.paranamer, com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.guice, com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.cfg to  com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.type to  com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.ser to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8;
+	exports com.fasterxml.jackson.databind.ser.impl  to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8;
+	exports com.fasterxml.jackson.databind.jsontype to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.util to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
+
+	exports com.fasterxml.jackson.databind.deser to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8;
+	exports com.fasterxml.jackson.databind.deser.impl to  com.fasterxml.jackson.module.afterburner;
+	exports com.fasterxml.jackson.databind.jsonFormatVisitors to  com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.node to com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.jsontype.impl to com.fasterxml.jackson.module.jaxb;
+
+
+	requires transitive com.fasterxml.jackson.core;
+
+	requires java.xml;
+	requires java.logging;
+
+	//Optionals
+	requires static com.fasterxml.jackson.annotation;
+	requires static java.sql;
+	//TODThe JDK 7 Impl, Think about getting rid of this
+	requires static java.desktop;
+
+	provides ObjectCodec with com.fasterxml.jackson.databind.ObjectMapper;
+}

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -2,6 +2,8 @@ import com.fasterxml.jackson.core.ObjectCodec;
 
 module com.fasterxml.jackson.databind {
 	uses java.nio.file.spi.FileSystemProvider;
+	uses com.fasterxml.jackson.databind.Module;
+
 	exports com.fasterxml.jackson.databind;
 	exports com.fasterxml.jackson.databind.annotation;
 

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -9,18 +9,18 @@ module com.fasterxml.jackson.databind {
 	exports com.fasterxml.jackson.databind.deser.std;
 
 
-	exports com.fasterxml.jackson.databind.module to com.fasterxml.jackson.module.paranamer;
-	exports com.fasterxml.jackson.databind.introspect  to com.fasterxml.jackson.module.paranamer, com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.guice, com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.module.jaxb;
-	exports com.fasterxml.jackson.databind.cfg to  com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.module to com.fasterxml.jackson.module.paranamer, com.fasterxml.jackson.module.parameternames, com.fasterxml.jackson.datatype.jsr310;
+	exports com.fasterxml.jackson.databind.introspect  to com.fasterxml.jackson.module.paranamer, com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.guice, com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.module.jaxb, com.fasterxml.jackson.module.parameternames, com.fasterxml.jackson.datatype.jsr310;
+	exports com.fasterxml.jackson.databind.cfg to  com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.jaxb, com.fasterxml.jackson.module.parameternames;
 	exports com.fasterxml.jackson.databind.type to  com.fasterxml.jackson.module.mrbean, com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
-	exports com.fasterxml.jackson.databind.ser to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8;
+	exports com.fasterxml.jackson.databind.ser to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.datatype.jsr310;
 	exports com.fasterxml.jackson.databind.ser.impl  to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8;
-	exports com.fasterxml.jackson.databind.jsontype to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.jsontype to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb, com.fasterxml.jackson.datatype.jsr310;
 	exports com.fasterxml.jackson.databind.util to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
 
-	exports com.fasterxml.jackson.databind.deser to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8;
+	exports com.fasterxml.jackson.databind.deser to  com.fasterxml.jackson.module.afterburner, com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.datatype.jsr310;
 	exports com.fasterxml.jackson.databind.deser.impl to  com.fasterxml.jackson.module.afterburner;
-	exports com.fasterxml.jackson.databind.jsonFormatVisitors to  com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb;
+	exports com.fasterxml.jackson.databind.jsonFormatVisitors to  com.fasterxml.jackson.datatype.jdk8, com.fasterxml.jackson.module.jaxb, com.fasterxml.jackson.datatype.jsr310;
 	exports com.fasterxml.jackson.databind.node to com.fasterxml.jackson.module.jaxb;
 	exports com.fasterxml.jackson.databind.jsontype.impl to com.fasterxml.jackson.module.jaxb;
 


### PR DESCRIPTION
* JAXB Bump to 2.3.0
* Guice Minimum set to 4.2.2 for JPMS
* JSON Setter - couldn't find merge annotation method on branch 2.9
* JPMS Strictly Named Modules with Hard Exports ONLY

JPMS Considerations
===================
For Private/Protected Field Scanning, The required package should open to com.fasterxml.jackson.databind.
This is how it currently works with automatic module naming, but it is now strictly enforced