### PR TITLE
Fix #2592: JsonInclude support for any getters

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/AnyGetterWriter.java
@@ -59,7 +59,7 @@ public class AnyGetterWriter
         }
         // 23-Feb-2015, tatu: Nasty, but has to do (for now)
         if (_mapSerializer != null) {
-            _mapSerializer.serializeFields((Map<?,?>) value, gen, provider);
+            _mapSerializer.serializeWithoutTypeInfo((Map<?,?>) value, gen, provider);
             return;
         }
         _serializer.serialize(value, gen, provider);


### PR DESCRIPTION
### Description

Fixes #2592 

Fix will not work if filter is used as it triggers separate execution path. (see `#testAnyGetterWithMapperDefaultIncludeNonEmptyAndFilterOnBean`).

### Notes

* I've chosen `2.11` as target branch. I can move patch to a different one.