### PR TITLE
WIP: TestMultipleConstructors.java

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestMultipleConstructors.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestMultipleConstructors.java
@@ -1,0 +1,41 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestMultipleConstructors extends BaseMapTest {
+    static class MultipleConstructorClass {
+        private final String message;
+        private final int code;
+
+        MultipleConstructorClass(String message, int code) {
+            this.message = message;
+            this.code = code;
+        }
+
+        MultipleConstructorClass(String message) {
+            this(message, 0);
+        }
+
+        MultipleConstructorClass(int code) {
+            this("", code);
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    public void testClassWithMultipleConstructors() throws Exception
+    {
+        ObjectMapper m = new ObjectMapper();
+        MultipleConstructorClass result1 = m.readValue("{ \"code\":3}", MultipleConstructorClass.class);
+        assertEquals(3, result1.code);
+        assertEquals("", result1.message);
+        MultipleConstructorClass result2 = m.readValue("{ \"message\":\"test123\"}", MultipleConstructorClass.class);
+        assertEquals(0, result1.code);
+        assertEquals("test123", result1.message);
+    }
+}


### PR DESCRIPTION
@cowtowncoder apologies if this is not a correct test case - I'm trying to produce a Java test case that highlights a problem that we have in Jackson-Module-Scala. The test here fails with

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.008 s <<< FAILURE! - in com.fasterxml.jackson.databind.deser.TestMultipleConstructors
[ERROR] testClassWithMultipleConstructors(com.fasterxml.jackson.databind.deser.TestMultipleConstructors)  Time elapsed: 0.008 s  <<< ERROR!
com.fasterxml.jackson.databind.exc.MismatchedInputException: 
Cannot construct instance of `com.fasterxml.jackson.databind.deser.TestMultipleConstructors$MultipleConstructorClass` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (String)"{ "code":3}"; line: 1, column: 3]
	at com.fasterxml.jackson.databind.deser.TestMultipleConstructors.testClassWithMultipleConstructors(TestMultipleConstructors.java:34)
```