### PR TITLE
Remove java8 API invocation from AnnotatedConstructor

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
@@ -165,7 +165,8 @@ public final class AnnotatedConstructor
 
     @Override
     public String toString() {
-        final int argCount = _constructor.getParameterCount();
+        // 03-Nov-2020 ckozak: This can use _constructor.getParameterCount() once java 8 is required.
+        final int argCount = _constructor.getParameterTypes().length;
         return String.format("[constructor for %s (%d arg%s), annotations: %s",
                 ClassUtil.nameOf(_constructor.getDeclaringClass()), argCount,
                 (argCount == 1) ? "" : "s", _annotations);


### PR DESCRIPTION
[getParameterCount](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Constructor.html#getParameterCount--) was added in java 8. We can pay the cost of an array allocation in the toString method.