### PR TITLE
new protected constructor on AsArraySerializerBase

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -76,15 +76,7 @@ public abstract class AsArraySerializerBase<T>
     protected AsArraySerializerBase(Class<?> cls, JavaType et, boolean staticTyping,
             TypeSerializer vts, JsonSerializer<Object> elementSerializer)
     {
-        super(cls, false);
-        _elementType = et;
-        // static if explicitly requested, or if element type is final
-        _staticTyping = staticTyping || (et != null && et.isFinal());
-        _valueTypeSerializer = vts;
-        _property = null;
-        _elementSerializer = elementSerializer;
-        _dynamicSerializers = PropertySerializerMap.emptyForProperties();
-        _unwrapSingle = null;
+        this(cls, et, staticTyping, vts, null, elementSerializer, null);
     }
 
     /**
@@ -95,6 +87,18 @@ public abstract class AsArraySerializerBase<T>
     protected AsArraySerializerBase(Class<?> cls, JavaType et, boolean staticTyping,
             TypeSerializer vts, BeanProperty property, JsonSerializer<Object> elementSerializer)
     {
+        this(cls, et, staticTyping, vts, property, elementSerializer, null);
+    }
+
+    /**
+     * General purpose constructor. Use contextual constructors, if possible.
+     *
+     * @since 2.12
+     */
+    protected AsArraySerializerBase(Class<?> cls, JavaType et, boolean staticTyping,
+                                    TypeSerializer vts, BeanProperty property, JsonSerializer<Object> elementSerializer,
+                                    Boolean unwrapSingle)
+    {
         // typing with generics is messy... have to resort to this:
         super(cls, false);
         _elementType = et;
@@ -104,7 +108,7 @@ public abstract class AsArraySerializerBase<T>
         _property = property;
         _elementSerializer = elementSerializer;
         _dynamicSerializers = PropertySerializerMap.emptyForProperties();
-        _unwrapSingle = null;
+        _unwrapSingle = unwrapSingle;
     }
 
     @SuppressWarnings("unchecked")
@@ -130,7 +134,7 @@ public abstract class AsArraySerializerBase<T>
     protected AsArraySerializerBase(AsArraySerializerBase<?> src,
             BeanProperty property, TypeSerializer vts, JsonSerializer<?> elementSerializer)
     {
-        this(src, property, vts, elementSerializer, src.unwrapSingle());
+        this(src, property, vts, elementSerializer, src._unwrapSingle);
     }
     
     /**
@@ -139,7 +143,7 @@ public abstract class AsArraySerializerBase<T>
     @Deprecated
     public final AsArraySerializerBase<T> withResolved(BeanProperty property,
             TypeSerializer vts, JsonSerializer<?> elementSerializer) {
-        return withResolved(property, vts, elementSerializer, unwrapSingle());
+        return withResolved(property, vts, elementSerializer, _unwrapSingle);
     }
 
     /**
@@ -205,7 +209,7 @@ public abstract class AsArraySerializerBase<T>
         if ((ser != _elementSerializer)
                 || (property != _property)
                 || (_valueTypeSerializer != typeSer)
-                || (unwrapSingle() != unwrapSingle)) {
+                || (_unwrapSingle != unwrapSingle)) {
             return withResolved(property, typeSer, ser, unwrapSingle);
         }
         return this;
@@ -317,15 +321,5 @@ public abstract class AsArraySerializerBase<T>
             _dynamicSerializers = result.map;
         }
         return result.serializer;
-    }
-
-    /**
-     * This function exposes the <code>_unwrapSingle</code> value but allows for easier subclassing.
-     * Intended to be used by jackson-module-scala.
-     *
-     * @since 2.12
-     */
-    protected Boolean unwrapSingle() {
-        return _unwrapSingle;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -130,7 +130,7 @@ public abstract class AsArraySerializerBase<T>
     protected AsArraySerializerBase(AsArraySerializerBase<?> src,
             BeanProperty property, TypeSerializer vts, JsonSerializer<?> elementSerializer)
     {
-        this(src, property, vts, elementSerializer, src._unwrapSingle);
+        this(src, property, vts, elementSerializer, src.unwrapSingle());
     }
     
     /**
@@ -139,7 +139,7 @@ public abstract class AsArraySerializerBase<T>
     @Deprecated
     public final AsArraySerializerBase<T> withResolved(BeanProperty property,
             TypeSerializer vts, JsonSerializer<?> elementSerializer) {
-        return withResolved(property, vts, elementSerializer, _unwrapSingle);
+        return withResolved(property, vts, elementSerializer, unwrapSingle());
     }
 
     /**
@@ -205,7 +205,7 @@ public abstract class AsArraySerializerBase<T>
         if ((ser != _elementSerializer)
                 || (property != _property)
                 || (_valueTypeSerializer != typeSer)
-                || (_unwrapSingle != unwrapSingle)) {
+                || (unwrapSingle() != unwrapSingle)) {
             return withResolved(property, typeSer, ser, unwrapSingle);
         }
         return this;
@@ -317,5 +317,15 @@ public abstract class AsArraySerializerBase<T>
             _dynamicSerializers = result.map;
         }
         return result.serializer;
+    }
+
+    /**
+     * This function exposes the <code>_unwrapSingle</code> value but allows for easier subclassing.
+     * Intended to be used by jackson-module-scala.
+     *
+     * @since 2.12
+     */
+    protected Boolean unwrapSingle() {
+        return _unwrapSingle;
     }
 }


### PR DESCRIPTION
@cowtowncoder I've been trying to subclass AsArraySerializerBase in Scala but the class inheritance works a bit differently in Scala.

This patch is not guaranteed to help me but if it is merged as is, I can see if the change helps in jackson-module-scala and if not, I can submit a revert.

An alternative would be to add protected constructor that allows all the protected final fields to be set. I know that you have deprecated one constructor that is close to what I'd need but a protected constructor might be better than this.

```
    protected AsArraySerializerBase(Class<?> cls, JavaType et, boolean staticTyping,
                                    TypeSerializer vts, BeanProperty property, JsonSerializer<Object> elementSerializer,
                                    Boolean unwrapSingle)
```

