### PR TITLE
Add support for strict property ordering

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -271,6 +271,20 @@ public enum MapperFeature implements ConfigFeature
      */
     SORT_PROPERTIES_ALPHABETICALLY(false),
 
+    /**
+     * Feature that enforces strict ordering as requested by other configuration methods
+     * for POJO fields (note: does <b>not</b> apply to {@link java.util.Map}
+     * serialization!):
+     * if enabled, ordering is preserved even if {@link com.fasterxml.jackson.annotation.JsonCreator}
+     * is present. Without this feature properties referenced by {@link com.fasterxml.jackson.annotation.JsonCreator}
+     * taking precedence over other properties even if sorting is requested.
+     *<p>
+     * Note that if ordering is not enabled using other ways, this feature has no effect.
+     *<p>
+     * Feature is disabled by default.
+     */
+    STRICT_PROPERTIES_ORDERING(false),
+
     /*
     /**********************************************************************
     /* Name-related features

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java
@@ -134,6 +134,14 @@ public abstract class MapperConfig<T extends MapperConfig<T>>
     }
 
     /**
+     * Accessor for checking whether default settings for forcing property
+     * ordering is enabled.
+     */
+    public final boolean shouldPreservePropertiesOrdering() {
+        return isEnabled(MapperFeature.STRICT_PROPERTIES_ORDERING);
+    }
+
+    /**
      * Accessor for checking whether configuration indicates that
      * "root wrapping" (use of an extra property/name pair at root level)
      * is expected or not.

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1034,7 +1034,8 @@ public class POJOPropertiesCollector
         }
 
         // Third by sorting Creator properties before other unordered properties
-        if (_creatorProperties != null) {
+        // (unless strict ordering is requested)
+        if (_creatorProperties != null && !_config.shouldPreservePropertiesOrdering()) {
             /* As per [databind#311], this is bit delicate; but if alphabetic ordering
              * is mandated, at least ensure creator properties are in alphabetic
              * order. Related question of creator vs non-creator is punted for now,

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -143,7 +143,33 @@ public class ObjectMapperTest extends BaseMapTest
         assertTrue(dc.shouldSortPropertiesAlphabetically());
     }
 
-    public void testDeserializationContextCache() throws Exception   
+    // Test to ensure that we can check forced property ordering defaults...
+    public void testConfigForForcedPropertySorting() throws Exception
+    {
+        ObjectMapper m = new ObjectMapper();
+
+        // sort-alphabetically is disabled by default:
+        assertFalse(m.isEnabled(MapperFeature.STRICT_PROPERTIES_ORDERING));
+        SerializationConfig sc = m.serializationConfig();
+        assertFalse(sc.isEnabled(MapperFeature.STRICT_PROPERTIES_ORDERING));
+        assertFalse(sc.shouldPreservePropertiesOrdering());
+        DeserializationConfig dc = m.deserializationConfig();
+        assertFalse(dc.shouldPreservePropertiesOrdering());
+
+        // but when enabled, should be visible:
+        m = jsonMapperBuilder()
+                .enable(MapperFeature.STRICT_PROPERTIES_ORDERING)
+                .build();
+        sc = m.serializationConfig();
+        assertTrue(sc.isEnabled(MapperFeature.STRICT_PROPERTIES_ORDERING));
+        assertTrue(sc.shouldPreservePropertiesOrdering());
+        dc = m.deserializationConfig();
+        // and not just via SerializationConfig, but also via DeserializationConfig
+        assertTrue(dc.isEnabled(MapperFeature.STRICT_PROPERTIES_ORDERING));
+        assertTrue(dc.shouldPreservePropertiesOrdering());
+    }
+
+    public void testDeserializationContextCache() throws Exception
     {
         ObjectMapper m = new ObjectMapper();
         final String JSON = "{ \"x\" : 3 }";

--- a/src/test/java/com/fasterxml/jackson/databind/ser/SerializationOrderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/SerializationOrderTest.java
@@ -82,6 +82,22 @@ public class SerializationOrderTest
         public int getB() { return b; }
     }
 
+    static class BeanForStrictOrdering {
+        private final int a;
+        private int b;
+        private final int c;
+
+        @JsonCreator
+        public BeanForStrictOrdering(@JsonProperty("c") int c, @JsonProperty("a") int a) { //b and a are out of order, although alphabetic = true
+            this.a = a;
+            this.c = c;
+        }
+
+        public int getA() { return a; }
+        public int getB() { return b; }
+        public int getC() { return c; }
+    }
+
     // We'll expect ordering of "FUBAR"
     @JsonPropertyOrder({ "f"  })
     static class OrderingByIndexBean {
@@ -107,6 +123,11 @@ public class SerializationOrderTest
 
     private final ObjectMapper ALPHA_MAPPER = jsonMapperBuilder()
             .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .build();
+
+    private final ObjectMapper STRICT_ALPHA_MAPPER = jsonMapperBuilder()
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .enable(MapperFeature.STRICT_PROPERTIES_ORDERING)
             .build();
 
     public void testImplicitOrderByCreator() throws Exception {
@@ -159,5 +180,11 @@ public class SerializationOrderTest
         // case of alphabetic-as-default
         assertEquals(aposToQuotes("{'f':0,'u':0,'b':0,'a':0,'r':0}"),
                 ALPHA_MAPPER.writeValueAsString(new OrderingByIndexBean()));
+    }
+
+    public void testStrictAlphaAndCreatorOrdering() throws Exception
+    {
+        String json = STRICT_ALPHA_MAPPER.writeValueAsString(new BeanForStrictOrdering(1, 2));
+        assertEquals("{\"a\":2,\"b\":0,\"c\":1}", json);
     }
 }


### PR DESCRIPTION
The purpose of this feature is to enable strict field ordering (without prioritization of properties referenced by @JsonCreator). 
This feature is extremely useful in cases when serialized output need to be, for example, predictably and interoperably hashed.