### PR TITLE
Fix bug in #3146

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
@@ -302,7 +302,9 @@ public class AnnotationIntrospectorPair
         JacksonInject.Value r = _primary.findInjectableValue(m);
         if (r == null || r.getUseInput() == null) {
             JacksonInject.Value secondary = _secondary.findInjectableValue(m);
-            r = (r == null || secondary == null) ? secondary : r.withUseInput(secondary.getUseInput());
+            if (secondary != null) {
+                r = (r == null) ? secondary : r.withUseInput(secondary.getUseInput());
+            }
         }
         return r;
     }


### PR DESCRIPTION
If primary is not null but primary.useInput is null,
and secondary is null, just return primary.