### PR TITLE
WRAP_EXCEPTIONS test cases and exception wrapping fix

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -3227,7 +3227,7 @@ public class ObjectMapper
     @Override
     public <T> T treeToValue(TreeNode n, Class<T> valueType)
         throws IllegalArgumentException,
-            JsonProcessingException // is NOT actually thrown but retained as per #2878
+            JsonProcessingException
     {
         if (n == null) {
             return null;
@@ -3255,6 +3255,8 @@ public class ObjectMapper
                 }
             }
             return readValue(treeAsTokens(n), valueType);
+        } catch (JsonProcessingException e) {
+            throw e;
         } catch (IOException e) { // should not occur, no real i/o...
             throw new IllegalArgumentException(e.getMessage(), e);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/builder/BuilderSimpleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/builder/BuilderSimpleTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
 
 public class BuilderSimpleTest extends BaseMapTest
@@ -295,6 +296,54 @@ public class BuilderSimpleTest extends BaseMapTest
         }
     }
 
+    @JsonDeserialize(builder = ValidatingValue.Builder.class)
+    static class ValidatingValue
+    {
+        private final String first;
+        private final String second;
+
+        ValidatingValue(String first, String second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        static class ValidationException extends RuntimeException
+        {
+            ValidationException(String message) {
+                super(message);
+            }
+        }
+
+        static class Builder
+        {
+
+            private String first;
+            private String second;
+
+            @JsonSetter("a")
+            Builder first(String value) {
+                this.first = value;
+                return this;
+            }
+
+            @JsonSetter("b")
+            Builder second(String value) {
+                this.second = value;
+                return this;
+            }
+
+            ValidatingValue build() {
+                if (first == null) {
+                    throw new ValidationException("Missing first");
+                }
+                if (second == null) {
+                    throw new ValidationException("Missing second");
+                }
+                return new ValidatingValue(first, second);
+            }
+        }
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -429,5 +478,67 @@ public class BuilderSimpleTest extends BaseMapTest
         String json = aposToQuotes("{'value':13}");
         Value2354 result = MAPPER.readValue(json, Value2354.class);
         assertEquals(13, result.value());
+    }
+
+    public void testSuccessfulValidatingBuilder() throws Exception
+    {
+        ValidatingValue result = MAPPER.readValue(aposToQuotes("{'a':'1','b':'2'}"), ValidatingValue.class);
+        assertEquals("1", result.first);
+        assertEquals("2", result.second);
+    }
+
+
+    public void testFailingValidatingBuilderWithExceptionWrapping() throws Exception
+    {
+        ObjectMapper withWrapping = MAPPER.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS)
+                ? MAPPER : MAPPER.copy().enable(DeserializationFeature.WRAP_EXCEPTIONS);
+        try {
+            withWrapping
+                    .readValue(aposToQuotes("{'a':'1'}"), ValidatingValue.class);
+            fail("Expected an exception");
+        } catch (JsonMappingException e) {
+            assertTrue(e.getMessage().contains("Missing second"));
+            assertTrue(e.getCause() instanceof ValidatingValue.ValidationException);
+        }
+    }
+
+    public void testFailingValidatingBuilderWithExceptionWrappingFromTree() throws Exception
+    {
+        ObjectMapper withWrapping = MAPPER.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS)
+                ? MAPPER : MAPPER.copy().enable(DeserializationFeature.WRAP_EXCEPTIONS);
+        try {
+            JsonNode tree = withWrapping.readTree(aposToQuotes("{'a':'1'}"));
+            withWrapping.treeToValue(tree, ValidatingValue.class);
+            fail("Expected an exception");
+        } catch (ValueInstantiationException e) {
+            assertTrue(e.getMessage().contains("Missing second"));
+            assertTrue(e.getCause() instanceof ValidatingValue.ValidationException);
+        }
+    }
+
+    public void testFailingValidatingBuilderWithoutExceptionWrapping() throws Exception
+    {
+        ObjectMapper withoutWrapping = MAPPER.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS)
+                ? MAPPER.copy().disable(DeserializationFeature.WRAP_EXCEPTIONS) : MAPPER;
+        try {
+            withoutWrapping
+                    .readValue(aposToQuotes("{'a':'1'}"), ValidatingValue.class);
+            fail("Expected an exception");
+        } catch (ValidatingValue.ValidationException e) {
+            assertEquals("Missing second", e.getMessage());
+        }
+    }
+
+    public void testFailingValidatingBuilderWithoutExceptionWrappingFromTree() throws Exception
+    {
+        ObjectMapper withoutWrapping = MAPPER.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS)
+                ? MAPPER.copy().disable(DeserializationFeature.WRAP_EXCEPTIONS) : MAPPER;
+        try {
+            JsonNode tree = withoutWrapping.readTree(aposToQuotes("{'a':'1'}"));
+            withoutWrapping.treeToValue(tree, ValidatingValue.class);
+            fail("Expected an exception");
+        } catch (ValidatingValue.ValidationException e) {
+            assertEquals("Missing second", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
While exceptions reading the input into tokens are impossible,
it's very possible that the requested type does not match the
provided JsonNode, in which case a JsonProcessingException subtype
is thrown.

This PR includes the test case commit from #2938 along with a fix