### PR TITLE
Use errorprone static analysis to detect bugs at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,103 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>errorprone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>
+                  -Xplugin:ErrorProne
+                  <!--
+                  Disable all checks in test code. Bugs in tests can hide runtime failures,
+                  however these can be enabled later on. Many issues may require sub-optional
+                  code to reproduce failures.
+                  -->
+                  -XepExcludedPaths:.*/src/test/java/.*
+
+                  <!-- ############### -->
+                  <!-- UPGRADED CHECKS -->
+                  <!-- ############### -->
+
+                  <!-- Boxed primitive equality checks can be dangerous when presented with unexpected inputs -->
+                  -Xep:BoxedPrimitiveEquality:ERROR
+
+                  <!-- ############### -->
+                  <!-- DISABLED CHECKS -->
+                  <!-- ############### -->
+
+                  <!-- UnusedVariable is great at catching mistakes quickly, but
+                  requires a few suppressions to avoid noise. Deferring to avoid noise
+                  with the introduction of ErrorProne. -->
+                  -Xep:UnusedVariable:OFF
+                  <!--
+                  Disabled to avoid potential API changes. It's not clear if custom JsonNode types
+                  exist, and if any do implement equals without hashCode, it's likely they cause bugs.
+                  I plan to try fixing this separately.
+                  -->
+                  -Xep:EqualsHashCode:OFF
+                  <!-- Style: javadoc tag validation -->
+                  -Xep:MissingSummary:OFF
+                  -Xep:InvalidInlineTag:OFF
+                  -Xep:EmptyBlockTag:OFF
+                  -Xep:AlmostJavadoc:OFF
+                  -Xep:InvalidLink:OFF
+                  <!-- Style: low reward for enabling. -->
+                  -Xep:UnnecessaryParentheses:OFF
+                  <!-- Style: low signal -->
+                  -Xep:InconsistentCapitalization:OFF
+                  <!-- Style: requires specific comments when switch branches neither break nor return -->
+                  -Xep:FallThrough:OFF
+                  <!-- Style: disable noisy check for importing common names from nested classes -->
+                  -Xep:BadImport:OFF
+                  <!-- Style: requires a default case when not all cases are handled -->
+                  -Xep:MissingCasesInEnumSwitch:OFF
+                  <!-- Style: avoid clashes with java.lang. Possibly worth enabling, but this can be done later -->
+                  -Xep:JavaLangClash:OFF
+                  <!-- These can likely be updated from protected to private, but it's relatively low signal -->
+                  -Xep:ProtectedMembersInFinalClass:OFF
+                  <!-- These can likely be updated from public to protected, but it's relatively low signal -->
+                  -Xep:PublicConstructorForAbstractClass:OFF
+                  <!-- jackson-databind doesn't have a logger, in many cases there's no way to pre-validate inputs -->
+                  -Xep:EmptyCatch:OFF
+                  -Xep:EqualsGetClass:OFF
+                  <!-- Noisy check that's largely unnecessary unless the result is mutated.
+                  Returning only immutable collections requires additional overhead and
+                  impact must be carefully considered. -->
+                  -Xep:MixedMutabilityReturnType:OFF
+                  <!-- Noisy in jackson and libraries which must interact with generics -->
+                  -Xep:TypeParameterUnusedInFormals:OFF
+                  <!-- Check is noisy around code that's meant to handle types that are considered obsolete -->
+                  -Xep:JdkObsolete:OFF
+                  <!-- Avoid noise from tests -->
+                  -Xep:JUnit3FloatingPointComparisonWithoutDelta:OFF
+                  <!-- Disable the StringSplitter check because it requires a guava dependency -->
+                  -Xep:StringSplitter:OFF
+                  <!-- Disable checks which require custom annotations -->
+                  -Xep:AnnotateFormatMethod:OFF
+                  -Xep:GuardedBy:OFF
+                  <!-- This check is generally high signal, however it is noisy in
+                  low level projects which implement caches and interning. -->
+                  -Xep:ReferenceEquality:OFF
+                </arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>2.4.0</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DataFormatReaders.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DataFormatReaders.java
@@ -248,7 +248,7 @@ public class DataFormatReaders
     /**
      * We need sub-class here as well, to be able to access efficiently.
      */
