### PR TITLE
Adds support for `@JsonKey` annotation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -980,7 +980,7 @@ public abstract class AnnotationIntrospector
      *
      * @since TODO
      */
-    public Boolean hasAsKey(Annotated a) {
+    public Boolean hasAsKey(MapperConfig<?> config, Annotated a) {
         return null;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -969,6 +969,23 @@ public abstract class AnnotationIntrospector
 
     /**
      * Method for checking whether given method has an annotation
+     * that suggests the return value of annotated method
+     * should be used as "the key" of the object instance; usually
+     * serialized as a primitive value such as String or number.
+     *
+     * @return {@link Boolean#TRUE} if such annotation is found and is not disabled;
+     *   {@link Boolean#FALSE} if disabled annotation (block) is found (to indicate
+     *   accessor is definitely NOT to be used "as value"); or `null` if no
+     *   information found.
+     *
+     * @since TODO
+     */
+    public Boolean hasAsKey(Annotated a) {
+        return null;
+    }
+
+    /**
+     * Method for checking whether given method has an annotation
      * that suggests that the return value of annotated method
      * should be used as "the value" of the object instance; usually
      * serialized as a primitive value such as String or number.

--- a/src/main/java/com/fasterxml/jackson/databind/BeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/BeanDescription.java
@@ -182,7 +182,9 @@ public abstract class BeanDescription
      *
      * @since TODO
      */
-    public abstract AnnotatedMember findJsonKeyAccessor();
+    public AnnotatedMember findJsonKeyAccessor() {
+        return null;
+    }
 
     /**
      * Method for locating accessor (readable field, or "getter" method)

--- a/src/main/java/com/fasterxml/jackson/databind/BeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/BeanDescription.java
@@ -176,6 +176,17 @@ public abstract class BeanDescription
     /**
      * Method for locating accessor (readable field, or "getter" method)
      * that has
+     * {@link com.fasterxml.jackson.annotation.JsonKey} annotation,
+     * if any. If multiple ones are found,
+     * an error is reported by throwing {@link IllegalArgumentException}
+     *
+     * @since TODO
+     */
+    public abstract AnnotatedMember findJsonKeyAccessor();
+
+    /**
+     * Method for locating accessor (readable field, or "getter" method)
+     * that has
      * {@link com.fasterxml.jackson.annotation.JsonValue} annotation,
      * if any. If multiple ones are found,
      * an error is reported by throwing {@link IllegalArgumentException}

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
@@ -240,6 +240,12 @@ public class BasicBeanDescription extends BeanDescription
     }
 
     @Override
+    public AnnotatedMember findJsonKeyAccessor() {
+        return (_propCollector == null) ? null
+                : _propCollector.getJsonKeyAccessor();
+    }
+
+    @Override
     @Deprecated // since 2.9
     public AnnotatedMethod findJsonValueMethod() {
         return (_propCollector == null) ? null

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -1072,7 +1072,7 @@ public class JacksonAnnotationIntrospector
     }
 
     @Override
-    public Boolean hasAsKey(Annotated a) {
+    public Boolean hasAsKey(MapperConfig<?> config, Annotated a) {
         JsonKey ann = _findAnnotation(a, JsonKey.class);
         if (ann == null) {
             return null;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -1071,6 +1071,15 @@ public class JacksonAnnotationIntrospector
         return null;
     }
 
+    @Override
+    public Boolean hasAsKey(Annotated a) {
+        JsonKey ann = _findAnnotation(a, JsonKey.class);
+        if (ann == null) {
+            return null;
+        }
+        return ann.value();
+    }
+
     @Override // since 2.9
     public Boolean hasAsValue(Annotated a) {
         JsonValue ann = _findAnnotation(a, JsonValue.class);

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -6,6 +6,8 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import com.fasterxml.jackson.annotation.JsonKey;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.*;
 
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
@@ -107,12 +109,12 @@ public class POJOPropertiesCollector
     protected LinkedList<AnnotatedMember> _anySetterField;
 
     /**
-     * Method(s) annotated with 'JsonKey' annotation
+     * Accessors (field or "getter" method annotated with {@link JsonKey}
      */
     protected LinkedList<AnnotatedMember> _jsonKeyAccessors;
 
     /**
-     * Method(s) marked with 'JsonValue' annotation
+     *Accessors (field or "getter" method) annotated with {@link JsonValue}
      *<p>
      * NOTE: before 2.9, was `AnnotatedMethod`; with 2.9 allows fields too
      */
@@ -199,7 +201,7 @@ public class POJOPropertiesCollector
         // If @JsonKey defined, must have a single one
         if (_jsonKeyAccessors != null) {
             if (_jsonKeyAccessors.size() > 1) {
-                reportProblem("Multiple 'as-value' properties defined (%s vs %s)",
+                reportProblem("Multiple 'as-key' properties defined (%s vs %s)",
                         _jsonKeyAccessors.get(0),
                         _jsonKeyAccessors.get(1));
             }
@@ -407,7 +409,7 @@ public class POJOPropertiesCollector
 
         for (AnnotatedField f : _classDef.fields()) {
             // @JsonKey?
-            if (Boolean.TRUE.equals(ai.hasAsKey(f))) {
+            if (Boolean.TRUE.equals(ai.hasAsKey(_config, f))) {
                 if (_jsonKeyAccessors == null) {
                     _jsonKeyAccessors = new LinkedList<>();
                 }
@@ -626,7 +628,7 @@ public class POJOPropertiesCollector
             return;
         }
         // @JsonKey?
-        if (Boolean.TRUE.equals(ai.hasAsKey(m))) {
+        if (Boolean.TRUE.equals(ai.hasAsKey(_config, m))) {
             if (_jsonKeyAccessors == null) {
                 _jsonKeyAccessors = new LinkedList<>();
             }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BasicSerializerFactory.java
@@ -228,18 +228,30 @@ public abstract class BasicSerializerFactory
                     ser = StdKeySerializers.getStdKeySerializer(config, keyType.getRawClass(), false);
                     // As per [databind#47], also need to support @JsonValue
                     if (ser == null) {
-                        AnnotatedMember am = beanDesc.findJsonValueAccessor();
-                        if (am != null) {
-                            final Class<?> rawType = am.getRawType();
-                            JsonSerializer<?> delegate = StdKeySerializers.getStdKeySerializer(config,
-                                    rawType, true);
+                        AnnotatedMember keyAm = beanDesc.findJsonKeyAccessor();
+                        if (keyAm != null) {
+                            final Class<?> rawType = keyAm.getRawType();
+                            JsonSerializer<?> delegate = createKeySerializer(ctxt, config.constructType(rawType), null);
                             if (config.canOverrideAccessModifiers()) {
-                                ClassUtil.checkAndFixAccess(am.getMember(),
+                                ClassUtil.checkAndFixAccess(keyAm.getMember(),
                                         config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
                             }
-                            ser = new JsonValueSerializer(am, delegate);
-                        } else {
-                            ser = StdKeySerializers.getFallbackKeySerializer(config, keyType.getRawClass());
+                            ser = new JsonValueSerializer(keyAm, delegate);
+                        }
+                        if (ser == null) {
+                            AnnotatedMember am = beanDesc.findJsonValueAccessor();
+                            if (am != null) {
+                                final Class<?> rawType = am.getRawType();
+                                JsonSerializer<?> delegate = StdKeySerializers.getStdKeySerializer(config,
+                                        rawType, true);
+                                if (config.canOverrideAccessModifiers()) {
+                                    ClassUtil.checkAndFixAccess(am.getMember(),
+                                            config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
+                                }
+                                ser = new JsonValueSerializer(am, delegate);
+                            } else {
+                                ser = StdKeySerializers.getFallbackKeySerializer(config, keyType.getRawClass());
+                            }
                         }
                     }
                 }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/MapSerializingTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/MapSerializingTest.java
@@ -1,0 +1,79 @@
+package com.fasterxml.jackson.databind.jsontype;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class MapSerializingTest {
+	class Inner {
+		@JsonKey
+		String key;
+
+		@JsonValue
+		String value;
+
+		Inner(String key, String value) {
+			this.key = key;
+			this.value = value;
+		}
+
+		public String toString() {
+			return "Inner(" + this.key + "," + this.value + ")";
+		}
+
+	}
+
+	class Outer {
+		@JsonKey
+		@JsonValue
+		Inner inner;
+
+		Outer(Inner inner) {
+			this.inner = inner;
+		}
+
+	}
+
+	class NoKeyOuter {
+		@JsonValue
+		Inner inner;
+
+		NoKeyOuter(Inner inner) {
+			this.inner = inner;
+		}
+	}
+
+	@Ignore
+	@Test
+	public void testClassAsKey() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		Outer outer = new Outer(new Inner("innerKey", "innerValue"));
+		Map<Outer, String> map = Collections.singletonMap(outer, "value");
+		String actual = mapper.writeValueAsString(map);
+		Assert.assertEquals("{\"innerKey\":\"value\"}", actual);
+	}
+
+	@Ignore
+	@Test
+	public void testClassAsValue() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		Map<String, Outer> mapA = Collections.singletonMap("key", new Outer(new Inner("innerKey", "innerValue")));
+		String actual = mapper.writeValueAsString(mapA);
+		Assert.assertEquals("{\"key\":\"innerValue\"}", actual);
+	}
+
+	@Ignore
+	@Test
+	public void testNoKeyOuter() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		Map<String, NoKeyOuter> mapA = Collections.singletonMap("key", new NoKeyOuter(new Inner("innerKey", "innerValue")));
+		String actual = mapper.writeValueAsString(mapA);
+		Assert.assertEquals("{\"key\":\"innerValue\"}", actual);
+	}
+}

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/MapSerializingTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/MapSerializingTest.java
@@ -48,8 +48,7 @@ public class MapSerializingTest {
 			this.inner = inner;
 		}
 	}
-
-	@Ignore
+	
 	@Test
 	public void testClassAsKey() throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
@@ -59,7 +58,6 @@ public class MapSerializingTest {
 		Assert.assertEquals("{\"innerKey\":\"value\"}", actual);
 	}
 
-	@Ignore
 	@Test
 	public void testClassAsValue() throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
@@ -68,7 +66,6 @@ public class MapSerializingTest {
 		Assert.assertEquals("{\"key\":\"innerValue\"}", actual);
 	}
 
-	@Ignore
 	@Test
 	public void testNoKeyOuter() throws Exception {
 		ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
When serializing the key of a Map, look for a `@JsonKey` annotation.
When present (taking priority over `@JsonValue`), skip the
StdKey:Serializer and attempt to find a serializer for the inner type.

Depends on https://github.com/FasterXML/jackson-annotations/pull/179

Fixes #2871