### PR TITLE
Fix static JsonCreator generic type deserialization regression in 2.11.3

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolver.java
@@ -1,0 +1,221 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeBindings;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * Internal utility functionality to handle type resolution for method type variables based on the requested
+ * result type.
+ */
+final class MethodGenericTypeResolver {
+
+    /*
+     * Attempt to narrow types on a generic factory method based on the expected result (requestedType).
+     * If narrowing was possible, a new TypeResolutionContext is returned with the discovered TypeBindings,
+     * otherwise the emptyTypeResCtxt argument is returned.
+     *
+     * For example:
+     * Given type Wrapper<T> with
+     * @JsonCreator static <T> Wrapper<T> fromJson(T value)
+     * When a Wrapper<Duck> is requested the factory must return a Wrapper<Duck> and we can bind T to Duck
+     * as though the method was written with defined types:
+     * @JsonCreator static Wrapper<Duck> fromJson(Duck value)
+     */
+    static TypeResolutionContext narrowMethodTypeParameters(
+            Method candidate,
+            JavaType requestedType,
+            TypeFactory typeFactory,
+            TypeResolutionContext emptyTypeResCtxt) {
+        TypeBindings newTypeBindings = bindMethodTypeParameters(candidate, requestedType, emptyTypeResCtxt);
+        return newTypeBindings == null
+                ? emptyTypeResCtxt
+                : new TypeResolutionContext.Basic(typeFactory, newTypeBindings);
+    }
+
+    /**
+     * Returns {@link TypeBindings} with additional type information
+     * based on {@code requestedType} if possible, otherwise {@code null}.
+     */
+    static TypeBindings bindMethodTypeParameters(
+            Method candidate,
+            JavaType requestedType,
+            TypeResolutionContext emptyTypeResCtxt) {
+        TypeVariable<Method>[] methodTypeParameters = candidate.getTypeParameters();
+        if (methodTypeParameters.length == 0
+                // If the primary type has no type parameters, there's nothing to do
+                || requestedType.getBindings().isEmpty()) {
+            // Method has no type parameters: no need to modify the resolution context.
+            return null;
+        }
+        Type genericReturnType = candidate.getGenericReturnType();
+        if (!(genericReturnType instanceof ParameterizedType)) {
+            // Return value is not parameterized, it cannot be used to associate the requestedType expectations
+            // onto parameters.
+            return null;
+        }
+
+        ParameterizedType parameterizedGenericReturnType = (ParameterizedType) genericReturnType;
+        // Primary type and result type must be the same class, otherwise we would need to
+        // trace generic parameters to a common superclass or interface.
+        if (!Objects.equals(requestedType.getRawClass(), parameterizedGenericReturnType.getRawType())) {
+            return null;
+        }
+
+        // Construct TypeBindings based on the requested type, and type variables that occur in the generic return type.
+        // For example given requestedType: Foo<String, Int>
+        // and method static <T, U> Foo<T, U> func(Bar<T, U> in)
+        // Produces TypeBindings{T=String, U=Int}.
+        Type[] methodReturnTypeArguments = parameterizedGenericReturnType.getActualTypeArguments();
+        ArrayList<String> names = new ArrayList<>(methodTypeParameters.length);
+        ArrayList<JavaType> types = new ArrayList<>(methodTypeParameters.length);
+        for (int i = 0; i < methodReturnTypeArguments.length; i++) {
+            Type methodReturnTypeArgument = methodReturnTypeArguments[i];
+            // Note: This strictly supports only TypeVariables of the forms "T" and "? extends T",
+            // not complex wildcards with nested type variables
+            TypeVariable<?> typeVar = maybeGetTypeVariable(methodReturnTypeArgument);
+            if (typeVar != null) {
+                String typeParameterName = typeVar.getName();
+                if (typeParameterName == null) {
+                    return null;
+                }
+
+                JavaType bindTarget = requestedType.getBindings().getBoundType(i);
+                if (bindTarget == null) {
+                    return null;
+                }
+                // If the type parameter name is not present in the method type parameters we
+                // fall back to default type handling.
+                TypeVariable<?> methodTypeVariable = findByName(methodTypeParameters, typeParameterName);
+                if (methodTypeVariable == null) {
+                    return null;
+                }
+                if (pessimisticallyValidateBounds(emptyTypeResCtxt, bindTarget, methodTypeVariable.getBounds())) {
+                    // Avoid duplicate entries for the same type variable, e.g. '<T> Map<T, T> foo(Class<T> in)'
+                    int existingIndex = names.indexOf(typeParameterName);
+                    if (existingIndex != -1) {
+                        JavaType existingBindTarget = types.get(existingIndex);
+                        if (bindTarget.equals(existingBindTarget)) {
+                            continue;
+                        }
+                        boolean existingIsSubtype = existingBindTarget.isTypeOrSubTypeOf(bindTarget.getRawClass());
+                        boolean newIsSubtype = bindTarget.isTypeOrSubTypeOf(existingBindTarget.getRawClass());
+                        if (!existingIsSubtype && !newIsSubtype) {
+                            // No way to satisfy the requested type.
+                            return null;
+                        }
+                        if (existingIsSubtype ^ newIsSubtype && newIsSubtype) {
+                            // If the new type is more specific than the existing type, the new type replaces the old.
+                            types.set(existingIndex, bindTarget);
+                        }
+                    } else {
+                        names.add(typeParameterName);
+                        types.add(bindTarget);
+                    }
+                }
+            }
+        }
+        // Fall back to default handling if no specific types from the requestedType are used
+        if (names.isEmpty()) {
+            return null;
+        }
+        return TypeBindings.create(names, types);
+    }
+
+    /* Returns the TypeVariable if it can be extracted, otherwise null. */
+    private static TypeVariable<?> maybeGetTypeVariable(Type type) {
+        if (type instanceof TypeVariable) {
+            return (TypeVariable<?>) type;
+        }
+        // Extract simple type variables from wildcards matching '? extends T'
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            // Exclude any form of '? super T'
+            if (wildcardType.getLowerBounds().length != 0) {
+                return null;
+            }
+            Type[] upperBounds = wildcardType.getUpperBounds();
+            if (upperBounds.length == 1) {
+                return maybeGetTypeVariable(upperBounds[0]);
+            }
+        }
+        return null;
+    }
+
+    /* Returns the TypeVariable if it can be extracted, otherwise null. */
+    private static ParameterizedType maybeGetParameterizedType(Type type) {
+        if (type instanceof ParameterizedType) {
+            return (ParameterizedType) type;
+        }
+        // Extract simple type variables from wildcards matching '? extends T'
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            // Exclude any form of '? super T'
+            if (wildcardType.getLowerBounds().length != 0) {
+                return null;
+            }
+            Type[] upperBounds = wildcardType.getUpperBounds();
+            if (upperBounds.length == 1) {
+                return maybeGetParameterizedType(upperBounds[0]);
+            }
+        }
+        return null;
+    }
+
+    private static boolean pessimisticallyValidateBounds(
+            TypeResolutionContext context, JavaType boundType, Type[] upperBound) {
+        for (Type type : upperBound) {
+            if (!pessimisticallyValidateBound(context, boundType, type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean pessimisticallyValidateBound(
+            TypeResolutionContext context, JavaType boundType, Type type) {
+        if (!boundType.isTypeOrSubTypeOf(context.resolveType(type).getRawClass())) {
+            return false;
+        }
+        ParameterizedType parameterized = maybeGetParameterizedType(type);
+        if (parameterized != null) {
+            Type[] typeArguments = parameterized.getActualTypeArguments();
+            TypeBindings bindings = boundType.getBindings();
+            if (bindings.size() != typeArguments.length) {
+                return false;
+            }
+            for (int i = 0; i < bindings.size(); i++) {
+                JavaType boundTypeBound = bindings.getBoundType(i);
+                Type typeArg = typeArguments[i];
+                if (!pessimisticallyValidateBound(context, boundTypeBound, typeArg)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static TypeVariable<?> findByName(TypeVariable<?>[] typeVariables, String name) {
+        if (typeVariables == null || name == null) {
+            return null;
+        }
+        for (TypeVariable<?> typeVariable : typeVariables) {
+            if (name.equals(typeVariable.getName())) {
+                return typeVariable;
+            }
+        }
+        return null;
+    }
+
+    private MethodGenericTypeResolver() {
+        // Utility class
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -142,7 +142,18 @@ public class TypeBindings
         return new TypeBindings(new String[] { vars[0].getName(), vars[1].getName() },
                 new JavaType[] { typeArg1, typeArg2 }, null);
     }
-    
+
+    /**
+     * Factory method for constructing bindings given names and associated types.
+     */
+    public static TypeBindings create(List<String> names, List<JavaType> types)
+    {
+        if (names == null || names.isEmpty() || types == null || types.isEmpty()) {
+            return EMPTY;
+        }
+        return new TypeBindings(names.toArray(NO_STRINGS), types.toArray(NO_TYPES), null);
+    }
+
     /**
      * Alternate factory method that may be called if it is possible that type
      * does or does not require type parameters; this is mostly useful for

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolverTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolverTest.java
@@ -1,0 +1,183 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeBindings;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MethodGenericTypeResolverTest extends BaseMapTest {
+
+    private static final TypeResolutionContext EMPTY_CONTEXT =
+            new TypeResolutionContext.Empty(TypeFactory.defaultInstance());
+
+    public static <T> AtomicReference<T> simple(T input) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static AtomicReference<?> noGenerics(String input) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> Map<T, T> mapWithSameKeysAndValues(List<T> input) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> Map<?, ?> disconnected(List<T> input) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <A, B> Map<A, B> multipleTypeVariables(Map<A, B> input) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <A, B> Map<? extends A, ? extends B> multipleTypeVariablesWithUpperBound(Map<A, B> input) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static class StubA {
+        private final String value;
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        private StubA(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public static class StubB extends StubA {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public StubB(String value) {
+            super(value);
+        }
+    }
+
+    public void testWithoutGenerics() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("noGenerics"), type(String.class), EMPTY_CONTEXT);
+        assertNull(bindings);
+    }
+
+    public void testWithoutGenericsInResult() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("simple"), type(AtomicReference.class), EMPTY_CONTEXT);
+        assertNull(bindings);
+    }
+
+    public void testResultDoesNotUseTypeVariables() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("disconnected"), type(new TypeReference<Map<String, String>>() {
+                }), EMPTY_CONTEXT);
+        assertNull(bindings);
+    }
+
+    public void testWithoutGenericsInMethod() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("noGenerics"), type(new TypeReference<Map<String, String>>() {
+                }), EMPTY_CONTEXT);
+        assertNull(bindings);
+    }
+
+    public void testWithRepeatedGenericInReturn() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("mapWithSameKeysAndValues"), type(new TypeReference<Map<String, String>>() {
+                }), EMPTY_CONTEXT);
+        assertEquals(asMap("T", type(String.class)), asMap(bindings));
+    }
+
+    public void testWithRepeatedGenericInReturnWithIncreasingSpecificity() {
+        Method method = method("mapWithSameKeysAndValues");
+        TypeBindings bindingsAb = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method, type(new TypeReference<Map<StubA, StubB>>() {
+                }), EMPTY_CONTEXT);
+        TypeBindings bindingsBa = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method, type(new TypeReference<Map<StubB, StubA>>() {
+                }), EMPTY_CONTEXT);
+        assertEquals(asMap(bindingsBa), asMap(bindingsAb));
+        assertEquals(asMap(bindingsBa), asMap("T", type(StubB.class)));
+    }
+
+    public void testMultipleTypeVariables() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("multipleTypeVariables"), type(new TypeReference<Map<Integer, Long>>() {
+                }), EMPTY_CONTEXT);
+        assertEquals(
+                asMap("A", type(Integer.class), "B", type(Long.class)),
+                asMap(bindings));
+    }
+
+    public void testMultipleTypeVariablesWithUpperBounds() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("multipleTypeVariablesWithUpperBound"), type(new TypeReference<Map<Integer, Long>>() {
+                }), EMPTY_CONTEXT);
+        assertEquals(
+                asMap("A", type(Integer.class), "B", type(Long.class)),
+                asMap(bindings));
+    }
+
+    public void testResultTypeDoesNotExactlyMatch() {
+        TypeBindings bindings = MethodGenericTypeResolver.bindMethodTypeParameters(
+                method("multipleTypeVariables"), type(new TypeReference<HashMap<Integer, Long>>() {
+                }), EMPTY_CONTEXT);
+        // Mapping the result to a common supertype is not supported.
+        assertNull(bindings);
+    }
+
+    private static Method method(String name) {
+        Method result = null;
+        for (Method method : MethodGenericTypeResolverTest.class.getMethods()) {
+            if (Modifier.isStatic(method.getModifiers()) && name.equals(method.getName())) {
+                if (result != null) {
+                    throw new AssertionError("Multiple methods discovered with name "
+                            + name + ": " + result + " and " + method);
+                }
+                result = method;
+            }
+        }
+        assertNotNull("Failed to find method", result);
+        return result;
+    }
+
+    private static JavaType type(TypeReference<?> reference) {
+        return type(reference.getType());
+    }
+
+    private static JavaType type(Type type) {
+        return EMPTY_CONTEXT.resolveType(type);
+    }
+
+    private static Map<String, JavaType> asMap(TypeBindings bindings) {
+        assertNotNull(bindings);
+        Map<String, JavaType> result = new HashMap<>(bindings.size());
+        for (int i = 0; i < bindings.size(); i++) {
+            result.put(bindings.getBoundName(i), bindings.getBoundType(i));
+        }
+        assertEquals(bindings.size(), result.size());
+        return result;
+    }
+
+    private static Map<String, JavaType> asMap(String name, JavaType javaType) {
+        return Collections.singletonMap(name, javaType);
+    }
+
+    private static Map<String, JavaType> asMap(
+            String name0, JavaType javaType0, String name1, JavaType javaType1) {
+        Map<String, JavaType> result = new HashMap<>(2);
+        result.put(name0, javaType0);
+        result.put(name1, javaType1);
+        return result;
+    }
+}


### PR DESCRIPTION
This issue impacts deserialization with generic types using
the [immutables](https://immutables.github.io/) library. Immutables
transforms from Json specific implementations to the core immutable
implementation using a static `@JsonCreator` method.

In cases where the input delegate deserialized object shares a
common generic type with the return type, we may be able to share
some subset of the binding context.