### PR TITLE
(2.6) Backport all CVE fixes up to 2.9.10.6

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -4,28 +4,60 @@ Project: jackson-databind
 === Releases ===
 ------------------------------------------------------------------------
 
-2.6.8.3 (16-Nov-2019)
+2.6.7.4 (not yet released)
 
-Backport of full set of CVEs as of 2.9.10, including now
+Backported all CVE fixes up to 2.9.10.6
 
-#1680
-#1855
-#1899
-#2032
-#2052
-#2058
-#2097
-#2186
-#2326
-#2334
-#2341
-#2487
-#2389
-#2410
-#2449
-#2462
-#2478
-#2498
+#2469: Block one more gadget type (xalan2)
+#2526: Block two more gadget types (ehcache/JNDI - CVE-2019-20330)
+#2620: Block one more gadget type (xbean-reflect/JNDI - CVE-2020-8840)
+#2631: Block one more gadget type (shaded-hikari-config, CVE-2020-9546)
+#2634: Block two more gadget types (ibatis-sqlmap, anteros-core; CVE-2020-9547 / CVE-2020-9548)
+#2642: Block one more gadget type (javax.swing, CVE-2020-10969)
+#2648: Block one more gadget type (shiro-core)
+#2653: Block one more gadget type (shiro-core, 2nd class)
+#2658: Block one more gadget type (ignite-jta, CVE-2020-10650)
+#2659: Block one more gadget type (aries.transaction.jms, CVE-2020-10672)
+#2660: Block one more gadget type (caucho-quercus, CVE-2020-10673)
+#2662: Block one more gadget type (bus-proxy, CVE-2020-10968)
+#2664: Block one more gadget type (activemq-pool[-jms], CVE-2020-11111)
+#2666: Block one more gadget type (apache/commons-proxy, CVE-2020-11112)
+#2670: Block one more gadget type (openjpa, CVE-2020-11113)
+#2680: Block one more gadget type (SSRF, spring-jpa, CVE-2020-11619)
+#2682: Block one more gadget type (commons-jelly, CVE-2020-11620)
+#2688: Block one more gadget type (apache-drill, CVE-2020-14060)
+#2698: Block one more gadget type (weblogic/oracle-aqjms, CVE-2020-14061)
+#2704: Block one more gadget type (jaxp-ri, CVE-2020-14062)
+#2765: Block one more gadget type (org.jsecurity, CVE-2020-14195)
+#2798: Block one more gadget type (com.pastdev.httpcomponents, CVE-2020-24750)
+#2814: Block one more gadget type (Anteros-DBCP, CVE-2020-24616)
+#2826: Block one more gadget type (com.nqadmin.rowset, no CVE allocated yet)
+#2827: Block one more gadget type (org.arrahtec:profiler-core, no CVE allocated yet)
+
+2.6.7.3 (16-Oct-2019)
+
+Backported all CVE fixes up to 2.9.10
+
+#1680: Block more JDK gadget types (com.sun.rowset)
+#1855: Block more serialization gadgets (dbcp/tomcat, spring / CVE-2017-17485]
+#1899: Another two gadgets to exploit default typing issue in jackson-databind (CVE-2018-5968)
+#2032: Block one more gadget type (mybatis, CVE-2018-11307)
+#2052: Block one more gadget type (jodd-db, CVE-2018-12022)
+#2058: Block one more gadget type (oracle-jdbc, CVE-2018-12023)
+#2097: Block more classes from polymorphic deserialization (CVE-2018-14718 - CVE-2018-14721)
+#2186: Block more classes from polymorphic deserialization (CVE-2018-19360, CVE-2018-19361, CVE-2018-19362)
+#2326: Block one more gadget type (mysql, CVE-2019-12086)
+#2334: Block one more gadget type (logback, CVE-2019-12384)
+#2341: Block yet another gadget type (jdom, CVE-2019-12814)
+#2387: Block one more gadget type (ehcache, CVE-2019-14379)
+#2389: Block one more gadget type (logback, CVE-2019-14439)
+#2410: Block one more gadget type (HikariCP, CVE-2019-14540)
+#2420: Block one more gadget type (cxf-jax-rs, no CVE allocated yet)
+#2449: Block one more gadget type (HikariCP, CVE-2019-14439 / CVE-2019-16335)
+#2462: Block two more gadget types (commons-configuration/-2)
+#2478: Block two more gadget types (commons-dbcp, p6spy, CVE-2019-16942 / CVE-2019-16943)
+#2498: Block one more gadget type (apache-log4j-extras/1.2, CVE-2019-17531)
+
 
 2.6.7.2 (13-Nov-2018)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -65,11 +65,14 @@ public class BeanDeserializerFactory
         s.add("java.util.logging.FileHandler");
         s.add("java.rmi.server.UnicastRemoteObject");
         // [databind#1737]; 3rd party
