### PR TITLE
Use locale passed to ObjectMapper configuration everywhere

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -393,6 +393,8 @@ public class ObjectMapper
      */
     protected final ConfigOverrides _configOverrides;
 
+    private Locale _locale = Locale.getDefault();
+
     /*
     /**********************************************************
     /* Configuration settings: mix-in annotations
@@ -639,7 +641,7 @@ public class ObjectMapper
      * @since 2.5
      */
     protected ClassIntrospector defaultClassIntrospector() {
-        return new BasicClassIntrospector();
+        return new BasicClassIntrospector(_locale);
     }
 
     /*
@@ -2085,6 +2087,7 @@ public class ObjectMapper
      * Default value used is {@link Locale#getDefault()}.
      */
     public ObjectMapper setLocale(Locale l) {
+        _locale = l;
         _deserializationConfig = _deserializationConfig.with(l);
         _serializationConfig = _serializationConfig.with(l);
         return this;

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
 
+import java.util.Locale;
+
 /**
  * Class that defines how names of JSON properties ("external names")
  * are derived from names of POJO methods and fields ("internal names"),
@@ -57,12 +59,12 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * @since 2.7 (was formerly called {@link #PASCAL_CASE_TO_CAMEL_CASE})
      */
     public static final PropertyNamingStrategy LOWER_CAMEL_CASE = new PropertyNamingStrategy();
-    
+
     /**
      * Naming convention in which all words of the logical name are in lower case, and
      * no separator is used between words.
      * See {@link LowerCaseStrategy} for details.
-     * 
+     *
      * @since 2.4
      */
     public static final PropertyNamingStrategy LOWER_CASE = new LowerCaseStrategy();
@@ -71,7 +73,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * Naming convention used in languages like Lisp, where words are in lower-case
      * letters, separated by hyphens.
      * See {@link KebabCaseStrategy} for details.
-     * 
+     *
      * @since 2.7
      */
     public static final PropertyNamingStrategy KEBAB_CASE = new KebabCaseStrategy();
@@ -95,17 +97,17 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * Method called to find external name (name used in JSON) for given logical
      * POJO property,
      * as defined by given field.
-     * 
+     *
      * @param config Configuration in used: either <code>SerializationConfig</code>
      *   or <code>DeserializationConfig</code>, depending on whether method is called
      *   during serialization or deserialization
      * @param field Field used to access property
      * @param defaultName Default name that would be used for property in absence of custom strategy
-     * 
+     *
      * @return Logical name to use for property that the field represents
      */
     public String nameForField(MapperConfig<?> config, AnnotatedField field,
-            String defaultName)
+            String defaultName, Locale locale)
     {
         return defaultName;
     }
@@ -116,17 +118,17 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * as defined by given getter method; typically called when building a serializer.
      * (but not always -- when using "getter-as-setter", may be called during
      * deserialization)
-     * 
+     *
      * @param config Configuration in used: either <code>SerializationConfig</code>
      *   or <code>DeserializationConfig</code>, depending on whether method is called
      *   during serialization or deserialization
      * @param method Method used to access property.
      * @param defaultName Default name that would be used for property in absence of custom strategy
-     * 
+     *
      * @return Logical name to use for property that the method represents
      */
     public String nameForGetterMethod(MapperConfig<?> config, AnnotatedMethod method,
-            String defaultName)
+            String defaultName, Locale locale)
     {
         return defaultName;
     }
@@ -136,17 +138,17 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * POJO property,
      * as defined by given setter method; typically called when building a deserializer
      * (but not necessarily only then).
-     * 
+     *
      * @param config Configuration in used: either <code>SerializationConfig</code>
      *   or <code>DeserializationConfig</code>, depending on whether method is called
      *   during serialization or deserialization
      * @param method Method used to access property.
      * @param defaultName Default name that would be used for property in absence of custom strategy
-     * 
+     *
      * @return Logical name to use for property that the method represents
      */
     public String nameForSetterMethod(MapperConfig<?> config, AnnotatedMethod method,
-            String defaultName)
+            String defaultName, Locale locale)
     {
         return defaultName;
     }
@@ -156,7 +158,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * POJO property,
      * as defined by given constructor parameter; typically called when building a deserializer
      * (but not necessarily only then).
