### PR TITLE
Issue 2486 test update

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -212,7 +212,25 @@ public abstract class BeanDeserializerBase
         _injectables = (injectables == null || injectables.isEmpty()) ? null
                 : injectables.toArray(new ValueInjector[injectables.size()]);
         _objectIdReader = builder.getObjectIdReader();
+
+        // If you check for canCreateFromInt() below which appears to be the equivalent
+        // of the existing canCreateUsingArrayDelegate() it also causes the included
+        // test testPOJOWithPrimitiveCreatorFromObjectRepresentation() to break in the
+        // same way as the test testPOJOWithArrayCreatorFromObjectRepresentation() which
+        // I assert is failing because of the call to canCreateUsingArrayDelegate() below.
+        //
+        // Removing the call to canCreateUsingArrayDelegate() below allows the test
+        // testPOJOWithArrayCreatorFromObjectRepresentation() to pass and interestingly
+        // all existing tests continue to pass. I somehow doubt that it's that simple.
+        //
+        // Specifically, it seems to me that the vanilla-ness of the deserialization can
+        // only be determined once the structure of the incoming JSON can be compared to
+        // what creator methods exist. For example, if there is an array delegate and we
+        // are asked to deserialize from an array then it's not vanilla. However, if we
+        // are asked to deserialize from an object then it's vanilla (subject to no other
+        // non-vanilla-ness being present).
         _nonStandardCreation = (_unwrappedPropertyHandler != null)
+            //|| _valueInstantiator.canCreateFromInt()
             || _valueInstantiator.canCreateUsingDelegate()
             || _valueInstantiator.canCreateUsingArrayDelegate() // new in 2.7
             || _valueInstantiator.canCreateFromObjectWith()

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -218,7 +218,6 @@ public abstract class BeanDeserializerBase
         //     "default creator + POJO" -- is not available. But this is not actually
         //     known before seeing Array value (unlike with more general "any" delegate).
         _nonStandardCreation = (_unwrappedPropertyHandler != null)
-            //|| _valueInstantiator.canCreateFromInt()
             || _valueInstantiator.canCreateUsingDelegate()
             || _valueInstantiator.canCreateUsingArrayDelegate()
             || _valueInstantiator.canCreateFromObjectWith()

--- a/src/test/java/com/fasterxml/jackson/failing/BuilderDeserializationTest2486.java
+++ b/src/test/java/com/fasterxml/jackson/failing/BuilderDeserializationTest2486.java
@@ -29,12 +29,20 @@ public class BuilderDeserializationTest2486
                 // Default constructor
             }
 
-            @JsonCreator
+            // NOTE: no change with or without mode
+            @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
             public Builder(final List<Object> jsonArray) {
                 withIndex((int) jsonArray.get(0));
             }
 
+            // When deserialized via builder
             public Builder withIndex(int i) {
+                index = i;
+                return this;
+            }
+
+            // When deserialized into a builder
+            public Builder setIndex(int i) {
                 index = i;
                 return this;
             }
@@ -64,12 +72,20 @@ public class BuilderDeserializationTest2486
                 // Default constructor
             }
 
-            @JsonCreator
+            // NOTE: no change with or without mode
+            @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
             public Builder(final int i) {
                 withIndex(i);
             }
 
+            // When deserialized via builder
             public Builder withIndex(int i) {
+                index = i;
+                return this;
+            }
+
+            // When deserialized into a builder
+            public Builder setIndex(int i) {
                 index = i;
                 return this;
             }
@@ -88,31 +104,65 @@ public class BuilderDeserializationTest2486
     // pass in both cases.
     //
     // I left some notes in BeanDeserializerBase as to behavior.
-    public void testPOJOWithArrayCreatorFromObjectRepresentation() throws Exception {
+    public void testPOJOFromBuilderWithArrayCreatorFromObjectRepresentation() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         final String json = aposToQuotes("{ 'index': 123 }");
         final MyPOJOWithArrayCreator deserialized = mapper.readValue(json, MyPOJOWithArrayCreator.class);
         assertEquals(123, deserialized.getIndex());
     }
 
-    public void testPOJOWithArrayCreatorFromArrayRepresentation() throws Exception {
+    public void testPOJOFromBuilderWithArrayCreatorFromArrayRepresentation() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         final String json = aposToQuotes("[123]");
         final MyPOJOWithArrayCreator deserialized = mapper.readValue(json, MyPOJOWithArrayCreator.class);
         assertEquals(123, deserialized.getIndex());
     }
 
-    public void testPOJOWithPrimitiveCreatorFromObjectRepresentation() throws Exception {
+    public void testPOJOFromBuilderWithPrimitiveCreatorFromObjectRepresentation() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         final String json = aposToQuotes("{ 'index': 123 }");
         final MyPOJOWithPrimitiveCreator deserialized = mapper.readValue(json, MyPOJOWithPrimitiveCreator.class);
         assertEquals(123, deserialized.getIndex());
     }
 
