### PR TITLE
Type safety for `readValue()` with `TypeReference`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -1453,7 +1453,7 @@ public class ObjectMapper
      *   expected for result type (or has other mismatch issues)
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(String content, TypeReference valueTypeRef)
+    public <T> T readValue(String content, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
         DefaultDeserializationContext ctxt = createDeserializationContext();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForContentTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForContentTest.java
@@ -46,7 +46,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     public void testFailOnNullFromDefaults() throws Exception
     {
         final String JSON = aposToQuotes("{'values':[null]}");
-        TypeReference<?> listType = new TypeReference<NullContentUndefined<List<String>>>() { };
+        TypeReference<NullContentUndefined<List<String>>> listType = new TypeReference<NullContentUndefined<List<String>>>() { };
 
         // by default fine to get nulls
         NullContentUndefined<List<String>> result = MAPPER.readValue(JSON, listType);
@@ -80,7 +80,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     
     public void testFailOnNullWithCollections() throws Exception
     {
-        TypeReference<?> typeRef = new TypeReference<NullContentFail<List<Integer>>>() { };
+        TypeReference<NullContentFail<List<Integer>>> typeRef = new TypeReference<NullContentFail<List<Integer>>>() { };
 
         // first, ok if assigning non-null to not-nullable, null for nullable
         NullContentFail<List<Integer>> result = MAPPER.readValue(aposToQuotes("{'nullsOk':[null]}"),
@@ -207,7 +207,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     public void testNullsAsEmptyUsingDefaults() throws Exception
     {
         final String JSON = aposToQuotes("{'values':[null]}");
-        TypeReference<?> listType = new TypeReference<NullContentUndefined<List<Integer>>>() { };
+        TypeReference<NullContentUndefined<List<Integer>>> listType = new TypeReference<NullContentUndefined<List<Integer>>>() { };
 
         // Let's see defaulting in action
         ObjectMapper mapper = jsonMapperBuilder()
@@ -301,7 +301,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     public void testNullsSkipUsingDefaults() throws Exception
     {
         final String JSON = aposToQuotes("{'values':[null]}");
-        TypeReference<?> listType = new TypeReference<NullContentUndefined<List<Long>>>() { };
+        TypeReference<NullContentUndefined<List<Long>>> listType = new TypeReference<NullContentUndefined<List<Long>>>() { };
 
         // Let's see defaulting in action
         ObjectMapper mapper = jsonMapperBuilder()
@@ -323,7 +323,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     public void testNullsSkipWithOverrides() throws Exception
     {
         final String JSON = aposToQuotes("{'values':[null]}");
-        TypeReference<?> listType = new TypeReference<NullContentSkip<List<Long>>>() { };
+        TypeReference<NullContentSkip<List<Long>>> listType = new TypeReference<NullContentSkip<List<Long>>>() { };
 
         ObjectMapper mapper = jsonMapperBuilder()
                 // defaults call for fail; but POJO specifies "skip"; latter should win

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKCollectionsDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKCollectionsDeserTest.java
@@ -30,7 +30,7 @@ public class JDKCollectionsDeserTest extends BaseMapTest
     // And then a round-trip test for singleton collections
     public void testSingletonCollections() throws Exception
     {
-        final TypeReference<?> xbeanListType = new TypeReference<List<XBean>>() { };
+        final TypeReference<List<XBean>> xbeanListType = new TypeReference<List<XBean>>() { };
 
         String json = MAPPER.writeValueAsString(Collections.singleton(new XBean(3)));
         Collection<XBean> result = MAPPER.readValue(json, xbeanListType);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapDeserializationTest.java
@@ -223,7 +223,7 @@ public class MapDeserializationTest
     {
         // to get typing, must use type reference
         String JSON = "{ \"1\" : true, \"-1\" : false }";
-        Map<Object,Object> result = MAPPER.readValue
+        Map<?,?> result = MAPPER.readValue
             (JSON, new TypeReference<HashMap<Integer,Boolean>>() { });
         assertNotNull(result);
         assertEquals(HashMap.class, result.getClass());
@@ -239,7 +239,7 @@ public class MapDeserializationTest
     {
         // to get typing, must use type reference
         String JSON = "{ \"a\" : \"b\" }";
-        Map<String,Integer> result = MAPPER.readValue
+        Map<String,String> result = MAPPER.readValue
             (JSON, new TypeReference<TreeMap<String,String>>() { });
 
         assertNotNull(result);
@@ -307,7 +307,7 @@ public class MapDeserializationTest
         String JSON = "{ \"KEY2\" : \"WHATEVER\" }";
 
         // to get typing, must use type reference
-        Map<Enum<?>,Enum<?>> result = MAPPER.readValue
+        Map<? extends Enum,? extends Enum> result = MAPPER.readValue
             (JSON, new TypeReference<Map<Key,Key>>() { });
 
         assertNotNull(result);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapKeyDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapKeyDeserializationTest.java
@@ -47,8 +47,8 @@ public class MapKeyDeserializationTest extends BaseMapTest
 
     public void testBooleanMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Boolean, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'true':'foobar'}}"), type);
+        TypeReference<MapWrapper<Boolean, String>> type = new TypeReference<MapWrapper<Boolean, String>>() { };
+        MapWrapper<Boolean, String> result = MAPPER.readValue(aposToQuotes("{'map':{'true':'foobar'}}"), type);
                 
         assertEquals(1, result.map.size());
         Assert.assertEquals(Boolean.TRUE, result.map.entrySet().iterator().next().getKey());
@@ -60,48 +60,48 @@ public class MapKeyDeserializationTest extends BaseMapTest
 
     public void testByteMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Byte, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'13':'foobar'}}"), type);
+        TypeReference<MapWrapper<Byte, String>> type = new TypeReference<MapWrapper<Byte, String>>() { };
+        MapWrapper<Byte, String> result = MAPPER.readValue(aposToQuotes("{'map':{'13':'foobar'}}"), type);
         assertEquals(1, result.map.size());
         Assert.assertEquals(Byte.valueOf((byte) 13), result.map.entrySet().iterator().next().getKey());
     }
 
     public void testShortMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Short, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'13':'foobar'}}"), type);
+        TypeReference<MapWrapper<Short, String>> type = new TypeReference<MapWrapper<Short, String>>() { };
+        MapWrapper<Short, String> result = MAPPER.readValue(aposToQuotes("{'map':{'13':'foobar'}}"), type);
         assertEquals(1, result.map.size());
         Assert.assertEquals(Short.valueOf((short) 13), result.map.entrySet().iterator().next().getKey());
     }
 
     public void testIntegerMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Integer, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'-3':'foobar'}}"), type);
