### PR TITLE
Sorting fields and use LinkedHashMap for deterministic order

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/format/MapFormatShapeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/format/MapFormatShapeTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 @SuppressWarnings("serial")
 public class MapFormatShapeTest extends BaseMapTest
@@ -64,7 +65,7 @@ public class MapFormatShapeTest extends BaseMapTest
     @JsonPropertyOrder({ "property", "map" })
     static class Map1540Implementation implements Map<Integer, Integer> {
         public int property;
-        public Map<Integer, Integer> map = new HashMap<>();
+        public Map<Integer, Integer> map = new LinkedHashMap<>();
  
         public Map<Integer, Integer> getMap() {
             return map;
@@ -166,10 +167,10 @@ public class MapFormatShapeTest extends BaseMapTest
         input.property = 55;
         input.put(12, 45);
         input.put(6, 88);
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        String json = mapper.writeValueAsString(input);
 
-        String json = MAPPER.writeValueAsString(input);
-
-        assertEquals(aposToQuotes("{'property':55,'map':{'6':88,'12':45}}"), json);
+        assertEquals(aposToQuotes("{'property':55,'map':{'12':45,'6':88}}"), json);
 
         Map1540Implementation result = MAPPER.readValue(json, Map1540Implementation.class);
         assertEquals(result.property, input.property);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 // Tests for External type id, one that exists at same level as typed Object,
 // that is, property is not within typed object but a member of its parent.
@@ -491,10 +493,10 @@ public class ExternalTypeIdTest extends BaseMapTest
     // for [databind#222]
     public void testExternalTypeWithProp222() throws Exception
     {
-        final ObjectMapper mapper = new ObjectMapper();
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
         Issue222Bean input = new Issue222Bean(13);
         String json = mapper.writeValueAsString(input);
-        assertEquals("{\"value\":{\"x\":13},\"type\":\"foo\"}", json);
+        assertEquals("{\"type\":\"foo\",\"value\":{\"x\":13}}", json);
     }
 
     // [databind#928]

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectId.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectId.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class TestObjectId extends BaseMapTest
 {
@@ -154,11 +155,12 @@ public class TestObjectId extends BaseMapTest
         comp.add(e1);
         comp.add(e2);
 
-        String json = MAPPER.writeValueAsString(comp);
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        String json = mapper.writeValueAsString(comp);
         
         assertEquals("{\"employees\":["
-                +"{\"id\":1,\"name\":\"First\",\"manager\":null,\"reports\":[2]},"
-                +"{\"id\":2,\"name\":\"Second\",\"manager\":1,\"reports\":[]}"
+                +"{\"id\":1,\"manager\":null,\"name\":\"First\",\"reports\":[2]},"
+                +"{\"id\":2,\"manager\":1,\"name\":\"Second\",\"reports\":[]}"
                 +"]}",
                 json);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdSerialization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * Unit test to verify handling of Object Id deserialization
@@ -184,7 +185,7 @@ public class TestObjectIdSerialization extends BaseMapTest
     /*****************************************************
      */
 
-    private final static String EXP_SIMPLE_INT_CLASS = "{\"id\":1,\"value\":13,\"next\":1}";
+    private final static String EXP_SIMPLE_INT_CLASS = "{\"id\":1,\"next\":1,\"value\":13}";
     
     private final ObjectMapper MAPPER = objectMapper();
 
@@ -194,16 +195,17 @@ public class TestObjectIdSerialization extends BaseMapTest
         src.next = src;
         
         // First, serialize:
-        String json = MAPPER.writeValueAsString(src);
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        String json = mapper.writeValueAsString(src);
         assertEquals(EXP_SIMPLE_INT_CLASS, json);
 
         // and ensure that state is cleared in-between as well:
-        json = MAPPER.writeValueAsString(src);
+        json = mapper.writeValueAsString(src);
         assertEquals(EXP_SIMPLE_INT_CLASS, json);
     }
     
     // Bit more complex, due to extra wrapping etc:
-    private final static String EXP_SIMPLE_INT_PROP = "{\"node\":{\"@id\":1,\"value\":7,\"next\":{\"node\":1}}}";
+    private final static String EXP_SIMPLE_INT_PROP = "{\"node\":{\"@id\":1,\"next\":{\"node\":1},\"value\":7}}";
 
     public void testSimpleSerializationProperty() throws Exception
     {
@@ -211,10 +213,11 @@ public class TestObjectIdSerialization extends BaseMapTest
         src.node.next = src;
         
         // First, serialize:
-        String json = MAPPER.writeValueAsString(src);
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        String json = mapper.writeValueAsString(src);
         assertEquals(EXP_SIMPLE_INT_PROP, json);
         // and second time too, for a good measure
-        json = MAPPER.writeValueAsString(src);
+        json = mapper.writeValueAsString(src);
         assertEquals(EXP_SIMPLE_INT_PROP, json);
     }
 
@@ -260,34 +263,35 @@ public class TestObjectIdSerialization extends BaseMapTest
     /*****************************************************
      */
 
-    private final static String EXP_CUSTOM_PROP = "{\"customId\":123,\"value\":-19,\"next\":123}";
+    private final static String EXP_CUSTOM_PROP = "{\"customId\":123,\"next\":123,\"value\":-19}";
     // Test for verifying that custom
     public void testCustomPropertyForClass() throws Exception
     {
         IdentifiableWithProp src = new IdentifiableWithProp(123, -19);
         src.next = src;
-        
+
+        JsonMapper mapper =  JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
         // First, serialize:
-        String json = MAPPER.writeValueAsString(src);
+        String json = mapper.writeValueAsString(src);
         assertEquals(EXP_CUSTOM_PROP, json);
 
         // and ensure that state is cleared in-between as well:
-        json = MAPPER.writeValueAsString(src);
+        json = mapper.writeValueAsString(src);
         assertEquals(EXP_CUSTOM_PROP, json);
     }
 
-    private final static String EXP_CUSTOM_PROP_VIA_REF = "{\"node\":{\"id\":123,\"value\":7,\"next\":{\"node\":123}}}";
+    private final static String EXP_CUSTOM_PROP_VIA_REF = "{\"node\":{\"id\":123,\"next\":{\"node\":123},\"value\":7}}";
     // Test for verifying that custom
     public void testCustomPropertyViaProperty() throws Exception
     {
         IdWrapperCustom src = new IdWrapperCustom(123, 7);
         src.node.next = src;
-        
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
         // First, serialize:
-        String json = MAPPER.writeValueAsString(src);
+        String json = mapper.writeValueAsString(src);
         assertEquals(EXP_CUSTOM_PROP_VIA_REF, json);
         // and second time too, for a good measure
-        json = MAPPER.writeValueAsString(src);
+        json = mapper.writeValueAsString(src);
         assertEquals(EXP_CUSTOM_PROP_VIA_REF, json);
     }
 
@@ -302,10 +306,10 @@ public class TestObjectIdSerialization extends BaseMapTest
         TreeNode root = new TreeNode(null, 1, "root");     
         TreeNode leaf = new TreeNode(root, 2, "leaf");
         root.child = leaf;
-        String json = MAPPER.writeValueAsString(root);
-//        System.out.println(json);
-        assertEquals("{\"id\":1,\"name\":\"root\",\"parent\":null,\"child\":"
-                +"{\"id\":2,\"name\":\"leaf\",\"parent\":1,\"child\":null}}",
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        String json = mapper.writeValueAsString(root);
+        assertEquals("{\"id\":1,\"child\":"
+                +"{\"id\":2,\"child\":null,\"name\":\"leaf\",\"parent\":1},\"name\":\"root\",\"parent\":null}",
                 json);
         		
     }

--- a/src/test/java/com/fasterxml/jackson/databind/seq/SequenceWriterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/seq/SequenceWriterTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.io.SerializedString;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class SequenceWriterTest extends BaseMapTest
 {
@@ -189,7 +190,8 @@ public class SequenceWriterTest extends BaseMapTest
     @SuppressWarnings("resource")
     public void testSimpleCloseable() throws Exception
     {
-        ObjectWriter w = MAPPER.writer()
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        ObjectWriter w = mapper.writer()
                 .with(SerializationFeature.CLOSE_CLOSEABLE);
         CloseableValue input = new CloseableValue();
         assertFalse(input.closed);
@@ -201,7 +203,7 @@ public class SequenceWriterTest extends BaseMapTest
         assertTrue(input.closed);
         seq.close();
         input.close();
-        assertEquals(aposToQuotes("{'x':0,'closed':false}"), out.toString());
+        assertEquals(aposToQuotes("{'closed':false,'x':0}"), out.toString());
     }
 
     public void testWithExplicitType() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestJsonSerialize.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestJsonSerialize.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 /**
@@ -212,8 +213,9 @@ public class TestJsonSerialize
 
     public void testIssue294() throws Exception
     {
-        assertEquals("{\"id\":\"fooId\",\"bar\":\"barId\"}",
-                MAPPER.writeValueAsString(new Foo294("fooId", "barId")));
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        assertEquals("{\"bar\":\"barId\",\"id\":\"fooId\"}",
+                mapper.writeValueAsString(new Foo294("fooId", "barId")));
     }
 
     @JsonPropertyOrder({ "a", "something" })

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestRootType.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestRootType.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrapped.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrapped.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.struct;
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * Unit tests for verifying that basic {@link JsonUnwrapped} annotation
@@ -148,13 +149,15 @@ public class TestUnwrapped extends BaseMapTest
     private final ObjectMapper MAPPER = new ObjectMapper();
 
     public void testSimpleUnwrappingSerialize() throws Exception {
-        assertEquals("{\"name\":\"Tatu\",\"x\":1,\"y\":2}",
-                MAPPER.writeValueAsString(new Unwrapping("Tatu", 1, 2)));
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        assertEquals("{\"x\":1,\"y\":2,\"name\":\"Tatu\"}",
+                mapper.writeValueAsString(new Unwrapping("Tatu", 1, 2)));
     }
 
     public void testDeepUnwrappingSerialize() throws Exception {
-        assertEquals("{\"name\":\"Tatu\",\"x\":1,\"y\":2}",
-                MAPPER.writeValueAsString(new DeepUnwrapping("Tatu", 1, 2)));
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        assertEquals("{\"x\":1,\"y\":2,\"name\":\"Tatu\"}",
+                mapper.writeValueAsString(new DeepUnwrapping("Tatu", 1, 2)));
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithPrefix.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithPrefix.java
@@ -2,7 +2,9 @@ package com.fasterxml.jackson.databind.struct;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class TestUnwrappedWithPrefix extends BaseMapTest
 {
@@ -148,14 +150,16 @@ public class TestUnwrappedWithPrefix extends BaseMapTest
 
     public void testPrefixedUnwrappingSerialize() throws Exception
     {
-        assertEquals("{\"name\":\"Tatu\",\"_x\":1,\"_y\":2}",
-                MAPPER.writeValueAsString(new PrefixUnwrap("Tatu", 1, 2)));
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        assertEquals("{\"_x\":1,\"_y\":2,\"name\":\"Tatu\"}",
+                mapper.writeValueAsString(new PrefixUnwrap("Tatu", 1, 2)));
     }
 
     public void testDeepPrefixedUnwrappingSerialize() throws Exception
     {
-        String json = MAPPER.writeValueAsString(new DeepPrefixUnwrap("Bubba", 1, 1));
-        assertEquals("{\"u.name\":\"Bubba\",\"u._x\":1,\"u._y\":1}", json);
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+        String json = mapper.writeValueAsString(new DeepPrefixUnwrap("Bubba", 1, 1));
+        assertEquals("{\"u._x\":1,\"u._y\":1,\"u.name\":\"Bubba\"}", json);
     }
 
     public void testHierarchicConfigSerialize() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithTypeInfo.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithTypeInfo.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -78,9 +79,11 @@ public class TestUnwrappedWithTypeInfo extends BaseMapTest
 
 		ObjectMapper mapper = jsonMapperBuilder()
 		        .disable(SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS)
+                .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
 		        .build();
 
 		String json = mapper.writeValueAsString(outer);
-		assertEquals("{\"@type\":\"OuterType\",\"p1\":\"101\",\"p2\":\"202\"}", json);
+
+		assertEquals("{\"@type\":\"OuterType\",\"p2\":\"202\",\"p1\":\"101\"}", json);
 	}
 }


### PR DESCRIPTION
`AnnotatedFieldCollector` class uses `java.lang.Class.getDeclaredField()`. However, there is no guarantee in order of the returned array of fields and thus, some tests can fail due to a different order. 
Also, the test class `MapFormatShapeTest` uses multiple HashMap. However, HashMap does not guarantee any specific order of entries. Therefore, the assertions in those test cases will fail if the order is different. 

It can be reproduced by switching the field orders declared in the class. 

This PR proposes to change the following:

1. Sort the fields returned by the API by the field name, so the order is deterministic (by alphabetical order).
2. Use LinkedHashMap to make the iteration order deterministic (i.e. insertion order)
3. Modify the corresponding testing assertions.

These will make the test assertions more stable.

Please let me know if you want to discuss the changes more.
