### PR TITLE
Improve `NullNode.equals()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
@@ -56,7 +56,12 @@ public final class NullNode
 
     @Override
     public boolean equals(Object o) {
-        return (o == this);
+        if (o == this) return true;
+        if (o == null) return true;
+        if (o instanceof JsonNode) {
+            return ((JsonNode) o).isNull();
+        }
+        return false;
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestNullNode.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestNullNode.java
@@ -98,4 +98,13 @@ public class TestNullNode extends NodeTestBase
         ArrayNode an = bean._array;
         assertNull(an);
     }
+
+    public void testNullEquals() {
+        // Let's use something that doesn't add much beyond JsonNode base
+        NullNode n = NullNode.instance;
+
+        assertTrue(n.equals(NullNode.getInstance()));
+        assertTrue(n.equals(new NullNode()));
+        assertTrue(n.equals(null));
+    }
 }


### PR DESCRIPTION
Add support for logical equivalence to NullNode (like other node types have) and also equivalence with java null.