### PR TITLE
Support DEDUCTION of empty subtypes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
@@ -131,8 +131,10 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
             p.clearCurrentToken();
             p = JsonParserSequence.createFlattened(false, tb.asParser(p), p);
         }
-        // Must point to the next value; tb had no current, jp pointed to VALUE_STRING:
-        p.nextToken(); // to skip past String value
+        if (p.currentToken() != JsonToken.END_OBJECT) {
+            // Must point to the next value; tb had no current, p pointed to VALUE_STRING:
+            p.nextToken(); // to skip past String value
+        }
         // deserializer should take care of closing END_OBJECT as well
         return deser.deserialize(p, ctxt);
     }


### PR DESCRIPTION
Support deduction of empty subtypes (classes with no distinguishing properties *at all*) against empty json (`{}`).

Incoming `null`, `<absent>` and use of `ignoreUnknownProperties` will not NOT match an empty subtype. In keeping with the affirmative matching used by the rest of the deduction mode, there can be only a single empty subtype and only an explicitly empty object (`{}`) will match it.

Inspired by #3137 - thanks to @xJoewoo for the report

This is raised against 2.12 but can be rebased onto 2.13 on request