### PR TITLE
AnnotatedCreatorCollector avoids processing synthetic methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
@@ -195,7 +195,7 @@ final class AnnotatedCreatorCollector
 
         // First find all potentially relevant static methods
         for (Method m : ClassUtil.getClassMethods(type.getRawClass())) {
-            if (!Modifier.isStatic(m.getModifiers())) {
+            if (!_isIncludableFactoryMethod(m)) {
                 continue;
             }
             // all factory methods are fine:
@@ -233,7 +233,7 @@ final class AnnotatedCreatorCollector
         if (primaryMixIn != null) {
             MemberKey[] methodKeys = null;
             for (Method mixinFactory : primaryMixIn.getDeclaredMethods()) {
-                if (!Modifier.isStatic(mixinFactory.getModifiers())) {
+                if (!_isIncludableFactoryMethod(mixinFactory)) {
                     continue;
                 }
                 if (methodKeys == null) {
@@ -268,6 +268,14 @@ final class AnnotatedCreatorCollector
             }
         }
         return result;
+    }
+
+    private static boolean _isIncludableFactoryMethod(Method m)
+    {
+        return Modifier.isStatic(m.getModifiers())
+                // 09-Nov-2020, ckozak: Avoid considering synthetic methods such as
+                // lambdas used within methods because they're not relevant.
+                && !m.isSynthetic();
     }
 
     protected AnnotatedConstructor constructDefaultConstructor(ClassUtil.Ctor ctor,

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
@@ -174,7 +174,7 @@ public class AnnotatedMethodCollector
         }
     }
 
-    private boolean _isIncludableMemberMethod(Method m)
+    private static boolean _isIncludableMemberMethod(Method m)
     {
         if (Modifier.isStatic(m.getModifiers())
                 // Looks like generics can introduce hidden bridge and/or synthetic methods.


### PR DESCRIPTION
This implementation matches the `AnnotatedMethodCollector` which
also avoids synthetic methods. In the debugger I found most
iterations through `_findPotentialFactories` were checking synthetic
methods from lambdas rather than human-declared methods.