### PR TITLE
add extra contructor to AsArraySerializerBase

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/ContainerSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/ContainerSerializer.java
@@ -41,8 +41,12 @@ public abstract class ContainerSerializer<T>
      */
 
     protected ContainerSerializer(Class<?> t) {
+        this(t, null);
+    }
+
+    protected ContainerSerializer(Class<?> t, BeanProperty prop) {
         super(t);
-        _property = null;
+        _property = prop;
         _dynamicValueSerializers = PropertySerializerMap.emptyForProperties();
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -78,12 +78,11 @@ public abstract class AsArraySerializerBase<T>
      * General purpose constructor. Use contextual constructors, if possible.
      */
     @SuppressWarnings("unchecked")
-    protected AsArraySerializerBase(JavaType elementType, boolean staticTyping,
-                                    BeanProperty property, TypeSerializer vts,
-                                    JsonSerializer<?> elementSerializer,
+    protected AsArraySerializerBase(Class<?> cls, JavaType elementType, boolean staticTyping,
+                                    TypeSerializer vts, BeanProperty property, JsonSerializer<?> elementSerializer,
                                     Boolean unwrapSingle)
     {
-        super(elementType, property);
+        super(cls, property);
         _elementType = elementType;
         // static if explicitly requested, or if element type is final
         _staticTyping = staticTyping || (elementType != null && elementType.isFinal());

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -74,6 +74,24 @@ public abstract class AsArraySerializerBase<T>
         _unwrapSingle = unwrapSingle;
     }
 
+    /**
+     * General purpose constructor. Use contextual constructors, if possible.
+     */
+    @SuppressWarnings("unchecked")
+    protected AsArraySerializerBase(JavaType elementType, boolean staticTyping,
+                                    BeanProperty property, TypeSerializer vts,
+                                    JsonSerializer<?> elementSerializer,
+                                    Boolean unwrapSingle)
+    {
+        super(elementType, property);
+        _elementType = elementType;
+        // static if explicitly requested, or if element type is final
+        _staticTyping = staticTyping || (elementType != null && elementType.isFinal());
+        _valueTypeSerializer = vts;
+        _elementSerializer = (JsonSerializer<Object>) elementSerializer;
+        _unwrapSingle = unwrapSingle;
+    }
+
     @SuppressWarnings("unchecked")
     protected AsArraySerializerBase(AsArraySerializerBase<?> src,
             BeanProperty property, TypeSerializer vts, JsonSerializer<?> elementSerializer,


### PR DESCRIPTION
The constructor forward fit from 2.12 is not what I need for jackson-module-scala. I need something more like this one.