### PR TITLE
New feature to handle circular references individually for each item upon collection serialization

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -420,6 +420,15 @@ public enum SerializationFeature implements ConfigFeature
      * @since 2.3
      */
     USE_EQUALITY_FOR_OBJECT_ID(false)
+    ,
+
+    /**
+     * Feature that determines if serialization avoiding circular dependencies
+     * (i.e. remembering visited elements and fully serializing only the first)
+     * should be applied to arrays as a whole, or should treat individually each
+     * item, "wiping the memory" for visited elements in every iteration.
+     */
+    HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS(false)
     ;
 
     private final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -425,10 +425,10 @@ public enum SerializationFeature implements ConfigFeature
     /**
      * Feature that determines if serialization avoiding circular dependencies
      * (i.e. remembering visited elements and fully serializing only the first)
-     * should be applied to arrays as a whole, or should treat individually each
-     * item, "wiping the memory" for visited elements in every iteration.
+     * should be applied to collections as a whole, or should treat individually
+     * each item, "wiping the memory" for visited elements in every iteration.
      */
-    HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS(false)
+    HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_COLLECTIONS(false)
     ;
 
     private final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -1443,9 +1443,15 @@ public abstract class SerializerProvider
     }
 
     /**
-     * This method wipes out from memory
+     * This method wipes out from memory all recollection of visited
+     * items used to avoid recursive serialization due to circular
+     * references.
+     * Note: This method used from within serialization logic of a
+     * single object could indeed cause recursive serialization,
+     * disabling the necessary measures to distinguish already
+     * serialized elements from those that have not yet been.
      */
     public void resetMemoryCircularReference() {
-        // unimplemented method
+        // empty method to guarantee backwards compatibility
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -1441,4 +1441,11 @@ public abstract class SerializerProvider
         */
         return df;
     }
