### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1498,7 +1498,6 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
                 return bean;
             }
         }
-        // TODO: maybe add support for ValueInstantiator, embedded?
 
         // 26-Jul-2017, tatu: related to [databind#1711], let's actually verify assignment
         //    compatibility before returning. Bound to catch misconfigured cases and produce


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java (line:1501)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: 
https://github.com/FasterXML/jackson-databind/commit/659408c3f5a0cf7d5cd9e5079ffa1ed828848f2a