-     * 
+     *
      * @param config Configuration in used: either <code>SerializationConfig</code>
      *   or <code>DeserializationConfig</code>, depending on whether method is called
      *   during serialization or deserialization
@@ -164,7 +166,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * @param defaultName Default name that would be used for property in absence of custom strategy
      */
     public String nameForConstructorParameter(MapperConfig<?> config, AnnotatedParameter ctorParam,
-            String defaultName)
+            String defaultName, Locale locale)
     {
         return defaultName;
     }
@@ -174,35 +176,35 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     /* Public base class for simple implementations
     /**********************************************************
      */
-    
+
     public static abstract class PropertyNamingStrategyBase extends PropertyNamingStrategy
     {
         @Override
-        public String nameForField(MapperConfig<?> config, AnnotatedField field, String defaultName)
+        public String nameForField(MapperConfig<?> config, AnnotatedField field, String defaultName, Locale locale)
         {
-            return translate(defaultName);
+            return translate(defaultName, locale);
         }
 
         @Override
-        public String nameForGetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName)
+        public String nameForGetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName, Locale locale)
         {
-            return translate(defaultName);
+            return translate(defaultName, locale);
         }
 
         @Override
-        public String nameForSetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName)
+        public String nameForSetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName,Locale locale)
         {
-            return translate(defaultName);
+            return translate(defaultName, locale);
         }
 
         @Override
         public String nameForConstructorParameter(MapperConfig<?> config, AnnotatedParameter ctorParam,
-                String defaultName)
+                String defaultName, Locale locale)
         {
-            return translate(defaultName);
+            return translate(defaultName, locale);
         }
-        
-        public abstract String translate(String propertyName);
+
+        public abstract String translate(String propertyName, Locale locale);
 
         /**
          * Helper method to share implementation between snake and dotted case.
@@ -216,13 +218,13 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
             if (length == 0) {
                 return input;
             }
-    
+
             final StringBuilder result = new StringBuilder(length + (length >> 1));
             int upperCount = 0;
             for (int i = 0; i < length; ++i) {
                 char ch = input.charAt(i);
                 char lc = Character.toLowerCase(ch);
-    
+
                 if (lc == ch) { // lower-case letter means we can get new word
                     // but need to check for multi-letter upper-case (acronym), where assumption
                     // is that the last upper-case char is start of a new word
@@ -249,41 +251,41 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     /* Standard implementations 
     /**********************************************************
      */
