### PR TITLE
Add build profile for JDK14+ #2709

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,57 @@
         <skipTests>true</skipTests>
       </properties>
     </profile>
+    <profile>
+      <!-- Build Record tests using Java 14 if JDK is available -->
+      <id>java14+</id>
+      <activation>
+        <jdk>[14,</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/test-jdk14/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <inherited>true</inherited>
+            <configuration>
+              <optimize>true</optimize>
+              <!-- Enable Java 14+ for all sources so that Intellij picks the right language level -->
+              <source>14</source>
+              <release>14</release>
+              <compilerArgs>
+                <arg>-parameters</arg>
+                <arg>--enable-preview</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--enable-preview</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
With the support of Java records, a Maven build profile has been introduced to
Java 14 language and preview features.

This was done in 2.12 branch, just porting it back to master as records are
supported there too.