-        s.add("org.springframework.aop.support.AbstractBeanFactoryPointcutAdvisor");
+        //s.add("org.springframework.aop.support.AbstractBeanFactoryPointcutAdvisor"); // deprecated by [databind#1855]
         s.add("org.springframework.beans.factory.config.PropertyPathFactoryBean");
-        s.add("com.mchange.v2.c3p0.JndiRefForwardingDataSource");
-        s.add("com.mchange.v2.c3p0.WrapperConnectionPoolDataSource");
+        // [databind#2680]
+        s.add("org.springframework.aop.config.MethodLocatingFactoryBean");
+        s.add("org.springframework.beans.factory.config.BeanReferenceFactoryBean");
 
+        // s.add("com.mchange.v2.c3p0.JndiRefForwardingDataSource"); // deprecated by [databind#1931]
+        // s.add("com.mchange.v2.c3p0.WrapperConnectionPoolDataSource"); // - "" -
         // [databind#1855]: more 3rd party
         s.add("org.apache.tomcat.dbcp.dbcp2.BasicDataSource");
         s.add("com.sun.org.apache.bcel.internal.util.ClassLoader");
@@ -92,10 +95,11 @@ public class BeanDeserializerFactory
         s.add("com.sun.deploy.security.ruleset.DRSHelper");
         s.add("org.apache.axis2.jaxws.spi.handler.HandlerResolverImpl");
 
-        // [databind#2186]: yet more 3rd party gadgets
+        // [databind#2186], [databind#2670]: yet more 3rd party gadgets
         s.add("org.jboss.util.propertyeditor.DocumentEditor");
         s.add("org.apache.openjpa.ee.RegistryManagedRuntime");
         s.add("org.apache.openjpa.ee.JNDIManagedRuntime");
+        s.add("org.apache.openjpa.ee.WASRegistryManagedRuntime"); // [#2670] addition
         s.add("org.apache.axis2.transport.jms.JMSOutTransportInfo");
 
         // [databind#2326]
@@ -127,8 +131,10 @@ public class BeanDeserializerFactory
         s.add("org.apache.commons.configuration.JNDIConfiguration");
         s.add("org.apache.commons.configuration2.JNDIConfiguration");
 
-        // [databind#2469]: xalan2
+        // [databind#2469]: xalan
         s.add("org.apache.xalan.lib.sql.JNDIConnectionPool");