-    
+
     /**
-     * A {@link PropertyNamingStrategy} that translates typical camel case Java 
-     * property names to lower case JSON element names, separated by 
-     * underscores.  This implementation is somewhat lenient, in that it 
-     * provides some additional translations beyond strictly translating from 
-     * camel case only.  In particular, the following translations are applied 
+     * A {@link PropertyNamingStrategy} that translates typical camel case Java
+     * property names to lower case JSON element names, separated by
+     * underscores.  This implementation is somewhat lenient, in that it
+     * provides some additional translations beyond strictly translating from
+     * camel case only.  In particular, the following translations are applied
      * by this PropertyNamingStrategy.
-     * 
-     * <ul><li>Every upper case letter in the Java property name is translated 
-     * into two characters, an underscore and the lower case equivalent of the 
+     *
+     * <ul><li>Every upper case letter in the Java property name is translated
+     * into two characters, an underscore and the lower case equivalent of the
      * target character, with three exceptions.
      * <ol><li>For contiguous sequences of upper case letters, characters after
-     * the first character are replaced only by their lower case equivalent, 
+     * the first character are replaced only by their lower case equivalent,
      * and are not preceded by an underscore.
-     * <ul><li>This provides for reasonable translations of upper case acronyms, 
+     * <ul><li>This provides for reasonable translations of upper case acronyms,
      * e.g., &quot;theWWW&quot; is translated to &quot;the_www&quot;.</li></ul></li>
-     * <li>An upper case character in the first position of the Java property 
-     * name is not preceded by an underscore character, and is translated only 
+     * <li>An upper case character in the first position of the Java property
+     * name is not preceded by an underscore character, and is translated only
      * to its lower case equivalent.
-     * <ul><li>For example, &quot;Results&quot; is translated to &quot;results&quot;, 
+     * <ul><li>For example, &quot;Results&quot; is translated to &quot;results&quot;,
      * and not to &quot;_results&quot;.</li></ul></li>
-     * <li>An upper case character in the Java property name that is already 
-     * preceded by an underscore character is translated only to its lower case 
+     * <li>An upper case character in the Java property name that is already
+     * preceded by an underscore character is translated only to its lower case
      * equivalent, and is not preceded by an additional underscore.
-     * <ul><li>For example, &quot;user_Name&quot; is translated to 
-     * &quot;user_name&quot;, and not to &quot;user__name&quot; (with two 
+     * <ul><li>For example, &quot;user_Name&quot; is translated to
+     * &quot;user_name&quot;, and not to &quot;user__name&quot; (with two
      * underscore characters).</li></ul></li></ol></li>
-     * <li>If the Java property name starts with an underscore, then that 
-     * underscore is not included in the translated name, unless the Java 
-     * property name is just one character in length, i.e., it is the 
-     * underscore character.  This applies only to the first character of the 
+     * <li>If the Java property name starts with an underscore, then that
+     * underscore is not included in the translated name, unless the Java
+     * property name is just one character in length, i.e., it is the
+     * underscore character.  This applies only to the first character of the
      * Java property name.</li></ul>
-     * 
-     * These rules result in the following additional example translations from 
+     *
+     * These rules result in the following additional example translations from
      * Java property names to JSON element names.
      * <ul><li>&quot;userName&quot; is translated to &quot;user_name&quot;</li>
      * <li>&quot;UserName&quot; is translated to &quot;user_name&quot;</li>
@@ -294,7 +296,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * <li>&quot;USER&quot; is translated to &quot;user&quot;</li>
      * <li>&quot;_user&quot; is translated to &quot;user&quot;</li>
      * <li>&quot;_User&quot; is translated to &quot;user&quot;</li>
-     * <li>&quot;__user&quot; is translated to &quot;_user&quot; 
+     * <li>&quot;__user&quot; is translated to &quot;_user&quot;
      * (the first of two underscores was removed)</li>
      * <li>&quot;user__name&quot; is translated to &quot;user__name&quot;
      * (unchanged, with two underscores)</li></ul>
@@ -304,7 +306,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     public static class SnakeCaseStrategy extends PropertyNamingStrategyBase
     {
         @Override
-        public String translate(String input)
+        public String translate(String input, Locale locale)
         {
             if (input == null) return input; // garbage in, garbage out
             int length = input.length();
@@ -339,25 +341,25 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     }
 
     /**
-     * A {@link PropertyNamingStrategy} that translates typical camelCase Java 
+     * A {@link PropertyNamingStrategy} that translates typical camelCase Java
      * property names to PascalCase JSON element names (i.e., with a capital
-     * first letter).  In particular, the following translations are applied by 
+     * first letter).  In particular, the following translations are applied by
      * this PropertyNamingStrategy.
-     * 
-     * <ul><li>The first lower-case letter in the Java property name is translated 
+     *
+     * <ul><li>The first lower-case letter in the Java property name is translated
      * into its equivalent upper-case representation.</li></ul>
-     * 
-     * This rules result in the following example translation from 
+     *
+     * This rules result in the following example translation from
      * Java property names to JSON element names.
      * <ul><li>&quot;userName&quot; is translated to &quot;UserName&quot;</li></ul>
-     * 
+     *
      * @since 2.7 (was formerly called {@link PascalCaseStrategy})
      */
     public static class UpperCamelCaseStrategy extends PropertyNamingStrategyBase
     {
         /**
          * Converts camelCase to PascalCase
-         * 
+         *
          * For example, "userName" would be converted to
          * "UserName".
          *
@@ -365,7 +367,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
          * @return input converted to PascalCase format
          */
         @Override
-        public String translate(String input) {
+        public String translate(String input, Locale locale) {
             if (input == null || input.length() == 0){
                 return input; // garbage in, garbage out
             }
@@ -386,14 +388,14 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      * and no separators.
      * Conversion from internal name like "someOtherValue" would be into external name
      * if "someothervalue".
-     * 
+     *
      * @since 2.4
      */
     public static class LowerCaseStrategy extends PropertyNamingStrategyBase
     {
         @Override
-        public String translate(String input) {
-            return input.toLowerCase();
+        public String translate(String input, Locale locale) {
+            return input.toLowerCase(locale);
         }
     }
 
@@ -407,7 +409,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     public static class KebabCaseStrategy extends PropertyNamingStrategyBase
     {
         @Override
-        public String translate(String input) {
+        public String translate(String input, Locale locale) {
             return translateLowerCaseWithSeparator(input, '-');
         }
     }
@@ -420,7 +422,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
      */
     public static class LowerDotCaseStrategy extends PropertyNamingStrategyBase {
         @Override
-        public String translate(String input){
+        public String translate(String input, Locale locale){
             return translateLowerCaseWithSeparator(input, '.');
         }
     }
@@ -430,7 +432,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
     /* Deprecated variants, aliases
     /**********************************************************
      */
-    
+
     /**
      * @deprecated Since 2.7 use {@link #SNAKE_CASE} instead;
      */

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -344,13 +344,14 @@ public class BeanDeserializerBuilder
      * Method for constructing a {@link BeanDeserializer}, given all
      * information collected.
      */
-    public JsonDeserializer<?> build()
+    //TODO change
+    public JsonDeserializer<?> build(Locale locale)
     {
         Collection<SettableBeanProperty> props = _properties.values();
         _fixAccess(props);
         BeanPropertyMap propertyMap = BeanPropertyMap.construct(props,
                 _config.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES),
-                _collectAliases(props));
+                _collectAliases(props), locale);
         propertyMap.assignIndexes();
 
         // view processing must be enabled if:
@@ -427,7 +428,7 @@ public class BeanDeserializerBuilder
         _fixAccess(props);
         BeanPropertyMap propertyMap = BeanPropertyMap.construct(props,
                 _config.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES),
-                _collectAliases(props));
+                _collectAliases(props), _context.getLocale());
         propertyMap.assignIndexes();
 
         boolean anyViews = !_config.isEnabled(MapperFeature.DEFAULT_VIEW_INCLUSION);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -344,7 +344,6 @@ public class BeanDeserializerBuilder
      * Method for constructing a {@link BeanDeserializer}, given all
      * information collected.
      */
-    //TODO change
     public JsonDeserializer<?> build(Locale locale)
     {
         Collection<SettableBeanProperty> props = _properties.values();

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -249,7 +249,7 @@ public class BeanDeserializerFactory
         if (type.isAbstract() && !valueInstantiator.canInstantiate()) {
             deserializer = builder.buildAbstract();
         } else {
-            deserializer = builder.build();
+            deserializer = builder.build(config.getLocale());
         }
         // may have modifier(s) that wants to modify or replace serializer we just built
         // (note that `resolve()` and `createContextual()` called later on)
@@ -408,7 +408,7 @@ public class BeanDeserializerFactory
                 builder = mod.updateBuilder(config, beanDesc, builder);
             }
         }
-        JsonDeserializer<?> deserializer = builder.build();
+        JsonDeserializer<?> deserializer = builder.build(config.getLocale());
         
         /* At this point it ought to be a BeanDeserializer; if not, must assume
          * it's some other thing that can handle deserialization ok...

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyBasedCreator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyBasedCreator.java
@@ -58,7 +58,7 @@ public final class PropertyBasedCreator
     {
         _valueInstantiator = valueInstantiator;
         if (caseInsensitive) {
-            _propertyLookup = new CaseInsensitiveMap();
+            _propertyLookup = new CaseInsensitiveMap(ctxt.getLocale());
         } else {
             _propertyLookup = new HashMap<String, SettableBeanProperty>();
         }
@@ -225,15 +225,20 @@ public final class PropertyBasedCreator
     static class CaseInsensitiveMap extends HashMap<String, SettableBeanProperty>
     {
         private static final long serialVersionUID = 1L;
+        private final Locale locale;
+
+        CaseInsensitiveMap(Locale locale) {
+            this.locale = locale;
+        }
 
         @Override
         public SettableBeanProperty get(Object key0) {
-            return super.get(((String) key0).toLowerCase());
+            return super.get(((String) key0).toLowerCase(locale));
         }
 
         @Override
         public SettableBeanProperty put(String key, SettableBeanProperty value) {
-            key = key.toLowerCase();
+            key = key.toLowerCase(locale);
             return super.put(key, value);
         }
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicClassIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicClassIntrospector.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.introspect;
 
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
@@ -57,18 +58,21 @@ public class BasicClassIntrospector
                 AnnotatedClassResolver.createPrimordial(CLS_OBJECT));
     }
 
+    private final Locale _locale;
+
     /*
     /**********************************************************
     /* Life cycle
     /**********************************************************
      */
 
-    public BasicClassIntrospector() {
+    public BasicClassIntrospector(Locale locale) {
+        _locale = locale;
     }
 
     @Override
     public ClassIntrospector copy() {
-        return new BasicClassIntrospector();
+        return new BasicClassIntrospector(_locale);
     }
 
     /*
@@ -195,7 +199,7 @@ public class BasicClassIntrospector
     protected POJOPropertiesCollector constructPropertyCollector(MapperConfig<?> config,
             AnnotatedClass ac, JavaType type, boolean forSerialization, String mutatorPrefix)
     {
-        return new POJOPropertiesCollector(config, forSerialization, type, ac, mutatorPrefix);
+        return new POJOPropertiesCollector(config, forSerialization, type, ac, mutatorPrefix, _locale);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -66,6 +66,8 @@ public class POJOPropertiesCollector
      * but differs for builder objects ("with" by default).
      */
     protected final String _mutatorPrefix;
+
+    private final Locale _locale;
     
     /*
     /**********************************************************
@@ -124,7 +126,7 @@ public class POJOPropertiesCollector
      */
 
     protected POJOPropertiesCollector(MapperConfig<?> config, boolean forSerialization,
-            JavaType type, AnnotatedClass classDef, String mutatorPrefix)
+                                      JavaType type, AnnotatedClass classDef, String mutatorPrefix, Locale locale)
     {
         _config = config;
         _stdBeanNaming = config.isEnabled(MapperFeature.USE_STD_BEAN_NAMING);
@@ -132,6 +134,7 @@ public class POJOPropertiesCollector
         _type = type;
         _classDef = classDef;
         _mutatorPrefix = (mutatorPrefix == null) ? "set" : mutatorPrefix;
+        _locale = locale;
         if (config.isAnnotationProcessingEnabled()) {
             _useAnnotations = true;
             _annotationIntrospector = _config.getAnnotationIntrospector();
@@ -845,22 +848,22 @@ public class POJOPropertiesCollector
             if (!prop.isExplicitlyNamed() || _config.isEnabled(MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING)) {
                 if (_forSerialization) {
                     if (prop.hasGetter()) {
-                        rename = naming.nameForGetterMethod(_config, prop.getGetter(), fullName.getSimpleName());
+                        rename = naming.nameForGetterMethod(_config, prop.getGetter(), fullName.getSimpleName(), _locale);
                     } else if (prop.hasField()) {
-                        rename = naming.nameForField(_config, prop.getField(), fullName.getSimpleName());
+                        rename = naming.nameForField(_config, prop.getField(), fullName.getSimpleName(), _locale);
                     }
                 } else {
                     if (prop.hasSetter()) {
-                        rename = naming.nameForSetterMethod(_config, prop.getSetter(), fullName.getSimpleName());
+                        rename = naming.nameForSetterMethod(_config, prop.getSetter(), fullName.getSimpleName(), _locale);
                     } else if (prop.hasConstructorParameter()) {
-                        rename = naming.nameForConstructorParameter(_config, prop.getConstructorParameter(), fullName.getSimpleName());
+                        rename = naming.nameForConstructorParameter(_config, prop.getConstructorParameter(), fullName.getSimpleName(), _locale);
                     } else if (prop.hasField()) {
-                        rename = naming.nameForField(_config, prop.getField(), fullName.getSimpleName());
+                        rename = naming.nameForField(_config, prop.getField(), fullName.getSimpleName(), _locale);
                     } else if (prop.hasGetter()) {
                         /* Plus, when getter-as-setter is used, need to convert that too..
                          * (should we verify that's enabled? For now, assume it's ok always)
                          */
-                        rename = naming.nameForGetterMethod(_config, prop.getGetter(), fullName.getSimpleName());
+                        rename = naming.nameForGetterMethod(_config, prop.getGetter(), fullName.getSimpleName(), _locale);
                     }
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/databind/jsonFormatVisitors/JsonFormatTypes.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonFormatVisitors/JsonFormatTypes.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+//TODO what to do here
 public enum JsonFormatTypes
 {
 	STRING,

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollectorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollectorTest.java
@@ -537,7 +537,7 @@ public class POJOPropertiesCollectorTest
     protected POJOPropertiesCollector collector(ObjectMapper m0,
             Class<?> cls, boolean forSerialization)
     {
-        BasicClassIntrospector bci = new BasicClassIntrospector();
+        BasicClassIntrospector bci = new BasicClassIntrospector(Locale.getDefault());
         // no real difference between serialization, deserialization, at least here
         if (forSerialization) {
             return bci.collectProperties(m0.getSerializationConfig(),

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestBuilderMethods.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestBuilderMethods.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.introspect;
 
+import java.util.Locale;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.*;
@@ -47,7 +48,7 @@ public class TestBuilderMethods extends BaseMapTest
 
     protected POJOPropertiesCollector collector(Class<?> cls, String prefix)
     {
-        BasicClassIntrospector bci = new BasicClassIntrospector();
+        BasicClassIntrospector bci = new BasicClassIntrospector(Locale.getDefault());
         // no real difference between serialization, deserialization, at least here
         return bci.collectProperties(mapper.getSerializationConfig(),
                 mapper.constructType(cls), null, false, prefix);

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyCustom.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyCustom.java
@@ -28,21 +28,21 @@ public class TestNamingStrategyCustom extends BaseMapTest
     {
         @Override
         public String nameForField(MapperConfig<?> config,
-                AnnotatedField field, String defaultName)
+                AnnotatedField field, String defaultName, Locale locale)
         {
             return "Field-"+defaultName;
         }
 
         @Override
         public String nameForGetterMethod(MapperConfig<?> config,
-                AnnotatedMethod method, String defaultName)
+                AnnotatedMethod method, String defaultName, Locale locale)
         {
             return "Get-"+defaultName;
         }
 
         @Override
         public String nameForSetterMethod(MapperConfig<?> config,
-                AnnotatedMethod method, String defaultName)
+                AnnotatedMethod method, String defaultName, Locale locale)
         {
             return "Set-"+defaultName;
         }
@@ -51,19 +51,19 @@ public class TestNamingStrategyCustom extends BaseMapTest
     static class CStyleStrategy extends PropertyNamingStrategy
     {
         @Override
-        public String nameForField(MapperConfig<?> config, AnnotatedField field, String defaultName)
+        public String nameForField(MapperConfig<?> config, AnnotatedField field, String defaultName, Locale locale)
         {
             return convert(defaultName);
         }
 
         @Override
-        public String nameForGetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName)
+        public String nameForGetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName, Locale locale)
         {
             return convert(defaultName);
         }
 
         @Override
-        public String nameForSetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName)
+        public String nameForSetterMethod(MapperConfig<?> config, AnnotatedMethod method, String defaultName, Locale locale)
         {
             return convert(defaultName);
         }
@@ -140,7 +140,7 @@ public class TestNamingStrategyCustom extends BaseMapTest
     static class LcStrategy extends PropertyNamingStrategy.PropertyNamingStrategyBase
     {
         @Override
-        public String translate(String propertyName) {
+        public String translate(String propertyName, Locale locale) {
             return propertyName.toLowerCase();
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.introspect;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.*;
 
@@ -197,7 +198,7 @@ public class TestNamingStrategyStd extends BaseMapTest
     {
         for (Object[] pair : SNAKE_CASE_NAME_TRANSLATIONS) {
             String translatedJavaName = PropertyNamingStrategy.SNAKE_CASE.nameForField(null, null,
-                    (String) pair[0]);
+                    (String) pair[0], Locale.getDefault());
             assertEquals((String) pair[1], translatedJavaName);
         }
     }
@@ -270,13 +271,13 @@ public class TestNamingStrategyStd extends BaseMapTest
      */
     public void testPascalCaseStandAlone()
     {
-        assertEquals("UserName", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "userName"));
-        assertEquals("User", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "User"));
-        assertEquals("User", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "user"));
-        assertEquals("X", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "x"));
+        assertEquals("UserName", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "userName", Locale.getDefault()));
+        assertEquals("User", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "User", Locale.getDefault()));
+        assertEquals("User", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "user", Locale.getDefault()));
+        assertEquals("X", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "x", Locale.getDefault()));
 
-        assertEquals("BADPublicName", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "bADPublicName"));
-        assertEquals("BADPublicName", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForGetterMethod(null, null, "bADPublicName"));
+        assertEquals("BADPublicName", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForField(null, null, "bADPublicName", Locale.getDefault()));
+        assertEquals("BADPublicName", PropertyNamingStrategy.UPPER_CAMEL_CASE.nameForGetterMethod(null, null, "bADPublicName", Locale.getDefault()));
     }
 
     // [databind#428]
