### PR TITLE
Adding ppc64le architecture support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ git:
   quiet: true
   submodules: false
 
+#Adding support for ppc64le architecture
+arch:
+  - ppc64le
+  - amd64
+
 # Jackson 3.x only compiles on Java 8 and above so...
 jdk:
   - openjdk8
@@ -16,7 +21,13 @@ cache:
 
 # Below this line is configuration for deploying to the Sonatype OSS repo
 # https://knowm.org/configure-travis-ci-to-deploy-snapshots/
-before_install: "git clone -b travis `git config --get remote.origin.url` target/travis"
+before_install: 
+  - "git clone -b travis `git config --get remote.origin.url` target/travis"
+  - mkdir -p /opt/maven
+  - curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz|tar -xz --strip 1 -C /opt/maven
+  - export MAVEN_HOME=/opt/maven
+  - export PATH=${MAVEN_HOME}/bin:${PATH}
+
 script: "[ ${TRAVIS_PULL_REQUEST} = 'false' ] && mvn -B source:jar deploy --settings target/travis/settings.xml || mvn clean verify --settings target/travis/settings.xml"
 
 # whitelist


### PR DESCRIPTION
Hi,
I had added ppc64le support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge.

The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/jackson-databind/builds/181293972
Please have a look.

Thanks!!"