### PR TITLE
Fixes#2360 Restore JDK 6 compatibility (for 2.9.9.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.fasterxml.jackson.core</groupId>
   <artifactId>jackson-databind</artifactId>
-  <version>2.9.10-SNAPSHOT</version>
+  <version>2.9.9.1-SNAPSHOT</version>
   <name>jackson-databind</name>
   <packaging>bundle</packaging>
   <description>General data-binding functionality for Jackson: works on core streaming API</description>
@@ -31,8 +31,8 @@
          (small number of types); this allows use on JDK 6 platforms still (including
          Android)
       -->
-    <javac.src.version>1.7</javac.src.version>
-    <javac.target.version>1.7</javac.target.version>
+    <javac.src.version>1.6</javac.src.version>
+    <javac.target.version>1.6</javac.target.version>
 
     <!-- Can not use default, since group id != Java package name here -->
     <osgi.export>com.fasterxml.jackson.databind.*;version=${project.version}</osgi.export>

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -1,17 +1,37 @@
 package com.fasterxml.jackson.databind;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.net.URL;
-import java.util.*;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.FormatFeature;
+import com.fasterxml.jackson.core.FormatSchema;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.Versioned;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
 import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.core.type.ResolvedType;
 import com.fasterxml.jackson.core.type.TypeReference;
-
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.deser.DataFormatReaders;
 import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
@@ -1589,7 +1609,8 @@ public class ObjectReader
 
     protected Object _bindAndClose(JsonParser p0) throws IOException
     {
-        try (JsonParser p = p0) {
+		JsonParser p = p0;
+		try {
             Object result;
 
             DeserializationContext ctxt = createDeserializationContext(p);
@@ -1619,12 +1640,23 @@ public class ObjectReader
                 _verifyNoTrailingTokens(p, ctxt, _valueType);
             }
             return result;
+		} finally {
+			try {
+				p.close();
+			} catch (IOException ioe) {
+			}
         }
     }
 
     protected final JsonNode _bindAndCloseAsTree(JsonParser p0) throws IOException {
-        try (JsonParser p = p0) {
+		JsonParser p = p0;
+		try {
             return _bindAsTree(p);
+		} finally {
+			try {
+				p.close();
+			} catch (IOException ioe) {
+			}
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -453,7 +453,7 @@ index, owner, defs[index], propDef);
             }
         }
         // 21-Sep-2017, tatu: First let's handle explicitly annotated ones
-        List<CreatorCandidate> nonAnnotated = new LinkedList<>();
+        List<CreatorCandidate> nonAnnotated = new LinkedList<CreatorCandidate>();
         int explCount = 0;
         for (AnnotatedConstructor ctor : beanDesc.getConstructors()) {
             JsonCreator.Mode creatorMode = intr.findCreatorAnnotation(ctxt.getConfig(), ctor);
@@ -599,7 +599,7 @@ nonAnnotatedParamIndex, ctor);
             // [#725]: as a fallback, all-implicit names may work as well
             if (!creators.hasDefaultCreator()) {
                 if (implicitCtors == null) {
-                    implicitCtors = new LinkedList<>();
+                    implicitCtors = new LinkedList<AnnotatedWithParams>();
                 }
                 implicitCtors.add(ctor);
             }
