### PR TITLE
Use correct reader to test null property

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/FailOnNullCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/FailOnNullCreatorTest.java
@@ -35,7 +35,7 @@ public class FailOnNullCreatorTest extends BaseMapTest
 
         // Second: fine if feature is enabled but default value is not null
         ObjectReader r = POINT_READER.with(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES);
-        p = POINT_READER.readValue(aposToQuotes("{'name':'John', 'age': null}"));
+        p = r.readValue(aposToQuotes("{'name':'John', 'age': null}"));
         assertEquals("John", p.name);
         assertEquals(Integer.valueOf(0), p.age);
 


### PR DESCRIPTION
Test the null property on the reader that has the deser feature enabled.