### PR TITLE
Add support for module bundles

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/Module.java
+++ b/src/main/java/com/fasterxml/jackson/databind/Module.java
@@ -79,6 +79,8 @@ public abstract class Module
      * Returns the list of dependent modules.
      *
      * It is called to let modules register other modules as dependencies.
+     *
+     * @since 2.10
      */
     public Iterable<? extends Module> getDependencies() {
         return Collections.emptyList();

--- a/src/main/java/com/fasterxml/jackson/databind/Module.java
+++ b/src/main/java/com/fasterxml/jackson/databind/Module.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.Serializers;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.type.TypeModifier;
+import java.util.Collections;
 
 /**
  * Simple interface for extensions that can be registered with {@link ObjectMapper}
@@ -73,6 +74,15 @@ public abstract class Module
      * using callback methods passed-in context object exposes.
      */
     public abstract void setupModule(SetupContext context);
+
+    /**
+     * Returns the list of dependent modules.
+     *
+     * It is called to let modules register other modules as dependencies.
+     */
+    public Iterable<? extends Module> getDependencies() {
+        return Collections.emptyList();
+    }
     
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -776,6 +776,8 @@ public class ObjectMapper
             throw new IllegalArgumentException("Module without defined version");
         }
 
+        registerModules(module.getDependencies());
+
         // And then call registration
         module.setupModule(new Module.SetupContext()
         {
@@ -941,8 +943,6 @@ public class ObjectMapper
                 setPropertyNamingStrategy(naming);
             }
         });
-
-        registerModules(module.getDependencies());
 
         return this;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -941,6 +941,9 @@ public class ObjectMapper
                 setPropertyNamingStrategy(naming);
             }
         });
+
+        registerModules(module.getDependencies());
+
         return this;
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind;
 
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.*;
 import java.util.*;
 
@@ -409,5 +410,42 @@ public class ObjectMapperTest extends BaseMapTest
         JsonNode n = MAPPER.readerFor(Map.class)
                 .readTree(input);
         assertNotNull(n);
+    }
+
+    public void testRegisterDependentModules() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        final SimpleModule secondModule = new SimpleModule() {
+            @Override
+            public Object getTypeId() {
+                return "second";
+            }
+        };
+
+        final SimpleModule thirdModule = new SimpleModule() {
+            @Override
+            public Object getTypeId() {
+                return "third";
+            }
+        };
+
+        final SimpleModule firstModule = new SimpleModule() {
+            @Override
+            public Iterable<? extends Module> getDependencies() {
+                return Arrays.asList(secondModule, thirdModule);
+            }
+
+            @Override
+            public Object getTypeId() {
+                return "first";
+            }
+        };
+
+        objectMapper.registerModule(firstModule);
+
+        assertEquals(
+            new HashSet<>(Arrays.asList("first", "second", "third")),
+            objectMapper.getRegisteredModuleIds()
+        );
     }
 }


### PR DESCRIPTION
This PR adds support for module bundles. 

This feature is useful in cases where you have explicit dependencies on other modules, but you have to ensure that these dependencies will be registered as well, making it easier to depend on them without worrying about transitive dependencies.

I propose making it a built-in feature, rather than a composite module in the userland, due to the module deduplication feature that would be not able to detect the aggregated modules.