### PR TITLE
Fixed copy constructor in ObjectMapper for subtype resolver

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -565,9 +565,9 @@ public class ObjectMapper
 
         RootNameLookup rootNames = new RootNameLookup();
         _serializationConfig = new SerializationConfig(src._serializationConfig,
-                _mixIns, rootNames, _configOverrides);
+                _mixIns, rootNames, _configOverrides).with(_subtypeResolver);
         _deserializationConfig = new DeserializationConfig(src._deserializationConfig,
-                _mixIns, rootNames,  _configOverrides);
+                _mixIns, rootNames,  _configOverrides).with(_subtypeResolver);
         _serializerProvider = src._serializerProvider.copy();
         _deserializationContext = src._deserializationContext.copy();
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicDeserialization2785.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicDeserialization2785.java
@@ -1,0 +1,23 @@
+package com.fasterxml.jackson.databind.jsontype;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestPolymorphicDeserialization2785 extends BaseMapTest {
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "packetType")
+    public interface A {
+    }
+    @JsonTypeName("myType")
+    static class B implements A {
+    }
+
+    public void testDeserialize() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper().copy();
+        objectMapper.getSubtypeResolver().registerSubtypes(B.class);
+        String json = "{ \"packetType\": \"myType\" }";
+        objectMapper.readValue(json, A.class);
+    }
+}


### PR DESCRIPTION
This is related to #2785 

Changes in https://github.com/FasterXML/jackson-databind/commit/97ed5c9880f417e0fadd6ede51eac2cc82731ba1 had the unintended side effect of making the copied `ObjectMapper` use a copied `SubtypeResolver`, but the serialization config and deserialization config were still "linked" to the original `ObjectMapper`.

This change has a similar effect to just calling `setSubypeResolver()` because this makes sure that the serialization config and deserialization config's `with()` method are both called with the correct `SubtypeResolver`.

I added a test that shows this working. If I should move it or rename the test let me know. I'm also unfamiliar with contributing to this project, so any guidance is appreciated. I would make this PR against the 2.12, branch, but I think this is already fixed in 2.12.

Closes #2785 