### PR TITLE
dont track unknown props in buffer if ignoreAllUnknown is true

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -506,12 +506,15 @@ public class BeanDeserializer
                 }
                 continue;
             }
-            // Ok then, let's collect the whole field; name and value
-            if (unknown == null) {
-                unknown = new TokenBuffer(p, ctxt);
+
+            if(!_ignoreAllUnknown) {
+                // Ok then, let's collect the whole field; name and value
+                if (unknown == null) {
+                    unknown = new TokenBuffer(p, ctxt);
+                }
+                unknown.writeFieldName(propName);
+                unknown.copyCurrentStructure(p);
             }
-            unknown.writeFieldName(propName);
-            unknown.copyCurrentStructure(p);
         }
 
         // We hit END_OBJECT, so:

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreUnknownPropertyUsingPropertyBasedTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreUnknownPropertyUsingPropertyBasedTest.java
@@ -1,0 +1,81 @@
+package com.fasterxml.jackson.databind.deser.filter;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IgnoreUnknownPropertyUsingPropertyBasedTest extends BaseMapTest {
+
+  private final ObjectMapper MAPPER = newJsonMapper();
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class IgnoreUnknownAnySetter {
+
+    int a, b;
+
+    @JsonCreator
+    public IgnoreUnknownAnySetter(@JsonProperty("a") int a, @JsonProperty("b") int b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    Map<String, Object> props = new HashMap<>();
+
+    @JsonAnySetter
+    public void addProperty(String key, Object value) {
+      props.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getProperties() {
+      return props;
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class IgnoreUnknownUnwrapped {
+
+    int a, b;
+    
+    @JsonCreator
+    public IgnoreUnknownUnwrapped(@JsonProperty("a") int a, @JsonProperty("b") int b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    @JsonUnwrapped
+    UnwrappedChild child;
+
+    static class UnwrappedChild {
+      public int x, y;
+    }
+  }
+  
+  public void testAnySetterWithFailOnUnknownDisabled() throws Exception {
+    IgnoreUnknownAnySetter value = MAPPER.readValue("{\"a\":1, \"b\":2, \"x\":3, \"y\": 4}", IgnoreUnknownAnySetter.class);
+    assertNotNull(value);
+    assertEquals(1, value.a);
+    assertEquals(2, value.b);
+    assertEquals(3, value.props.get("x"));
+    assertEquals(4, value.props.get("y"));
+    assertEquals(2, value.props.size());
+  }
+
+  public void testUnwrappedWithFailOnUnknownDisabled() throws Exception {
+    IgnoreUnknownUnwrapped value = MAPPER.readValue("{\"a\":1, \"b\": 2, \"x\":3, \"y\":4}", IgnoreUnknownUnwrapped.class);
+    assertNotNull(value);
+    assertEquals(1, value.a);
+    assertEquals(2, value.b);
+    assertEquals(3, value.child.x);
+    assertEquals(4, value.child.y);
+  }
+
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/TestUnknownPropertyDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/TestUnknownPropertyDeserialization.java
@@ -71,6 +71,33 @@ public class TestUnknownPropertyDeserialization
         public int a;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown=true)
+    static class IgnoreUnknownAnySetter {
+
+        Map<String, Object> props = new HashMap<>();
+        
+        @JsonAnySetter
+        public void addProperty(String key, Object value) {
+            props.put(key, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getProperties() {
+            return props;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown=true)
+    static class IgnoreUnknownUnwrapped {
+      
+      @JsonUnwrapped
+      UnwrappedChild child;
+      
+      static class UnwrappedChild {
+        public int a, b;
+      }
+    }
+
     @SuppressWarnings("serial")
     @JsonIgnoreProperties({"a", "d"})
     static class IgnoreMap extends HashMap<String,Object> { }
@@ -222,6 +249,21 @@ public class TestUnknownPropertyDeserialization
         IgnoreUnknown result = MAPPER.readValue
             ("{\"b\":3,\"c\":[1,2],\"x\":{ },\"a\":-3}", IgnoreUnknown.class);
         assertEquals(-3, result.a);
+    }
+
+    public void testAnySetterWithFailOnUnknownDisabled() throws Exception
+    {
+        IgnoreUnknownAnySetter value = MAPPER.readValue("{\"x\":\"y\", \"a\":\"b\"}",  IgnoreUnknownAnySetter.class);
+        assertNotNull(value);
+        assertEquals(2, value.props.size());
+    }
+
+    public void testUnwrappedWithFailOnUnknownDisabled() throws Exception
+    {
+      IgnoreUnknownUnwrapped value = MAPPER.readValue("{\"a\":1, \"b\":2}",  IgnoreUnknownUnwrapped.class);
+      assertNotNull(value);
+      assertEquals(1, value.child.a);
+      assertEquals(2, value.child.b);
     }
 
     /**


### PR DESCRIPTION
In performance testing I was seeing that keeping track of unknown properties had an impact. If ignoreUnknownProperties is true, this buffer is ignored anyway.