### PR TITLE
(2.6) Backport all CVE fixes up to CVE-2021-20190

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -4,6 +4,20 @@ Project: jackson-databind
 === Releases ===
 ------------------------------------------------------------------------
 
+2.6.7.5 (not yet released)
+
+Backported all CVE fixes up to CVE-2021-20190
+
+#3004: Block some more DBCP-related potential gadget classes (CVE-2020-36179 / CVE-2020-36182)
+#3003: Block one more gadget type (org.docx4j.org.apache:xalan-interpretive, CVE-2020-36183)
+#2999: Block one more gadget type (org.glassfish.web/javax.servlet.jsp.jstl, CVE-2020-35728)
+#2998: Block 2 more gadget types (org.apache.tomcat/tomcat-dbcp, CVE-2020-36184 / CVE-2020-36185)
+#2997: Block 2 more gadget types (tomcat/naming-factory-dbcp, CVE-2020-36186 / CVE-2020-36187)
+#2996: Block 2 more gadget types (newrelic-agent, CVE-2020-36188 / CVE-2020-36189)
+#2986: Block 2 more gadget types (commons-dbcp2, CVE-2020-35490 / CVE-2020-35491)
+#2854: Block one more gadget type (javax.swing, CVE-2021-20190)
+#2798: Block one more gadget type (com.pastdev.httpcomponents, CVE-2020-24750)
+
 2.6.7.4 (25-Oct-2020)
 
 Backported all CVE fixes up to 2.9.10.6

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -102,13 +102,13 @@ public class BeanDeserializerFactory
         s.add("org.apache.openjpa.ee.WASRegistryManagedRuntime"); // [#2670] addition
         s.add("org.apache.axis2.transport.jms.JMSOutTransportInfo");
 
-        // [databind#2326]
+        // [databind#2326] (2.9.9)
         s.add("com.mysql.cj.jdbc.admin.MiniAdmin");
 
-        // [databind#2334]: logback-core
+        // [databind#2334]: logback-core (2.9.9.1)
         s.add("ch.qos.logback.core.db.DriverManagerConnectionSource");
 
-        // [databind#2341]: jdom/jdom2
+        // [databind#2341]: jdom/jdom2 (2.9.9.1)
         s.add("org.jdom.transform.XSLTransformer");
         s.add("org.jdom2.transform.XSLTransformer");
 
@@ -136,9 +136,12 @@ public class BeanDeserializerFactory
         // [databind#2704]: xalan2
         s.add("com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool");
 
-        // [databind#2478]: comons-dbcp, p6spy
+        // [databind#2478]: commons-dbcp 1.x, p6spy
+        // [databind#3004]: commons-dbcp 1.x
+        s.add("org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS");
         s.add("org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
         s.add("org.apache.commons.dbcp.datasources.SharedPoolDataSource");
+
         s.add("com.p6spy.engine.spy.P6DataSource");
 
         // [databind#2498]: log4j-extras (1.2)
@@ -203,8 +206,11 @@ public class BeanDeserializerFactory
         // [databind#2682]: commons-jelly
         s.add("org.apache.commons.jelly.impl.Embedded");
 
-        // [databind#2688]: apache/drill
+        // [databind#2688], [databind#3004]: apache/drill
         s.add("oadd.org.apache.xalan.lib.sql.JNDIConnectionPool");
+        s.add("oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS");
+        s.add("oadd.org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
+        s.add("oadd.org.apache.commons.dbcp.datasources.SharedPoolDataSource");
 
         // [databind#2698]: weblogic w/ oracle/aq-jms
         // (note: dependency not available via Maven Central, but as part of
@@ -215,7 +221,7 @@ public class BeanDeserializerFactory
         s.add("oracle.jms.AQjmsXAQueueConnectionFactory");
         s.add("oracle.jms.AQjmsXAConnectionFactory");
 
-        // [databind#2765]: org.jsecurity:
+        // [databind#2764]: org.jsecurity:
         s.add("org.jsecurity.realm.jndi.JndiRealmFactory");
 
         // [databind#2798]: com.pastdev.httpcomponents:
@@ -224,6 +230,35 @@ public class BeanDeserializerFactory
         // [databind#2826], [databind#2827]
         s.add("com.nqadmin.rowset.JdbcRowSetImpl");
         s.add("org.arrah.framework.rdbms.UpdatableJdbcRowsetImpl");
+
+        // [databind#2986], [databind#3004]: dbcp2
+        s.add("org.apache.commons.dbcp2.datasources.PerUserPoolDataSource");
+        s.add("org.apache.commons.dbcp2.datasources.SharedPoolDataSource");
+        s.add("org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS");
+
+        // [databind#2996]: newrelic-agent + embedded-logback-core
+        // (derivative of #2334 and #2389)
+        s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource");
+        s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource");
+
+        // [databind#2997]/[databind#3004]: tomcat/naming-factory-dbcp (embedded dbcp 1.x)
+        // (derivative of #2478)
+        s.add("org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS");
+        s.add("org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource");
+        s.add("org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource");
+
+        // [databind#2998]/[databind#3004]: org.apache.tomcat/tomcat-dbcp (embedded dbcp 2.x)
+        // (derivative of #2478)
+        s.add("org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS");
+        s.add("org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource");
+        s.add("org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource");
+
+        // [databind#2999]: org.glassfish.web/javax.servlet.jsp.jstl (embedded Xalan)
+        // (derivative of #2469)
+        s.add("com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool");
+
+        // [databind#3003]: another case of embedded Xalan (derivative of #2469)
+        s.add("org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool");
 
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }


### PR DESCRIPTION
**Motivation:** Jackson-2.6 is still widely used, despite being deprecated (including in the AWS SDK for Java 1.11.x). Until those consumers can migrate to a supported version of Jackson-2.6, this patch will protect those customers from the CVEs currently open against 2.6.7.4.

**We're not asking that these changes be released**, because we understand that it takes time and effort. Regardless, we wanted to offer these changes upstream.

A similar change was made as part of 2.6.7.4 with similar motivation: https://github.com/FasterXML/jackson-databind/pull/2864