### PR TITLE
Fixed #2729 conflicting getters/setters when not respecting capitaliz…

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -580,11 +580,10 @@ public class POJOPropertyBuilder
     {
         final String name = m.getName();
         // [databind#238]: Also, regular getters have precedence over "is-getters"
-        if (name.startsWith("get") && name.length() > 3) {
-            // should we check capitalization?
+        if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3))) {
             return 1;
         }
-        if (name.startsWith("is") && name.length() > 2) {
+        if (name.startsWith("is") && name.length() > 2 && Character.isUpperCase(name.charAt(2))) {
             return 2;
         }
         return 3;
@@ -593,8 +592,7 @@ public class POJOPropertyBuilder
     protected int _setterPriority(AnnotatedMethod m)
     {
         final String name = m.getName();
-        if (name.startsWith("set") && name.length() > 3) {
-            // should we check capitalization?
+        if (name.startsWith("set") && name.length() > 3 && Character.isUpperCase(name.charAt(3))) {
             return 1;
         }
         return 2;

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/PropertyNameSetterGetterConflictTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/PropertyNameSetterGetterConflictTest.java
@@ -1,0 +1,151 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Field;
+
+// [databind#2729]
+public class PropertyNameSetterGetterConflictTest extends BaseMapTest {
+  
+  private final ObjectMapper MAPPER = mapperWithScalaModule();
+
+  // Should work with setters named exactly like the property
+  static class Issue2729BeanWithFieldNameSetterGetter {
+    private String value;
+
+    public void value(String v) { value = v; }
+    public String value() { return value; }
+  }
+
+  // Should prefer java bean naming convention over property names
+  static class Issue2729BeanWithoutCaseSensitivityBean {
+    private String value;
+
+    public void value(String v) { throw new Error("Should not get called"); }
+    public String value() { throw new Error("Should not get called"); }
+    public void setValue(String v) { value = v; }
+    public String getValue() { return value; }
+  }
+
+  // Should prefer java bean naming convention over property names while respecting case-sensitivity
+  static class Issue2729WithCaseSensitivityBean {
+    private String settlementDate;
+    private String getaways;
+    private Boolean island;
+
+    public void settlementDate(String v) { throw new Error("Should not get called"); }
+    public String settlementDate() { throw new Error("Should not get called"); }
+    public void setSettlementDate(String v) { settlementDate = v; }
+    public String getSettlementDate() { return settlementDate; }
+
+    public void getaways(String v) { throw new Error("Should not get called"); }
+    public String getaways() { throw new Error("Should not get called"); }
+    public void setGetaways(String v) { getaways = v; }
+    public String getGetaways() { return getaways; }
+
+    public void island(Boolean v) { throw new Error("Should not get called"); }
+    public Boolean island() { throw new Error("Should not get called"); }
+    public void setIsland(Boolean v) { island = v; }
+    public Boolean isIsland() { return island; }
+  }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+  public void testSetterPriorityForFieldNameSetter() throws Exception
+  {
+    Issue2729BeanWithFieldNameSetterGetter bean = MAPPER.readValue(aposToQuotes("{'value':'42'}"),
+        Issue2729BeanWithFieldNameSetterGetter.class);
+    assertEquals("42", bean.value);
+  }
+
+  public void testSetterPriorityForJavaBeanNamingConvention() throws Exception
+  {
+    Issue2729BeanWithoutCaseSensitivityBean bean = MAPPER.readValue(aposToQuotes("{'value':'42'}"),
+        Issue2729BeanWithoutCaseSensitivityBean.class);
+    assertEquals("42", bean.value);
+  }
+
+  public void testSetterPriorityForJavaBeanNamingConventionWhileRespectingCaseSensitivity() throws Exception
+  {
+    final Issue2729WithCaseSensitivityBean bean = MAPPER.readValue(aposToQuotes("{'settlementDate':'42'}"),
+        Issue2729WithCaseSensitivityBean.class);
+    assertEquals("42", bean.settlementDate);
+  }
+
+  public void testSetterPriorityForJavaBeanNamingConventionWhileRespectingCaseSensitivity2() throws Exception
+  {
+    final Issue2729WithCaseSensitivityBean bean = MAPPER.readValue(aposToQuotes("{'island':true}"),
+        Issue2729WithCaseSensitivityBean.class);
+    assertEquals(Boolean.TRUE, bean.island);
+  }
+
+  public void testGetterPriorityForFieldNameSetter() throws Exception
+  {
+    final Issue2729BeanWithFieldNameSetterGetter bean = new Issue2729BeanWithFieldNameSetterGetter();
+    bean.value("42");
+    assertEquals(aposToQuotes("{'value':'42'}"), MAPPER.writeValueAsString(bean));
+  }
+
+  public void testGetterPriorityForJavaBeanNamingConvention() throws Exception
+  {
+
+    final Issue2729BeanWithoutCaseSensitivityBean bean = new Issue2729BeanWithoutCaseSensitivityBean();
+    bean.setValue("42");
+    assertEquals(aposToQuotes("{'value':'42'}"), MAPPER.writeValueAsString(bean));
+  }
+
+  public void testGetterPriorityForJavaBeanNamingConventionWhileRespectingCaseSensitivity() throws Exception
+  {
+    final Issue2729WithCaseSensitivityBean bean = new Issue2729WithCaseSensitivityBean();
+    bean.setGetaways("42");
+    assertEquals(aposToQuotes("{'settlementDate':null,'getaways':'42','island':null}"), MAPPER.writeValueAsString(bean));
+  }
+
+  public void testGetterPriorityForJavaBeanNamingConventionWhileRespectingCaseSensitivity2() throws Exception
+  {
+    final Issue2729WithCaseSensitivityBean bean = new Issue2729WithCaseSensitivityBean();
+    bean.setIsland(true);
+    assertEquals(aposToQuotes("{'settlementDate':null,'getaways':null,'island':true}"), MAPPER.writeValueAsString(bean));
+  }
+
+    /*
+    /**********************************************************
+    /* Helper methods
+    /**********************************************************
+     */
+
+  private ObjectMapper mapperWithScalaModule()
+  {
+    ObjectMapper m = new ObjectMapper();
+    m.setAnnotationIntrospector(new ScalaLikeAnnotationIntrospector());
+    return m;
+  }
+
+  static class ScalaLikeAnnotationIntrospector extends JacksonAnnotationIntrospector
+  {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String findImplicitPropertyName(AnnotatedMember member) {
+      if (member instanceof AnnotatedMethod) {
+        return hasCorrespondingProperty(((AnnotatedMethod) member)) ? member.getName() : null;
+      }
+      return null;
+    }
+
+    private static boolean hasCorrespondingProperty(AnnotatedMethod method) {
+      final String name = method.getName();
+      for (Field f : method.getDeclaringClass().getDeclaredFields()) {
+        if (name.equals(f.getName())) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestPropertyConflicts.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestPropertyConflicts.java
@@ -12,13 +12,6 @@ import com.fasterxml.jackson.databind.*;
  */
 public class TestPropertyConflicts extends BaseMapTest
 {
-    // error message for conflicting getters sub-optimal
-    static class BeanWithConflict
-    {
-        public int getX() { return 3; }
-        public boolean getx() { return false; }
-    }
-
     // [databind#238]
     protected static class Getters1A
     {
@@ -87,17 +80,6 @@ public class TestPropertyConflicts extends BaseMapTest
     /* Test methods
     /**********************************************************
      */
-
-    public void testFailWithDupProps() throws Exception
-    {
-        BeanWithConflict bean = new BeanWithConflict();
-        try {
-            String json = objectWriter().writeValueAsString(bean);
-            fail("Should have failed due to conflicting accessor definitions; got JSON = "+json);
-        } catch (JsonProcessingException e) {
-            verifyException(e, "Conflicting getter definitions");
-        }
-    }        
 
     // [databind#238]: ok to have getter, "isGetter"
     public void testRegularAndIsGetter() throws Exception


### PR DESCRIPTION
Please note that I had to remove a test that assumed an exception that should be thrown when the methods `getX()` and `getx()` are defined, but since `getx()` is not a proper name for a getter with respect to the java bean naming convention that test did not make much sense to me.