### PR TITLE
#2283 - Renaming Read Only Properties with USE_GETTERS_AS_SETTERS

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -847,6 +847,10 @@ Joffrey Bion (joffrey-bion@github)
     Collections$UnmodifiableRandomAccessList
    (2.9.9)
 
+Yona Appletree (YonaAppletree@github)
+  * Reported, fixed #2283: JsonProperty.Access.READ_ONLY fails with collections when a property name is specified
+   (2.9.9)
+
 Christoph Breitkopf (bokesan@github)
   * Reported #2217: Suboptimal memory allocation in `TextNode.getBinaryValue()`
    (2.10.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -53,6 +53,8 @@ Project: jackson-databind
  (reported by Joffrey B)
 - Prevent String coercion of `null` in `WritableObjectId` when calling `JsonGenerator.writeObjectId()`,
   mostly relevant for formats like YAML that have native Object Ids
+#2283: JsonProperty.Access.READ_ONLY fails with collections when a property name is specified
+ (reported by Yona A)
 
 2.9.8 (15-Dec-2018)
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/ReadOnlyCollectionDeserRenamed2283Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/ReadOnlyCollectionDeserRenamed2283Test.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ReadOnlyCollectionDeserRenamed2283Test extends BaseMapTest
+{
+    static class RenamedToSameOnGetter {
+        @JsonProperty(value = "list", access = JsonProperty.Access.READ_ONLY)
+        List<Long> getList() {
+            return Collections.unmodifiableList(Collections.emptyList());
+        }
+    }
+
+    static class RenamedToDifferentOnGetter {
+        @JsonProperty(value = "renamedList", access = JsonProperty.Access.READ_ONLY)
+        List<Long> getList() {
+            return Collections.unmodifiableList(Collections.emptyList());
+        }
+    }
+
+    @JsonIgnoreProperties(value={ "renamedList" }, allowGetters=true)
+    static class RenamedOnClass {
+        @JsonProperty("renamedList")
+        List<Long> getList() {
+            return Collections.unmodifiableList(Collections.emptyList());
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder().configure(MapperFeature.USE_GETTERS_AS_SETTERS, true).build();
+
+    public void testRenamedToSameOnGetter() throws Exception
+    {
+        String payload = "{\"list\":[1,2,3,4]}";
+        RenamedToSameOnGetter foo = MAPPER.readValue(payload, RenamedToSameOnGetter.class);
+        assertTrue("List should be empty", foo.getList().isEmpty());
+    }
+
+    public void testRenamedToDifferentOnGetter() throws Exception
+    {
+        String payload = "{\"renamedList\":[1,2,3,4]}";
+        RenamedToDifferentOnGetter foo = MAPPER.readValue(payload, RenamedToDifferentOnGetter.class);
+        assertTrue("List should be empty", foo.getList().isEmpty());
+    }
+
+    public void testRenamedOnClass() throws Exception
+    {
+        String payload = "{\"renamedList\":[1,2,3,4]}";
+        RenamedOnClass foo = MAPPER.readValue(payload, RenamedOnClass.class);
+        assertTrue("List should be empty", foo.getList().isEmpty());
+    }
+}


### PR DESCRIPTION
This is my first time with this codebase, so this may be wrong, but I did my best to understand what was going on.

Basically, I changed the renamed property set to a multimap, keeping track of which property definitions were involved in the rename. This allows us to undo the ignoring of a property when it's renamed for #2001, by checking if the renaming property is one of the ones that originally ignored it.

Then I added logic to update the list of ignored properties to the new name.

I did some minor refactoring in `_renameProperties` while I was there in service to this change. I found the original generic names in some places hard to understand, so I made them more descriptive.