### PR TITLE
support deserialize the class without default constructor

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -451,7 +451,7 @@ public abstract class DeserializationContext
      * to the active parser, that should be used instead.
      */
     public final JsonParser getParser() { return _parser; }
-    
+
     public final Object findInjectableValue(Object valueId,
             BeanProperty forProperty, Object beanInstance)
     {
@@ -979,7 +979,7 @@ public abstract class DeserializationContext
      * but a Scalar value (potentially coercible from String value) is expected.
      * This would typically be used to deserializer a Number, Boolean value or some other
      * "simple" unstructured value type.
-     * 
+     *
      * @param p Actual parser to read content from
      * @param deser Deserializer that needs extracted String value
      * @param scalarType Immediate type of scalar to extract; usually type deserializer
@@ -1317,6 +1317,13 @@ public abstract class DeserializationContext
         }
         msg = _format(msg, msgArgs);
         LinkedNode<DeserializationProblemHandler> h = _config.getProblemHandlers();
+        if (isEnabled(MapperFeature.CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS)) {
+            LinkedNode<DeserializationProblemHandler> node = new LinkedNode<>(MissingInstantiatorHandler.getInstance(), null);
+            if (h == null) {
+                h = node;
+            }
+            h.linkNext(node);
+        }
         while (h != null) {
             // Can bail out if it's handled
             Object instance = h.value().handleMissingInstantiator(this,

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -395,10 +395,10 @@ public enum MapperFeature
      * Feature that determines whether create default constructor if not exists;
      * either deserialize the class without default constructor will throw an exception
      *<p>
-     * Feature is enabled by default (for backwards compatibility since this was the
+     * Feature is disabled by default (for backwards compatibility since this was the
      * default behavior)
      */
-    CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS(true),
+    CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS(false),
     ;
 
     private final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -389,8 +389,16 @@ public enum MapperFeature
      * Feature is enabled by default, to allow use of merge defaults even in presence
      * of some unmergeable properties.
      */
-    IGNORE_MERGE_FOR_UNMERGEABLE(true)
+    IGNORE_MERGE_FOR_UNMERGEABLE(true),
 
+    /**
+     * Feature that determines whether create default constructor if not exists;
+     * either deserialize the class without default constructor will throw an exception
+     *<p>
+     * Feature is enabled by default (for backwards compatibility since this was the
+     * default behavior)
+     */
+    CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS(true),
     ;
 
     private final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/MissingInstantiatorHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/MissingInstantiatorHandler.java
@@ -1,0 +1,41 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ValueDeserializer;
+import com.fasterxml.jackson.databind.util.ReflectionUtil;
+
+public class MissingInstantiatorHandler extends DeserializationProblemHandler {
+
+    private static volatile MissingInstantiatorHandler INSTANCE;
+
+    private MissingInstantiatorHandler() {
+    }
+
+    public static MissingInstantiatorHandler getInstance() {
+        if (INSTANCE == null) {
+            synchronized (MissingInstantiatorHandler.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new MissingInstantiatorHandler();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    @Override
+    public Object handleMissingInstantiator(DeserializationContext ctxt, Class<?> instClass, ValueInstantiator valueInsta,
+                                            JsonParser jsonParser, String msg) throws JacksonException {
+        Object instance = ReflectionUtil.newConstructorAndCreateInstance(instClass);
+        if (instance == null) {
+            return NOT_HANDLED;
+        }
+
+        ValueDeserializer<Object> deserializer = ctxt.findRootValueDeserializer(ctxt.constructType(instClass));
+        if (deserializer != null) {
+            return deserializer.deserialize(jsonParser, ctxt, instance);
+        }
+        return NOT_HANDLED;
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/util/ReflectionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ReflectionUtil.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.util;
 import sun.reflect.ReflectionFactory;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -12,6 +13,9 @@ public class ReflectionUtil {
             new ConcurrentHashMap<>();
 
     public static Object newConstructorAndCreateInstance(Class<?> classToInstantiate) {
+        if (classToInstantiate.isInterface() || Modifier.isAbstract(classToInstantiate.getModifiers())) {
+            return null;
+        }
         Constructor<?> constructor = constructorCache.get(classToInstantiate);
 
         try {

--- a/src/main/java/com/fasterxml/jackson/databind/util/ReflectionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ReflectionUtil.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.databind.util;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ReflectionUtil {
+
+    private static final Map<Class<?>, Constructor<?>> constructorCache =
+            new ConcurrentHashMap<>();
+
+    public static Object newConstructorAndCreateInstance(Class<?> classToInstantiate) {
+        Constructor<?> constructor = constructorCache.get(classToInstantiate);
+
+        try {
+            if (constructor == null) {
+                constructor = ReflectionFactory.getReflectionFactory()
+                        .newConstructorForSerialization(classToInstantiate, Object.class.getDeclaredConstructor());
+                constructor.setAccessible(true);
+                constructorCache.put(classToInstantiate, constructor);
+            }
+            return constructor.newInstance();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -741,7 +741,7 @@ public class ObjectMapperTest extends BaseMapTest
         try {
             jsonMapper.readValue(bytes, BeanWithoutDefaultConstructor.class);
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("Cannot construct instance"));
+            verifyException(e, "Cannot construct instance");
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -735,11 +735,12 @@ public class ObjectMapperTest extends BaseMapTest
     public void test_readValue_withoutDefaultContructor() throws Exception {
         BeanWithoutDefaultConstructor bean = new BeanWithoutDefaultConstructor(1);
         byte[] bytes = MAPPER.writeValueAsBytes(bean);
-        BeanWithoutDefaultConstructor result1 = MAPPER.readValue(bytes, BeanWithoutDefaultConstructor.class);
-        assertNotNull(result1);
-        JsonMapper jsonMapper = jsonMapperBuilder().disable(MapperFeature.CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS).build();
+
+        JsonMapper jsonMapper = jsonMapperBuilder().enable(MapperFeature.CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS).build();
+        BeanWithoutDefaultConstructor result = jsonMapper.readValue(bytes, BeanWithoutDefaultConstructor.class);
+        assertNotNull(result);
         try {
-            jsonMapper.readValue(bytes, BeanWithoutDefaultConstructor.class);
+            MAPPER.readValue(bytes, BeanWithoutDefaultConstructor.class);
         } catch (Exception e) {
             verifyException(e, "Cannot construct instance");
         }


### PR DESCRIPTION
**Motivation**
Currently we cannot deserialize the class without default constructor, while serialize successfully.

**Modification**
Add new feature `CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS` in `MapperFeature`(default false)
if enable `CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS`
add `MissingInstantiatorHandler` to the handle link.

**Verify**
Add unit test

**Potential problem should take into consideration**
There are some case like "pure string", must match `String-argument` constructor, but still can construct successfully when enable config `CREATE_DEFAULT_CONSTRUCTOR_IF_NOT_EXISTS`