### PR TITLE
Include property names in error in case of FAIL_ON_NULL_FOR_PRIMITIVES

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.SettableAnyProperty;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 
 /**
  * Simple container used for temporarily buffering a set of
@@ -198,15 +199,24 @@ public class PropertyValueBuffer
                     "Missing creator property '%s' (index %d); `DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES` enabled",
                     prop.getName(), prop.getCreatorIndex());
         }
-        // Third: NullValueProvider? (22-Sep-2019, [databind#2458])
-        Object nullValue = prop.getNullValueProvider().getNullValue(_context);
-        if (nullValue != null) {
-            return nullValue;
-        }
+        try {
+            // Third: NullValueProvider? (22-Sep-2019, [databind#2458])
+            Object nullValue = prop.getNullValueProvider().getNullValue(_context);
+            if (nullValue != null) {
+                return nullValue;
+            }
 
-        // Fourth: default value
-        JsonDeserializer<Object> deser = prop.getValueDeserializer();
-        return deser.getNullValue(_context);
+            // Fourth: default value
+            JsonDeserializer<Object> deser = prop.getValueDeserializer();
+            return deser.getNullValue(_context);
+        } catch (JsonMappingException e) {
+            // [databind#2101]: Include property name, if we have it
+            AnnotatedMember member = prop.getMember();
+            if (member != null) {
+                e.prependPath(member.getDeclaringClass(), prop.getName());
+            }
+            throw e;
+        }
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/TestCreatorNullPrimitives.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/TestCreatorNullPrimitives.java
@@ -1,0 +1,68 @@
+package com.fasterxml.jackson.databind.deser.creators;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class TestCreatorNullPrimitives extends BaseMapTest {
+
+    // [databind#2101]
+    static class JsonEntity {
+        protected final int x;
+        protected final int y;
+
+        @JsonCreator
+        private JsonEntity(@JsonProperty("x") int x, @JsonProperty("y") int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static class NestedJsonEntity {
+        protected final JsonEntity entity;
+
+        @JsonCreator
+        private NestedJsonEntity(@JsonProperty("entity") JsonEntity entity) {
+            this.entity = entity;
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Unit tests
+    /**********************************************************
+     */
+
+    // [databind#2101]: ensure that the property is included in the path
+    public void testCreatorNullPrimitive() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper().enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+        String json = aposToQuotes("{'x': 2}");
+        try {
+            objectMapper.readValue(json, JsonEntity.class);
+            fail("Should not have succeeded");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Cannot map `null` into type int");
+            assertEquals(1, e.getPath().size());
+            assertEquals("y", e.getPath().get(0).getFieldName());
+        }
+    }
+
+    public void testCreatorNullPrimitiveInNestedObject() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper().enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+        String json = aposToQuotes("{ 'entity': {'x': 2}}");
+        try {
+            objectMapper.readValue(json, NestedJsonEntity.class);
+            fail("Should not have succeeded");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Cannot map `null` into type int");
+            assertEquals(2, e.getPath().size());
+            assertEquals("y", e.getPath().get(1).getFieldName());
+            assertEquals("entity", e.getPath().get(0).getFieldName());
+        }
+    }
+}


### PR DESCRIPTION
Ensure that property names are included in the path of the exception when FAIL_ON_NULL_FOR_PRIMITIVES is enabled

fixes #2101