### PR TITLE
Return empty unmodifiable set when no registered modules types.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -988,9 +988,10 @@ public class ObjectMapper
      *
      * @since 2.9.6
      */
-    public Set<Object> getRegisteredModuleIds()
-    {
-        return Collections.unmodifiableSet(_registeredModuleTypes);
+    public Set<Object> getRegisteredModuleIds() {
+        return _registeredModuleTypes == null ?
+                Collections.emptySet() :
+                Collections.unmodifiableSet(_registeredModuleTypes);
     }
 
     /**


### PR DESCRIPTION
`#getRegisteredModuleIds()` does not throws `NullPointerException` when there is no registered modules, now it returns a empty unmodifiable set.

```java
new ObjectMapper().getRegisteredModuleIds() // throws NPE
```