### PR TITLE
Close/flush the `OutputStream` before calling `toByteArray()`on underlying `ByteArrayOutputStream`

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -212,12 +212,14 @@ public class ObjectMapperTest extends BaseMapTest
         DataOutput data = new DataOutputStream(bytes);
         final String exp = "{\"a\":1}";
         MAPPER.writeValue(data, input);
+        bytes.flush();
         assertEquals(exp, bytes.toString("UTF-8"));
 
         // and also via ObjectWriter...
         bytes.reset();
         data = new DataOutputStream(bytes);
         MAPPER.writer().writeValue(data, input);
+        bytes.close();
         assertEquals(exp, bytes.toString("UTF-8"));
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypesTest.java
@@ -379,6 +379,7 @@ public class JDKStringLikeTypesTest extends BaseMapTest
         DataOutputStream out = new DataOutputStream(bytes);
         out.writeLong(value.getMostSignificantBits());
         out.writeLong(value.getLeastSignificantBits());
+        out.close();
         byte[] data = bytes.toByteArray();
         assertEquals(16, data.length);
         


### PR DESCRIPTION
When an `OutputStream` instance wraps an underlying `ByteArrayOutputStream` instance, it is recommended to flush or close the `OutputStream` before invoking the underlying instances' `toByteArray()`. Although in some of these case it is not strictly necessary because the `writeObject()` method is invoked right before `toByteArray()`, and `writeObject()` internally calls `flush()`/`drain()`. However, it is good practice to call `flush()`/`close()` explicitly as mentioned, for example, [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).

This pull request adds a call to `close()` or `flush()` before calls to `toByteArray()`.