+        // [databind#2704]: xalan2
+        s.add("com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool");
 
         // [databind#2478]: comons-dbcp, p6spy
         s.add("org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
@@ -138,6 +144,86 @@ public class BeanDeserializerFactory
         // [databind#2498]: log4j-extras (1.2)
         s.add("org.apache.log4j.receivers.db.DriverManagerConnectionSource");
         s.add("org.apache.log4j.receivers.db.JNDIConnectionSource");
+
+        // [databind#2526]: some more ehcache
+        s.add("net.sf.ehcache.transaction.manager.selector.GenericJndiSelector");
+        s.add("net.sf.ehcache.transaction.manager.selector.GlassfishSelector");
+
+        // [databind#2620]: xbean-reflect
+        s.add("org.apache.xbean.propertyeditor.JndiConverter");
+
+        // [databind#2631]: shaded hikari-config
+        s.add("org.apache.hadoop.shaded.com.zaxxer.hikari.HikariConfig");
+
+        // [databind#2634]: ibatis-sqlmap, anteros-core/-dbcp
+        s.add("com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig");
+        s.add("br.com.anteros.dbcp.AnterosDBCPConfig");
+        // [databind#2814]: anteros-dbcp
+        s.add("br.com.anteros.dbcp.AnterosDBCPDataSource");
+
+        // [databind#2642][databind#2854]: javax.swing (jdk)
+        s.add("javax.swing.JEditorPane");
+        s.add("javax.swing.JTextPane");
+
+        // [databind#2648], [databind#2653]: shiro-core
+        s.add("org.apache.shiro.realm.jndi.JndiRealmFactory");
+        s.add("org.apache.shiro.jndi.JndiObjectFactory");
+
+        // [databind#2658]: ignite-jta (, quartz-core)
+        s.add("org.apache.ignite.cache.jta.jndi.CacheJndiTmLookup");
+        s.add("org.apache.ignite.cache.jta.jndi.CacheJndiTmFactory");
+        s.add("org.quartz.utils.JNDIConnectionProvider");
+
+        // [databind#2659]: aries.transaction.jms
+        s.add("org.apache.aries.transaction.jms.internal.XaPooledConnectionFactory");
+        s.add("org.apache.aries.transaction.jms.RecoverablePooledConnectionFactory");
+
+        // [databind#2660]: caucho-quercus
+        s.add("com.caucho.config.types.ResourceRef");
+
+        // [databind#2662]: aoju/bus-proxy
+        s.add("org.aoju.bus.proxy.provider.RmiProvider");
+        s.add("org.aoju.bus.proxy.provider.remoting.RmiProvider");
+
+        // [databind#2664]: activemq-core, activemq-pool, activemq-pool-jms
+
+        s.add("org.apache.activemq.ActiveMQConnectionFactory"); // core
+        s.add("org.apache.activemq.ActiveMQXAConnectionFactory");
+        s.add("org.apache.activemq.spring.ActiveMQConnectionFactory");
+        s.add("org.apache.activemq.spring.ActiveMQXAConnectionFactory");
+        s.add("org.apache.activemq.pool.JcaPooledConnectionFactory"); // pool
+        s.add("org.apache.activemq.pool.PooledConnectionFactory");
+        s.add("org.apache.activemq.pool.XaPooledConnectionFactory");
+        s.add("org.apache.activemq.jms.pool.XaPooledConnectionFactory"); // pool-jms
+        s.add("org.apache.activemq.jms.pool.JcaPooledConnectionFactory");
+
+        // [databind#2666]: apache/commons-jms
+        s.add("org.apache.commons.proxy.provider.remoting.RmiProvider");
+
+        // [databind#2682]: commons-jelly
+        s.add("org.apache.commons.jelly.impl.Embedded");
+
+        // [databind#2688]: apache/drill
+        s.add("oadd.org.apache.xalan.lib.sql.JNDIConnectionPool");
+
+        // [databind#2698]: weblogic w/ oracle/aq-jms
+        // (note: dependency not available via Maven Central, but as part of
+        // weblogic installation, possibly fairly old version(s))
+        s.add("oracle.jms.AQjmsQueueConnectionFactory");
+        s.add("oracle.jms.AQjmsXATopicConnectionFactory");
+        s.add("oracle.jms.AQjmsTopicConnectionFactory");
+        s.add("oracle.jms.AQjmsXAQueueConnectionFactory");
+        s.add("oracle.jms.AQjmsXAConnectionFactory");
+
+        // [databind#2765]: org.jsecurity:
+        s.add("org.jsecurity.realm.jndi.JndiRealmFactory");
+
+        // [databind#2798]: com.pastdev.httpcomponents:
+        s.add("com.pastdev.httpcomponents.configuration.JndiConfiguration");
+
+        // [databind#2826], [databind#2827]
+        s.add("com.nqadmin.rowset.JdbcRowSetImpl");
+        s.add("org.arrah.framework.rdbms.UpdatableJdbcRowsetImpl");
 
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }


### PR DESCRIPTION
**Motivation:** Jackson-2.6 is still widely used, despite being deprecated (including in [the AWS SDK for Java 1.11.x](https://github.com/aws/aws-sdk-java)). Until those consumers can migrate to a supported version of Jackson-2.6, this patch will protect those customers from the CVEs currently open against 2.6.7.3.

A similar change was made as part of 2.6.7.3 with similar motivation: https://github.com/FasterXML/jackson-databind/commit/a3939d36edcc755c8af55bdc1969e0fa8438f9db