### PR TITLE
Replace `str.length() == 0` with `str.isEmpty()` where possible

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java
@@ -376,7 +376,7 @@ public class JsonMappingException
             // [databind#2128]: try to avoid duplication
             String msg = ClassUtil.exceptionMessage(src);
             // Let's use a more meaningful placeholder if all we have is null
-            if (msg == null || msg.length() == 0) {
+            if (msg == null || msg.isEmpty()) {
                 msg = "(was "+src.getClass().getName()+")";
             }
             // 17-Aug-2015, tatu: Let's also pass the processor (parser/generator) along

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyName.java
@@ -89,7 +89,7 @@ public class PropertyName
      */
     public static PropertyName construct(String simpleName)
     {
-        if (simpleName == null || simpleName.length() == 0) {
+        if (simpleName == null || simpleName.isEmpty()) {
             return USE_DEFAULT;
         }
         return new PropertyName(InternCache.instance.intern(simpleName), null);
@@ -100,7 +100,7 @@ public class PropertyName
         if (simpleName == null) {
             simpleName = "";
         }
-        if (ns == null && simpleName.length() == 0) {
+        if (ns == null && simpleName.isEmpty()) {
             return USE_DEFAULT;
         }
         return new PropertyName(InternCache.instance.intern(simpleName), ns);
@@ -108,7 +108,7 @@ public class PropertyName
 
     public PropertyName internSimpleName()
     {
-        if (_simpleName.length() == 0) { // empty String is canonical already
+        if (_simpleName.isEmpty()) { // empty String is canonical already
             return this;
         }
         String interned = InternCache.instance.intern(_simpleName);
@@ -182,7 +182,7 @@ public class PropertyName
     }
 
     public boolean hasSimpleName() {
-        return _simpleName.length() > 0;
+        return !_simpleName.isEmpty();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -293,7 +293,7 @@ public abstract class PropertyNamingStrategies
          */
         @Override
         public String translate(String input) {
-            if (input == null || input.length() == 0){
+            if (input == null || input.isEmpty()){
                 return input; // garbage in, garbage out
             }
             // Replace first lower-case letter with upper-case equivalent

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java
@@ -329,7 +329,7 @@ public class PropertyNamingStrategy // NOTE: was abstract until 2.7
          */
         @Override
         public String translate(String input) {
-            if (input == null || input.length() == 0){
+            if (input == null || input.isEmpty()){
                 return input; // garbage in, garbage out
             }
             // Replace first lower-case letter with upper-case equivalent

--- a/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ValueInstantiator.java
@@ -423,7 +423,7 @@ public abstract class ValueInstantiator
             throws IOException
     {
         // also, empty Strings might be accepted as null Object...
-        if (value.length() == 0) {
+        if (value.isEmpty()) {
             if (ctxt.isEnabled(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)) {
                 return null;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/DateDeserializers.java
@@ -177,7 +177,7 @@ public class DateDeserializers
             if (_customFormat != null) {
                 if (p.hasToken(JsonToken.VALUE_STRING)) {
                     String str = p.getText().trim();
-                    if (str.length() == 0) {
+                    if (str.isEmpty()) {
                         final CoercionAction act = _checkFromStringCoercion(ctxt, str);
                         switch (act) { // note: Fail handled above
                         case AsEmpty:

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -271,9 +271,9 @@ public class EnumDeserializer
             CompactStringObjectMap lookup, String nameOrig) throws IOException
     {
         String name = nameOrig.trim();
-        if (name.length() == 0) { // empty or blank
+        if (name.isEmpty()) { // empty or blank
             CoercionAction act;
-            if (nameOrig.length() == 0) { 
+            if (nameOrig.isEmpty()) {
                 act = _findCoercionFromEmptyString(ctxt);
                 act = _checkCoercionFail(ctxt, act, handledType(), nameOrig,
                         "empty String (\"\")");

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
@@ -150,7 +150,7 @@ public abstract class FromStringDeserializer<T> extends StdScalarDeserializer<T>
             // 29-Jun-2020, tatu: New! "Scalar from Object" (mostly for XML)
             text = ctxt.extractScalarFromObject(p, this, _valueClass);
         }
-        if (text.length() == 0 || (text = text.trim()).length() == 0) {
+        if (text.isEmpty() || (text = text.trim()).isEmpty()) {
             // 09-Jun-2020, tatu: Commonly `null` but may coerce to "empty" as well
             return (T) _deserializeFromEmptyString(ctxt);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -264,7 +264,7 @@ public abstract class StdDeserializer<T>
         if ((inst != null) && inst.canCreateFromString()) {
             return (T) inst.createFromString(ctxt, value);
         }
-        if (value.length() == 0) {
+        if (value.isEmpty()) {
             final CoercionAction act = ctxt.findCoercionAction(logicalType(), rawTargetType,
                     CoercionInputShape.EmptyString);
             return (T) _deserializeFromEmptyString(p, ctxt, act, rawTargetType,
@@ -1170,7 +1170,7 @@ public abstract class StdDeserializer<T>
     {
         try {
             // Take empty Strings to mean 'empty' Value, usually 'null':
-            if (value.length() == 0) {
+            if (value.isEmpty()) {
                 final CoercionAction act = _checkFromStringCoercion(ctxt, value);
                 switch (act) { // note: Fail handled above
                 case AsEmpty:
@@ -1285,7 +1285,7 @@ public abstract class StdDeserializer<T>
     {
         final CoercionAction act;
 
-        if (value.length() == 0) {
+        if (value.isEmpty()) {
             act = ctxt.findCoercionAction(logicalType, rawTargetType,
                     CoercionInputShape.EmptyString);
             return _checkCoercionFail(ctxt, act, rawTargetType, value,

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
@@ -279,7 +279,7 @@ public class AnnotationIntrospectorPair
     public String findTypeName(AnnotatedClass ac)
     {
         String name = _primary.findTypeName(ac);
-        if (name == null || name.length() == 0) {
+        if (name == null || name.isEmpty()) {
             name = _secondary.findTypeName(ac);                
         }
         return name;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -286,7 +286,7 @@ public class JacksonAnnotationIntrospector
             return null;
         }
         String ns = ann.namespace();
-        if (ns != null && ns.length() == 0) {
+        if (ns != null && ns.isEmpty()) {
             ns = null;
         }
         return PropertyName.construct(ann.value(), ns);
@@ -331,7 +331,7 @@ public class JacksonAnnotationIntrospector
         if (ann != null) {
             String id = ann.value();
             // Empty String is same as not having annotation, to allow overrides
-            if (id.length() > 0) {
+            if (!id.isEmpty()) {
                 return id;
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/NamedType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/NamedType.java
@@ -25,7 +25,7 @@ public final class NamedType implements java.io.Serializable
 
     public Class<?> getType() { return _class; }
     public String getName() { return _name; }
-    public void setName(String name) { _name = (name == null || name.length() == 0) ? null : name; }
+    public void setName(String name) { _name = (name == null || name.isEmpty()) ? null : name; }
 
     public boolean hasName() { return _name != null; }
     

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/MinimalClassNameIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/MinimalClassNameIdResolver.java
@@ -63,7 +63,7 @@ public class MinimalClassNameIdResolver
     {
         if (id.startsWith(".")) {
             StringBuilder sb = new StringBuilder(id.length() + _basePackageName.length());
-            if  (_basePackageName.length() == 0) {
+            if  (_basePackageName.isEmpty()) {
                 // no package; must remove leading '.' from id
                 sb.append(id.substring(1));
             } else {

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -233,7 +233,7 @@ public class StdTypeResolverBuilder
     @Override
     public StdTypeResolverBuilder typeProperty(String typeIdPropName) {
         // ok to have null/empty; will restore to use defaults
-        if (typeIdPropName == null || typeIdPropName.length() == 0) {
+        if (typeIdPropName == null || typeIdPropName.isEmpty()) {
             typeIdPropName = _idType.getDefaultPropertyName();
         }
         _typeProperty = typeIdPropName;

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -38,7 +38,7 @@ public class TextNode
         if (v == null) {
             return null;
         }
-        if (v.length() == 0) {
+        if (v.isEmpty()) {
             return EMPTY_STRING_NODE;
         }
         return new TextNode(v);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -849,7 +849,7 @@ public abstract class BeanSerializerBase
         JsonSerializableSchema ann = _handledType.getAnnotation(JsonSerializableSchema.class);
         if (ann != null) {
             String id = ann.id();
-            if (id != null && id.length() > 0) {
+            if (id != null && !id.isEmpty()) {
                 o.put("id", id);
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StringSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StringSerializer.java
@@ -33,7 +33,7 @@ public final class StringSerializer
     @Override
     public boolean isEmpty(SerializerProvider prov, Object value) {
         String str = (String) value;
-        return str.length() == 0;
+        return str.isEmpty();
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/util/NameTransformer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NameTransformer.java
@@ -38,8 +38,8 @@ public abstract class NameTransformer
      */
     public static NameTransformer simpleTransformer(final String prefix, final String suffix)
     {
-        boolean hasPrefix = (prefix != null) && (prefix.length() > 0);
-        boolean hasSuffix = (suffix != null) && (suffix.length() > 0);
+        boolean hasPrefix = (prefix != null) && !prefix.isEmpty();
+        boolean hasSuffix = (suffix != null) && !suffix.isEmpty();
 
         if (hasPrefix) {
             if (hasSuffix) {


### PR DESCRIPTION
This makes the code easier for humans to read, and allows the jvm
to optimize more code around method size inlining limits.

Unsure which branch is the best target for this sort of thing, feel free to
close out the PR if you'd rather avoid code churn. Just some cleanup
I noticed while contributing in other areas.