### PR TITLE
Fix an edge case in MethodGenericTypeResolver validation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolver.java
@@ -190,7 +190,10 @@ final class MethodGenericTypeResolver
             return false;
         }
         ParameterizedType parameterized = maybeGetParameterizedType(type);
-        if (parameterized != null) {
+        if (parameterized != null
+                // 09-Nov-2020, ckozak: Validate equivalent parameters if possible, however when types do not
+                // exactly match, there's not much validation we can reasonably do.
+                && Objects.equals(boundType.getRawClass(), parameterized.getRawType())) {
             Type[] typeArguments = parameterized.getActualTypeArguments();
             TypeBindings bindings = boundType.getBindings();
             if (bindings.size() != typeArguments.length) {


### PR DESCRIPTION
This was discovered while testing an internal project against
2.12.0-rc2-SNAPSHOT. The new test is a minimal reproducer based
very closely on a collection which failed deserialization.