### PR TITLE
Merge findInjectableValues() results in AnnotationIntrospectorPair

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
@@ -300,7 +300,11 @@ public class AnnotationIntrospectorPair
     @Override
     public JacksonInject.Value findInjectableValue(AnnotatedMember m) {
         JacksonInject.Value r = _primary.findInjectableValue(m);
-        return (r == null) ? _secondary.findInjectableValue(m) : r;
+        if (r == null || r.getUseInput() == null) {
+            JacksonInject.Value secondary = _secondary.findInjectableValue(m);
+            r = (r == null || secondary == null) ? secondary : r.withUseInput(secondary.getUseInput());
+        }
+        return r;
     }
 
     @Override


### PR DESCRIPTION
As many AnnotationIntrospector implementations use default values
for useInput, allow the secondary introspector's useInput value to
combine with the primary's id to prevent losing the useInput value.

Fixes a special case of #962 seen by the GuiceAnnotationInspector
in https://github.com/FasterXML/jackson-modules-base/issues/134