+        TypeReference<MapWrapper<Integer, String>> type = new TypeReference<MapWrapper<Integer, String>>() { };
+        MapWrapper<Integer, String> result = MAPPER.readValue(aposToQuotes("{'map':{'-3':'foobar'}}"), type);
         assertEquals(1, result.map.size());
         Assert.assertEquals(Integer.valueOf(-3), result.map.entrySet().iterator().next().getKey());
     }
 
     public void testLongMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Long, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'42':'foobar'}}"), type);
+        TypeReference<MapWrapper<Long, String>> type = new TypeReference<MapWrapper<Long, String>>() { };
+        MapWrapper<Long, String> result = MAPPER.readValue(aposToQuotes("{'map':{'42':'foobar'}}"), type);
         assertEquals(1, result.map.size());
         Assert.assertEquals(Long.valueOf(42), result.map.entrySet().iterator().next().getKey());
     }
 
     public void testFloatMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Float, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'3.5':'foobar'}}"), type);
+        TypeReference<MapWrapper<Float, String>> type = new TypeReference<MapWrapper<Float, String>>() { };
+        MapWrapper<Float, String> result = MAPPER.readValue(aposToQuotes("{'map':{'3.5':'foobar'}}"), type);
         assertEquals(1, result.map.size());
         Assert.assertEquals(Float.valueOf(3.5f), result.map.entrySet().iterator().next().getKey());
     }
 
     public void testDoubleMapKeyDeserialization() throws Exception
     {
-        TypeReference<?> type = new TypeReference<MapWrapper<Double, String>>() { };
-        MapWrapper<byte[], String> result = MAPPER.readValue(aposToQuotes("{'map':{'0.25':'foobar'}}"), type);
+        TypeReference<MapWrapper<Double, String>> type = new TypeReference<MapWrapper<Double, String>>() { };
+        MapWrapper<Double, String> result = MAPPER.readValue(aposToQuotes("{'map':{'0.25':'foobar'}}"), type);
         assertEquals(1, result.map.size());
         Assert.assertEquals(Double.valueOf(0.25), result.map.entrySet().iterator().next().getKey());
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapRelatedTypesDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapRelatedTypesDeserTest.java
@@ -71,7 +71,7 @@ public class MapRelatedTypesDeserTest
     // JDK singletonMap
     public void testSingletonMapRoundtrip() throws Exception
     {
-        final TypeReference<?> type = new TypeReference<Map<String,IntWrapper>>() { };
+        final TypeReference<Map<String,IntWrapper>> type = new TypeReference<Map<String,IntWrapper>>() { };
 
         String json = MAPPER.writeValueAsString(Collections.singletonMap("value", new IntWrapper(5)));
         Map<String,IntWrapper> result = MAPPER.readValue(json, type);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedContainerSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypedContainerSerialization.java
@@ -139,10 +139,10 @@ public class TestTypedContainerSerialization
             List<Issue508A> l2 = new ArrayList<Issue508A>();
             l2.add(new Issue508A());
             l.add(l2);
-            TypeReference<?> typeRef = new TypeReference<List<List<Issue508A>>>() {};
+            TypeReference<List<List<Issue508A>>> typeRef = new TypeReference<List<List<Issue508A>>>() {};
             String json = mapper.writerFor(typeRef).writeValueAsString(l);
 
-            List<?> output = mapper.readValue(json, typeRef);
+			List<List<Issue508A>> output = mapper.readValue(json, typeRef);
             assertEquals(1, output.size());
             Object ob = output.get(0);
             assertTrue(ob instanceof List<?>);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeId999Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeId999Test.java
@@ -39,7 +39,7 @@ public class ExternalTypeId999Test extends BaseMapTest
 
     public void testExternalTypeId() throws Exception
     {
-        TypeReference<?> type = new TypeReference<Message<FooPayload>>() { };
+        TypeReference<Message<FooPayload>> type = new TypeReference<Message<FooPayload>>() { };
 
         Message<?> msg = MAPPER.readValue(aposToQuotes("{ 'type':'foo', 'payload': {} }"), type);
         assertNotNull(msg);

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/ObjectIdReordering1388Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/ObjectIdReordering1388Test.java
@@ -48,7 +48,7 @@ public class ObjectIdReordering1388Test extends BaseMapTest
         final UUID id = UUID.fromString("a59aa02c-fe3c-43f8-9b5a-5fe01878a818");
         final NamedThing thing = new NamedThing(id, "Hello");
 
-        final TypeReference<?> namedThingListType = new TypeReference<List<NamedThing>>() { };
+        final TypeReference<List<NamedThing>> namedThingListType = new TypeReference<List<NamedThing>>() { };
 
         {
             final String jsog = mapper.writeValueAsString(Arrays.asList(thing, thing, thing));


### PR DESCRIPTION
In Java the type safety is enforced at run-time for reifiable types (e.g. arrays that throw ArrayStoreException) but for non-reifiable types such as generic collections, it is important that type safety is enforced at compile time. Its not possible to enforce type safety at runtime, because of the type erasure. 

The ObjectMapper.readValue(String, TypeReference) was not type-safe at
compile time, because the type of parameter valueTypeRef was missing
generic type parameter T. This fact could cause heap pollution when
client would write something like this:

```
List<String> list;
list = mapper.readValue("[33]", new TypeReference<List<Integer>>(){});
String str = list.get(0); // throws ClassCastException
```

