### PR TITLE
#2013: add support for reading from / writing to a Path

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.databind;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -777,6 +779,20 @@ public class ObjectReader
      * Factory method for constructing {@link JsonParser} that is properly
      * wired to allow callbacks for deserialization: basically
      * constructs a {@link ObjectReadContext} and then calls
+     * {@link TokenStreamFactory#createParser(ObjectReadContext,Path)}.
+     *
+     * @since 3.0
+     */
+    public JsonParser createParser(Path src) throws JacksonException {
+        _assertNotNull("src", src);
+        DeserializationContextExt ctxt = _deserializationContext();
+        return ctxt.assignAndReturnParser(_parserFactory.createParser(ctxt, src));
+    }
+
+    /**
+     * Factory method for constructing {@link JsonParser} that is properly
+     * wired to allow callbacks for deserialization: basically
+     * constructs a {@link ObjectReadContext} and then calls
      * {@link TokenStreamFactory#createParser(ObjectReadContext,java.net.URL)}.
      *
      * @since 3.0
@@ -1203,6 +1219,25 @@ public class ObjectReader
     }
 
     /**
+     * Method that binds content read from given {@link Path}
+     * using configuration of this reader.
+     * Value return is either newly constructed, or root value that
+     * was specified with {@link #withValueToUpdate(Object)}.
+     *
+     * @param p Path that contains content to read
+     *
+     * @since 3.0
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T readValue(Path p) throws JacksonException
+    {
+        _assertNotNull("p", p);
+        DeserializationContextExt ctxt = _deserializationContext();
+        return (T) _bindAndClose(ctxt,
+                _considerFilter(_parserFactory.createParser(ctxt, p), false));
+    }
+
+    /**
      * Method that binds content read from given input source,
      * using configuration of this reader.
      * Value return is either newly constructed, or root value that
@@ -1457,6 +1492,19 @@ public class ObjectReader
     }
 
     /**
+     * Overloaded version of {@link #readValues(InputStream)}.
+     *
+     * @since 3.0
+     */
+    public <T> MappingIterator<T> readValues(Path src) throws JacksonException
+    {
+        _assertNotNull("src", src);
+        DeserializationContextExt ctxt = _deserializationContext();
+        return _bindAndReadValues(ctxt,
+                _considerFilter(_parserFactory.createParser(ctxt, src), true));
+    }
+
+    /**
      * Overloaded version of {@link #readValue(InputStream)}.
      *<p>
      * NOTE: handling of {@link java.net.URL} is delegated to
@@ -1696,6 +1744,14 @@ public class ObjectReader
     protected InputStream _inputStream(File f) throws JacksonException {
         try {
             return new FileInputStream(f);
+        } catch (IOException e) {
+            throw WrappedIOException.construct(e);
+        }
+    }
+
+    protected InputStream _inputStream(Path p) throws JacksonException {
+        try {
+            return Files.newInputStream(p);
         } catch (IOException e) {
             throw WrappedIOException.construct(e);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
@@ -1,6 +1,9 @@
 package com.fasterxml.jackson.databind;
 
-import java.io.StringWriter;
+import java.io.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -470,5 +473,329 @@ public class ObjectReaderTest extends BaseMapTest
         A2297 aObject = mapper.readValue("{\"unknownField\" : 1, \"knownField\": \"test\"}", A2297.class);
 
         assertEquals("test", aObject.knownField);
+    }
+
+    public void test_createParser_InputStream() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        JsonParser jsonParser =  new ObjectMapper().reader().createParser(inputStream);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(path.toFile());
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(path);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_Url() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(path.toUri().toURL());
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_Reader() throws Exception
+    {
+        Reader reader = new StringReader("\"value\"");
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(reader);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_ByteArray() throws Exception
+    {
+        byte[] bytes = "\"value\"".getBytes(StandardCharsets.UTF_8);
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(bytes);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_String() throws Exception
+    {
+        String string = "\"value\"";
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(string);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_CharArray() throws Exception
+    {
+        char[] chars = "\"value\"".toCharArray();
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(chars);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    public void test_createParser_DataInput() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        DataInput dataInput = new DataInputStream(inputStream);
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(dataInput);
+
+        assertEquals(jsonParser.nextTextValue(), "value");
+    }
+
+    private static void test_method_failsIfArgumentIsNull(Runnable runnable) throws Exception
+    {
+        try {
+            runnable.run();
+            fail("IllegalArgumentException expected.");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void test_createParser_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectReader objectReader = new ObjectMapper().reader();
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((InputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((DataInput) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((URL) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((Path) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((File) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((Reader) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((String) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((byte[]) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((byte[]) null, -1, -1));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((char[]) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.createParser((char[]) null, -1, -1));
+    }
+
+    public void test_readTree_InputStream() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        JsonNode jsonNode =  new ObjectMapper().reader().readTree(inputStream);
+
+        assertEquals(jsonNode.textValue(), "value");
+    }
+
+    public void test_readTree_Reader() throws Exception
+    {
+        Reader reader = new StringReader("\"value\"");
+        JsonNode jsonNode = new ObjectMapper().reader().readTree(reader);
+
+        assertEquals(jsonNode.textValue(), "value");
+    }
+
+    public void test_readTree_ByteArray() throws Exception
+    {
+        // with offset and length
+        byte[] bytes = "\"value\"".getBytes(StandardCharsets.UTF_8);
+        JsonNode jsonNode1 = new ObjectMapper().reader().readTree(bytes);
+
+        assertEquals(jsonNode1.textValue(), "value");
+
+        // without offset and length
+        JsonNode jsonNode2 = new ObjectMapper().reader().readTree(bytes, 0, bytes.length);
+
+        assertEquals(jsonNode2.textValue(), "value");
+    }
+
+    public void test_readTree_String() throws Exception
+    {
+        String string = "\"value\"";
+        JsonNode jsonNode = new ObjectMapper().reader().readTree(string);
+
+        assertEquals(jsonNode.textValue(), "value");
+    }
+
+    public void test_readTree_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectReader objectReader = new ObjectMapper().reader();
+        test_method_failsIfArgumentIsNull(() -> objectReader.readTree((InputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readTree((Reader) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readTree((String) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readTree((byte[]) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readTree((byte[]) null, -1, -1));
+    }
+
+    public void test_readValue_InputStream() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        String result = new ObjectMapper().readerFor(String.class).readValue(inputStream);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        String result = new ObjectMapper().readerFor(String.class).readValue(path.toFile());
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        String result = new ObjectMapper().readerFor(String.class).readValue(path);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_Url() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        String result = new ObjectMapper().readerFor(String.class).readValue(path.toUri().toURL());
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_Reader() throws Exception
+    {
+        Reader reader = new StringReader("\"value\"");
+        String result = new ObjectMapper().readerFor(String.class).readValue(reader);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_ByteArray() throws Exception
+    {
+        byte[] bytes = "\"value\"".getBytes(StandardCharsets.UTF_8);
+        String result = new ObjectMapper().readerFor(String.class).readValue(bytes);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_String() throws Exception
+    {
+        String string = "\"value\"";
+        String result = new ObjectMapper().readerFor(String.class).readValue(string);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_DataInput() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        DataInput dataInput = new DataInputStream(inputStream);
+        String result = new ObjectMapper().readerFor(String.class).readValue(dataInput);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_JsonParser() throws Exception
+    {
+        String string = "\"value\"";
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(string);
+        String result = new ObjectMapper().readerFor(String.class).readValue(jsonParser);
+        assertEquals(result, "value");
+    }
+
+    public void test_readValue_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectReader objectReader = new ObjectMapper().reader();
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((InputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((DataInput) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((URL) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((Path) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((File) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((Reader) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((String) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((JsonParser) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((byte[]) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValue((byte[]) null, -1, -1));
+    }
+
+    public void test_readValues_InputStream() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(inputStream);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(path.toFile());
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(path);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_Url() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(path.toUri().toURL());
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_Reader() throws Exception
+    {
+        Reader reader = new StringReader("\"value\"");
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(reader);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_ByteArray() throws Exception
+    {
+        byte[] bytes = "\"value\"".getBytes(StandardCharsets.UTF_8);
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(bytes);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_String() throws Exception
+    {
+        String string = "\"value\"";
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(string);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_DataInput() throws Exception
+    {
+        InputStream inputStream = new ByteArrayInputStream("\"value\"".getBytes(StandardCharsets.UTF_8));
+        DataInput dataInput = new DataInputStream(inputStream);
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(dataInput);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_JsonParser() throws Exception
+    {
+        String string = "\"value\"";
+        JsonParser jsonParser = new ObjectMapper().reader().createParser(string);
+        MappingIterator result = new ObjectMapper().readerFor(String.class).readValues(jsonParser);
+        assertEquals(result.next(), "value");
+        assertEquals(result.hasNext(), false);
+    }
+
+    public void test_readValues_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectReader objectReader = new ObjectMapper().reader();
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((InputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((DataInput) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((URL) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((Path) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((File) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((Reader) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((String) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((JsonParser) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((byte[]) null));
+        test_method_failsIfArgumentIsNull(() -> objectReader.readValues((byte[]) null, -1, -1));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectWriterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectWriterTest.java
@@ -1,9 +1,8 @@
 package com.fasterxml.jackson.databind;
 
-import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.StringWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -298,5 +297,335 @@ public class ObjectWriterTest
         } catch (IllegalArgumentException e) {
             verifyException(e, "Cannot use FormatSchema");
         }
+    }
+
+    private static void test_method_failsIfArgumentIsNull(Runnable runnable) throws Exception
+    {
+        try {
+            runnable.run();
+            fail("IllegalArgumentException expected.");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void test_createGenerator_OutputStream() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JsonGenerator jsonGenerator = new ObjectMapper().writer().createGenerator(outputStream);
+
+        jsonGenerator.writeString("value");
+        jsonGenerator.close();
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the stream has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_createGenerator_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        JsonGenerator jsonGenerator = new ObjectMapper().writer().createGenerator(path.toFile(), JsonEncoding.UTF8);
+
+        jsonGenerator.writeString("value");
+        jsonGenerator.close();
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+    }
+
+    public void test_createGenerator_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        JsonGenerator jsonGenerator = new ObjectMapper().writer().createGenerator(path, JsonEncoding.UTF8);
+
+        jsonGenerator.writeString("value");
+        jsonGenerator.close();
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+    }
+
+    public void test_createGenerator_Writer() throws Exception
+    {
+        Writer writer = new StringWriter();
+        JsonGenerator jsonGenerator = new ObjectMapper().writer().createGenerator(writer);
+
+        jsonGenerator.writeString("value");
+        jsonGenerator.close();
+
+        assertEquals(writer.toString(), "\"value\"");
+
+        // the writer has not been closed by close
+        writer.append('1');
+    }
+
+    public void test_createGenerator_DataOutput() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        DataOutput dataOutput = new DataOutputStream(outputStream);
+        JsonGenerator jsonGenerator = new ObjectMapper().writer().createGenerator(dataOutput);
+
+        jsonGenerator.writeString("value");
+        jsonGenerator.close();
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the data output has not been closed by close
+        dataOutput.write(1);
+    }
+
+    public void test_createGenerator_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectWriter objectWriter = new ObjectMapper().writer();
+        test_method_failsIfArgumentIsNull(() -> objectWriter.createGenerator((OutputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectWriter.createGenerator((OutputStream) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectWriter.createGenerator((DataOutput) null));
+        test_method_failsIfArgumentIsNull(() -> objectWriter.createGenerator((Path) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectWriter.createGenerator((File) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectWriter.createGenerator((Writer) null));
+    }
+
+    public void test_writeValue_OutputStream() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new ObjectMapper().writer().writeValue(outputStream, "value");
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the stream has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_writeValue_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        new ObjectMapper().writer().writeValue(path.toFile(), "value");
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+    }
+
+    public void test_writeValue_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        new ObjectMapper().writer().writeValue(path, "value");
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+    }
+
+    public void test_writeValue_Writer() throws Exception
+    {
+        Writer writer = new StringWriter();
+        new ObjectMapper().writer().writeValue(writer, "value");
+
+        assertEquals(writer.toString(), "\"value\"");
+
+        // the writer has not been closed by close
+        writer.append('1');
+    }
+
+    public void test_writeValue_DataOutput() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        DataOutput dataOutput = new DataOutputStream(outputStream);
+        new ObjectMapper().writer().writeValue(dataOutput, "value");
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the data output has not been closed by close
+        dataOutput.write(1);
+    }
+
+    public void test_writeValue_JsonGenerator() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JsonGenerator jsonGenerator = new ObjectMapper().createGenerator(outputStream);
+        new ObjectMapper().writer().writeValue(jsonGenerator, "value");
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the output stream has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_writeValue_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValue((OutputStream) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValue((DataOutput) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValue((Path) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValue((File) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValue((Writer) null, null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValue((JsonGenerator) null, null));
+    }
+
+    public void test_writeValues_OutputStream() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValues(outputStream);
+        sequenceWriter.write("value");
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the stream has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_writeValues_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValues(path.toFile());
+        sequenceWriter.write("value");
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+    }
+
+    public void test_writeValues_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValues(path);
+        sequenceWriter.write("value");
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+    }
+
+    public void test_writeValues_Writer() throws Exception
+    {
+        Writer writer = new StringWriter();
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValues(writer);
+        sequenceWriter.write("value");
+
+        assertEquals(writer.toString(), "\"value\"");
+
+        // the writer has not been closed by close
+        writer.append('1');
+    }
+
+    public void test_writeValues_DataOutput() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        DataOutput dataOutput = new DataOutputStream(outputStream);
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValues(dataOutput);
+        sequenceWriter.write("value");
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the data output has not been closed by close
+        dataOutput.write(1);
+    }
+
+    public void test_writeValues_JsonGenerator() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JsonGenerator jsonGenerator = new ObjectMapper().createGenerator(outputStream);
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValues(jsonGenerator);
+        sequenceWriter.write("value");
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+
+        // the data output has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_writeValues_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValues((OutputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValues((DataOutput) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValues((Path) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValues((File) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValues((Writer) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValues((JsonGenerator) null));
+    }
+
+    public void test_writeValuesAsArray_OutputStream() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValuesAsArray(outputStream);
+        sequenceWriter.write("value");
+        sequenceWriter.flush();
+        sequenceWriter.close();
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "[\"value\"]");
+
+        // the stream has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_writeValuesAsArray_File() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValuesAsArray(path.toFile());
+        sequenceWriter.write("value");
+        sequenceWriter.flush();
+        sequenceWriter.close();
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "[\"value\"]");
+    }
+
+    public void test_writeValuesAsArray_Path() throws Exception
+    {
+        Path path = Files.createTempFile("", "");
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValuesAsArray(path);
+        sequenceWriter.write("value");
+        sequenceWriter.flush();
+        sequenceWriter.close();
+
+        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "[\"value\"]");
+    }
+
+    public void test_writeValuesAsArray_Writer() throws Exception
+    {
+        Writer writer = new StringWriter();
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValuesAsArray(writer);
+        sequenceWriter.write("value");
+        sequenceWriter.flush();
+        sequenceWriter.close();
+
+        assertEquals(writer.toString(), "[\"value\"]");
+
+        // the writer has not been closed by close
+        writer.append('1');
+    }
+
+    public void test_writeValuesAsArray_DataOutput() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        DataOutput dataOutput = new DataOutputStream(outputStream);
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValuesAsArray(dataOutput);
+        sequenceWriter.write("value");
+        sequenceWriter.flush();
+        sequenceWriter.close();
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "[\"value\"]");
+
+        // the data output has not been closed by close
+        dataOutput.write(1);
+    }
+
+    public void test_writeValuesAsArray_JsonGenerator() throws Exception
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JsonGenerator jsonGenerator = new ObjectMapper().createGenerator(outputStream);
+        SequenceWriter sequenceWriter = new ObjectMapper().writer().writeValuesAsArray(jsonGenerator);
+        sequenceWriter.write("value");
+        sequenceWriter.flush();
+        sequenceWriter.close();
+        jsonGenerator.flush();
+        jsonGenerator.close();
+
+        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "[\"value\"]");
+
+        // the data output has not been closed by close
+        outputStream.write(1);
+    }
+
+    public void test_writeValuesAsArray_failsIfArgumentIsNull() throws Exception
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValuesAsArray((OutputStream) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValuesAsArray((DataOutput) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValuesAsArray((Path) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValuesAsArray((File) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValuesAsArray((Writer) null));
+        test_method_failsIfArgumentIsNull(() -> objectMapper.writer().writeValuesAsArray((JsonGenerator) null));
     }
 }


### PR DESCRIPTION
Here, too, there seems no need for adding unit tests. :fearful:

That PR is the counterpart to: https://github.com/FasterXML/jackson-core/pull/680