### PR TITLE
Possible fix for #2944

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -403,12 +403,13 @@ public class BeanDeserializer
         for (; t == JsonToken.FIELD_NAME; t = p.nextToken()) {
             String propName = p.getCurrentName();
             p.nextToken(); // to point to value
+            SettableBeanProperty creatorProp = creator.findCreatorProperty(propName);
             // Object Id property?
-            if (buffer.readIdProperty(propName)) {
+            if (buffer.readIdProperty(propName) && creatorProp == null) {
                 continue;
             }
             // creator property?
-            SettableBeanProperty creatorProp = creator.findCreatorProperty(propName);
+
             if (creatorProp != null) {
                 // Last creator property to set?
                 Object value;


### PR DESCRIPTION
I believe that it's only appropriate to skip setting the property value for an id property when there isn't a corresponding creatorProp. So I've added a check for null on the creatorProp and it now seems to work.