### PR TITLE
findCustomEnumDeserializer by interfaces

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1545,6 +1545,16 @@ factory.toString()));
                     break;
                 }
             }
+
+            List<JavaType> interfaces = type.getInterfaces();
+
+            for (JavaType javaType : interfaces) {
+                Class<?> rawClass = javaType.getRawClass();
+                deser = _findCustomEnumDeserializer(rawClass, config, beanDesc);
+                if (deser != null) {
+                    return deser;
+                }
+            }
            
             // Need to consider @JsonValue if one found
             if (deser == null) {


### PR DESCRIPTION
[Chinese]我最近研究枚举的时候遇到一个需求就是希望在SpringBoot框架中将枚举正序列化和反序列化。希望在Controller层接收参数或者返回结果的时候，jackson对我定义的枚举正序列化和反序列化都是可以的。按照面向接口编程的思想，我对所有定义的枚举是先统一实现了一个接口，这个接口有两个方法，code()和description()。也就是枚举在序列化和反序列化的时候，我希望是按照code和description来的，不希望是按照枚举固有的name和ordinal来正反序列化和反序列化。
我阅读了jackson的源码了解到了jackson对枚举的正反序列化之后，我自定义了一个正序列化的枚举序列化器。然后注册到了jackson中，并且也是正常工作的。
```java
    @Bean
    public Jackson2ObjectMapperBuilderCustomizer enumCustomizer() {
//        将枚举转成json返回给前端
        return jacksonObjectMapperBuilder -> {
//            自定义序列化器注入
            Map<Class<?>, JsonSerializer<?>> serializers = new LinkedHashMap<>();
            serializers.put(BaseEnum.class, new BaseEnumSerializer());
            serializers.put(Date.class, new DateJsonSerializer());
            jacksonObjectMapperBuilder.serializersByType(serializers);

//            自定义反序列化器注入
            Map<Class<?>, JsonDeserializer<?>> deserializers = new LinkedHashMap<>();
            deserializers.put(BaseEnum.class, new BaseEnumDeserializer());
//            deserializers.put(GenderEnum.class, new BaseEnumDeserializer());
            jacksonObjectMapperBuilder.deserializersByType(deserializers);

        };
    }
```



但是接下来我在反序列化枚举的时候，发生了一直只能由name或者ordinal来反序列化。我阅读源码后发现我自定义的反序列化器并没有生效，jackson依旧走的是默认的反序列化器，所以不是按照我预期的code或者description来反序列化的。经过阅读源代码之后发现代码中是有查找自定义序列化器的代码。一开始是先找当前类对应的序列化器，但是很明显没有找到，最后只能使用默认的反序列化器。通过源代码发现jackson并没有去查找当前类实现的接口对应的反序列化器。由于缺少这一步，我针对接口注册的反序列化器并没有被使用，因此我在jackson的源码中加入了使用接口去查找自定义序列化器的代码，用来解决这个问题。
```java
            List<JavaType> interfaces = type.getInterfaces();

            for (JavaType javaType : interfaces) {
                Class<?> rawClass = javaType.getRawClass();
                deser = _findCustomEnumDeserializer(rawClass, config, beanDesc);
                if (deser != null) {
                    return deser;
                }
            }
```

这样一来我们就可以做到面向接口编程了。希望采纳。具体使用场景可以参考我的代码。
https://github.com/aohanhongzhi/SpringCloud-multiple-gradle