@@ -845,7 +845,7 @@ nonAnnotatedParamIndex, ctor);
          Map<AnnotatedWithParams,BeanPropertyDefinition[]> creatorParams)
         throws JsonMappingException
     {
-        List<CreatorCandidate> nonAnnotated = new LinkedList<>();
+        List<CreatorCandidate> nonAnnotated = new LinkedList<CreatorCandidate>();
         int explCount = 0;
 
         // 21-Sep-2017, tatu: First let's handle explicitly annotated ones

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -511,7 +511,7 @@ public class BeanDeserializerBuilder
                     continue;
                 }
                 if (mapping == null) {
-                    mapping = new HashMap<>();
+                    mapping = new HashMap<String, List<PropertyName>>();
                 }
                 mapping.put(prop.getName(), aliases);
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -562,7 +562,7 @@ public class BeanDeserializerFactory
                     }
                 }
                 if (cprop == null) {
-                    List<String> n = new ArrayList<>();
+                    List<String> n = new ArrayList<String>();
                     for (SettableBeanProperty cp : creatorProps) {
                         n.add(cp.getName());
                     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -775,7 +775,7 @@ public class BeanPropertyMap
         if ((defs == null) || defs.isEmpty()) {
             return Collections.emptyMap();
         }
-        Map<String,String> aliases = new HashMap<>();
+        Map<String,String> aliases = new HashMap<String, String>();
         for (Map.Entry<String,List<PropertyName>> entry : defs.entrySet()) {
             String key = entry.getKey();
             if (_caseInsensitive) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -377,8 +377,8 @@ public class ExternalTypeHandler
     {
         private final JavaType _beanType;
 
-        private final List<ExtTypedProperty> _properties = new ArrayList<>();
-        private final Map<String, Object> _nameToPropertyIndex = new HashMap<>();
+        private final List<ExtTypedProperty> _properties = new ArrayList<ExtTypedProperty>();
+        private final Map<String, Object> _nameToPropertyIndex = new HashMap<String, Object>();
 
         protected Builder(JavaType t) {
             _beanType = t;
@@ -401,7 +401,7 @@ public class ExternalTypeHandler
                 List<Object> list = (List<Object>) ob;
                 list.add(index);
             } else {
-                List<Object> list = new LinkedList<>();
+                List<Object> list = new LinkedList<Object>();
                 list.add(ob);
                 list.add(index);
                 _nameToPropertyIndex.put(name, list);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -12,9 +13,14 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.util.VersionUtil;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
@@ -143,10 +149,11 @@ public abstract class FromStringDeserializer<T> extends StdScalarDeserializer<T>
                 //    indicated error; but that seems wrong. Should be able to return
                 //    `null` as value.
                 return _deserialize(text, ctxt);
-            } catch (IllegalArgumentException | MalformedURLException e) {
+			} catch (IllegalArgumentException e) {
+				cause = e;
+			} catch (MalformedURLException e) {
                 cause = e;
-            }
-            // note: `cause` can't be null
+			} // note: `cause` can't be null
             String msg = "not a valid textual representation";
             String m2 = cause.getMessage();
             if (m2 != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass.Creators;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.ClassUtil.Ctor;
 
 /**
  * Helper class used to contain details of how Creators (annotated constructors
@@ -107,7 +108,7 @@ final class AnnotatedCreatorCollector
                     defaultCtor = ctor;
                 } else {
                     if (ctors == null) {
-                        ctors = new ArrayList<>();
+                        ctors = new ArrayList<Ctor>();
                     }
                     ctors.add(ctor);
                 }
@@ -124,7 +125,7 @@ final class AnnotatedCreatorCollector
             ctorCount = 0;
         } else {
             ctorCount = ctors.size();
-            result = new ArrayList<>(ctorCount);
+            result = new ArrayList<AnnotatedConstructor>(ctorCount);
             for (int i = 0; i < ctorCount; ++i) {
                 result.add(null);
             }
@@ -186,7 +187,7 @@ final class AnnotatedCreatorCollector
             // all factory methods are fine:
             //int argCount = m.getParameterTypes().length;
             if (candidates == null) {
-                candidates = new ArrayList<>();
+                candidates = new ArrayList<Method>();
             }
             candidates.add(m);
         }
@@ -195,7 +196,7 @@ final class AnnotatedCreatorCollector
             return Collections.emptyList();
         }
         int factoryCount = candidates.size();
-        List<AnnotatedMethod> result = new ArrayList<>(factoryCount);
+        List<AnnotatedMethod> result = new ArrayList<AnnotatedMethod>(factoryCount);
         for (int i = 0; i < factoryCount; ++i) {
             result.add(null);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -42,7 +42,7 @@ public class AnnotatedFieldCollector
         if (foundFields == null) {
             return Collections.emptyList();
         }
-        List<AnnotatedField> result = new ArrayList<>(foundFields.size());
+        List<AnnotatedField> result = new ArrayList<AnnotatedField>(foundFields.size());
         for (FieldBuilder b : foundFields.values()) {
             result.add(b.build());
         }
@@ -72,7 +72,7 @@ public class AnnotatedFieldCollector
             // because mix-ins haven't been added, and partly because logic can be done
             // when determining get/settability of the field.
             if (fields == null) {
-                fields = new LinkedHashMap<>();
+                fields = new LinkedHashMap<String, FieldBuilder>();
             }
             FieldBuilder b = new FieldBuilder(tc, f);
             if (_intr != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.databind.introspect;
 
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.util.ClassUtil;
@@ -170,7 +172,10 @@ public final class AnnotatedMethod
     {
         try {
             _method.invoke(pojo, value);
-        } catch (IllegalAccessException | InvocationTargetException e) {
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(
+					"Failed to setValue() with method " + getFullName() + ": " + e.getMessage(), e);
+		} catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to setValue() with method "
                     +getFullName()+": "+e.getMessage(), e);
         }
@@ -181,7 +186,10 @@ public final class AnnotatedMethod
     {
         try {
             return _method.invoke(pojo, (Object[]) null);
-        } catch (IllegalAccessException | InvocationTargetException e) {
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(
+					"Failed to getValue() with method " + getFullName() + ": " + e.getMessage(), e);
+		} catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to getValue() with method "
                     +getFullName()+": "+e.getMessage(), e);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
@@ -36,7 +36,7 @@ public class AnnotatedMethodCollector
     AnnotatedMethodMap collect(TypeFactory typeFactory, TypeResolutionContext tc,
             JavaType mainType, List<JavaType> superTypes, Class<?> primaryMixIn)
     {
-        Map<MemberKey,MethodBuilder> methods = new LinkedHashMap<>();
+        Map<MemberKey,MethodBuilder> methods = new LinkedHashMap<MemberKey, MethodBuilder>();
         
         // first: methods from the class itself
         _addMemberMethods(tc, mainType.getRawClass(), methods, primaryMixIn);
@@ -86,7 +86,7 @@ public class AnnotatedMethodCollector
         if (methods.isEmpty()) {
             return new AnnotatedMethodMap();
         }
-        Map<MemberKey,AnnotatedMethod> actual = new LinkedHashMap<>(methods.size());
+        Map<MemberKey,AnnotatedMethod> actual = new LinkedHashMap<MemberKey, AnnotatedMethod>(methods.size());
         for (Map.Entry<MemberKey,MethodBuilder> entry : methods.entrySet()) {
             AnnotatedMethod am = entry.getValue().build();
             if (am != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodMap.java
@@ -1,7 +1,9 @@
 package com.fasterxml.jackson.databind.introspect;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * Simple helper class used to keep track of collection of
@@ -52,8 +54,25 @@ public final class AnnotatedMethodMap
     public Iterator<AnnotatedMethod> iterator()
     {
         if (_methods == null) {
-            return Collections.emptyIterator();
+			return new EmptyIterator<AnnotatedMethod>();
         }
         return _methods.values().iterator();
     }
+
+	private final static class EmptyIterator<T> implements Iterator<T> {
+		@Override
+		public boolean hasNext() {
+			return false;
+		}
+
+		@Override
+		public T next() {
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+	}
 }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationCollector.java
@@ -131,7 +131,7 @@ public abstract class AnnotationCollector
                 Class<?> type1, Annotation value1,
                 Class<?> type2, Annotation value2) {
             super(data);
-            _annotations = new HashMap<>();
+            _annotations = new HashMap<Class<?>, Annotation>();
             _annotations.put(type1, value1);
             _annotations.put(type2, value2);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationMap.java
@@ -18,7 +18,7 @@ public final class AnnotationMap implements Annotations
     public AnnotationMap() { }
 
     public static AnnotationMap of(Class<?> type, Annotation value) {
-        HashMap<Class<?>,Annotation> ann = new HashMap<>(4);
+        HashMap<Class<?>,Annotation> ann = new HashMap<Class<?>, Annotation>(4);
         ann.put(type, value);
         return new AnnotationMap(ann);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
@@ -494,7 +494,7 @@ anyField.getName()));
             final String refName = refDef.getName();
             if (result == null) {
                 result = new ArrayList<BeanPropertyDefinition>();
-                names = new HashSet<>();
+                names = new HashSet<String>();
                 names.add(refName);
             } else {
                 if (!names.add(refName)) {
@@ -514,7 +514,7 @@ anyField.getName()));
         if (props == null) {
             return null;
         }
-        Map<String,AnnotatedMember> result = new HashMap<>();
+        Map<String,AnnotatedMember> result = new HashMap<String, AnnotatedMember>();
         for (BeanPropertyDefinition prop : props) {
             result.put(prop.getName(), prop.getMutator());
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -347,7 +347,7 @@ public class JacksonAnnotationIntrospector
         if (len == 0) {
             return Collections.emptyList();
         }
-        List<PropertyName> result = new ArrayList<>(len);
+        List<PropertyName> result = new ArrayList<PropertyName>(len);
         for (int i = 0; i < len; ++i) {
             result.add(PropertyName.construct(strs[i]));
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -381,7 +381,7 @@ public class POJOPropertiesCollector
             // @JsonValue?
             if (Boolean.TRUE.equals(ai.hasAsValue(f))) {
                 if (_jsonValueAccessors == null) {
-                    _jsonValueAccessors = new LinkedList<>();
+                    _jsonValueAccessors = new LinkedList<AnnotatedMember>();
                 }
                 _jsonValueAccessors.add(f);
                 continue;
@@ -566,7 +566,7 @@ public class POJOPropertiesCollector
         // @JsonValue?
         if (Boolean.TRUE.equals(ai.hasAsValue(m))) {
             if (_jsonValueAccessors == null) {
-                _jsonValueAccessors = new LinkedList<>();
+                _jsonValueAccessors = new LinkedList<AnnotatedMember>();
             }
             _jsonValueAccessors.add(m);
             return;

--- a/src/main/java/com/fasterxml/jackson/databind/module/SimpleModule.java
+++ b/src/main/java/com/fasterxml/jackson/databind/module/SimpleModule.java
@@ -380,7 +380,7 @@ public class SimpleModule
     public SimpleModule registerSubtypes(Class<?> ... subtypes)
     {
         if (_subtypes == null) {
-            _subtypes = new LinkedHashSet<>();
+            _subtypes = new LinkedHashSet<NamedType>();
         }
         for (Class<?> subtype : subtypes) {
             _checkNotNull(subtype, "subtype to register");
@@ -397,7 +397,7 @@ public class SimpleModule
     public SimpleModule registerSubtypes(NamedType ... subtypes)
     {
         if (_subtypes == null) {
-            _subtypes = new LinkedHashSet<>();
+            _subtypes = new LinkedHashSet<NamedType>();
         }
         for (NamedType subtype : subtypes) {
             _checkNotNull(subtype, "subtype to register");
@@ -416,7 +416,7 @@ public class SimpleModule
     public SimpleModule registerSubtypes(Collection<Class<?>> subtypes)
     {
         if (_subtypes == null) {
-            _subtypes = new LinkedHashSet<>();
+            _subtypes = new LinkedHashSet<NamedType>();
         }
         for (Class<?> subtype : subtypes) {
             _checkNotNull(subtype, "subtype to register");

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -368,7 +368,7 @@ public abstract class StdSerializer<T>
                 return existingSerializer;
             }
         } else {
-            conversions = new IdentityHashMap<>();
+            conversions = new IdentityHashMap<Object, Object>();
             provider.setAttribute(KEY_CONTENT_CONVERTER_LOCK, conversions);
         }
         conversions.put(property, Boolean.TRUE);

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -3,8 +3,23 @@ package com.fasterxml.jackson.databind.util;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
-import java.util.*;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -20,7 +35,24 @@ public final class ClassUtil
     private final static Annotation[] NO_ANNOTATIONS = new Annotation[0];
     private final static Ctor[] NO_CTORS = new Ctor[0];
 
-    private final static Iterator<?> EMPTY_ITERATOR = Collections.emptyIterator();
+	private final static class EmptyIterator<T> implements Iterator<T> {
+		@Override
+		public boolean hasNext() {
+			return false;
+		}
+
+		@Override
+		public T next() {
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private final static Iterator<?> EMPTY_ITERATOR = new EmptyIterator<Object>();
 
     /*
     /**********************************************************
@@ -487,7 +519,7 @@ public final class ClassUtil
         try {
             g.close();
         } catch (Exception e) {
-            fail.addSuppressed(e);
+			// fail.addSuppressed(e);
         }
         throwIfIOE(fail);
         throwIfRTE(fail);
@@ -512,14 +544,14 @@ public final class ClassUtil
             try {
                 g.close();
             } catch (Exception e) {
-                fail.addSuppressed(e);
+				// fail.addSuppressed(e);
             }
         }
         if (toClose != null) {
             try {
                 toClose.close();
             } catch (Exception e) {
-                fail.addSuppressed(e);
+				// fail.addSuppressed(e);
             }
         }
         throwIfIOE(fail);
@@ -1118,7 +1150,7 @@ public final class ClassUtil
             try {
                 contextClass = loader.loadClass(cls.getName());
             } catch (ClassNotFoundException e) {
-                ex.addSuppressed(e);
+				// ex.addSuppressed(e);
                 throw ex;
             }
             return contextClass.getDeclaredMethods(); // Cross fingers

--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -110,7 +110,7 @@ public abstract class BaseMapTest
             map = m;
         }
         public MapWrapper(K key, V value) {
-            map = new LinkedHashMap<>();
+            map = new LinkedHashMap<K, V>();
             map.put(key, value);
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/convert/UpdateValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/UpdateValueTest.java
@@ -21,9 +21,9 @@ public class UpdateValueTest extends BaseMapTest
 
     public void testMapUpdate() throws Exception
     {
-        Map<String,Object> base = new LinkedHashMap<>();
+        Map<String,Object> base = new LinkedHashMap<String, Object>();
         base.put("a", 345);
-        Map<String,Object> overrides = new LinkedHashMap<>();
+        Map<String,Object> overrides = new LinkedHashMap<String, Object>();
         overrides.put("xyz", Boolean.TRUE);
         overrides.put("foo", "bar");
         
@@ -38,7 +38,7 @@ public class UpdateValueTest extends BaseMapTest
 
     public void testListUpdate() throws Exception
     {
-        List<Object> base = new ArrayList<>();
+        List<Object> base = new ArrayList<Object>();
         base.add(123456);
         base.add(Boolean.FALSE);
         Object[] overrides = new Object[] { Boolean.TRUE, "zoink!" };
@@ -76,7 +76,7 @@ public class UpdateValueTest extends BaseMapTest
     public void testPOJO() throws Exception
     {
         Point base = new Point(42, 28);
-        Map<String,Object> overrides = new LinkedHashMap<>();
+        Map<String,Object> overrides = new LinkedHashMap<String, Object>();
         overrides.put("y", 1234);
         Point result = MAPPER.updateValue(base, overrides);
         assertSame(base, result);
@@ -94,7 +94,7 @@ public class UpdateValueTest extends BaseMapTest
     {
         // if either is `null`, should return first arg
         assertNull(MAPPER.updateValue(null, "foo"));
-        List<String> input = new ArrayList<>();
+        List<String> input = new ArrayList<String>();
         assertSame(input, MAPPER.updateValue(input, null));
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter349Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter349Test.java
@@ -14,7 +14,7 @@ public class AnySetter349Test extends BaseMapTest
         public String type;
         public int x, y;
     
-        private Map<String, Object> props = new HashMap<>();
+        private Map<String, Object> props = new HashMap<String, Object>();
     
         @JsonAnySetter
         public void addProperty(String key, Object value) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/ReadOnlyDeser1805Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/ReadOnlyDeser1805Test.java
@@ -10,7 +10,7 @@ public class ReadOnlyDeser1805Test extends BaseMapTest
 {
     static class Foo {
         @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        private List<Long> list = new ArrayList<>();
+        private List<Long> list = new ArrayList<Long>();
 
         List<Long> getList() {
             return list;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerLocation1440Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerLocation1440Test.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 public class ProblemHandlerLocation1440Test extends BaseMapTest
 {
     static class DeserializationProblem {
-        public List<String> unknownProperties = new ArrayList<>();
+        public List<String> unknownProperties = new ArrayList<String>();
 
         public DeserializationProblem() { }
 
@@ -45,7 +45,7 @@ public class ProblemHandlerLocation1440Test extends BaseMapTest
                         throws IOException
         {
             final JsonStreamContext parsingContext = p.getParsingContext();
-            final List<String> pathList = new ArrayList<>();
+            final List<String> pathList = new ArrayList<String>();
             addParent(parsingContext, pathList);
             Collections.reverse(pathList);
             final String path = _join(".", pathList) + "#" + propertyName;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumMapDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumMapDeserializationTest.java
@@ -152,7 +152,7 @@ public class EnumMapDeserializationTest extends BaseMapTest
     // [databind#1859]
     public void testEnumMapAsPolymorphic() throws Exception
     {
-        EnumMap<Enum1859, String> enumMap = new EnumMap<>(Enum1859.class);
+        EnumMap<Enum1859, String> enumMap = new EnumMap<Enum1859, String>(Enum1859.class);
         enumMap.put(Enum1859.A, "Test");
         enumMap.put(Enum1859.B, "stuff");
         Pojo1859 input = new Pojo1859(enumMap);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UtilCollectionsTypesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UtilCollectionsTypesTest.java
@@ -62,7 +62,7 @@ public class UtilCollectionsTypesTest extends BaseMapTest
 
    // [databind#2265]
    public void testUnmodifiableListFromLinkedList() throws Exception {
-       final List<String> input = new LinkedList<>();
+       final List<String> input = new LinkedList<String>();
        input.add("first");
        input.add("second");
 
@@ -72,18 +72,18 @@ public class UtilCollectionsTypesTest extends BaseMapTest
        assertEquals(input, act);
 
        // and this check may be bit fragile (may need to revisit), but is good enough for now:
-       assertEquals(Collections.unmodifiableList(new ArrayList<>(input)).getClass(), act.getClass());
+       assertEquals(Collections.unmodifiableList(new ArrayList<String>(input)).getClass(), act.getClass());
    }
 
    public void testUnmodifiableSet() throws Exception
    {
-       Set<String> input = new LinkedHashSet<>(Arrays.asList("first", "second"));
+       Set<String> input = new LinkedHashSet<String>(Arrays.asList("first", "second"));
        _verifyCollection(Collections.unmodifiableSet(input));
    }
 
    public void testUnmodifiableMap() throws Exception
    {
-       Map<String,String> input = new LinkedHashMap<>();
+       Map<String,String> input = new LinkedHashMap<String, String>();
        input.put("a", "b");
        input.put("c", "d");
        _verifyMap(Collections.unmodifiableMap(input));

--- a/src/test/java/com/fasterxml/jackson/databind/deser/merge/CollectionMergeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/merge/CollectionMergeTest.java
@@ -23,7 +23,7 @@ public class CollectionMergeTest extends BaseMapTest
     static class MergedList
     {
         @JsonMerge
-        public List<String> values = new ArrayList<>();
+        public List<String> values = new ArrayList<String>();
         {
             values.add("a");
         }
@@ -76,7 +76,7 @@ public class CollectionMergeTest extends BaseMapTest
     // Test that uses generic type
     public void testGenericListMerging() throws Exception
     {
-        Collection<String> l = new ArrayList<>();
+        Collection<String> l = new ArrayList<String>();
         l.add("foo");
         MergedX<Collection<String>> input = new MergedX<Collection<String>>(l);
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/merge/MapMerge1844Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/merge/MapMerge1844Test.java
@@ -28,9 +28,9 @@ public class MapMerge1844Test extends BaseMapTest
             this.mapIntegerInteger = mapIntegerInteger;
         }
 
-        private Map<String, Integer> mapStringInteger = new LinkedHashMap<>();
+        private Map<String, Integer> mapStringInteger = new LinkedHashMap<String, Integer>();
 
-        private Map<Integer, Integer> mapIntegerInteger = new LinkedHashMap<>();
+        private Map<Integer, Integer> mapIntegerInteger = new LinkedHashMap<Integer, Integer>();
     }
 
     // for [databind#1844]

--- a/src/test/java/com/fasterxml/jackson/databind/deser/merge/MapMergeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/merge/MapMergeTest.java
@@ -15,12 +15,12 @@ public class MapMergeTest extends BaseMapTest
         public Map<String,Object> values;
 
         protected MergedMap() {
-            values = new LinkedHashMap<>();
+            values = new LinkedHashMap<String, Object>();
             values.put("a", "x");
         }
 
         public MergedMap(String a, String b) {
-            values = new LinkedHashMap<>();
+            values = new LinkedHashMap<String, Object>();
             values.put(a, b);
         }
 
@@ -35,7 +35,7 @@ public class MapMergeTest extends BaseMapTest
         public Map<Integer,Object> values;
 
         protected MergedIntMap() {
-            values = new LinkedHashMap<>();
+            values = new LinkedHashMap<Integer, Object>();
             values.put(Integer.valueOf(13), "a");
         }
     }
@@ -91,10 +91,10 @@ public class MapMergeTest extends BaseMapTest
     {
         // first, create base Map
         MergedMap base = new MergedMap("name", "foobar");
-        Map<String,Object> props = new LinkedHashMap<>();
+        Map<String,Object> props = new LinkedHashMap<String, Object>();
         props.put("default", "yes");
         props.put("x", "abc");
-        Map<String,Object> innerProps = new LinkedHashMap<>();
+        Map<String,Object> innerProps = new LinkedHashMap<String, Object>();
         innerProps.put("z", Integer.valueOf(13));
         props.put("extra", innerProps);
         base.values.put("props", props);
@@ -122,8 +122,8 @@ public class MapMergeTest extends BaseMapTest
     {
         // first, create base Map
         MergedMap base = new MergedMap("name", "foobar");
-        Map<String,Object> props = new LinkedHashMap<>();
-        List<String> names = new ArrayList<>();
+        Map<String,Object> props = new LinkedHashMap<String, Object>();
+        List<String> names = new ArrayList<String>();
         names.add("foo");
         props.put("names", names);
         base.values.put("props", props);
@@ -154,8 +154,8 @@ public class MapMergeTest extends BaseMapTest
     public void testDefaultDeepMapMerge() throws Exception
     {
         // First: deep merge should be enabled by default
-        HashMap<String,Object> input = new HashMap<>();
-        input.put("list", new ArrayList<>(Arrays.asList("a")));
+        HashMap<String,Object> input = new HashMap<String, Object>();
+        input.put("list", new ArrayList<String>(Arrays.asList("a")));
 
         Map<?,?> resultMap = MAPPER.readerForUpdating(input)
                 .readValue(aposToQuotes("{'list':['b']}"));
@@ -170,8 +170,8 @@ public class MapMergeTest extends BaseMapTest
         // disable merging, globally; does not affect main level
         mapper.setDefaultMergeable(false);
 
-        HashMap<String,Object> input = new HashMap<>();
-        input.put("list", new ArrayList<>(Arrays.asList("a")));
+        HashMap<String,Object> input = new HashMap<String, Object>();
+        input.put("list", new ArrayList<String>(Arrays.asList("a")));
 
         Map<?,?> resultMap = mapper.readerForUpdating(input)
                 .readValue(aposToQuotes("{'list':['b']}"));
@@ -188,8 +188,8 @@ public class MapMergeTest extends BaseMapTest
         mapper.configOverride(Object.class)
             .setMergeable(false);
 
-        HashMap<String,Object> input = new HashMap<>();
-        input.put("list", new ArrayList<>(Arrays.asList("a")));
+        HashMap<String,Object> input = new HashMap<String, Object>();
+        input.put("list", new ArrayList<String>(Arrays.asList("a")));
 
         Map<?,?> resultMap = mapper.readerForUpdating(input)
                 .readValue(aposToQuotes("{'list':['b']}"));
@@ -204,8 +204,8 @@ public class MapMergeTest extends BaseMapTest
         mapper.configOverride(Object.class)
             .setMergeable(true);
 
-        input = new HashMap<>();
-        input.put("list", new ArrayList<>(Arrays.asList("x")));
+        input = new HashMap<String, Object>();
+        input.put("list", new ArrayList<String>(Arrays.asList("x")));
 
         resultMap = mapper.readerForUpdating(input)
                 .readValue(aposToQuotes("{'list':['y']}"));

--- a/src/test/java/com/fasterxml/jackson/databind/format/MapEntryFormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/format/MapEntryFormatTest.java
@@ -16,7 +16,7 @@ public class MapEntryFormatTest extends BaseMapTest
 
         protected BeanWithMapEntry() { }
         public BeanWithMapEntry(String key, String value) {
-            Map<String,String> map = new HashMap<>();
+            Map<String,String> map = new HashMap<String, String>();
             map.put(key, value);
             entry = map.entrySet().iterator().next();
         }
@@ -55,7 +55,7 @@ public class MapEntryFormatTest extends BaseMapTest
         public Map.Entry<String,String> entry;
 
         public EntryWithNullWrapper(String key, String value) {
-            HashMap<String,String> map = new HashMap<>();
+            HashMap<String,String> map = new HashMap<String, String>();
             map.put(key, value);
             entry = map.entrySet().iterator().next();
         }
@@ -67,7 +67,7 @@ public class MapEntryFormatTest extends BaseMapTest
         public Map.Entry<String,String> entry;
 
         public EntryWithDefaultWrapper(String key, String value) {
-            HashMap<String,String> map = new HashMap<>();
+            HashMap<String,String> map = new HashMap<String, String>();
             map.put(key, value);
             entry = map.entrySet().iterator().next();
         }
@@ -79,7 +79,7 @@ public class MapEntryFormatTest extends BaseMapTest
         public Map.Entry<String,AtomicReference<String>> entry;
 
         public EntryWithNonAbsentWrapper(String key, String value) {
-            HashMap<String,AtomicReference<String>> map = new HashMap<>();
+            HashMap<String,AtomicReference<String>> map = new HashMap<String, AtomicReference<String>>();
             map.put(key, new AtomicReference<String>(value));
             entry = map.entrySet().iterator().next();
         }
@@ -91,7 +91,7 @@ public class MapEntryFormatTest extends BaseMapTest
         public Map.Entry<String,String> entry;
 
         public EmptyEntryWrapper(String key, String value) {
-            HashMap<String,String> map = new HashMap<>();
+            HashMap<String,String> map = new HashMap<String, String>();
             map.put(key, value);
             entry = map.entrySet().iterator().next();
         }

--- a/src/test/java/com/fasterxml/jackson/databind/format/MapFormatShapeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/format/MapFormatShapeTest.java
@@ -64,7 +64,7 @@ public class MapFormatShapeTest extends BaseMapTest
     @JsonPropertyOrder({ "property", "map" })
     static class Map1540Implementation implements Map<Integer, Integer> {
         public int property;
-        public Map<Integer, Integer> map = new HashMap<>();
+        public Map<Integer, Integer> map = new HashMap<Integer, Integer>();
  
         public Map<Integer, Integer> getMap() {
             return map;

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
@@ -76,7 +76,7 @@ public class IntrospectorPairTest extends BaseMapTest
 
     static class IntrospectorWithMap extends AnnotationIntrospector
     {
-        private final Map<String, Object> values = new HashMap<>();
+        private final Map<String, Object> values = new HashMap<String, Object>();
 
         private Version version = Version.unknownVersion();
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/SubTypeResolution1964Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/SubTypeResolution1964Test.java
@@ -21,7 +21,7 @@ public class SubTypeResolution1964Test extends BaseMapTest
         private Map<String, Collection<String>> repositoryPrivileges;
 
         public AccessModel() {
-            repositoryPrivileges = new HashMap<>();
+            repositoryPrivileges = new HashMap<String, Collection<String>>();
         }
 
         // 19-Apr-2018, tatu; this would prevent issues
@@ -45,10 +45,10 @@ public class SubTypeResolution1964Test extends BaseMapTest
     static class MetaModel<M, B> extends AbstractMetaValue<M, M, B> {
 
         @JsonProperty
-        protected final Map<String, AbstractMetaValue<M, ?, B>> attributes = new HashMap<>();
+        protected final Map<String, AbstractMetaValue<M, ?, B>> attributes = new HashMap<String, AbstractMetaValue<M, ?, B>>();
 
         public <V> ListMetaAttribute<M, V, B> describeList(final String attributeName) {
-          final ListMetaAttribute<M, V, B> metaAttribute = new ListMetaAttribute<>();
+          final ListMetaAttribute<M, V, B> metaAttribute = new ListMetaAttribute<M, V, B>();
           attributes.put(attributeName, metaAttribute);
           return metaAttribute;
         }
@@ -82,7 +82,7 @@ public class SubTypeResolution1964Test extends BaseMapTest
         @SuppressWarnings({ "unchecked", "rawtypes" })
         Map<String, Collection<String>> repoPrivilegesMap = new CustomMap();
         String key = "/storages/storage0/releases";
-        Collection<String> values = new HashSet<>();
+        Collection<String> values = new HashSet<String>();
         values.add("ARTIFACTS_RESOLVE");
         repoPrivilegesMap.put(key, values);
         
@@ -97,7 +97,7 @@ public class SubTypeResolution1964Test extends BaseMapTest
     // [databind#2034]
     public void testTypeSpecialization2034() throws Exception
     {
-        MetaModel<Dummy, Dummy> metaModel = new MetaModel<>();
+        MetaModel<Dummy, Dummy> metaModel = new MetaModel<Dummy, Dummy>();
         metaModel.describeList("a1");
         String jsonStr = MAPPER.writeValueAsString(metaModel);
         // ... could/should verify more, perhaps, but for now let it be.

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
@@ -194,7 +194,7 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
         // and as per [databind#1653]:
         mapper = new ObjectMapper();
         module = new SimpleModule();
-        List<Class<?>> l = new ArrayList<>();
+        List<Class<?>> l = new ArrayList<Class<?>>();
         l.add(SubB.class);
         l.add(SubC.class);
         l.add(SubD.class);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypeNames.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestTypeNames.java
@@ -50,7 +50,7 @@ public class TestTypeNames extends BaseMapTest
                 null,
                 mapper.constructType(Base1616.class));
         assertEquals(2, subtypes.size());
-        Set<String> ok = new HashSet<>(Arrays.asList("A", "B"));
+        Set<String> ok = new HashSet<String>(Arrays.asList("A", "B"));
         for (NamedType type : subtypes) {
             String id = type.getName();
             if (!ok.contains(id)) {

--- a/src/test/java/com/fasterxml/jackson/databind/misc/ThreadSafety1759Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/misc/ThreadSafety1759Test.java
@@ -35,7 +35,7 @@ public class ThreadSafety1759Test extends BaseMapTest
         }
 
         ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-        List<Future<Throwable>> results = new ArrayList<>();
+        List<Future<Throwable>> results = new ArrayList<Future<Throwable>>();
         for (Callable<Throwable> c : calls) {
             results.add(executor.submit(c));
         }

--- a/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleTest.java
@@ -292,7 +292,7 @@ public class SimpleModuleTest extends BaseMapTest
         mod1.addSerializer(SimpleEnum.class, new SimpleEnumSerializer());
         mod1.addDeserializer(CustomBean.class, new CustomBeanDeserializer());
 
-        Map<Class<?>,JsonDeserializer<?>> desers = new HashMap<>();
+        Map<Class<?>,JsonDeserializer<?>> desers = new HashMap<Class<?>, JsonDeserializer<?>>();
         desers.put(SimpleEnum.class, new SimpleEnumDeserializer());
         mod2.setDeserializers(new SimpleDeserializers(desers));
         mod2.addSerializer(CustomBean.class, new CustomBeanSerializer());

--- a/src/test/java/com/fasterxml/jackson/databind/node/ArrayNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ArrayNodeTest.java
@@ -95,7 +95,7 @@ public class ArrayNodeTest
     public void testDirectCreation2() throws IOException
     {
         JsonNodeFactory f = objectMapper().getNodeFactory();
-        ArrayList<JsonNode> list = new ArrayList<>();
+        ArrayList<JsonNode> list = new ArrayList<JsonNode>();
         list.add(f.booleanNode(true));
         list.add(f.textNode("foo"));
         ArrayNode n = new ArrayNode(f, list);

--- a/src/test/java/com/fasterxml/jackson/databind/node/POJONodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/POJONodeTest.java
@@ -38,7 +38,7 @@ public class POJONodeTest extends NodeTestBase
       Data data = new Data();
       data.aStr = "Hello";
 
-      Map<String, Object> mapTest = new HashMap<>();
+      Map<String, Object> mapTest = new HashMap<String, Object>();
       mapTest.put("data", data);
 
       ObjectNode treeTest = MAPPER.createObjectNode();

--- a/src/test/java/com/fasterxml/jackson/databind/ser/JsonValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/JsonValueTest.java
@@ -93,7 +93,7 @@ public class JsonValueTest
     static class MapFieldBean
     {
         @JsonValue
-        Map<String,String> stuff = new HashMap<>();
+        Map<String,String> stuff = new HashMap<String, String>();
         {
             stuff.put("b", "2");
         }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestCustomSerializers.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestCustomSerializers.java
@@ -139,7 +139,7 @@ public class TestCustomSerializers extends BaseMapTest
         public List<String> list;
 
         public StringListWrapper(String... values) {
-            list = new ArrayList<>();
+            list = new ArrayList<String>();
             for (String value : values) {
                 list.add(value);
             }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestIterable.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestIterable.java
@@ -145,7 +145,7 @@ public class TestIterable extends BaseMapTest
                 STATIC_MAPPER.writeValueAsString(new BeanWithIterator()));
 
         // [databind#1977]
-        ArrayList<Number> numbersList = new ArrayList<>();
+        ArrayList<Number> numbersList = new ArrayList<Number>();
         numbersList.add(1);
         numbersList.add(0.25);
         String json = MAPPER.writeValueAsString(numbersList.iterator());

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestKeySerializers.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestKeySerializers.java
@@ -173,7 +173,7 @@ public class TestKeySerializers extends BaseMapTest
         final ObjectMapper mapper = new ObjectMapper();
         mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer("NULL-KEY"));
         mapper.getSerializerProvider().setNullValueSerializer(new NullValueSerializer("NULL"));
-        Map<String,Integer> input = new HashMap<>();
+        Map<String,Integer> input = new HashMap<String, Integer>();
         input.put(null, 3);
         String json = mapper.writeValueAsString(input);
         assertEquals("{\"NULL-KEY\":3}", json);

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/TestAnyGetterFiltering.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/TestAnyGetterFiltering.java
@@ -62,7 +62,7 @@ public class TestAnyGetterFiltering extends BaseMapTest
 
          @JsonAnyGetter
          public Map<String, Object> getAny() {
-              Map<String, Object> extra = new HashMap<>();
+              Map<String, Object> extra = new HashMap<String, Object>();
               extra.put("dynamicProperty", "I will not serialize");
               return extra;
          }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/AtomicTypeSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/AtomicTypeSerializationTest.java
@@ -39,15 +39,15 @@ public class AtomicTypeSerializationTest
     // [databind#1673]
     static class ContainerA {
         public AtomicReference<Strategy> strategy =
-                new AtomicReference<>((Strategy) new Foo(42));
+                new AtomicReference<Strategy>((Strategy) new Foo(42));
     }
 
     static class ContainerB {
         public AtomicReference<List<Strategy>> strategy;
         {
-            List<Strategy> list = new ArrayList<>();
+            List<Strategy> list = new ArrayList<Strategy>();
             list.add(new Foo(42));
-            strategy = new AtomicReference<>(list);
+            strategy = new AtomicReference<List<Strategy>>(list);
         }
     }
 
@@ -109,9 +109,9 @@ public class AtomicTypeSerializationTest
         final ObjectMapper mapper = objectMapper();
         mapper.setDateFormat(df);
         ContextualOptionals input = new ContextualOptionals();
-        input.date = new AtomicReference<>(new Date(0L));
-        input.date1 = new AtomicReference<>(new Date(0L));
-        input.date2 = new AtomicReference<>(new Date(0L));
+        input.date = new AtomicReference<Date>(new Date(0L));
+        input.date1 = new AtomicReference<Date>(new Date(0L));
+        input.date2 = new AtomicReference<Date>(new Date(0L));
         final String json = mapper.writeValueAsString(input);
         assertEquals(aposToQuotes(
                 "{'date1':'1970+01+01','date2':'1970*01*01','date':'1970/01/01'}"),

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/MapKeySerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/MapKeySerializationTest.java
@@ -88,14 +88,14 @@ public class MapKeySerializationTest extends BaseMapTest
         byte[] binary = new byte[] { 1, 2, 3, 4, 5 };
 
         // First, using wrapper
-        MapWrapper<byte[], String> input = new MapWrapper<>(binary, "stuff");
+        MapWrapper<byte[], String> input = new MapWrapper<byte[], String>(binary, "stuff");
         String expBase64 = Base64Variants.MIME.encode(binary);
         
         assertEquals(aposToQuotes("{'map':{'"+expBase64+"':'stuff'}}"),
                 MAPPER.writeValueAsString(input));
 
         // and then dynamically..
-        Map<byte[],String> map = new LinkedHashMap<>();
+        Map<byte[],String> map = new LinkedHashMap<byte[], String>();
         map.put(binary, "xyz");
         assertEquals(aposToQuotes("{'"+expBase64+"':'xyz'}"),
                 MAPPER.writeValueAsString(map));

--- a/src/test/java/com/fasterxml/jackson/databind/struct/FormatFeatureOrderedMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/FormatFeatureOrderedMapTest.java
@@ -12,7 +12,7 @@ public class FormatFeatureOrderedMapTest extends BaseMapTest
 {
     static class SortedKeysMap {
         @JsonFormat(with = JsonFormat.Feature.WRITE_SORTED_MAP_ENTRIES)
-        public Map<String,Integer> values = new LinkedHashMap<>();
+        public Map<String,Integer> values = new LinkedHashMap<String, Integer>();
 
         protected SortedKeysMap() { }
 

--- a/src/test/java/com/fasterxml/jackson/databind/struct/SingleValueAsArrayTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/SingleValueAsArrayTest.java
@@ -78,7 +78,7 @@ public class SingleValueAsArrayTest extends BaseMapTest
     public void testWithSingleString() throws Exception {
         Bean1421B<List<String>> a = MAPPER.readValue(quote("test2"),
                 new TypeReference<Bean1421B<List<String>>>() {});
-        List<String> expected = new ArrayList<>();
+        List<String> expected = new ArrayList<String>();
         expected.add("test2");
         assertEquals(expected, a.value);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/type/NestedTypes1604Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/NestedTypes1604Test.java
@@ -20,11 +20,11 @@ public class NestedTypes1604Test extends BaseMapTest
         }
 
         public static <T> Data<List<T>> of(List<T> data) {
-             return new DataList<>(data);
+             return new DataList<T>(data);
         }
 
         public static <T> Data<List<T>> ofRefined(List<T> data) {
-            return new RefinedDataList<>(data);
+            return new RefinedDataList<T>(data);
         }
 
         public static <T> Data<List<T>> ofSneaky(List<T> data) {
@@ -93,7 +93,7 @@ public class NestedTypes1604Test extends BaseMapTest
     
     public void testIssue1604Simple() throws Exception
     {
-        List<Inner> inners = new ArrayList<>();
+        List<Inner> inners = new ArrayList<Inner>();
         for (int i = 0; i < 2; i++) {
             inners.add(new Inner(i));
         }
@@ -108,7 +108,7 @@ public class NestedTypes1604Test extends BaseMapTest
 
     public void testIssue1604Subtype() throws Exception
     {
-        List<Inner> inners = new ArrayList<>();
+        List<Inner> inners = new ArrayList<Inner>();
         for (int i = 0; i < 2; i++) {
             inners.add(new Inner(i));
         }
@@ -119,7 +119,7 @@ public class NestedTypes1604Test extends BaseMapTest
 
     public void testIssue1604Sneaky() throws Exception
     {
-        List<Inner> inners = new ArrayList<>();
+        List<Inner> inners = new ArrayList<Inner>();
         for (int i = 0; i < 2; i++) {
             inners.add(new Inner(i));
         }

--- a/src/test/java/com/fasterxml/jackson/databind/util/CompactStringObjectMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/CompactStringObjectMapTest.java
@@ -8,7 +8,7 @@ public class CompactStringObjectMapTest extends BaseMapTest
 {
     public void testBig()
     {
-        Map<String,String> all = new LinkedHashMap<>();
+        Map<String,String> all = new LinkedHashMap<String, String>();
         for (int i = 0; i < 1000; ++i) {
             String key = "key"+i;
             all.put(key, key);

--- a/src/test/java/com/fasterxml/jackson/failing/AnyPropSorting518Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/AnyPropSorting518Test.java
@@ -15,7 +15,7 @@ public class AnyPropSorting518Test extends BaseMapTest
     {
         public int b;
 
-        protected Map<String,Object> extra = new HashMap<>();
+        protected Map<String,Object> extra = new HashMap<String, Object>();
 
         public int a;
 
@@ -39,7 +39,7 @@ public class AnyPropSorting518Test extends BaseMapTest
 
     public void testAnyBeanWithSort() throws Exception
     {
-        Map<String,Object> extra = new LinkedHashMap<>();
+        Map<String,Object> extra = new LinkedHashMap<String, Object>();
         extra.put("y", 4);
         extra.put("x", 3);
         String json = MAPPER.writeValueAsString(new Bean(1, 2, extra));

--- a/src/test/java/com/fasterxml/jackson/failing/EnumAsIndexMapKey1877Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/EnumAsIndexMapKey1877Test.java
@@ -38,7 +38,7 @@ public class EnumAsIndexMapKey1877Test extends BaseMapTest
     {
         ObjectMapper mapper = newObjectMapper();
 
-        Map<Type, String> map = new HashMap<>();
+        Map<Type, String> map = new HashMap<Type, String>();
         map.put(Type.OTHER, "hello world");
         Container container = new Container();
         container.setSimpleType(Type.ANY);

--- a/src/test/java/com/fasterxml/jackson/failing/InnerClassNonStaticCore384Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/InnerClassNonStaticCore384Test.java
@@ -198,7 +198,7 @@ for (Vehicle v : fleet.vehicles) {
         Car car = new Car("Mercedes-Benz", "S500", 5, 250.0);
         Truck truck = new Truck("Isuzu", "NQR", 7500.0);
 
-        List<Vehicle> vehicles = new ArrayList<>();
+        List<Vehicle> vehicles = new ArrayList<Vehicle>();
         vehicles.add(car);
         vehicles.add(truck);
 

--- a/src/test/java/com/fasterxml/jackson/failing/MapEntryFormat1419Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/MapEntryFormat1419Test.java
@@ -14,7 +14,7 @@ public class MapEntryFormat1419Test extends BaseMapTest
 
         protected BeanWithMapEntryAsObject() { }
         public BeanWithMapEntryAsObject(String key, String value) {
-            Map<String,String> map = new HashMap<>();
+            Map<String,String> map = new HashMap<String, String>();
             map.put(key, value);
             entry = map.entrySet().iterator().next();
         }

--- a/src/test/java/com/fasterxml/jackson/failing/MapInclusion1649Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/MapInclusion1649Test.java
@@ -13,7 +13,7 @@ public class MapInclusion1649Test extends BaseMapTest
         public Map<String, String> map;
 
         public Bean1649(String key, String value) {
-            map = new LinkedHashMap<>();
+            map = new LinkedHashMap<String, String>();
             map.put(key, value);
         }
     }

--- a/src/test/java/com/fasterxml/jackson/failing/NodeContext2049Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/NodeContext2049Test.java
@@ -43,7 +43,7 @@ public class NodeContext2049Test extends BaseMapTest
 
         @Override
         public Object createUsingDefault(DeserializationContext ctxt) throws IOException {
-             return new ArrayList<>();
+             return new ArrayList<Object>();
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/failing/ObjectIdWithBuilder1496Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/ObjectIdWithBuilder1496Test.java
@@ -37,7 +37,7 @@ public class ObjectIdWithBuilder1496Test extends BaseMapTest
         public POJO build() { return new POJO(id, var); }
         
         // Special build method for jackson deserializer that caches objects already deserialized
-        private final static ConcurrentHashMap<Long, POJO> cache = new ConcurrentHashMap<>();
+        private final static ConcurrentHashMap<Long, POJO> cache = new ConcurrentHashMap<Long, POJO>();
         public POJO readFromCacheOrBuild() {
             POJO pojo = cache.get(id);
             if (pojo == null) {

--- a/src/test/java/com/fasterxml/jackson/failing/StaticTyping1515Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/StaticTyping1515Test.java
@@ -38,16 +38,16 @@ public class StaticTyping1515Test extends BaseMapTest
 
     @JsonPropertyOrder({ "list", "aList", "dList" })
     static class Issue515Lists {
-        public List<Base> list = new ArrayList<>(); {
+        public List<Base> list = new ArrayList<Base>(); {
             list.add(new Derived());
         }
 
         @JsonSerialize(typing = JsonSerialize.Typing.DYNAMIC)
-        public List<Base> aList = new ArrayList<>(); {
+        public List<Base> aList = new ArrayList<Base>(); {
             aList.add(new Derived());
         }
 
-        public List<BaseDynamic> dList = new ArrayList<>(); {
+        public List<BaseDynamic> dList = new ArrayList<BaseDynamic>(); {
             dList.add(new DerivedDynamic());
         }
     }

--- a/src/test/java/com/fasterxml/jackson/failing/TestObjectIdWithUnwrapping1298.java
+++ b/src/test/java/com/fasterxml/jackson/failing/TestObjectIdWithUnwrapping1298.java
@@ -15,7 +15,7 @@ public class TestObjectIdWithUnwrapping1298 extends BaseMapTest
     private static Long nextId = 1L;
 
     public static final class ListOfParents{
-        public List<Parent> parents = new ArrayList<>();
+        public List<Parent> parents = new ArrayList<Parent>();
 
         public void addParent( Parent parent) { parents.add(parent);}
     }


### PR DESCRIPTION
Removes JDK 7 syntax and reverts pom configuration to generate a jdk 6
compliant jar

Changed items are of 3 kinds:
* Diamond operators, as in:
```
-        List<CreatorCandidate> nonAnnotated = new LinkedList<>();
+        List<CreatorCandidate> nonAnnotated = new
LinkedList<CreatorCandidate>();

```
These are usually managed automatically by the IDE (Eclipse in my case)
as the type arguments are always auto-detectable.

* Try-with-resources statements as in:
 ```
    protected JsonNode _readTreeAndClose(JsonParser p0) throws
IOException
     {
-        try (JsonParser p = p0) {
+    	JsonParser p = p0;
+        try {
             final JavaType valueType = JSON_NODE_TYPE;

             DeserializationConfig cfg = getDeserializationConfig();
@@ -4061,6 +4067,10 @@
             // No ObjectIds so can ignore
 //            ctxt.checkUnresolvedObjectId();
             return (JsonNode) result;
+        } finally {
+            try {
+                p.close();
+            } catch (IOException ioe) { }
         }
     }
```
Just done it the old way, with the declaration outside the try block and
a finally to close.

* Multi catches as in:
```
-        } catch (IllegalAccessException | InvocationTargetException e)
{
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(
+					"Failed to setValue() with method " + getFullName() + ": " +
e.getMessage(), e);
+		} catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to setValue()
with method "
                     +getFullName()+": "+e.getMessage(), e);
         }
```

Just separate the two exceptions, each with its own (copied) block