### PR TITLE
Fix flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>edu.illinois</groupId>
-        <artifactId>nondex-maven-plugin</artifactId>
-        <version>1.1.2</version>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,11 @@
 
   <build>
     <plugins>
-
+      <plugin>
+        <groupId>edu.illinois</groupId>
+        <artifactId>nondex-maven-plugin</artifactId>
+        <version>1.1.2</version>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,11 +126,7 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>edu.illinois</groupId>
-        <artifactId>nondex-maven-plugin</artifactId>
-        <version>1.1.2</version>
-      </plugin>
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
 public class AnnotatedFieldCollector
-    extends CollectorBase
+        extends CollectorBase
 {
     private final MixInResolver _mixInResolver;
 
@@ -18,7 +18,7 @@ public class AnnotatedFieldCollector
     // // // Collected state
 
     AnnotatedFieldCollector(MapperConfig<?> config, MixInResolver mixins,
-            boolean collectAnnotations)
+                            boolean collectAnnotations)
     {
         super(config);
         _mixInResolver = mixins;
@@ -26,15 +26,15 @@ public class AnnotatedFieldCollector
     }
 
     public static List<AnnotatedField> collectFields(MapperConfig<?> config,
-            TypeResolutionContext tc, MixInResolver mixins,
-            JavaType type, Class<?> primaryMixIn, boolean collectAnnotations)
+                                                     TypeResolutionContext tc, MixInResolver mixins,
+                                                     JavaType type, Class<?> primaryMixIn, boolean collectAnnotations)
     {
         return new AnnotatedFieldCollector(config, mixins, collectAnnotations)
                 .collect(tc, type, primaryMixIn);
     }
 
     List<AnnotatedField> collect(TypeResolutionContext tc,
-            JavaType type, Class<?> primaryMixIn)
+                                 JavaType type, Class<?> primaryMixIn)
     {
         Map<String,FieldBuilder> foundFields = _findFields(tc, type, primaryMixIn, null);
         if (foundFields == null) {
@@ -48,8 +48,8 @@ public class AnnotatedFieldCollector
     }
 
     private Map<String,FieldBuilder> _findFields(TypeResolutionContext tc,
-            JavaType type, Class<?> mixin,
-            Map<String,FieldBuilder> fields)
+                                                 JavaType type, Class<?> mixin,
+                                                 Map<String,FieldBuilder> fields)
     {
         // First, a quick test: we only care for regular classes (not interfaces,
         //primitive types etc), except for Object.class. A simple check to rule out
@@ -63,11 +63,10 @@ public class AnnotatedFieldCollector
             Class<?> parentMixin = (_mixInResolver == null) ? null
                     : _mixInResolver.findMixInClassFor(parentType.getRawClass());
             fields = _findFields(new TypeResolutionContext.Basic(_config.getTypeFactory(),
-                    parentType.getBindings()),
+                            parentType.getBindings()),
                     parentType, parentMixin, fields);
         }
         final Class<?> rawType = type.getRawClass();
-        //System.out.println("-------- rawType ----------- " + rawType);
         for (Field f : rawType.getDeclaredFields()) {
             // static fields not included (transients are at this point, filtered out later)
             if (!_isIncludableField(f)) {
@@ -98,7 +97,7 @@ public class AnnotatedFieldCollector
      * super-classes)
      */
     private void _addFieldMixIns(Class<?> mixInCls, Class<?> targetClass,
-            Map<String,FieldBuilder> fields)
+                                 Map<String,FieldBuilder> fields)
     {
         List<Class<?>> parents = ClassUtil.findSuperClasses(mixInCls, targetClass, true);
         for (Class<?> mixin : parents) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -67,7 +67,6 @@ public class AnnotatedFieldCollector
                     parentType, parentMixin, fields);
         }
         final Class<?> rawType = type.getRawClass();