+
+    /**
+     * This method wipes out from memory
+     */
+    public void resetMemoryCircularReference() {
+        // unimplemented method
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
@@ -615,6 +615,13 @@ filter.getClass().getName(), t.getClass().getName(), ClassUtil.exceptionMessage(
         }
 
         @Override
+        public void resetMemoryCircularReference() {
+            if(_seenObjectIds != null) {
+                _seenObjectIds.clear();
+            }
+        }
+
+        @Override
         public DefaultSerializerProvider copy()
         {
             if (getClass() != Impl.class) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.impl.WritableObjectId;
+import com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase;
+import com.fasterxml.jackson.databind.ser.std.CollectionSerializer;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
 /**
@@ -473,11 +475,17 @@ filter.getClass().getName(), t.getClass().getName(), ClassUtil.exceptionMessage(
     }
 
     private final void _serialize(JsonGenerator gen, Object value,
-            JsonSerializer<Object> ser)
+            JsonSerializer ser)
         throws IOException
     {
         try {
-            ser.serialize(value, gen, this);
+            if(ser instanceof AsArraySerializerBase){
+                ((AsArraySerializerBase)ser).serialize(value, gen, this, isEnabled(
+                    SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_COLLECTIONS
+                ));
+            } else {
+                ser.serialize(value, gen, this);
+            }
         } catch (Exception e) {
             throw _wrapAsIOE(gen, e);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/IndexedListSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/IndexedListSerializer.java
@@ -66,22 +66,36 @@ public final class IndexedListSerializer
     public final void serialize(List<?> value, JsonGenerator gen, SerializerProvider provider)
         throws IOException
     {
+        serialize(value, gen, provider, false);
+    }
+
+    @Override
+    public final void serialize(List<?> value, JsonGenerator gen, SerializerProvider provider, boolean handleCircularReferencesIndividually)
+        throws IOException
+    {
         final int len = value.size();
         if (len == 1) {
             if (((_unwrapSingle == null) &&
                     provider.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED))
                     || (_unwrapSingle == Boolean.TRUE)) {
-                serializeContents(value, gen, provider);
+                serializeContents(value, gen, provider, handleCircularReferencesIndividually);
                 return;
             }
         }
         gen.writeStartArray(len);
-        serializeContents(value, gen, provider);
+        serializeContents(value, gen, provider, handleCircularReferencesIndividually);
         gen.writeEndArray();
     }
     
     @Override
     public void serializeContents(List<?> value, JsonGenerator g, SerializerProvider provider)
+        throws IOException
+    {
+        serializeContents(value, g, provider, false);
+    }
+
+    @Override
+    public void serializeContents(List<?> value, JsonGenerator g, SerializerProvider provider, boolean handleCircularReferencesIndividually)
         throws IOException
     {
         if (_elementSerializer != null) {
@@ -101,6 +115,9 @@ public final class IndexedListSerializer
             PropertySerializerMap serializers = _dynamicSerializers;
             for (; i < len; ++i) {
                 Object elem = value.get(i);
+                if(handleCircularReferencesIndividually) {
+                    provider.resetMemoryCircularReference();
+                }
                 if (elem == null) {
                     provider.defaultSerializeNull(g);
                 } else {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/IteratorSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/IteratorSerializer.java
@@ -52,6 +52,13 @@ public class IteratorSerializer
     public final void serialize(Iterator<?> value, JsonGenerator gen,
             SerializerProvider provider) throws IOException
     {
+        serialize(value, gen, provider, false);
+    }
+
+    @Override
+    public final void serialize(Iterator<?> value, JsonGenerator gen,
+            SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
+    {
         // 02-Dec-2016, tatu: As per comments above, can't determine single element so...
         /*
         if (((_unwrapSingle == null) &&
@@ -64,13 +71,20 @@ public class IteratorSerializer
         }
         */
         gen.writeStartArray();
-        serializeContents(value, gen, provider);
+        serializeContents(value, gen, provider, handleCircularReferencesIndividually);
         gen.writeEndArray();
     }
     
     @Override
     public void serializeContents(Iterator<?> value, JsonGenerator g,
             SerializerProvider provider) throws IOException
+    {
+        serializeContents(value, g, provider, false);
+    }
+
+    @Override
+    public void serializeContents(Iterator<?> value, JsonGenerator g,
+            SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
     {
         if (!value.hasNext()) {
             return;
@@ -83,6 +97,9 @@ public class IteratorSerializer
         final TypeSerializer typeSer = _valueTypeSerializer;
         do {
             Object elem = value.next();
+            if(handleCircularReferencesIndividually) {
+                provider.resetMemoryCircularReference();
+            }
             if (elem == null) {
                 provider.defaultSerializeNull(g);
             } else if (typeSer == null) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -239,15 +239,20 @@ public abstract class AsArraySerializerBase<T>
     @Override
     public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException
     {
+        serialize(value, gen, provider);
+    }
+
+    public void serialize(T value, JsonGenerator gen, SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
+    {
         if (provider.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED)
                 && hasSingleElement(value)) {
-            serializeContents(value, gen, provider);
+            serializeContents(value, gen, provider, handleCircularReferencesIndividually);
             return;
         }
         gen.writeStartArray();
         // [databind#631]: Assign current value, to be accessible by custom serializers
         gen.setCurrentValue(value);
-        serializeContents(value, gen, provider);
+        serializeContents(value, gen, provider, handleCircularReferencesIndividually);
         gen.writeEndArray();
     }
 
@@ -263,7 +268,11 @@ public abstract class AsArraySerializerBase<T>
         typeSer.writeTypeSuffix(g, typeIdDef);
     }
 
-    protected abstract void serializeContents(T value, JsonGenerator gen, SerializerProvider provider)
+    protected void serializeContents(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        serializeContents(value, gen, provider, false);
+    }
+
+    protected abstract void serializeContents(T value, JsonGenerator gen, SerializerProvider provider, boolean handleCircularReferencesIndividually)
         throws IOException;
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -239,7 +239,7 @@ public abstract class AsArraySerializerBase<T>
     @Override
     public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException
     {
-        serialize(value, gen, provider);
+        serialize(value, gen, provider, false);
     }
 
     public void serialize(T value, JsonGenerator gen, SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
@@ -94,22 +94,34 @@ public class CollectionSerializer
     @Override
     public final void serialize(Collection<?> value, JsonGenerator g, SerializerProvider provider) throws IOException
     {
+      serialize(value, g, provider, false);
+    }
+
+  @Override
+  public final void serialize(Collection<?> value, JsonGenerator g, SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
+    {
         final int len = value.size();
         if (len == 1) {
             if (((_unwrapSingle == null) &&
                     provider.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED))
                     || (_unwrapSingle == Boolean.TRUE)) {
-                serializeContents(value, g, provider);
+                serializeContents(value, g, provider, handleCircularReferencesIndividually);
                 return;
             }
         }
         g.writeStartArray(len);
-        serializeContents(value, g, provider);
+        serializeContents(value, g, provider, handleCircularReferencesIndividually);
         g.writeEndArray();
     }
 
     @Override
     public void serializeContents(Collection<?> value, JsonGenerator g, SerializerProvider provider) throws IOException
+    {
+      serializeContents(value, g, provider, false);
+    }
+
+  @Override
+  public void serializeContents(Collection<?> value, JsonGenerator g, SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
     {
         g.setCurrentValue(value);
         if (_elementSerializer != null) {
@@ -122,10 +134,6 @@ public class CollectionSerializer
         }
         PropertySerializerMap serializers = _dynamicSerializers;
         final TypeSerializer typeSer = _valueTypeSerializer;
-
-        final boolean handleCircularReferencesIndividually = provider.isEnabled(
-            SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_COLLECTIONS
-        );
 
         int i = 0;
         try {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
@@ -50,13 +50,13 @@ public class CollectionSerializer
         // note: assumption is 'property' is always passed as null
         this(elemType, staticTyping, vts, valueSerializer);
     }
-    
+
     public CollectionSerializer(CollectionSerializer src,
             BeanProperty property, TypeSerializer vts, JsonSerializer<?> valueSerializer,
             Boolean unwrapSingle) {
         super(src, property, vts, valueSerializer, unwrapSingle);
     }
-    
+
     @Override
     public ContainerSerializer<?> _withValueTypeSerializer(TypeSerializer vts) {
         return new CollectionSerializer(this, _property, vts, _elementSerializer, _unwrapSingle);
@@ -107,7 +107,7 @@ public class CollectionSerializer
         serializeContents(value, g, provider);
         g.writeEndArray();
     }
-    
+
     @Override
     public void serializeContents(Collection<?> value, JsonGenerator g, SerializerProvider provider) throws IOException
     {
@@ -123,10 +123,17 @@ public class CollectionSerializer
         PropertySerializerMap serializers = _dynamicSerializers;
         final TypeSerializer typeSer = _valueTypeSerializer;
 
+        final boolean handleCircularReferencesIndividually = provider.isEnabled(
+            SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS
+        );
+
         int i = 0;
         try {
             do {
                 Object elem = it.next();
+                if(handleCircularReferencesIndividually) {
+                    provider.resetMemoryCircularReference();
+                }
                 if (elem == null) {
                     provider.defaultSerializeNull(g);
                 } else {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
@@ -124,7 +124,7 @@ public class CollectionSerializer
         final TypeSerializer typeSer = _valueTypeSerializer;
 
         final boolean handleCircularReferencesIndividually = provider.isEnabled(
-            SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS
+            SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_COLLECTIONS
         );
 
         int i = 0;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSetSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSetSerializer.java
@@ -51,17 +51,24 @@ public class EnumSetSerializer
     public final void serialize(EnumSet<? extends Enum<?>> value, JsonGenerator gen,
             SerializerProvider provider) throws IOException
     {
+        serialize(value, gen, provider, false);
+    }
+
+    @Override
+    public final void serialize(EnumSet<? extends Enum<?>> value, JsonGenerator gen,
+            SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
+    {
         final int len = value.size();
         if (len == 1) {
             if (((_unwrapSingle == null)
                     && provider.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED))
                     || (_unwrapSingle == Boolean.TRUE)) {
-                serializeContents(value, gen, provider);
+                serializeContents(value, gen, provider, handleCircularReferencesIndividually);
                 return;
             }
         }
         gen.writeStartArray(len);
-        serializeContents(value, gen, provider);
+        serializeContents(value, gen, provider, handleCircularReferencesIndividually);
         gen.writeEndArray();
     }
     
@@ -70,12 +77,23 @@ public class EnumSetSerializer
             SerializerProvider provider)
         throws IOException
     {
+        serializeContents(value, gen, provider, false);
+    }
+
+    @Override
+    public void serializeContents(EnumSet<? extends Enum<?>> value, JsonGenerator gen,
+            SerializerProvider provider, boolean handleCircularReferencesIndividually)
+        throws IOException
+    {
         JsonSerializer<Object> enumSer = _elementSerializer;
         /* Need to dynamically find instance serializer; unfortunately
          * that seems to be the only way to figure out type (no accessors
          * to the enum class that set knows)
          */
         for (Enum<?> en : value) {
+            if(handleCircularReferencesIndividually) {
+                provider.resetMemoryCircularReference();
+            }
             if (enumSer == null) {
                 /* 12-Jan-2010, tatu: Since enums cannot be polymorphic, let's
                  *   not bother with typed serializer variant here

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/IterableSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/IterableSerializer.java
@@ -62,22 +62,36 @@ public class IterableSerializer
     public final void serialize(Iterable<?> value, JsonGenerator gen,
         SerializerProvider provider)throws IOException
     {
+        serialize(value, gen, provider, false);
+    }
+
+    @Override
+    public final void serialize(Iterable<?> value, JsonGenerator gen,
+        SerializerProvider provider, boolean handleCircularReferencesIndividually)throws IOException
+    {
         if (((_unwrapSingle == null) &&
                 provider.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED))
                 || (_unwrapSingle == Boolean.TRUE)) {
             if (hasSingleElement(value)) {
-                serializeContents(value, gen, provider);
+                serializeContents(value, gen, provider, handleCircularReferencesIndividually);
                 return;
             }
         }
         gen.writeStartArray();
-        serializeContents(value, gen, provider);
+        serializeContents(value, gen, provider, handleCircularReferencesIndividually);
         gen.writeEndArray();
     }
     
     @Override
     public void serializeContents(Iterable<?> value, JsonGenerator jgen,
         SerializerProvider provider) throws IOException
+    {
+        serializeContents(value, jgen, provider, false);
+    }
+
+    @Override
+    public void serializeContents(Iterable<?> value, JsonGenerator jgen,
+        SerializerProvider provider, boolean handleCircularReferencesIndividually) throws IOException
     {
         Iterator<?> it = value.iterator();
         if (it.hasNext()) {
@@ -87,6 +101,9 @@ public class IterableSerializer
             
             do {
                 Object elem = it.next();
+                if(handleCircularReferencesIndividually) {
+                    provider.resetMemoryCircularReference();
+                }
                 if (elem == null) {
                     provider.defaultSerializeNull(jgen);
                     continue;

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestCollectionCyclicReference.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestCollectionCyclicReference.java
@@ -1,0 +1,83 @@
+package com.fasterxml.jackson.databind.ser;
+
+import java.util.*;
+
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.databind.*;
+
+/**
+ * Simple unit tests to verify that it is possible to handle
+ * potentially cyclic structures, as long as object graph itself
+ * is not cyclic. This is the case for directed hierarchies like
+ * trees and DAGs.
+ */
+public class TestCollectionCyclicReference
+    extends BaseMapTest
+{
+    /*
+    /**********************************************************
+    /* Helper bean classes
+    /**********************************************************
+     */
+
+
+    @JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class
+        , property = "id"
+        , scope = Bean.class
+    )
+    static class Bean {
+        final int _id;
+        Bean _next;
+        final String _name;
+
+        public Bean(int id, Bean next, String name) {
+            _id = id;
+            _next = next;
+            _name = name;
+        }
+
+        public int getId() { return _id; }
+
+        public Bean getNext() { return _next; }
+
+        public String getName() { return _name; }
+
+        public void assignNext(Bean n) { _next = n; }
+    }
+
+    /*
+    /**********************************************************
+    /* Types
+    /**********************************************************
+     */
+
+    public void testLinked() throws Exception {
+        Bean sameChild = new Bean(3, null, "sameChild");
+        Bean first = new Bean(1, sameChild, "first");
+        Bean second = new Bean(2, sameChild, "second");
+        sameChild.assignNext(first);
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_COLLECTIONS);
+        final String result = mapper.writeValueAsString(Arrays.asList(first, second));
+
+        final StringBuilder expected = new StringBuilder();
+        expected.append("[");
+        expected.append("{\"id\":1,\"name\":\"first\",\"next\":");
+        expected.append(
+            "{\"id\":3,\"name\":\"sameChild\",\"next\":1}}"); // 1 has been visited this iteration => next is a reference
+        expected.append(",{\"id\":2,\"name\":\"second\",\"next\":");
+        expected.append(
+            "{\"id\":3,\"name\":\"sameChild\",\"next\":"); // 1 has noy been visited this iteration => next is fully serialized
+        expected
+            .append("{\"id\":1,\"name\":\"first\",\"next\":3}"); // 3 has been visited this iteration => next is a reference
+        expected.append("}");
+        expected.append("}");
+        expected.append("]");
+
+        assertEquals(result, expected.toString());
+    }
+}


### PR DESCRIPTION

As I've mentioned in issue #2791 I propose the addition of a new feature to handle circular references for each item individually upon collections' serialization, in order to retrieve all necessary information in each iteration, but still avoiding recursive serialization due to circular references.