-    public void testPOJOWithPrimitiveCreatorFromPrimitiveRepresentation() throws Exception {
+    public void testPOJOFromBuilderWithPrimitiveCreatorFromPrimitiveRepresentation() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         final String json = aposToQuotes("123");
         final MyPOJOWithPrimitiveCreator deserialized = mapper.readValue(json, MyPOJOWithPrimitiveCreator.class);
         assertEquals(123, deserialized.getIndex());
+    }
+
+    // Now let's try it without the builder by deserializing directly into an
+    // instance of the POJO Builder class instead of via it into the POJO.
+
+    // This fails the same as above. So the failure of default deserialization
+    // from an object shape in the presence of a @JsonCreator accepting an array
+    // is not specific to the use of Builders as an intermediary.
+    public void testPOJOBuilderWithArrayCreatorFromObjectRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("{ 'index': 123 }");
+        final MyPOJOWithArrayCreator.Builder deserialized = mapper.readValue(json, MyPOJOWithArrayCreator.Builder.class);
+        assertEquals(123, deserialized.index);
+    }
+
+    public void testPOJOBuilderWithArrayCreatorFromArrayRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("[123]");
+        final MyPOJOWithArrayCreator.Builder deserialized = mapper.readValue(json, MyPOJOWithArrayCreator.Builder.class);
+        assertEquals(123, deserialized.index);
+    }
+
+    public void testPOJOBuilderWithPrimitiveCreatorFromObjectRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("{ 'index': 123 }");
+        final MyPOJOWithPrimitiveCreator.Builder deserialized = mapper.readValue(json, MyPOJOWithPrimitiveCreator.Builder.class);
+        assertEquals(123, deserialized.index);
+    }
+
+    public void testPOJOBuilderWithPrimitiveCreatorFromPrimitiveRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("123");
+        final MyPOJOWithPrimitiveCreator.Builder deserialized = mapper.readValue(json, MyPOJOWithPrimitiveCreator.Builder.class);
+        assertEquals(123, deserialized.index);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/failing/BuilderDeserializationTest2486.java
+++ b/src/test/java/com/fasterxml/jackson/failing/BuilderDeserializationTest2486.java
@@ -1,0 +1,118 @@
+package com.fasterxml.jackson.failing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+public class BuilderDeserializationTest2486
+        extends BaseMapTest
+{
+    @JsonDeserialize(builder = MyPOJOWithArrayCreator.Builder.class)
+    public static class MyPOJOWithArrayCreator {
+        private final int index;
+
+        private MyPOJOWithArrayCreator(int i) {
+            index = i;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public static class Builder {
+            private int index;
+
+            public Builder() {
+                // Default constructor
+            }
+
+            @JsonCreator
+            public Builder(final List<Object> jsonArray) {
+                withIndex((int) jsonArray.get(0));
+            }
+
+            public Builder withIndex(int i) {
+                index = i;
+                return this;
+            }
+
+            public MyPOJOWithArrayCreator build() {
+                return new MyPOJOWithArrayCreator(index);
+            }
+        }
+    }
+
+    @JsonDeserialize(builder = MyPOJOWithPrimitiveCreator.Builder.class)
+    public static class MyPOJOWithPrimitiveCreator {
+        private final int index;
+
+        private MyPOJOWithPrimitiveCreator(int i) {
+            index = i;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public static class Builder {
+            private int index;
+
+            public Builder() {
+                // Default constructor
+            }
+
+            @JsonCreator
+            public Builder(final int i) {
+                withIndex(i);
+            }
+
+            public Builder withIndex(int i) {
+                index = i;
+                return this;
+            }
+
+            public MyPOJOWithPrimitiveCreator build() {
+                return new MyPOJOWithPrimitiveCreator(index);
+            }
+        }
+    }
+
+    // This test passes when the array based @JsonCreator is removed from the
+    // MyPOJOWithArrayCreator.Builder implementation. The presence of the creator
+    // in the case of arrays breaks deserialize from an object.
+    //
+    // Compare that to the analogous tests for MyPOJOWithPrimitiveCreator which
+    // pass in both cases.
+    //
+    // I left some notes in BeanDeserializerBase as to behavior.
+    public void testPOJOWithArrayCreatorFromObjectRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("{ 'index': 123 }");
+        final MyPOJOWithArrayCreator deserialized = mapper.readValue(json, MyPOJOWithArrayCreator.class);
+        assertEquals(123, deserialized.getIndex());
+    }
+
+    public void testPOJOWithArrayCreatorFromArrayRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("[123]");
+        final MyPOJOWithArrayCreator deserialized = mapper.readValue(json, MyPOJOWithArrayCreator.class);
+        assertEquals(123, deserialized.getIndex());
+    }
+
+    public void testPOJOWithPrimitiveCreatorFromObjectRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("{ 'index': 123 }");
+        final MyPOJOWithPrimitiveCreator deserialized = mapper.readValue(json, MyPOJOWithPrimitiveCreator.class);
+        assertEquals(123, deserialized.getIndex());
+    }
+
+    public void testPOJOWithPrimitiveCreatorFromPrimitiveRepresentation() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = aposToQuotes("123");
+        final MyPOJOWithPrimitiveCreator deserialized = mapper.readValue(json, MyPOJOWithPrimitiveCreator.class);
+        assertEquals(123, deserialized.getIndex());
+    }
+}


### PR DESCRIPTION
Additional set of tests deserialize into the POJO Builder instances instead of via the Builder into the POJO. The same difference of behavior (between `@JsonCreator` array vs primitive disabling object shape deserialization)  results in these cases suggesting that it is not related to deserializing through a Builder.