-        //System.out.println("-------- rawType ----------- " + rawType);
         for (Field f : rawType.getDeclaredFields()) {
             // static fields not included (transients are at this point, filtered out later)
             if (!_isIncludableField(f)) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
 public class AnnotatedFieldCollector
-        extends CollectorBase
+    extends CollectorBase
 {
     private final MixInResolver _mixInResolver;
 
@@ -18,7 +18,7 @@ public class AnnotatedFieldCollector
     // // // Collected state
 
     AnnotatedFieldCollector(MapperConfig<?> config, MixInResolver mixins,
-                            boolean collectAnnotations)
+            boolean collectAnnotations)
     {
         super(config);
         _mixInResolver = mixins;
@@ -26,15 +26,15 @@ public class AnnotatedFieldCollector
     }
 
     public static List<AnnotatedField> collectFields(MapperConfig<?> config,
-                                                     TypeResolutionContext tc, MixInResolver mixins,
-                                                     JavaType type, Class<?> primaryMixIn, boolean collectAnnotations)
+            TypeResolutionContext tc, MixInResolver mixins,
+            JavaType type, Class<?> primaryMixIn, boolean collectAnnotations)
     {
         return new AnnotatedFieldCollector(config, mixins, collectAnnotations)
                 .collect(tc, type, primaryMixIn);
     }
 
     List<AnnotatedField> collect(TypeResolutionContext tc,
-                                 JavaType type, Class<?> primaryMixIn)
+            JavaType type, Class<?> primaryMixIn)
     {
         Map<String,FieldBuilder> foundFields = _findFields(tc, type, primaryMixIn, null);
         if (foundFields == null) {
@@ -48,8 +48,8 @@ public class AnnotatedFieldCollector
     }
 
     private Map<String,FieldBuilder> _findFields(TypeResolutionContext tc,
-                                                 JavaType type, Class<?> mixin,
-                                                 Map<String,FieldBuilder> fields)
+            JavaType type, Class<?> mixin,
+            Map<String,FieldBuilder> fields)
     {
         // First, a quick test: we only care for regular classes (not interfaces,
         //primitive types etc), except for Object.class. A simple check to rule out
@@ -63,10 +63,11 @@ public class AnnotatedFieldCollector
             Class<?> parentMixin = (_mixInResolver == null) ? null
                     : _mixInResolver.findMixInClassFor(parentType.getRawClass());
             fields = _findFields(new TypeResolutionContext.Basic(_config.getTypeFactory(),
-                            parentType.getBindings()),
+                    parentType.getBindings()),
                     parentType, parentMixin, fields);
         }
         final Class<?> rawType = type.getRawClass();
+        //System.out.println("-------- rawType ----------- " + rawType);
         for (Field f : rawType.getDeclaredFields()) {
             // static fields not included (transients are at this point, filtered out later)
             if (!_isIncludableField(f)) {
@@ -97,7 +98,7 @@ public class AnnotatedFieldCollector
      * super-classes)
      */
     private void _addFieldMixIns(Class<?> mixInCls, Class<?> targetClass,
-                                 Map<String,FieldBuilder> fields)
+            Map<String,FieldBuilder> fields)
     {
         List<Class<?>> parents = ClassUtil.findSuperClasses(mixInCls, targetClass, true);
         for (Class<?> mixin : parents) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -67,6 +67,7 @@ public class AnnotatedFieldCollector
                     parentType, parentMixin, fields);
         }
         final Class<?> rawType = type.getRawClass();
