### PR TITLE
#2360 Restore jdk 6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,60 @@
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
       </plugin>
+
+	<plugin>
+	    <artifactId>maven-compiler-plugin</artifactId>
+	    <version>2.5</version>
+	    <executions>
+	      <execution>
+          	<id>jdk7</id>
+	        <configuration>
+	          <source>1.7</source>
+	          <target>1.7</target>
+	          <fork>true</fork>
+	          <outputDirectory>${project.build.outputDirectory}_jdk7</outputDirectory>
+	        </configuration>
+	      </execution>
+	      <execution>
+          	<id>jdk6</id>
+	        <configuration>
+	          <source>1.6</source>
+	          <target>1.6</target>
+	          <fork>true</fork>
+	          <outputDirectory>${project.build.outputDirectory}_jdk6</outputDirectory>
+	        </configuration>
+	      </execution>
+	    </executions>
+	 </plugin>
+	 
+	 <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <executions>
+          <execution>
+          	<id>jdk7</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk7</classesDirectory>
+              <classifier></classifier>
+            </configuration>
+          </execution>
+          <execution>
+          	<id>jdk6</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk6</classesDirectory>
+              <classifier>jdk6</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+       
     </plugins>
   </build>
 

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -4101,7 +4101,8 @@ public class ObjectMapper
      */
     protected JsonNode _readTreeAndClose(JsonParser p0) throws IOException
     {
-        try (JsonParser p = p0) {
+    	JsonParser p = p0;
+        try {
             final JavaType valueType = constructType(JsonNode.class);
 
             DeserializationConfig cfg = getDeserializationConfig();
@@ -4143,6 +4144,10 @@ public class ObjectMapper
             // No ObjectIds so can ignore
 //            ctxt.checkUnresolvedObjectId();
             return resultNode;
+        } finally {
+            try {
+                p.close();
+            } catch (IOException ioe) { }
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -1,17 +1,37 @@
 package com.fasterxml.jackson.databind;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.net.URL;
-import java.util.*;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.FormatFeature;
+import com.fasterxml.jackson.core.FormatSchema;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.Versioned;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
 import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.core.type.ResolvedType;
 import com.fasterxml.jackson.core.type.TypeReference;
-
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.deser.DataFormatReaders;
 import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
@@ -1661,7 +1681,8 @@ public class ObjectReader
 
     protected Object _bindAndClose(JsonParser p0) throws IOException
     {
-        try (JsonParser p = p0) {
+		JsonParser p = p0;
+		try {
             Object result;
 
             DeserializationContext ctxt = createDeserializationContext(p);
@@ -1691,12 +1712,23 @@ public class ObjectReader
                 _verifyNoTrailingTokens(p, ctxt, _valueType);
             }
             return result;
+		} finally {
+			try {
+				p.close();
+			} catch (IOException ioe) {
+			}
         }
     }
 
     protected final JsonNode _bindAndCloseAsTree(JsonParser p0) throws IOException {
-        try (JsonParser p = p0) {
+		JsonParser p = p0;
+		try {
             return _bindAsTree(p);
+		} finally {
+			try {
+				p.close();
+			} catch (IOException ioe) {
+			}
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -405,7 +405,7 @@ index, owner, defs[index], propDef);
             }
         }
         // 21-Sep-2017, tatu: First let's handle explicitly annotated ones
-        List<CreatorCandidate> nonAnnotated = new LinkedList<>();
+        List<CreatorCandidate> nonAnnotated = new LinkedList<CreatorCandidate>();
         int explCount = 0;
         for (AnnotatedConstructor ctor : beanDesc.getConstructors()) {
             JsonCreator.Mode creatorMode = intr.findCreatorAnnotation(ctxt.getConfig(), ctor);
@@ -551,7 +551,7 @@ nonAnnotatedParamIndex, ctor);
             // [#725]: as a fallback, all-implicit names may work as well
             if (!creators.hasDefaultCreator()) {
                 if (implicitCtors == null) {
-                    implicitCtors = new LinkedList<>();
+                    implicitCtors = new LinkedList<AnnotatedWithParams>();
                 }
                 implicitCtors.add(ctor);
             }
@@ -797,7 +797,7 @@ nonAnnotatedParamIndex, ctor);
          Map<AnnotatedWithParams,BeanPropertyDefinition[]> creatorParams)
         throws JsonMappingException
     {
-        List<CreatorCandidate> nonAnnotated = new LinkedList<>();
+        List<CreatorCandidate> nonAnnotated = new LinkedList<CreatorCandidate>();
         int explCount = 0;
 
         // 21-Sep-2017, tatu: First let's handle explicitly annotated ones

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -511,7 +511,7 @@ public class BeanDeserializerBuilder
                     continue;
                 }
                 if (mapping == null) {
-                    mapping = new HashMap<>();
+                    mapping = new HashMap<String, List<PropertyName>>();
                 }
                 mapping.put(prop.getName(), aliases);
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -562,7 +562,7 @@ public class BeanDeserializerFactory
                     }
                 }
                 if (cprop == null) {
-                    List<String> n = new ArrayList<>();
+                    List<String> n = new ArrayList<String>();
                     for (SettableBeanProperty cp : creatorProps) {
                         n.add(cp.getName());
                     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -775,7 +775,7 @@ public class BeanPropertyMap
         if ((defs == null) || defs.isEmpty()) {
             return Collections.emptyMap();
         }
-        Map<String,String> aliases = new HashMap<>();
+        Map<String,String> aliases = new HashMap<String, String>();
         for (Map.Entry<String,List<PropertyName>> entry : defs.entrySet()) {
             String key = entry.getKey();
             if (_caseInsensitive) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -377,8 +377,8 @@ public class ExternalTypeHandler
     {
         private final JavaType _beanType;
 
-        private final List<ExtTypedProperty> _properties = new ArrayList<>();
-        private final Map<String, Object> _nameToPropertyIndex = new HashMap<>();
+        private final List<ExtTypedProperty> _properties = new ArrayList<ExtTypedProperty>();
+        private final Map<String, Object> _nameToPropertyIndex = new HashMap<String, Object>();
 
         protected Builder(JavaType t) {
             _beanType = t;
@@ -401,7 +401,7 @@ public class ExternalTypeHandler
                 List<Object> list = (List<Object>) ob;
                 list.add(index);
             } else {
-                List<Object> list = new LinkedList<>();
+                List<Object> list = new LinkedList<Object>();
                 list.add(ob);
                 list.add(index);
                 _nameToPropertyIndex.put(name, list);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -12,9 +13,14 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.util.VersionUtil;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
@@ -143,10 +149,11 @@ public abstract class FromStringDeserializer<T> extends StdScalarDeserializer<T>
                 //    indicated error; but that seems wrong. Should be able to return
                 //    `null` as value.
                 return _deserialize(text, ctxt);
-            } catch (IllegalArgumentException | MalformedURLException e) {
+			} catch (IllegalArgumentException e) {
+				cause = e;
+			} catch (MalformedURLException e) {
                 cause = e;
-            }
-            // note: `cause` can't be null
+			} // note: `cause` can't be null
             String msg = "not a valid textual representation";
             String m2 = cause.getMessage();
             if (m2 != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass.Creators;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.ClassUtil.Ctor;
 
 /**
  * Helper class used to contain details of how Creators (annotated constructors
@@ -107,7 +108,7 @@ final class AnnotatedCreatorCollector
                     defaultCtor = ctor;
                 } else {
                     if (ctors == null) {
-                        ctors = new ArrayList<>();
+                        ctors = new ArrayList<Ctor>();
                     }
                     ctors.add(ctor);
                 }
@@ -124,7 +125,7 @@ final class AnnotatedCreatorCollector
             ctorCount = 0;
         } else {
             ctorCount = ctors.size();
-            result = new ArrayList<>(ctorCount);
+            result = new ArrayList<AnnotatedConstructor>(ctorCount);
             for (int i = 0; i < ctorCount; ++i) {
                 result.add(null);
             }
@@ -186,7 +187,7 @@ final class AnnotatedCreatorCollector
             // all factory methods are fine:
             //int argCount = m.getParameterTypes().length;
             if (candidates == null) {
-                candidates = new ArrayList<>();
+                candidates = new ArrayList<Method>();
             }
             candidates.add(m);
         }
@@ -195,7 +196,7 @@ final class AnnotatedCreatorCollector
             return Collections.emptyList();
         }
         int factoryCount = candidates.size();
-        List<AnnotatedMethod> result = new ArrayList<>(factoryCount);
+        List<AnnotatedMethod> result = new ArrayList<AnnotatedMethod>(factoryCount);
         for (int i = 0; i < factoryCount; ++i) {
             result.add(null);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -42,7 +42,7 @@ public class AnnotatedFieldCollector
         if (foundFields == null) {
             return Collections.emptyList();
         }
-        List<AnnotatedField> result = new ArrayList<>(foundFields.size());
+        List<AnnotatedField> result = new ArrayList<AnnotatedField>(foundFields.size());
         for (FieldBuilder b : foundFields.values()) {
             result.add(b.build());
         }
@@ -72,7 +72,7 @@ public class AnnotatedFieldCollector
             // because mix-ins haven't been added, and partly because logic can be done
             // when determining get/settability of the field.
             if (fields == null) {
-                fields = new LinkedHashMap<>();
+                fields = new LinkedHashMap<String, FieldBuilder>();
             }
             FieldBuilder b = new FieldBuilder(tc, f);
             if (_intr != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.databind.introspect;
 
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.util.ClassUtil;
@@ -170,7 +172,10 @@ public final class AnnotatedMethod
     {
         try {
             _method.invoke(pojo, value);
-        } catch (IllegalAccessException | InvocationTargetException e) {
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(
+					"Failed to setValue() with method " + getFullName() + ": " + e.getMessage(), e);
+		} catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to setValue() with method "
                     +getFullName()+": "+e.getMessage(), e);
         }
@@ -181,7 +186,10 @@ public final class AnnotatedMethod
     {
         try {
             return _method.invoke(pojo, (Object[]) null);
-        } catch (IllegalAccessException | InvocationTargetException e) {
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(
+					"Failed to getValue() with method " + getFullName() + ": " + e.getMessage(), e);
+		} catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to getValue() with method "
                     +getFullName()+": "+e.getMessage(), e);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
@@ -36,7 +36,7 @@ public class AnnotatedMethodCollector
     AnnotatedMethodMap collect(TypeFactory typeFactory, TypeResolutionContext tc,
             JavaType mainType, List<JavaType> superTypes, Class<?> primaryMixIn)
     {
-        Map<MemberKey,MethodBuilder> methods = new LinkedHashMap<>();
+        Map<MemberKey,MethodBuilder> methods = new LinkedHashMap<MemberKey, MethodBuilder>();
         
         // first: methods from the class itself
         _addMemberMethods(tc, mainType.getRawClass(), methods, primaryMixIn);
@@ -86,7 +86,7 @@ public class AnnotatedMethodCollector
         if (methods.isEmpty()) {
             return new AnnotatedMethodMap();
         }
-        Map<MemberKey,AnnotatedMethod> actual = new LinkedHashMap<>(methods.size());
+        Map<MemberKey,AnnotatedMethod> actual = new LinkedHashMap<MemberKey, AnnotatedMethod>(methods.size());
         for (Map.Entry<MemberKey,MethodBuilder> entry : methods.entrySet()) {
             AnnotatedMethod am = entry.getValue().build();
             if (am != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationCollector.java
@@ -131,7 +131,7 @@ public abstract class AnnotationCollector
                 Class<?> type1, Annotation value1,
                 Class<?> type2, Annotation value2) {
             super(data);
-            _annotations = new HashMap<>();
+            _annotations = new HashMap<Class<?>, Annotation>();
             _annotations.put(type1, value1);
             _annotations.put(type2, value2);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationMap.java
@@ -18,7 +18,7 @@ public final class AnnotationMap implements Annotations
     public AnnotationMap() { }
 
     public static AnnotationMap of(Class<?> type, Annotation value) {
-        HashMap<Class<?>,Annotation> ann = new HashMap<>(4);
+        HashMap<Class<?>,Annotation> ann = new HashMap<Class<?>, Annotation>(4);
         ann.put(type, value);
         return new AnnotationMap(ann);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
@@ -494,7 +494,7 @@ anyField.getName()));
             final String refName = refDef.getName();
             if (result == null) {
                 result = new ArrayList<BeanPropertyDefinition>();
-                names = new HashSet<>();
+                names = new HashSet<String>();
                 names.add(refName);
             } else {
                 if (!names.add(refName)) {
@@ -514,7 +514,7 @@ anyField.getName()));
         if (props == null) {
             return null;
         }
-        Map<String,AnnotatedMember> result = new HashMap<>();
+        Map<String,AnnotatedMember> result = new HashMap<String, AnnotatedMember>();
         for (BeanPropertyDefinition prop : props) {
             result.put(prop.getName(), prop.getMutator());
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -347,7 +347,7 @@ public class JacksonAnnotationIntrospector
         if (len == 0) {
             return Collections.emptyList();
         }
-        List<PropertyName> result = new ArrayList<>(len);
+        List<PropertyName> result = new ArrayList<PropertyName>(len);
         for (int i = 0; i < len; ++i) {
             result.add(PropertyName.construct(strs[i]));
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -381,7 +381,7 @@ public class POJOPropertiesCollector
             // @JsonValue?
             if (Boolean.TRUE.equals(ai.hasAsValue(f))) {
                 if (_jsonValueAccessors == null) {
-                    _jsonValueAccessors = new LinkedList<>();
+                    _jsonValueAccessors = new LinkedList<AnnotatedMember>();
                 }
                 _jsonValueAccessors.add(f);
                 continue;
@@ -566,7 +566,7 @@ public class POJOPropertiesCollector
         // @JsonValue?
         if (Boolean.TRUE.equals(ai.hasAsValue(m))) {
             if (_jsonValueAccessors == null) {
-                _jsonValueAccessors = new LinkedList<>();
+                _jsonValueAccessors = new LinkedList<AnnotatedMember>();
             }
             _jsonValueAccessors.add(m);
             return;

--- a/src/main/java/com/fasterxml/jackson/databind/module/SimpleModule.java
+++ b/src/main/java/com/fasterxml/jackson/databind/module/SimpleModule.java
@@ -380,7 +380,7 @@ public class SimpleModule
     public SimpleModule registerSubtypes(Class<?> ... subtypes)
     {
         if (_subtypes == null) {
-            _subtypes = new LinkedHashSet<>();
+            _subtypes = new LinkedHashSet<NamedType>();
         }
         for (Class<?> subtype : subtypes) {
             _checkNotNull(subtype, "subtype to register");
@@ -397,7 +397,7 @@ public class SimpleModule
     public SimpleModule registerSubtypes(NamedType ... subtypes)
     {
         if (_subtypes == null) {
-            _subtypes = new LinkedHashSet<>();
+            _subtypes = new LinkedHashSet<NamedType>();
         }
         for (NamedType subtype : subtypes) {
             _checkNotNull(subtype, "subtype to register");
@@ -416,7 +416,7 @@ public class SimpleModule
     public SimpleModule registerSubtypes(Collection<Class<?>> subtypes)
     {
         if (_subtypes == null) {
-            _subtypes = new LinkedHashSet<>();
+            _subtypes = new LinkedHashSet<NamedType>();
         }
         for (Class<?> subtype : subtypes) {
             _checkNotNull(subtype, "subtype to register");

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -368,7 +368,7 @@ public abstract class StdSerializer<T>
                 return existingSerializer;
             }
         } else {
-            conversions = new IdentityHashMap<>();
+            conversions = new IdentityHashMap<Object, Object>();
             provider.setAttribute(KEY_CONTENT_CONVERTER_LOCK, conversions);
         }
         conversions.put(property, Boolean.TRUE);


### PR DESCRIPTION
Fixes#2360 Restore jdk 6 compatibility

Removes JDK 7 syntax and adds pom configuration to generate a jdk 6
compliant jar with the jdk6 qualifier 