### PR TITLE
Add sanity checks for `ObjectMapper.readXXX()` methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -1274,6 +1274,7 @@ public class ObjectMapper
     @SuppressWarnings({ "unchecked" })
     public <T> T readValue(File src, TypeReference<T> valueTypeRef) throws IOException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt, _streamFactory.createParser(ctxt, src),
                 _typeFactory.constructType(valueTypeRef));
@@ -1295,6 +1296,7 @@ public class ObjectMapper
     public <T> T readValue(File src, JavaType valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt, _streamFactory.createParser(ctxt, src), valueType);
     }
@@ -1321,6 +1323,7 @@ public class ObjectMapper
     public <T> T readValue(URL src, Class<T> valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueType));
@@ -1332,6 +1335,7 @@ public class ObjectMapper
     @SuppressWarnings({ "unchecked" })
     public <T> T readValue(URL src, TypeReference<T> valueTypeRef) throws IOException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueTypeRef));
@@ -1364,6 +1368,7 @@ public class ObjectMapper
     public <T> T readValue(String content, Class<T> valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("content", content);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, content), _typeFactory.constructType(valueType));
@@ -1384,6 +1389,7 @@ public class ObjectMapper
     @SuppressWarnings({ "unchecked" })
     public <T> T readValue(String content, TypeReference<T> valueTypeRef) throws IOException
     {
+        assertNotNull("content", content);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, content), _typeFactory.constructType(valueTypeRef));
@@ -1405,6 +1411,7 @@ public class ObjectMapper
     public <T> T readValue(String content, JavaType valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("content", content);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, content), valueType);
@@ -1414,6 +1421,7 @@ public class ObjectMapper
     public <T> T readValue(Reader src, Class<T> valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueType));
@@ -1423,6 +1431,7 @@ public class ObjectMapper
     public <T> T readValue(Reader src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueTypeRef));
@@ -1432,6 +1441,7 @@ public class ObjectMapper
     public <T> T readValue(Reader src, JavaType valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), valueType);
@@ -1441,6 +1451,7 @@ public class ObjectMapper
     public <T> T readValue(InputStream src, Class<T> valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueType));
@@ -1450,6 +1461,7 @@ public class ObjectMapper
     public <T> T readValue(InputStream src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueTypeRef));
@@ -1459,6 +1471,7 @@ public class ObjectMapper
     public <T> T readValue(InputStream src, JavaType valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), valueType);
@@ -1468,6 +1481,7 @@ public class ObjectMapper
     public <T> T readValue(byte[] src, Class<T> valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueType));
@@ -1477,6 +1491,7 @@ public class ObjectMapper
     public <T> T readValue(byte[] src, int offset, int len, Class<T> valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src, offset, len), _typeFactory.constructType(valueType));
@@ -1486,6 +1501,7 @@ public class ObjectMapper
     public <T> T readValue(byte[] src, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueTypeRef));
@@ -1495,6 +1511,7 @@ public class ObjectMapper
     public <T> T readValue(byte[] src, int offset, int len, TypeReference<T> valueTypeRef)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src, offset, len), _typeFactory.constructType(valueTypeRef));
@@ -1504,6 +1521,7 @@ public class ObjectMapper
     public <T> T readValue(byte[] src, JavaType valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), valueType);
@@ -1514,6 +1532,7 @@ public class ObjectMapper
                            JavaType valueType)
         throws IOException, JsonParseException, JsonMappingException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src, offset, len), valueType);
@@ -1522,6 +1541,7 @@ public class ObjectMapper
     @SuppressWarnings("unchecked")
     public <T> T readValue(DataInput src, Class<T> valueType) throws IOException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueType));
@@ -1530,9 +1550,16 @@ public class ObjectMapper
     @SuppressWarnings("unchecked")
     public <T> T readValue(DataInput src, JavaType valueType) throws IOException
     {
+        assertNotNull("src", src);
         DefaultDeserializationContext ctxt = createDeserializationContext();
         return (T) _readMapAndClose(ctxt,
                 _streamFactory.createParser(ctxt, src), valueType);
+    }
+
+    private void assertNotNull(String paramName, Object src) {
+        if (src==null){
+            throw new IllegalArgumentException(paramName + " is null");
+        }
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -249,7 +249,7 @@ public class ObjectMapperTest extends BaseMapTest
         try {
             m.readValue(is, Object.class);
         } catch (IllegalArgumentException e) {
-            assertEquals("InputStream is null", e.getMessage());
+            assertEquals("src is null", e.getMessage());
             return;
         }
         fail("Specific exception expected");

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -242,4 +242,16 @@ public class ObjectMapperTest extends BaseMapTest
                 .readTree(input);
         assertNotNull(n);
     }
+
+    public void testReadValueWithNullInputStream() throws Exception {
+        ObjectMapper m = new ObjectMapper();
+        InputStream is = null;
+        try {
+            m.readValue(is, Object.class);
+        } catch (IllegalArgumentException e) {
+            assertEquals("InputStream is null", e.getMessage());
+            return;
+        }
+        fail("Specific exception expected");
+    }
 }


### PR DESCRIPTION
Today by trying to read something that I though being an `InputStream `:

    InputStream stream = getClass().getResourceAsStream("/myFile.json");
    List<Foo> foos= Arrays.asList(objectMapper.readValue(stream, Foo[].class));

I get a quite broad end-of-input exception  : 

> com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
>  at [Source: UNKNOWN; line: 1, column: 0]
>         at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59) ~[jackson-databind-2.9.8.jar:2.9.8]
>         at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4145) ~[jackson-databind-2.9.8.jar:2.9.8]
>         at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4000) ~[jackson-databind-2.9.8.jar:2.9.8]
>         at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3070) ~[jackson-databind-2.9.8.jar:2.9.8]
> 

Actually, `readValue(InputStream src, Class<T> valueType)`  as well as  ObjectMapper reading methods do not perform sanity checks against the source parameters that they receive. In my case the `InputStream `variable referenced a null.  
The error message is so misleading and too broad.  
For example on SO, we can find other usecases that produces this error : 
[https://stackoverflow.com/questions/26925058/no-content-to-map-due-to-end-of-input-jackson-parser](https://stackoverflow.com/questions/26925058/no-content-to-map-due-to-end-of-input-jackson-parser)

 Applying fail fast principle and throwing  `IllegalArgumentException `or  `NullPointerException` with a meaningful message would make much more sense. 
So here is a pull request with this change. I didn't write whole unit tests for every case. But I can of course add it if the pull request makes sense for reviewers.

Regards,
David