+        //System.out.println("-------- rawType ----------- " + rawType);
         for (Field f : rawType.getDeclaredFields()) {
             // static fields not included (transients are at this point, filtered out later)
             if (!_isIncludableField(f)) {

--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -268,7 +268,7 @@ public abstract class BaseMapTest
         throws IOException
     {
         String str = m.writeValueAsString(value);
-        return (Map<String,Object>) m.readValue(str, Map.class);
+        return (Map<String,Object>) m.readValue(str, LinkedHashMap.class);
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/MapperJDKSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperJDKSerializationTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.Version;
 
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.databind.util.SimpleLookupCache;
  */
 public class MapperJDKSerializationTest extends BaseMapTest
 {
+    @JsonPropertyOrder({ "x", "y" })
     static class MyPojo {
         public int x;
         protected int y;
@@ -36,6 +38,7 @@ public class MapperJDKSerializationTest extends BaseMapTest
     }
 
     // for [databind#899]
+    @JsonPropertyOrder({ "abc", "stuff" })
     static class EnumPOJO {
         public ABC abc = ABC.B;
 

--- a/src/test/java/com/fasterxml/jackson/databind/convert/TestBeanConversions.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/TestBeanConversions.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.StdConverter;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * Tests for various conversions, especially ones using
  * {@link ObjectMapper#convertValue(Object, Class)}.
@@ -79,6 +81,7 @@ public class TestBeanConversions
        }
     }
 
+    @JsonPropertyOrder({ "a", "b" })
     public static class DummyBean {
        public final int a, b;
        public DummyBean(int v1, int v2) {

--- a/src/test/java/com/fasterxml/jackson/databind/convert/TestConvertingSerializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/TestConvertingSerializer.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 public class TestConvertingSerializer
     extends com.fasterxml.jackson.databind.BaseMapTest
 {
@@ -140,6 +142,7 @@ public class TestConvertingSerializer
     }
 
     // [databind#731]
+    @JsonPropertyOrder({ "a", "b" })
     public static class DummyBean {
         public final int a, b;
         public DummyBean(int v1, int v2) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/CyclicTypesDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/CyclicTypesDeserTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.deser;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.*;
 
 /**
@@ -42,6 +43,7 @@ public class CyclicTypesDeserTest
     static class StringLink extends GenericLink<String> {
     }
 
+    @JsonPropertyOrder({ "id", "parent" })
     static class Selfie405 {
         public int id;
 

--- a/src/test/java/com/fasterxml/jackson/databind/format/MapEntryFormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/format/MapEntryFormatTest.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.*;
 
 public class MapEntryFormatTest extends BaseMapTest
@@ -16,13 +17,14 @@ public class MapEntryFormatTest extends BaseMapTest
 
         protected BeanWithMapEntry() { }
         public BeanWithMapEntry(String key, String value) {
-            Map<String,String> map = new HashMap<>();
+            Map<String,String> map = new LinkedHashMap<>();
             map.put(key, value);
             entry = map.entrySet().iterator().next();
         }
     }
 
     @JsonFormat(shape=JsonFormat.Shape.POJO)
+    @JsonPropertyOrder({ "key", "value" })
     static class MapEntryAsObject implements Map.Entry<String,String> {
         protected String key, value;
 
@@ -172,6 +174,7 @@ public class MapEntryFormatTest extends BaseMapTest
         ObjectMapper mapper = jsonMapperBuilder()
                 .withConfigOverride(Map.Entry.class,
                         o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.POJO)))
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                 .build();
         Map.Entry<String,String> input = new BeanWithMapEntry("foo", "bar").entry;
         assertEquals(aposToQuotes("{'key':'foo','value':'bar'}"),

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ExistingPropertyTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ExistingPropertyTest.java
@@ -257,6 +257,8 @@ public class ExistingPropertyTest extends BaseMapTest
         assertEquals(fruitWrapperSerialized, pinguoWrapperJson);
 
         String fruitListSerialized = MAPPER.writeValueAsString(fruitList);
+
+        System.out.println(fruitListSerialized);
         assertEquals(fruitListSerialized, fruitListJson);
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ExistingPropertyTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ExistingPropertyTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -29,6 +30,7 @@ public class ExistingPropertyTest extends BaseMapTest
     }
 
     @JsonTypeName("apple")
+    @JsonPropertyOrder({ "name", "seedCount", "type" })
     static class Apple extends Fruit
     {
         public int seedCount;
@@ -43,6 +45,7 @@ public class ExistingPropertyTest extends BaseMapTest
     }
 
     @JsonTypeName("orange")
+    @JsonPropertyOrder({ "name", "color", "type" })
     static class Orange extends Fruit
     {
         public String color;

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ExistingPropertyTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ExistingPropertyTest.java
@@ -260,8 +260,6 @@ public class ExistingPropertyTest extends BaseMapTest
         assertEquals(fruitWrapperSerialized, pinguoWrapperJson);
 
         String fruitListSerialized = MAPPER.writeValueAsString(fruitList);
-
-        System.out.println(fruitListSerialized);
         assertEquals(fruitListSerialized, fruitListJson);
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
@@ -102,7 +102,6 @@ public class TestObjectIdWithEquals extends BaseMapTest
         foo.otherBars.add(bar2);
 
         String json = mapper.writeValueAsString(foo);
-        System.out.println( "-------- JSON --------- "+ json);
         assertEquals("{\"id\":1,\"bars\":[{\"id\":1},{\"id\":2}],\"otherBars\":[1,2]}", json);
 
         Foo foo2 = mapper.readValue(json, Foo.class);       

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
@@ -82,6 +82,7 @@ public class TestObjectIdWithEquals extends BaseMapTest
     {
         ObjectMapper mapper = jsonMapperBuilder()
                 .enable(SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID)
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                 .build();
 
         Foo foo = new Foo(1);
@@ -100,6 +101,7 @@ public class TestObjectIdWithEquals extends BaseMapTest
         foo.otherBars.add(bar2);
 
         String json = mapper.writeValueAsString(foo);
+        System.out.println( "-------- JSON --------- "+ json);
         assertEquals("{\"id\":1,\"bars\":[{\"id\":1},{\"id\":2}],\"otherBars\":[1,2]}", json);
 
         Foo foo2 = mapper.readValue(json, Foo.class);       

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.*;
 public class TestObjectIdWithEquals extends BaseMapTest
 {
     @JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property="id", scope=Foo.class)
+    @JsonPropertyOrder({ "id", "bars", "otherBars" })
     static class Foo {
         public int id;
 

--- a/src/test/java/com/fasterxml/jackson/databind/ser/AnyGetterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/AnyGetterTest.java
@@ -132,7 +132,7 @@ public class AnyGetterTest extends BaseMapTest
 
     static class Bean2592NoAnnotations
     {
-        protected Map<String, String> properties = new HashMap<>();
+        protected Map<String, String> properties = new LinkedHashMap<>();
 
         @JsonAnyGetter
         public Map<String, String> getProperties() {

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestRootType.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestRootType.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -57,6 +58,7 @@ public class TestRootType
     }
 
     // [databind#412]
+    @JsonPropertyOrder({ "uuid", "type" })
     static class TestCommandParent {
         public String uuid;
         public int type;

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArrayWithBuilder.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestPOJOAsArrayWithBuilder.java
@@ -30,6 +30,7 @@ public class TestPOJOAsArrayWithBuilder extends BaseMapTest
     }
 
     @JsonFormat(shape=JsonFormat.Shape.ARRAY)
+    @JsonPropertyOrder(alphabetic=true)
     static class SimpleBuilderXY
     {
         public int x, y;

--- a/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithPrefix.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/TestUnwrappedWithPrefix.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.struct;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -68,7 +69,7 @@ public class TestUnwrappedWithPrefix extends BaseMapTest
     }
 
     // Let's actually test hierarchic names with unwrapping bit more:
-    
+    @JsonPropertyOrder({ "general", "misc" })
     static class ConfigRoot
     {
         @JsonUnwrapped(prefix="general.")


### PR DESCRIPTION
Fix all 16 flaky tests by using the annotation, @JsonPropertyOrder, and converting HashMap to LinkedHashMap to guarantee the order. When running these tests on different machines, the hardcoded values might come in different orders this will cause some tests to fail. These changes will now give the same results in all environments.