### PR TITLE
make the testcase pass, ignoring the timezone of the execution machine

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/SqlDateSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/SqlDateSerializationTest.java
@@ -99,6 +99,7 @@ public class SqlDateSerializationTest extends BaseMapTest
     public void testSqlDateConfigOverride() throws Exception
     {
         ObjectMapper mapper = newObjectMapper();
+        mapper.setTimeZone(TimeZone.getDefault());
         mapper.configOverride(java.sql.Date.class)
             .setFormat(JsonFormat.Value.forPattern("yyyy+MM+dd"));        
         assertEquals("\"1980+04+14\"",


### PR DESCRIPTION
When the time zone of the execution machine is not the default time zone UTC+0, the serialized time is not 1980+04+14 00:00:00. 
In my computer, the timezone is UTC+8, so the date is 1980+04+13 16:00:00 after writeValueAsString, which not match the expected String "1980+04+14".