### PR TITLE
Builder Deserializer Factory Extension Point

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -439,6 +439,14 @@ public class BeanDeserializerBuilder
             }
         }
 
+        return createBuilderBasedDeserializer(valueType, propertyMap, anyViews);
+    }
+
+    /**
+     * Extension point for overriding the actual creation of the builder deserializer.
+     */
+    protected JsonDeserializer<?> createBuilderBasedDeserializer(JavaType valueType,
+            BeanPropertyMap propertyMap, boolean anyViews) {
         return new BuilderBasedDeserializer(this,
                 _beanDesc, valueType, propertyMap, _backRefProperties, _ignorableProps, _ignoreAllUnknown,
                 anyViews);


### PR DESCRIPTION
Expose extension point on `BeanDeserializerBuilder` which creates the builder deserializer instance separate from the configuration for builder based deserialization in `buildBuilderBased`. This is the minimal change solution described in #2487.