@@ -315,15 +316,15 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testKebabCaseStrategyStandAlone()
     {
         assertEquals("some-value",
-                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "someValue"));
+                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "someValue", Locale.getDefault()));
         assertEquals("some-value",
-                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "SomeValue"));
+                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "SomeValue", Locale.getDefault()));
         assertEquals("url",
-                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "URL"));
+                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "URL", Locale.getDefault()));
         assertEquals("url-stuff",
-                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "URLStuff"));
+                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "URLStuff", Locale.getDefault()));
         assertEquals("some-url-stuff",
-                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "SomeURLStuff"));
+                PropertyNamingStrategy.KEBAB_CASE.nameForField(null, null, "SomeURLStuff", Locale.getDefault()));
     }
     
     public void testSimpleKebabCase() throws Exception
@@ -347,15 +348,15 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testLowerCaseWithDotsStrategyStandAlone()
     {
         assertEquals("some.value",
-            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "someValue"));
+            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "someValue", Locale.getDefault()));
         assertEquals("some.value",
-            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "SomeValue"));
+            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "SomeValue", Locale.getDefault()));
         assertEquals("url",
-            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "URL"));
+            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "URL", Locale.getDefault()));
         assertEquals("url.stuff",
-            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "URLStuff"));
+            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "URLStuff", Locale.getDefault()));
         assertEquals("some.url.stuff",
-            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "SomeURLStuff"));
+            PropertyNamingStrategy.LOWER_DOT_CASE.nameForField(null, null, "SomeURLStuff", Locale.getDefault()));
     }
 
     public void testSimpleLowerCaseWithDots() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/misc/BeanPropertyMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/misc/BeanPropertyMapTest.java
