### PR TITLE
Deserialize WRAPPER_ARRAY with no second parameter as null value

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsArrayTypeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsArrayTypeDeserializer.java
@@ -113,6 +113,9 @@ public class AsArrayTypeDeserializer
             p = JsonParserSequence.createFlattened(false, tb.asParser(p), p);
             p.nextToken();
         }
+        if (hadStartArray && p.currentToken() == JsonToken.END_ARRAY) {
+            return deser.getNullValue(ctxt);
+        }
         Object value = deser.deserialize(p, ctxt);
         // And then need the closing END_ARRAY
         if (hadStartArray && p.nextToken() != JsonToken.END_ARRAY) {


### PR DESCRIPTION
Fixes #2467.

This PR will allow users to handle optional second parameters when using `JsonTypeInfo.As.WRAPPER_ARRAY`. A custom deserializer would allow to create a new instance or return a singleton without much effort. The default behavior is to return `null`.