-    protected class AccessorForReader extends InputAccessor.Std
+    protected static class AccessorForReader extends InputAccessor.Std
     {
         public AccessorForReader(InputStream in, byte[] buffer) {
             super(in, buffer);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
@@ -499,7 +499,7 @@ public final class DeserializerCache
                     KeyDeserializer kd = ctxt.keyDeserializerInstance(a, kdDef);
                     if (kd != null) {
                         type = ((MapLikeType) type).withKeyValueHandler(kd);
-                        keyType = type.getKeyType(); // just in case it's used below
+                        // keyType = type.getKeyType(); // just in case it's used below
                     }
                 }
             }            
@@ -511,7 +511,7 @@ public final class DeserializerCache
                 if (cdDef != null) {
                     JsonDeserializer<?> cd = null;
                     if (cdDef instanceof JsonDeserializer<?>) {
-                        cdDef = (JsonDeserializer<?>) cdDef;
+                        cd = (JsonDeserializer<?>) cdDef;
                     } else {
                         Class<?> cdClass = _verifyAsClass(cdDef, "findContentDeserializer", JsonDeserializer.None.class);
                         if (cdClass != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/BeanPropertyMap.java
@@ -586,7 +586,7 @@ public class BeanPropertyMap
         }
         // no? secondary?
         int hashSize = _hashMask+1;
-        int ix = hashSize + (slot>>1) << 1;
+        int ix = (hashSize + (slot>>1)) << 1;
         match = _hashArea[ix];
         if (key.equals(match)) {
             return (SettableBeanProperty) _hashArea[ix+1];
@@ -627,7 +627,7 @@ public class BeanPropertyMap
     {
         // no? secondary?
         int hashSize = _hashMask+1;
-        int ix = hashSize + (slot>>1) << 1;
+        int ix = (hashSize + (slot>>1)) << 1;
         match = _hashArea[ix];
         if (key.equals(match)) {
             return (SettableBeanProperty) _hashArea[ix+1];

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -1,12 +1,7 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-import java.util.*;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
@@ -16,6 +11,9 @@ import com.fasterxml.jackson.databind.deser.impl.ReadableObjectId.Referring;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import java.io.IOException;
+import java.util.*;
+import java.util.Objects;
 
 /**
  * Basic serializer that can take JSON "Array" structure and
@@ -196,7 +194,7 @@ _containerType,
             valueTypeDeser = valueTypeDeser.forProperty(property);
         }
         NullValueProvider nuller = findContentNullProvider(ctxt, property, valueDeser);
-        if ((unwrapSingle != _unwrapSingle)
+        if ((!Objects.equals(unwrapSingle, _unwrapSingle))
                 || (nuller != _nullProvider)
                 || (delegateDeser != _delegateDeserializer)
                 || (valueDeser != _valueDeserializer)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -1,11 +1,7 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
@@ -18,6 +14,8 @@ import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.databind.util.CompactStringObjectMap;
 import com.fasterxml.jackson.databind.util.EnumResolver;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Deserializer class that can deserialize instances of
@@ -136,7 +134,7 @@ public class EnumDeserializer
      * @since 2.9
      */
     public EnumDeserializer withResolved(Boolean caseInsensitive) {
-        if (_caseInsensitive == caseInsensitive) {
+        if (Objects.equals(_caseInsensitive, caseInsensitive)) {
             return this;
         }
         return new EnumDeserializer(this, caseInsensitive);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumSetDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumSetDeserializer.java
@@ -1,8 +1,5 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-import java.util.*;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
@@ -12,6 +9,9 @@ import com.fasterxml.jackson.databind.deser.impl.NullsConstantProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.AccessPattern;
+import java.io.IOException;
+import java.util.*;
+import java.util.Objects;
 
 /**
  * Standard deserializer for {@link EnumSet}s.
@@ -116,7 +116,7 @@ public class EnumSetDeserializer
      */
     public EnumSetDeserializer withResolved(JsonDeserializer<?> deser, NullValueProvider nuller,
             Boolean unwrapSingle) {
-        if ((_unwrapSingle == unwrapSingle) && (_enumDeserializer == deser) && (_nullProvider == deser)) {
+        if ((Objects.equals(_unwrapSingle, unwrapSingle)) && (_enumDeserializer == deser) && (_nullProvider == deser)) {
             return this;
         }
         return new EnumSetDeserializer(this, deser, nuller, unwrapSingle);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -1,12 +1,7 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-import java.lang.reflect.Array;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
@@ -16,6 +11,9 @@ import com.fasterxml.jackson.databind.type.ArrayType;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.AccessPattern;
 import com.fasterxml.jackson.databind.util.ObjectBuffer;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.Objects;
 
 /**
  * Basic serializer that can serialize non-primitive arrays.
@@ -105,7 +103,7 @@ public class ObjectArrayDeserializer
     public ObjectArrayDeserializer withResolved(TypeDeserializer elemTypeDeser,
             JsonDeserializer<?> elemDeser, NullValueProvider nuller, Boolean unwrapSingle)
     {
-        if ((unwrapSingle == _unwrapSingle) && (nuller == _nullProvider)
+        if ((Objects.equals(unwrapSingle, _unwrapSingle)) && (nuller == _nullProvider)
                 && (elemDeser == _elementDeserializer)
                 && (elemTypeDeser == _elementTypeDeserializer)) {
             return this;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/PrimitiveArrayDeserializers.java
@@ -1,9 +1,5 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-import java.lang.reflect.Array;
-import java.util.Arrays;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.*;
@@ -18,6 +14,10 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.AccessPattern;
 import com.fasterxml.jackson.databind.util.ArrayBuilders;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Container for deserializers used for instantiating "primitive arrays",
@@ -118,7 +118,7 @@ public abstract class PrimitiveArrayDeserializers<T> extends StdDeserializer<T>
                 nuller = NullsFailProvider.constructForProperty(property, property.getType().getContentType());
             }
         }
-        if ((unwrapSingle == _unwrapSingle) && (nuller == _nuller)) {
+        if ((Objects.equals(unwrapSingle, _unwrapSingle)) && (nuller == _nuller)) {
             return this;
         }
         return withResolved(nuller, unwrapSingle);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -1463,7 +1463,7 @@ inputDesc, _coercedTypeDesc());
     {
         String enableDesc = state ? "enable" : "disable";
         ctxt.reportInputMismatch(this, "Cannot coerce %s to Null value as %s (%s `%s.%s` to allow)",
-            inputDesc, _coercedTypeDesc(), enableDesc, feature.getClass().getSimpleName(), feature.name());
+            inputDesc, _coercedTypeDesc(), enableDesc, feature.getDeclaringClass().getSimpleName(), feature.name());
     }
 
     /**
@@ -1524,7 +1524,7 @@ inputDesc, _coercedTypeDesc());
         MapperFeature feat = MapperFeature.ALLOW_COERCION_OF_SCALARS;
         if (!ctxt.isEnabled(feat)) {
             ctxt.reportInputMismatch(this, "Cannot coerce String \"%s\" to %s (enable `%s.%s` to allow)",
-                str, _coercedTypeDesc(), feat.getClass().getSimpleName(), feat.name());
+                str, _coercedTypeDesc(), feat.getDeclaringClass().getSimpleName(), feat.name());
         }
     }
 
@@ -1579,7 +1579,7 @@ inputDesc, _coercedTypeDesc());
             //   access as a String: may require re-encoding by parser which should be fine
             String valueDesc = p.getText();
             ctxt.reportInputMismatch(this, "Cannot coerce Number (%s) to %s (enable `%s.%s` to allow)",
-                valueDesc, _coercedTypeDesc(), feat.getClass().getSimpleName(), feat.name());
+                valueDesc, _coercedTypeDesc(), feat.getDeclaringClass().getSimpleName(), feat.name());
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -398,7 +398,7 @@ public abstract class StdDeserializer<T>
             // may accept ints too, (0 == false, otherwise true)
 
             // call returns `null`, Boolean.TRUE or Boolean.FALSE so:
-            return _coerceBooleanFromInt(p, ctxt, Boolean.TYPE) == Boolean.TRUE;
+            return Boolean.TRUE.equals(_coerceBooleanFromInt(p, ctxt, Boolean.TYPE));
         case JsonTokenId.ID_TRUE: // usually caller should have handled but:
             return true;
         case JsonTokenId.ID_FALSE:

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
@@ -1,7 +1,5 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
@@ -13,6 +11,8 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.AccessPattern;
 import com.fasterxml.jackson.databind.util.ObjectBuffer;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Separate implementation for serializing String arrays (instead of
@@ -123,7 +123,7 @@ public final class StringArrayDeserializer
             deser = null;
         }
         if ((_elementDeserializer == deser)
-                && (_unwrapSingle == unwrapSingle)
+                && (Objects.equals(_unwrapSingle, unwrapSingle))
                 && (_nullProvider == nuller)) {
             return this;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -1,8 +1,5 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import java.io.IOException;
-import java.util.Collection;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
@@ -13,6 +10,9 @@ import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Specifically optimized version for {@link java.util.Collection}s
@@ -77,7 +77,7 @@ public final class StringCollectionDeserializer
             JsonDeserializer<?> valueDeser,
             NullValueProvider nuller, Boolean unwrapSingle)
     {
-        if ((_unwrapSingle == unwrapSingle) && (_nullProvider == nuller)
+        if ((Objects.equals(_unwrapSingle, unwrapSingle)) && (_nullProvider == nuller)
                 && (_valueDeserializer == valueDeser) && (_delegateDeserializer == delegateDeser)) {
             return this;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -183,7 +183,7 @@ public class JacksonAnnotationIntrospector
         //   reasons, including odd representation JVM uses); has to do for now
         try {
             // We know that values are actually static fields with matching name so:
-            Field f = value.getClass().getField(value.name());
+            Field f = value.getDeclaringClass().getField(value.name());
             if (f != null) {
                 JsonProperty prop = f.getAnnotation(JsonProperty.class);
                 if (prop != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/MethodGenericTypeResolver.java
@@ -116,7 +116,7 @@ final class MethodGenericTypeResolver
                             // No way to satisfy the requested type.
                             return null;
                         }
-                        if (existingIsSubtype ^ newIsSubtype && newIsSubtype) {
+                        if ((existingIsSubtype ^ newIsSubtype) && newIsSubtype) {
                             // If the new type is more specific than the existing type, the new type replaces the old.
                             types.set(existingIndex, bindTarget);
                         }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringArraySerializer.java
@@ -1,20 +1,20 @@
 package com.fasterxml.jackson.databind.ser.impl;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.ContainerSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.std.ArraySerializerBase;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Objects;
 
 /**
  * Standard serializer used for <code>String[]</code> values.
@@ -116,7 +116,7 @@ public class StringArraySerializer
             ser = null;
         }
         // note: will never have TypeSerializer, because Strings are "natural" type
-        if ((ser == _elementSerializer) && (unwrapSingle == _unwrapSingle)) {
+        if ((ser == _elementSerializer) && (Objects.equals(unwrapSingle, _unwrapSingle))) {
             return this;
         }
         return new StringArraySerializer(this, property, ser, unwrapSingle);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ArraySerializerBase.java
@@ -1,13 +1,13 @@
 package com.fasterxml.jackson.databind.ser.std;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.*;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Intermediate base class for serializers used for various
@@ -98,7 +98,7 @@ public abstract class ArraySerializerBase<T>
             JsonFormat.Value format = findFormatOverrides(serializers, property, handledType());
             if (format != null) {
                 unwrapSingle = format.getFeature(JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
-                if (unwrapSingle != _unwrapSingle) {
+                if (!Objects.equals(unwrapSingle, _unwrapSingle)) {
                     return _withResolved(property, unwrapSingle);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -1,10 +1,6 @@
 package com.fasterxml.jackson.databind.ser.std;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.*;
@@ -16,6 +12,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.ContainerSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Objects;
 
 /**
  * Base class for serializers that will output contents as JSON
@@ -210,7 +209,7 @@ public abstract class AsArraySerializerBase<T>
         if ((ser != _elementSerializer)
                 || (property != _property)
                 || (_valueTypeSerializer != typeSer)
-                || (_unwrapSingle != unwrapSingle)) {
+                || (!Objects.equals(_unwrapSingle, unwrapSingle))) {
             return withResolved(property, typeSer, ser, unwrapSingle);
         }
         return this;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
@@ -1,14 +1,8 @@
 package com.fasterxml.jackson.databind.ser.std;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.*;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
-
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
@@ -17,6 +11,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.util.EnumValues;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.Objects;
 
 /**
  * Standard serializer used for {@link java.lang.Enum} types.
@@ -94,7 +92,7 @@ public class EnumSerializer
             Class<?> type = handledType();
             Boolean serializeAsIndex = _isShapeWrittenUsingIndex(type,
                     format, false, _serializeAsIndex);
-            if (serializeAsIndex != _serializeAsIndex) {
+            if (!Objects.equals(serializeAsIndex, _serializeAsIndex)) {
                 return new EnumSerializer(_values, serializeAsIndex);
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ObjectArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ObjectArraySerializer.java
@@ -1,11 +1,7 @@
 package com.fasterxml.jackson.databind.ser.std;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
@@ -15,6 +11,8 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.ContainerSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Generic serializer for Object arrays (<code>Object[]</code>).
@@ -109,7 +107,7 @@ public class ObjectArraySerializer
     public ObjectArraySerializer withResolved(BeanProperty prop,
             TypeSerializer vts, JsonSerializer<?> ser, Boolean unwrapSingle) {
         if ((_property == prop) && (ser == _elementSerializer)
-                && (_valueTypeSerializer == vts) && (_unwrapSingle == unwrapSingle)) {
+                && (_valueTypeSerializer == vts) && (Objects.equals(_unwrapSingle, unwrapSingle))) {
             return this;
         }
         return new ObjectArraySerializer(this, prop, vts, ser, unwrapSingle);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StaticListSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StaticListSerializerBase.java
@@ -1,9 +1,5 @@
 package com.fasterxml.jackson.databind.ser.std;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.*;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
@@ -12,6 +8,10 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonArrayFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.Objects;
 
 /**
  * Intermediate base class for Lists, Collections and Arrays
@@ -87,7 +87,7 @@ public abstract class StaticListSerializerBase<T extends Collection<?>>
         }
         // Optimization: default serializer just writes String, so we can avoid a call:
         if (isDefaultSerializer(ser)) {
-            if (unwrapSingle == _unwrapSingle) {
+            if (Objects.equals(unwrapSingle, _unwrapSingle)) {
                 return this;
             }
             return _withResolved(property, unwrapSingle);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/UUIDSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/UUIDSerializer.java
@@ -1,8 +1,5 @@
 package com.fasterxml.jackson.databind.ser.std;
 
-import java.io.IOException;
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
@@ -10,6 +7,9 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrappe
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Specialized {@link JsonSerializer} to output {@link java.util.UUID}s.
@@ -72,7 +72,7 @@ public class UUIDSerializer
             }
             // otherwise leave as `null` meaning about same as NATURAL
         }
-        if (asBinary != _asBinary) {
+        if (!Objects.equals(asBinary, _asBinary)) {
             return new UUIDSerializer(asBinary);
         }
         return this;

--- a/src/main/java/com/fasterxml/jackson/databind/util/ArrayIterator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ArrayIterator.java
@@ -7,6 +7,7 @@ import java.util.NoSuchElementException;
  * Iterator implementation used to efficiently expose contents of an
  * Array as read-only iterator.
  */
+@SuppressWarnings("IterableAndIterator")
 public class ArrayIterator<T> implements Iterator<T>, Iterable<T>
 {
     private final T[] _a;

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -1049,15 +1049,10 @@ public final class ClassUtil
      * class of enum instance (for "simple" enumerations), or its
      * superclass (for enums with instance fields or methods)
      */
-    @SuppressWarnings("unchecked")
     public static Class<? extends Enum<?>> findEnumType(Enum<?> en)
     {
         // enums with "body" are sub-classes of the formal type
-    	Class<?> ec = en.getClass();
-    	if (ec.getSuperclass() != Enum.class) {
-    	    ec = ec.getSuperclass();
-    	}
-    	return (Class<? extends Enum<?>>) ec;
+        return en.getDeclaringClass();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/util/CompactStringObjectMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/CompactStringObjectMap.java
@@ -112,7 +112,7 @@ public final class CompactStringObjectMap
             return null;
         }
         int hashSize = _hashMask+1;
-        int ix = hashSize + (slot>>1) << 1;
+        int ix = (hashSize + (slot>>1)) << 1;
         match = _hashArea[ix];
         if (key.equals(match)) {
             return _hashArea[ix+1];

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -158,7 +158,7 @@ public class TokenBuffer
         _hasNativeTypeIds = hasNativeIds;
         _hasNativeObjectIds = hasNativeIds;
 
-        _mayHaveNativeIds = _hasNativeTypeIds | _hasNativeObjectIds;
+        _mayHaveNativeIds = _hasNativeTypeIds || _hasNativeObjectIds;
     }
 
     /**
@@ -182,7 +182,7 @@ public class TokenBuffer
         _appendAt = 0;
         _hasNativeTypeIds = p.canReadTypeId();
         _hasNativeObjectIds = p.canReadObjectId();
-        _mayHaveNativeIds = _hasNativeTypeIds | _hasNativeObjectIds;
+        _mayHaveNativeIds = _hasNativeTypeIds || _hasNativeObjectIds;
         _forceBigDecimal = (ctxt == null) ? false
                 : ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     }
@@ -322,7 +322,7 @@ public class TokenBuffer
         if (!_hasNativeObjectIds) {
             _hasNativeObjectIds = other.canWriteObjectId();
         }
-        _mayHaveNativeIds = _hasNativeTypeIds | _hasNativeObjectIds;
+        _mayHaveNativeIds = _hasNativeTypeIds || _hasNativeObjectIds;
         
         JsonParser p = other.asParser();
         while (p.nextToken() != null) {
@@ -1495,7 +1495,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             _parsingContext = TokenBufferReadContext.createRootContext(parentContext);
             _hasNativeTypeIds = hasNativeTypeIds;
             _hasNativeObjectIds = hasNativeObjectIds;
-            _hasNativeIds = (hasNativeTypeIds | hasNativeObjectIds);
+            _hasNativeIds = (hasNativeTypeIds || hasNativeObjectIds);
         }
 
         public void setLocation(JsonLocation l) {

--- a/src/test/java/com/fasterxml/jackson/databind/convert/TestArrayConversions.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/TestArrayConversions.java
@@ -96,28 +96,31 @@ public class TestArrayConversions
         // Byte overflow
         try {
             MAPPER.convertValue(new int[] { 1000 }, byte[].class);
+            fail("Expected an exception");
         } catch (IllegalArgumentException e) {
             verifyException(e, OVERFLOW_MSG_BYTE);
         }
         // Short overflow
         try {
             MAPPER.convertValue(new int[] { -99999 }, short[].class);
+            fail("Expected an exception");
         } catch (IllegalArgumentException e) {
             verifyException(e, OVERFLOW_MSG_SHORT);
         }
         // Int overflow
         try {
             MAPPER.convertValue(new long[] { Long.MAX_VALUE }, int[].class);
+            fail("Expected an exception");
         } catch (IllegalArgumentException e) {
             verifyException(e, OVERFLOW_MSG_INT);
         }
         // Longs need help of BigInteger...
-        BigInteger biggie = BigInteger.valueOf(Long.MAX_VALUE);
-        biggie.add(BigInteger.ONE);
+        BigInteger biggie = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);;
         List<BigInteger> l = new ArrayList<BigInteger>();
         l.add(biggie);
         try {
             MAPPER.convertValue(l, long[].class);
+            fail("Expected an exception");
         } catch (IllegalArgumentException e) {
             verifyException(e, OVERFLOW_MSG_LONG);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UntypedDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UntypedDeserializationTest.java
@@ -186,7 +186,7 @@ public class UntypedDeserializationTest
         // and that's all folks!
     }
 
-    @SuppressWarnings("unlikely-arg-type")
+    @SuppressWarnings({"unlikely-arg-type", "CollectionIncompatibleType"})
     public void testUntypedMap() throws Exception
     {
         // to get "untyped" default map-to-map, pass Object.class

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestConfig.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestConfig.java
@@ -198,7 +198,7 @@ public class TestConfig
     {
         ObjectMapper mapper = new ObjectMapper();
         TimeZone tz1 = TimeZone.getTimeZone("America/Los_Angeles");
-        TimeZone tz2 = TimeZone.getTimeZone("Central Standard Time");
+        TimeZone tz2 = TimeZone.getTimeZone("US/Central");
 
         // sanity checks
         assertEquals(tz1, tz1);

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestJavaType.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestJavaType.java
@@ -200,6 +200,7 @@ public class TestJavaType
         assertFalse(enumSubT.getRawClass().isEnum());
     }
 
+    @SuppressWarnings("SelfComparison")
     public void testClassKey()
     {
         ClassKey key = new ClassKey(String.class);

--- a/src/test/java/com/fasterxml/jackson/databind/util/ClassUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ClassUtilTest.java
@@ -32,7 +32,15 @@ public class ClassUtilTest extends BaseMapTest
 
     interface SubInt extends BaseInt { }
 
-    enum TestEnum { A; }
+    enum TestEnum {
+        A,
+        B {
+            @Override
+            public String toString() {
+                return "TestEnum{B}";
+            }
+        }
+    }
 
     abstract class InnerNonStatic { }
 
@@ -202,6 +210,7 @@ public class ClassUtilTest extends BaseMapTest
     public void testFindEnumType()
     {
         assertEquals(TestEnum.class, ClassUtil.findEnumType(TestEnum.A));
+        assertEquals(TestEnum.class, ClassUtil.findEnumType(TestEnum.B));
         // different codepaths for empty and non-empty EnumSets...
         assertEquals(TestEnum.class, ClassUtil.findEnumType(EnumSet.allOf(TestEnum.class)));
         assertEquals(TestEnum.class, ClassUtil.findEnumType(EnumSet.noneOf(TestEnum.class)));


### PR DESCRIPTION
This adds an additional `errorprone` compiler profile to run static analysis from https://errorprone.info/
I've included fixes for the most severe findings, though there are still a lot of warnings to work through. I can clean this up a bit if you think its worthwhile.

I've kept fixes for individual issues isolated in case they're worth backporting.

Thoughts?