### PR TITLE
Prevent `NullPointerException` on null tokens

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -485,6 +485,9 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
 
         while (true) {
             JsonToken t = p.nextToken();
+            if (t == null) {
+                t = JsonToken.NOT_AVAILABLE;
+            }
             switch (t.id()) {
             case JsonTokenId.ID_START_OBJECT:
                 node.add(deserializeObject(p, ctxt, nodeFactory));
@@ -515,6 +518,9 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
             }
 
             t = p.nextToken();
+            if (t == null) {
+                t = JsonToken.NOT_AVAILABLE;
+            }
             switch (t.id()) {
             case JsonTokenId.ID_START_OBJECT:
                 node.add(deserializeObject(p, ctxt, nodeFactory));
@@ -556,6 +562,9 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
         final JsonNodeFactory nodeFactory = ctxt.getNodeFactory();
         while (true) {
             JsonToken t = p.nextToken();
+            if (t == null) {
+                t = JsonToken.NOT_AVAILABLE;
+            }
             switch (t.id()) {
             case JsonTokenId.ID_START_OBJECT:
                 node.add(deserializeObject(p, ctxt, nodeFactory));


### PR DESCRIPTION
`deserializeArray` and `updateArray` can potentially crash with a `NullPointerException` if next `JsonToken` returned by the `JsonParser` is `null`. This always happens when using `json-dataformats-binary`'s `CBORParser` to decode an incomplete arrary (e.g. `new byte[1] { (byte) 0x84 }`).