### PR TITLE
`ExternalTypeHandler .java`does not check the validity of input property retrieved given the input name

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -142,6 +142,9 @@ public class ExternalTypeHandler
         // 28-Nov-2016, tatu: For [databind#291], need separate handling
         if (ob instanceof List<?>) {
             Iterator<Integer> it = ((List<Integer>) ob).iterator();
+            if (!it.hasNext()) {
+                return false;
+            }
             Integer index = it.next();
 
             ExtTypedProperty prop = _properties[index];


### PR DESCRIPTION
`ExternalTypeHandler.java` calls `it.next()` on `java.util.Iterator it` without checking
if there are any elements. Because the list is built from parameter object that is retrieved 
from the input `String paramName`, it could be invalid (e.g., an empty list), 
this can lead to a runtime exception. 

This pull request adds a `hasNext()` check.
