### PR TITLE
Make some java platform modules optional

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
@@ -25,8 +25,9 @@ public abstract class Java7Handlers
         } catch (Throwable t) {
             // 09-Sep-2019, tatu: Could choose not to log this, but since this is less likely
             //    to miss (than annotations), do it
-            java.util.logging.Logger.getLogger(Java7Handlers.class.getName())
-                .warning("Unable to load JDK7 types (java.nio.file.Path): no Java7 type support added");
+            // 02-Nov-2020, Xakep_SDK: Remove java.logging module dependency
+//            java.util.logging.Logger.getLogger(Java7Handlers.class.getName())
+//                .warning("Unable to load JDK7 types (java.nio.file.Path): no Java7 type support added");
         }
         IMPL = impl;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -40,6 +40,8 @@ public class OptionalHandlerFactory implements java.io.Serializable
     // // Since 2.7, we will assume DOM classes are always found, both due to JDK 1.6 minimum
     // // and because Android (and presumably GAE) have these classes
 
+    // // 02-Nov-2020, Xakep_SDK: java.xml module classes may be missing
+    // // in actual runtime, if module java.xml is not present
     private final static Class<?> CLASS_DOM_NODE;
     private final static Class<?> CLASS_DOM_DOCUMENT;
 

--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -1,8 +1,5 @@
 package com.fasterxml.jackson.databind.ext;
 
-import java.util.logging.Logger;
-import java.util.logging.Level;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.fasterxml.jackson.databind.ser.Serializers;
@@ -53,8 +50,9 @@ public class OptionalHandlerFactory implements java.io.Serializable
             doc = org.w3c.dom.Document.class;
         } catch (Throwable e) {
             // not optimal but will do
-            Logger.getLogger(OptionalHandlerFactory.class.getName())
-                .log(Level.INFO, "Could not load DOM `Node` and/or `Document` classes: no DOM support");
+            // 02-Nov-2020, Xakep_SDK: Remove java.logging module dependency
+//            Logger.getLogger(OptionalHandlerFactory.class.getName())
+//                .log(Level.INFO, "Could not load DOM `Node` and/or `Document` classes: no DOM support");
         }
         CLASS_DOM_NODE = node;
         CLASS_DOM_DOCUMENT = doc;

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -7,7 +7,7 @@ module com.fasterxml.jackson.databind {
     // these types were suggested as transitive, but aren't actually
     // exposed externally (only within internal APIs)
     requires java.sql;
-    requires java.xml;
+    requires static java.xml;
 
     exports com.fasterxml.jackson.databind;
     exports com.fasterxml.jackson.databind.annotation;

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -6,7 +6,7 @@ module com.fasterxml.jackson.databind {
     requires transitive com.fasterxml.jackson.core;
     // these types were suggested as transitive, but aren't actually
     // exposed externally (only within internal APIs)
-    requires java.sql;
+    requires static java.sql;
     requires static java.xml;
 
     exports com.fasterxml.jackson.databind;

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,6 +1,10 @@
 // Generated 08-Mar-2019 using Moditect maven plugin
 module com.fasterxml.jackson.databind {
-    requires java.desktop;
+    // required for
+    // java.beans.ConstructorProperties
+    // java.beans.Transient
+    // support
+    requires static java.desktop;
 
     requires transitive com.fasterxml.jackson.annotation;
     requires transitive com.fasterxml.jackson.core;

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,7 +1,6 @@
 // Generated 08-Mar-2019 using Moditect maven plugin
 module com.fasterxml.jackson.databind {
     requires java.desktop;
-    requires java.logging;
 
     requires transitive com.fasterxml.jackson.annotation;
     requires transitive com.fasterxml.jackson.core;


### PR DESCRIPTION
What i did:
1. Removed `java.logging` module, looks like it's not required at all
2. Made `java.desktop` module static
3. Made `java.xml` module static
4. Made `java.sql` module static, some changes in `DateDeserializers.java` were required

What i tested:
Env: Arch Linux, OpenJDK 14 (openjdk version "14.0.2" 2020-07-14)
1. `mvn package -P java14+` - compiles, all tests passed
2. `mvn package -P moditect,java14` - moditect plugin fails, happens for me on master too

Env: Arch Linux, OpenJDK 1.8 (openjdk version "1.8.0_265")
1. `mvn package` - compiles, all tests passed
2. `mvn package -P moditect` - moditect plugin fails, happens for me on master too
3. `mvn package -P java14+` - invalid flag --release
4. `mvn package -P moditect,java14+` - moditect plugin fails, happens for me on master too

Help wanted:
Not tested in environment without `java.desktop`, `java.xml` and `java.sql` modules
TODO: Test in environment without static modules
TODO: Make sure tests are running only if modules present

Fixes https://github.com/FasterXML/jackson-databind/issues/2910