### PR TITLE
implement #2626: provide overloadings of ObjectReader.readValue() taking Class valueType

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -1149,6 +1149,14 @@ public class ObjectReader
     }
 
     /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(InputStream src, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(src);
+    }
+
+    /**
      * Method that binds content read from given input source,
      * using configuration of this reader.
      * Value return is either newly constructed, or root value that
@@ -1161,6 +1169,14 @@ public class ObjectReader
         DefaultDeserializationContext ctxt = _deserializationContext();
         return (T) _bindAndClose(ctxt,
                 _considerFilter(_parserFactory.createParser(ctxt, src), false));
+    }
+
+    /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(Reader src, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(src);
     }
 
     /**
@@ -1179,6 +1195,14 @@ public class ObjectReader
     }
 
     /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(String src, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(src);
+    }
+
+    /**
      * Method that binds content read from given byte array,
      * using configuration of this reader.
      * Value return is either newly constructed, or root value that
@@ -1191,6 +1215,14 @@ public class ObjectReader
         DefaultDeserializationContext ctxt = _deserializationContext();
         return (T) _bindAndClose(ctxt,
                 _considerFilter(_parserFactory.createParser(ctxt, content), false));
+    }
+
+    /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(byte[] content, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(content);
     }
 
     /**
@@ -1207,7 +1239,15 @@ public class ObjectReader
         return (T) _bindAndClose(ctxt,
                 _considerFilter(_parserFactory.createParser(ctxt, content, offset, length), false));
     }
-    
+
+    /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(byte[] content, int offset, int length, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(content, offset, length);
+    }
+
     @SuppressWarnings("unchecked")
     public <T> T readValue(File src) throws IOException
     {
@@ -1215,6 +1255,14 @@ public class ObjectReader
         DefaultDeserializationContext ctxt = _deserializationContext();
         return (T) _bindAndClose(ctxt,
                 _considerFilter(_parserFactory.createParser(ctxt, src), false));
+    }
+
+    /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(File src, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(src);
     }
 
     /**
@@ -1240,6 +1288,14 @@ public class ObjectReader
     }
 
     /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(URL src, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(src);
+    }
+
+    /**
      * Convenience method for converting results from given JSON tree into given
      * value type. Basically short-cut for:
      *<pre>
@@ -1255,6 +1311,14 @@ public class ObjectReader
                 _considerFilter(treeAsTokens(content, ctxt), false));
     }
 
+    /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(JsonNode src, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(src);
+    }
+
     @SuppressWarnings("unchecked")
     public <T> T readValue(DataInput content) throws IOException
     {
@@ -1262,6 +1326,14 @@ public class ObjectReader
         DefaultDeserializationContext ctxt = _deserializationContext();
         return (T) _bindAndClose(ctxt,
                 _considerFilter(_parserFactory.createParser(ctxt, content), false));
+    }
+
+    /**
+     * Overloading to alert compiler as to the valueType
+     */
+    public <T> T readValue(DataInput content, Class<T> valueType) throws IOException
+    {
+        return (T) forType(valueType).readValue(content);
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
@@ -190,6 +190,24 @@ public class ObjectReaderTest extends BaseMapTest
         assertEquals(1234, pojo.name.get("value"));
     }
 
+
+    public void testCanPassResultToOverloadedMethod() throws Exception {
+        final String source = "{\"foo\":{\"bar\":{\"caller\":{\"name\":{\"value\":1234}}}}}";
+
+        ObjectReader reader = MAPPER.readerFor(POJO.class).at("/foo/bar/caller");
+
+        process(reader.readValue(source, POJO.class));
+    }
+
+    void process(POJO pojo) {
+        // do nothing - just used to show that the compiler can choose the correct method overloading to invoke
+    }
+
+    void process(String pojo) {
+        // do nothing - just used to show that the compiler can choose the correct method overloading to invoke
+    }
+
+
     public void testPointerLoadingAsJsonNode() throws Exception {
         final String source = "{\"foo\":{\"bar\":{\"caller\":{\"name\":{\"value\":1234}}}}}";
 

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectReaderValueOfWithValueTypeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectReaderValueOfWithValueTypeTest.java
@@ -1,0 +1,149 @@
+package com.fasterxml.jackson.databind;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.*;
+import java.net.URL;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ObjectReaderValueOfWithValueTypeTest {
+    final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    static class POJO {
+        public Map<String, Object> name;
+    }
+
+    private final POJO pojo = new POJO();
+
+    @Mock
+    ObjectReader objectReader;
+
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testValueOfStringWithValueType() throws IOException {
+        when(objectReader.readValue((String) any())).thenReturn(pojo);
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((String) any(), (Class) any())).thenCallRealMethod();
+
+        String source = "";
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+
+    @Test
+    public void testValueOfByteArrayWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((byte[]) any())).thenReturn(pojo);
+        when(objectReader.readValue((byte[]) any(), (Class) any())).thenCallRealMethod();
+
+        byte[] source = "{}".getBytes();
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+    @Test
+    public void testValueOfDataInputWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((DataInput) any())).thenReturn(pojo);
+        when(objectReader.readValue((DataInput) any(), (Class) any())).thenCallRealMethod();
+
+        DataInput source = new DataInputStream(new ByteArrayInputStream("{}".getBytes()));
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+    @Test
+    public void testValueOfFileWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((File) any())).thenReturn(pojo);
+        when(objectReader.readValue((File) any(), (Class) any())).thenCallRealMethod();
+
+        File source = new File("unknownpath");
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+    @Test
+    public void testValueOfInputStreamWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((InputStream) any())).thenReturn(pojo);
+        when(objectReader.readValue((InputStream) any(), (Class) any())).thenCallRealMethod();
+
+        InputStream source = new ByteArrayInputStream("{}".getBytes());
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+    @Test
+    public void testValueOfJsonNodeWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((JsonNode) any())).thenReturn(pojo);
+        when(objectReader.readValue((JsonNode) any(), (Class) any())).thenCallRealMethod();
+
+        JsonNode source = new TextNode("{}");
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+    @Test
+    public void testValueOfReaderWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((Reader) any())).thenReturn(pojo);
+        when(objectReader.readValue((Reader) any(), (Class) any())).thenCallRealMethod();
+
+        Reader source = new StringReader("{}");
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+
+    @Test
+    public void testValueOfURLWithValueType() throws IOException {
+        when(objectReader.forType((Class) any())).thenReturn(objectReader);
+        when(objectReader.readValue((URL) any())).thenReturn(pojo);
+        when(objectReader.readValue((URL) any(), (Class) any())).thenCallRealMethod();
+
+        URL source = new URL("http://www.test.com");
+        POJO result = objectReader.readValue(source, POJO.class);
+
+        assertEquals(result, pojo);
+        verify(objectReader).forType(POJO.class);
+        verify(objectReader).readValue(source);
+    }
+}


### PR DESCRIPTION
(to fix #2636)


This PR provides additional overloadings of ObjectReader.readValue() which take the "Class valueType" argument.

This serves to make a typecast unnecessary when the result of readValue is being passed to an overloaded method.

I also introduced a test, without assertions (!), which shows that the code compiles.