### PR TITLE
Ignore the explicit names of READONLY properties when they are available

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -755,10 +755,17 @@ public class POJOPropertiesCollector
 
         while (it.hasNext()) {
             POJOPropertyBuilder prop = it.next();
+            // [databind#2719]: ignore the explicit names when they are available
+            Collection<PropertyName> names = prop.findExplicitNames();
+            if (names.isEmpty()) {
+                names = Collections.singleton(prop.getFullName());
+            }
             // 26-Jan-2017, tatu: [databind#935]: need to denote removal of
             JsonProperty.Access acc = prop.removeNonVisible(inferMutators);
             if (acc == JsonProperty.Access.READ_ONLY) {
-                _collectIgnorals(prop.getName());
+                for (PropertyName explicitName : names) {
+                    _collectIgnorals(explicitName.getSimpleName());
+                }
             }
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/ReadOnlyDeser2719Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/ReadOnlyDeser2719Test.java
@@ -1,0 +1,55 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.*;
+
+import com.fasterxml.jackson.databind.*;
+
+public class ReadOnlyDeser2719Test extends BaseMapTest
+{
+
+    // [databind#2719]
+    static class UserWithReadOnly {
+        @JsonProperty(value = "username", access = JsonProperty.Access.READ_ONLY)
+        public String name;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+        public String password;
+        public String login;
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    public void testFailOnIgnore() throws Exception
+    {
+        ObjectReader r = MAPPER.readerFor(UserWithReadOnly.class);
+
+        // First, fine to get 'login'
+        UserWithReadOnly result = r.readValue(aposToQuotes("{'login':'foo'}"));
+        assertEquals("foo", result.login);
+
+        // but not 'password'
+        r = r.with(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
+        try {
+            r.readValue(aposToQuotes("{'login':'foo', 'password':'bar'}"));
+            fail("Should fail");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Ignored field");
+        }
+
+        // or 'username'
+        r = r.with(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
+        try {
+            r.readValue(aposToQuotes("{'login':'foo', 'username':'bar'}"));
+            fail("Should fail");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Ignored field");
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fix #2719 

This PR uses the explicit names of `READ_ONLY` properties when they are available, otherwise it falls back to the current behavior of using their implicit name. This allows for the proper behavior of `FAIL_ON_IGNORED_PROPERTIES` on these properties.