@@ -32,7 +32,7 @@ public class BeanPropertyMapTest extends BaseMapTest
         props.add(new ObjectIdValueProperty(new MyObjectIdReader("pk"), md));
         props.add(new ObjectIdValueProperty(new MyObjectIdReader("firstName"), md));
         BeanPropertyMap propMap = new BeanPropertyMap(false, props,
-                new HashMap<String,List<PropertyName>>());
+                new HashMap<String,List<PropertyName>>(), Locale.getDefault());
         propMap = propMap.withProperty(new ObjectIdValueProperty(new MyObjectIdReader("@id"), md));
         assertNotNull(propMap);
     }


### PR DESCRIPTION
Allows to fix Turkish i parsing https://github.com/FasterXML/jackson-databind/issues/953#event-813678035.

So the idea behind this fix is to propagate a proper Locale that user set during `ObjectMapper` configuration. This way, the user can decide if he wants to parse in a particular Locale. 

There's another consequence as well, previously, because the Json readers are cached, we could end up in a state when `Locale.getDefault()` is different than it was during reader creation. So the same reader would fail during parsing of the exact same Json it tried to parse before. 

Example:
1. Set Turkish locale
2. Parse to `Bean.class` having uppercase I in the property name
3. Set UK locale
4. Parse `Bean.class` again
5. Parsing fails

I deliberately didn't create unit tests for classes that use `toLowerCase(locale)`, and decided to test the whole `ObjectMapper` integrated with real implementations of those.

Apologies if I didn't follow some other conventions of the project, or if I'm targetting the wrong branch.