### PR TITLE
Issue#2926 method "setting(x)" shouldnot be treated as a setter

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/BeanUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/BeanUtil.java
@@ -241,6 +241,18 @@ public class BeanUtil
         char d = Character.toLowerCase(c);
         
         if (c == d) {
+
+            if(basename.length()  == offset + 1){
+                return null;
+            }
+
+            char c1 = basename.charAt(offset + 1);
+            char d1 = Character.toLowerCase(c1);
+
+            if(d1 == c1){
+                return null;
+            }
+
             return basename.substring(offset);
         }
         // otherwise, lower case initial chars. Common case first, just one char
@@ -272,6 +284,18 @@ public class BeanUtil
         char c0 = basename.charAt(offset);
         char c1 = Character.toLowerCase(c0);
         if (c0 == c1) {
+
+            if(basename.length()  == offset + 1){
+                return null;
+            }
+
+            char c2 = basename.charAt(offset + 1);
+            char c3 = Character.toLowerCase(c2);
+
+            if(c3 == c2){
+                return null;
+            }
+
             return basename.substring(offset);
         }
         // 17-Dec-2014, tatu: As per [databind#653], need to follow more

--- a/src/test/java/com/fasterxml/jackson/databind/util/BeanUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/BeanUtilTest.java
@@ -42,6 +42,15 @@ public class BeanUtilTest extends BaseMapTest
 
         assertEquals("url", BeanUtil.legacyManglePropertyName("getURL", 3));
         assertEquals("URL", BeanUtil.stdManglePropertyName("getURL", 3));
+
+        assertNull(BeanUtil.legacyManglePropertyName("setting", 3));
+        assertNull(BeanUtil.stdManglePropertyName("setting", 3));
+
+        assertEquals("setting", BeanUtil.legacyManglePropertyName("setSetting", 3));
+        assertEquals("setting", BeanUtil.stdManglePropertyName("setSetting", 3));
+
+        assertEquals("aField", BeanUtil.legacyManglePropertyName("setaField", 3));
+        assertEquals("aField", BeanUtil.stdManglePropertyName("setaField", 3));
     }
 
     public void testGetDefaultValue()


### PR DESCRIPTION
See [issue # 2926](https://github.com/FasterXML/jackson-databind/issues/2926)

- Do not treat `setting(xyz)` as a setter method (resulting in a property called `ting`)
- Kept backward compatibility by allowing setter `setaField()` (property `aField`)
