### PR TITLE
Expose message of cause in case of `InvocationTargetException`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethod.java
@@ -140,7 +140,7 @@ public final class AnnotatedMethod
             _method.invoke(pojo, value);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to setValue() with method "
-                    +getFullName()+": "+e.getMessage(), e);
+                    +getFullName()+": "+ClassUtil.exceptionMessage(e), e);
         }
     }
 
@@ -151,7 +151,7 @@ public final class AnnotatedMethod
             return _method.invoke(pojo, (Object[]) null);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to getValue() with method "
-                    +getFullName()+": "+e.getMessage(), e);
+                    +getFullName()+": "+ClassUtil.exceptionMessage(e), e);
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -660,14 +660,18 @@ public final class ClassUtil
 
     /**
      * Helper method that returns {@link Throwable#getMessage()} for all other exceptions
-     * except for {@link JacksonException}, for which {@code getOriginalMessage()} is
-     * returned instead.
+     * except for (a) {@link JacksonException}, for which {@code getOriginalMessage()} is
+     * returned, and (b) {@link InvocationTargetException}, for which the cause's message
+     * is returned, if available.
      * Method is used to avoid accidentally including trailing location information twice
      * in message when wrapping exceptions.
      */
     public static String exceptionMessage(Throwable t) {
         if (t instanceof JacksonException) {
             return ((JacksonException) t).getOriginalMessage();
+        }
+        if (t instanceof InvocationTargetException && t.getCause() != null) {
+            return t.getCause().getMessage();
         }
         return t.getMessage();
     }

--- a/src/test/java/com/fasterxml/jackson/databind/util/ClassUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ClassUtilTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.json.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
@@ -285,6 +286,26 @@ public class ClassUtilTest extends BaseMapTest
             assertTrue(gen.isClosed());
         }
         gen.close();
+    }
+
+    public void testExceptionMessage() {
+        DatabindException jacksonException = new DatabindException("A message") {
+            @Override
+            public String getOriginalMessage() {
+                return "The original message";
+            }
+        };
+        assertEquals("The original message", ClassUtil.exceptionMessage(jacksonException));
+
+        try {
+            ClassUtilTest.class.getDeclaredMethod("throwsException").invoke(null);
+        } catch (ReflectiveOperationException e) {
+            assertEquals("A custom message", ClassUtil.exceptionMessage(e));
+        }
+    }
+
+    private static void throwsException() {
+        throw new IllegalArgumentException("A custom message");
     }
 
     /*


### PR DESCRIPTION
I'm currently working on a workaround for #2158, by defining a custom `KeyDeserializer` with some code copied from `StdKeyDeserializers#findStringBasedKeyDeserializer` and `StdKeyDeserializer`. (On `master` these are renamed to `JDKKeyDeserializers#findStringBasedKeyDeserializer` and `StringFactoryKeyDeserializer`.) Upon writing some tests I found that the custom error message of any exception thrown by my DTO's `@JsonCreator` method is swallowed. It turns out that this is due to `JDKKeyDeserializer#deserializeKey` invoking `ClassUtil#exceptionMessage` on the exception thrown by `StringFactoryKeyDeserializer#_parse`, which doesn't nicely handle the `InvocationTargetException`s.

After working on this PR I noticed that a similar issue was flagged in #2509, so I expanded the scope a bit to also cover that case.