### PR TITLE
Allow registering the same subtype multiple times

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/NamedType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/NamedType.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.jsontype;
 
+import java.util.Objects;
+
 /**
  * Simple container class for types with optional logical name, used
  * as external identifier
@@ -14,10 +16,10 @@ public final class NamedType implements java.io.Serializable
     protected String _name;
     
     public NamedType(Class<?> c) { this(c, null); }
-    
+
     public NamedType(Class<?> c, String name) {
         _class = c;
-        _hashCode = c.getName().hashCode();
+        _hashCode = (c.getName() + (name != null ? name : "")).hashCode();
         setName(name);
     }
 
@@ -28,14 +30,16 @@ public final class NamedType implements java.io.Serializable
     public boolean hasName() { return _name != null; }
     
     /**
-     * Equality is defined based on class only, not on name
+     * Equality is defined based on class and name
      */
     @Override
     public boolean equals(Object o) {
         if (o == this) return true;
         if (o == null) return false;
         if (o.getClass() != getClass()) return false;
-        return _class == ((NamedType) o)._class;
+        NamedType other = (NamedType)o;
+        if (!Objects.equals(_name, other._name)) return false;
+        return _class == other._class;
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdSubtypeResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdSubtypeResolver.java
@@ -112,7 +112,8 @@ public class StdSubtypeResolver
             AnnotatedClass type)
     {
         final AnnotationIntrospector ai = config.getAnnotationIntrospector();
-        HashMap<NamedType, NamedType> subtypes = new HashMap<NamedType, NamedType>();
+        HashMap<NamedType, NamedType> subtypes = new HashMap<>();
+
         // then consider registered subtypes (which have precedence over annotations)
         if (_registeredSubtypes != null) {
             Class<?> rawBase = type.getRawType();
@@ -223,19 +224,23 @@ public class StdSubtypeResolver
             }
         }
 
+        //For Serialization we only want to return a single NamedType per class so it's
+        //unambiguous what name we use.
+        NamedType typeOnlyNamedType = new NamedType(namedType.getType());
+
         // First things first: is base type itself included?
-        if (collectedSubtypes.containsKey(namedType)) {
+        if (collectedSubtypes.containsKey(typeOnlyNamedType)) {
             // if so, no recursion; however, may need to update name?
             if (namedType.hasName()) {
-                NamedType prev = collectedSubtypes.get(namedType);
+                NamedType prev = collectedSubtypes.get(typeOnlyNamedType);
                 if (!prev.hasName()) {
-                    collectedSubtypes.put(namedType, namedType);
+                    collectedSubtypes.put(typeOnlyNamedType, namedType);
                 }
             }
             return;
         }
         // if it wasn't, add and check subtypes recursively
-        collectedSubtypes.put(namedType, namedType);
+        collectedSubtypes.put(typeOnlyNamedType, namedType);
         Collection<NamedType> st = ai.findSubtypes(annotatedType);
         if (st != null && !st.isEmpty()) {
             for (NamedType subtype : st) {


### PR DESCRIPTION
Before this commit NamedType hashes only on it's class and not on the
name. This only allowed you to register a class once using
ObjectMapper.registerSubtypes(NamedType... types). This commit now
uses name field to hash NamedTypes.

This successfully allows you to deserialize objects of the same type
but different name.

Serializing objects of the same type but different name (for example
fields of a POJO) still has some issues.
1. SerializerProvider caches Serializers based on class and doesn't
take name into account.
2. TypeIdResolver has no method to resolve an id that takes name into
account. Therefore when resolving an id we only have the value and
type.
3. TypeNameIdResolver stores type and id information as a
Map<String, String> that maps type to id, ignoring name

Fixes #2515