### PR TITLE
Patch class cast exception when argument is not a String subclass

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StringSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StringSerializer.java
@@ -33,7 +33,8 @@ public final class StringSerializer
 
     @Override
     public void serialize(Object value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        gen.writeString((String) value);
+        String str = value != null ? String.valueOf(value) : null; 
+        gen.writeString((String) str);
     }
 
     @Override


### PR DESCRIPTION
This commit patches a class cast exception that is thrown when the serialization value is a `GString` (Groovy string)