### PR TITLE
Update current & backports branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,8 +405,8 @@ usually a Jackson module.
 `master` branch is for developing the next major Jackson version -- 3.0 -- but there
 are active maintenance branches in which much of development happens:
 
-* `2.10` is the current stable minor 2.x version
-* `2.9` is for selected backported fixes 
+* `2.11` is the current stable minor 2.x version
+* `2.10` is for selected backported fixes 
 
 Older branches are usually not maintained after being declared as closed
 on [Jackson Releases](https://github.com/FasterXML/jackson/wiki/Jackson-Releases) page,


### PR DESCRIPTION
Mark 2.11 as the current stable branch and 2.10 as receiving backport fixes.

@cowtowncoder—I'm not sure whether dropping 2.9 from this list is appropriate; maybe that should wait until June, as mentioned on the [jackson-core wiki](https://github.com/FasterXML/jackson-core/wiki)