### PR TITLE
Minor cleanup of exception message for `Enum` binding failure

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -396,7 +396,7 @@ public class StdKeyDeserializer extends KeyDeserializer
                         && ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)) {
                     e = _enumDefaultValue;
                 } else if (!ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)) {
-                    return ctxt.handleWeirdKey(_keyClass, key, "not one of values excepted for Enum class: %s",
+                    return ctxt.handleWeirdKey(_keyClass, key, "not one of the values accepted for Enum class: %s",
                         res.getEnumIds());
                 }
                 // fall-through if problems are collected, not immediately thrown


### PR DESCRIPTION
A minor nitpick, but the wording for the error log was using the word 'except' meaning to exclude, when it was intending to use the word 'accept' meaning to take. Yes, it's a nit, but this clarifies the meaning of the error.