### PR TITLE
Fix type resolution for static methods (regression in 2.11.3)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
@@ -221,12 +221,6 @@ final class AnnotatedCreatorCollector
         if (candidates == null) {
             return Collections.emptyList();
         }
-        // 05-Sep-2020, tatu: Important fix wrt [databind#2821] -- static methods
-        //   do NOT have type binding context of the surrounding class and although
-        //   passing that should not break things, it appears to... Regardless,
-        //   it should not be needed or useful as those bindings are only available
-        //   to non-static members
-        TypeResolutionContext typeResCtxt = new TypeResolutionContext.Empty(_typeFactory);
 
         int factoryCount = candidates.size();
         List<AnnotatedMethod> result = new ArrayList<>(factoryCount);
@@ -250,8 +244,7 @@ final class AnnotatedCreatorCollector
                 for (int i = 0; i < factoryCount; ++i) {
                     if (key.equals(methodKeys[i])) {
                         result.set(i,
-                                constructFactoryCreator(candidates.get(i),
-                                        typeResCtxt, mixinFactory));
+                                constructFactoryCreator(candidates.get(i), mixinFactory));
                         break;
                     }
                 }
@@ -262,8 +255,7 @@ final class AnnotatedCreatorCollector
             AnnotatedMethod factory = result.get(i);
             if (factory == null) {
                 result.set(i,
-                        constructFactoryCreator(candidates.get(i),
-                                typeResCtxt, null));
+                        constructFactoryCreator(candidates.get(i), null));
             }
         }
         return result;
@@ -335,19 +327,18 @@ ctor.getDeclaringClass().getName(), paramCount, paramAnns.length));
                 collectAnnotations(ctor, mixin), resolvedAnnotations);
     }
 
-    protected AnnotatedMethod constructFactoryCreator(Method m,
-            TypeResolutionContext typeResCtxt, Method mixin)
+    protected AnnotatedMethod constructFactoryCreator(Method m, Method mixin)
     {
         final int paramCount = m.getParameterTypes().length;
         if (_intr == null) { // when annotation processing is disabled
-            return new AnnotatedMethod(typeResCtxt, m, _emptyAnnotationMap(),
+            return new AnnotatedMethod(_typeContext, m, _emptyAnnotationMap(),
                     _emptyAnnotationMaps(paramCount));
         }
         if (paramCount == 0) { // common enough we can slightly optimize
-            return new AnnotatedMethod(typeResCtxt, m, collectAnnotations(m, mixin),
+            return new AnnotatedMethod(_typeContext, m, collectAnnotations(m, mixin),
                     NO_ANNOTATION_MAPS);
         }
-        return new AnnotatedMethod(typeResCtxt, m, collectAnnotations(m, mixin),
+        return new AnnotatedMethod(_typeContext, m, collectAnnotations(m, mixin),
                 collectAnnotations(m.getParameterAnnotations(),
                         (mixin == null) ? null : mixin.getParameterAnnotations()));
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/TypeResolutionContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/TypeResolutionContext.java
@@ -44,25 +44,4 @@ public interface TypeResolutionContext {
         }
         */
     }
-
-    /**
-     * Dummy implementation for case where there are no bindings available
-     * (for example, for static methods and fields)
-     *
-     * @since 2.11.3
-     */
-    public static class Empty
-        implements TypeResolutionContext
-    {
-        private final TypeFactory _typeFactory;
-
-        public Empty(TypeFactory tf) {
-            _typeFactory = tf;
-        }
-
-        @Override
-        public JavaType resolveType(Type type) {
-            return _typeFactory.constructType(type);
-        }
-    }
 }


### PR DESCRIPTION
Updating Jackson (2.10.4 => 2.11.3) in https://github.com/prestosql/presto introduced a regression in types resolution for factory methods, ie. type reference is being dropped for static methods.
Given simplified scenario:
```java
class Wrapper<T> {
  List<T> values;

  static <T> Wrapper<T> fromValues(List<T> values) {
    return new Wrapper<>(values);
  }
}

class Value {
  int x;
}

Wrapper<Value> src = new Wrapper<>(Arrays.asList(new Value(1), new Value(2)));
Wrapper<Value> output = MAPPER.readValue(MAPPER.writeValueAsString(src), new TypeReference<Wrapper<Value>>() {});
```
`out` contains values of type `LinkedHashMap` produced by `UntypedObjectDeserializer`.

I think it's due to changes introduced in 10144939b99564eabdff8d870396cfeaa173fe5b.