### PR TITLE
Added validation on Builder.build() to check if any matcher will

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/exc/InsecureTypeMatchException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/InsecureTypeMatchException.java
@@ -1,0 +1,14 @@
+package com.fasterxml.jackson.databind.exc;
+
+
+/**
+ * Exception used when flagging a Matcher that will allow all subtypes of Object.class or Serializable.class
+ * As allowing such a wide array of classes to be deserialized will open the application up to security vulnerabilities
+ * and so should be avoided.
+ */
+public class InsecureTypeMatchException extends IllegalArgumentException {
+
+    public InsecureTypeMatchException(String msg) {
+        super(msg);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/BasicPTVTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/BasicPTVTest.java
@@ -1,9 +1,13 @@
 package com.fasterxml.jackson.databind.jsontype.vld;
 
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.exc.InsecureTypeMatchException;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -36,6 +40,10 @@ public class BasicPTVTest extends BaseMapTest
             this.x = x;
         }
     }
+
+    static class ValueC extends ValueB implements Serializable {}
+    static class ValueD extends Object {}
+
 
     // // // Value types
 
@@ -262,6 +270,211 @@ public class BasicPTVTest extends BaseMapTest
             verifyException(e, "as a subtype of");
         }
     }
+
+
+    public void testBlockSerializableClass() throws Exception {
+        try {
+            BasicPolymorphicTypeValidator.builder()
+                    .allowIfSubType(Serializable.class)
+                    .build();
+            fail("no exception was thrown when allowIfSubType Serializable.class");
+        } catch (InsecureTypeMatchException tme) {
+            assertEquals("Insecure Base class found : java.io.Serializable",tme.getMessage());
+        }
+    }
+
+    public void testBlockObjectClass() throws Exception {
+        try {
+            BasicPolymorphicTypeValidator.builder()
+                    .allowIfSubType(Object.class)
+                    .build();
+            fail("no exception was thrown when allowIfSubType Object.class");
+        } catch (InsecureTypeMatchException tme) {
+            assertEquals("Insecure Base class found : java.io.Serializable",tme.getMessage());
+        }
+    }
+
+
+
+    public void testBlockBaseTypeMatchSerializable() throws Exception {
+        try {
+            BasicPolymorphicTypeValidator.builder()
+                    .allowIfBaseType(Object.class)
+                    .build();
+            fail("no exception was thrown when allowIfSubType Object.class");
+        } catch (InsecureTypeMatchException tme) {
+            assertEquals("Insecure Base class found : java.io.Serializable",tme.getMessage());
+        }
+    }
+
+    public void testBlockBaseTypeMatchObject() throws Exception {
+        try {
+            BasicPolymorphicTypeValidator.builder()
+                    .allowIfBaseType(Object.class)
+                    .build();
+            fail("no exception was thrown when allowIfSubType Object.class");
+        } catch (InsecureTypeMatchException tme) {
+            assertEquals("Insecure Base class found : java.io.Serializable",tme.getMessage());
+        }
+    }
+
+    public void testBlockSubTypeMatchObject() throws Exception {
+        try {
+            BasicPolymorphicTypeValidator.builder()
+                    .allowIfSubType(Object.class.getName())
+                    .build();
+            fail("no exception was thrown when allowIfSubType Object.class");
+        } catch (InsecureTypeMatchException tme) {
+            assertEquals("Insecure Base class found : java.lang.Object",tme.getMessage());
+        }
+    }
+
+
+
+    public void testBlockSubTypeMatchSerializable() throws Exception {
+        try {
+            BasicPolymorphicTypeValidator.builder()
+                    .allowIfSubType(Serializable.class.getName())
+                    .build();
+            fail("no exception was thrown when allowIfSubType Object.class");
+        } catch (InsecureTypeMatchException tme) {
+            assertEquals("Insecure Base class found : java.io.Serializable",tme.getMessage());
+        }
+    }
+
+
+    public void testNotBlockValidBaseTypesByClassName() throws Exception {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(klass.getName())
+                        .build();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockValidBaseTypesByClass()  {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(klass)
+                        .build();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockValidSubTypesByClass() throws Exception {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(klass)
+                        .build();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockValidSubTypesByName() throws Exception {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(klass.getName())
+                        .build();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockValidSubTypesByNameWhenBuildingInsecurely() throws Exception {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(klass.getName())
+                        .build_insecure();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockValidBaseTypesByClassWhenBuildingInsecurely()  {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(klass)
+                        .build_insecure();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockValidSubTypesByClassWhenBuildingInsecurely() throws Exception {
+        List<Class<?>> validClasses = Arrays.asList(ValueB.class,ValueC.class,ValueD.class);
+        for(Class klass : validClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(klass)
+                        .build_insecure();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockInvalidSubTypesByNameWhenBuildingInsecurely() throws Exception {
+        List<Class<?>> invalidClasses = Arrays.asList(Object.class,Serializable.class);
+        for(Class klass : invalidClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(klass.getName())
+                        .build_insecure();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockInvalidBaseTypesByClassWhenBuildingInsecurely()  {
+        List<Class<?>> invalidClasses = Arrays.asList(Object.class,Serializable.class);
+        for(Class klass : invalidClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(klass)
+                        .build_insecure();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+    public void testNotBlockInvalidSubTypesByClassWhenBuildingInsecurely() throws Exception {
+        List<Class<?>> invalidClasses = Arrays.asList(Object.class,Serializable.class);
+        for(Class klass : invalidClasses) {
+            try {
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(klass)
+                        .build_insecure();
+            } catch (InsecureTypeMatchException tme) {
+                fail("Class "+klass.getName()+" was blocked");
+            }
+        }
+    }
+
+
+
 }
 
 


### PR DESCRIPTION
allow basetype/subtype of Serializable or Object.class

If so an unchecked TypeMatchException is thrown.
This can be bypassed by using build_insecure() instead which has no such checks.
The aim of this change is to :
A : Make developers realise what they are doing has serious security implications and hopefully accomplish their requirements in a different way.
B : Make it easier for static code analysis to flag insecure usage of Jackson-Databind as those tools can assume that if a developer is calling
build_insecure() they are doing that because they are allowing all or alot of classes on the classpath to be deserialized.