### PR TITLE
Java 14 specific tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,57 @@
         <skipTests>true</skipTests>
       </properties>
     </profile>
+    <profile>
+      <!-- Build Record tests using Java 14 if JDK is available -->
+      <id>java14+</id>
+      <activation>
+        <jdk>[14,</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/test-jdk14/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <inherited>true</inherited>
+            <configuration>
+              <optimize>true</optimize>
+              <!-- Enable Java 14+ for all sources so that Intellij picks the right language level -->
+              <source>14</source>
+              <release>14</release>
+              <compilerArgs>
+                <arg>-parameters</arg>
+                <arg>--enable-preview</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--enable-preview</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/RecordTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/RecordTest.java
@@ -1,0 +1,105 @@
+package com.fasterxml.jackson.databind;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+
+public class RecordTest extends BaseMapTest {
+
+    private JsonMapper jsonMapper;
+
+    public void setUp() {
+        jsonMapper = new JsonMapper();
+    }
+
+    record SimpleRecord(int id, String name) {
+    }
+
+    public void testSerializeSimpleRecord() throws JsonProcessingException {
+        SimpleRecord record = new SimpleRecord(123, "Bob");
+
+        String json = jsonMapper.writeValueAsString(record);
+
+        assertEquals("{\"id\":123,\"name\":\"Bob\"}", json);
+    }
+
+    public void testDeserializeSimpleRecord() throws IOException {
+        SimpleRecord value = jsonMapper.readValue("{\"id\":123,\"name\":\"Bob\"}", SimpleRecord.class);
+
+        assertEquals(new SimpleRecord(123, "Bob"), value);
+    }
+
+    public void testSerializeSimpleRecord_DisableAnnotationIntrospector() throws JsonProcessingException {
+        SimpleRecord record = new SimpleRecord(123, "Bob");
+
+        JsonMapper mapper = JsonMapper.builder()
+                .configure(MapperFeature.USE_ANNOTATIONS, false)
+                .build();
+        String json = mapper.writeValueAsString(record);
+
+        assertEquals("{\"id\":123,\"name\":\"Bob\"}", json);
+    }
+
+    public void testDeserializeSimpleRecord_DisableAnnotationIntrospector() throws IOException {
+        JsonMapper mapper = JsonMapper.builder()
+                .configure(MapperFeature.USE_ANNOTATIONS, false)
+                .build();
+        SimpleRecord value = mapper.readValue("{\"id\":123,\"name\":\"Bob\"}", SimpleRecord.class);
+
+        assertEquals(new SimpleRecord(123, "Bob"), value);
+    }
+
+    record RecordOfRecord(SimpleRecord record) {
+    }
+
+    public void testSerializeRecordOfRecord() throws JsonProcessingException {
+        RecordOfRecord record = new RecordOfRecord(new SimpleRecord(123, "Bob"));
+
+        String json = jsonMapper.writeValueAsString(record);
+
+        assertEquals("{\"record\":{\"id\":123,\"name\":\"Bob\"}}", json);
+    }
+
+    record JsonIgnoreRecord(int id, @JsonIgnore String name) {
+    }
+
+    public void testSerializeJsonIgnoreRecord() throws JsonProcessingException {
+        JsonIgnoreRecord record = new JsonIgnoreRecord(123, "Bob");
+
+        String json = jsonMapper.writeValueAsString(record);
+
+        assertEquals("{\"id\":123}", json);
+    }
+
+    record RecordWithConstructor(int id, String name) {
+        public RecordWithConstructor(int id) {
+            this(id, "name");
+        }
+    }
+
+    public void testDeserializeRecordWithConstructor() throws IOException {
+        RecordWithConstructor value = jsonMapper.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithConstructor.class);
+
+        assertEquals(new RecordWithConstructor(123, "Bob"), value);
+    }
+
+    record JsonPropertyRenameRecord(int id, @JsonProperty("rename")String name) {
+    }
+
+    public void testSerializeJsonRenameRecord() throws JsonProcessingException {
+        JsonPropertyRenameRecord record = new JsonPropertyRenameRecord(123, "Bob");
+
+        String json = jsonMapper.writeValueAsString(record);
+
+        assertEquals("{\"id\":123,\"rename\":\"Bob\"}", json);
+    }
+
+    public void testDeserializeJsonRenameRecord() throws IOException {
+        JsonPropertyRenameRecord value = jsonMapper.readValue("{\"id\":123,\"rename\":\"Bob\"}", JsonPropertyRenameRecord.class);
+
+        assertEquals(new JsonPropertyRenameRecord(123, "Bob"), value);
+    }
+}


### PR DESCRIPTION
Add a new test source folder, activated if JDK 14+ is used to build the project.
The test-jdk14 folder contains only one test for now for records (JEP 359).
The tests fail for now as record support will be implemented in another PR.