### PR TITLE
TestJava7Types fails on Windows.

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
@@ -20,9 +20,9 @@ public class TestJava7Types extends BaseMapTest
 
         Path p = mapper.readValue(json, Path.class);
         assertNotNull(p);
-        
+
         assertEquals(input.toUri(), p.toUri());
-        assertEquals(input, p);
+        assertEquals(input.toAbsolutePath(), p.toAbsolutePath());
     }
 
     // [databind#1688]:
@@ -41,6 +41,6 @@ public class TestJava7Types extends BaseMapTest
         Object ob = obs[0];
         assertTrue(ob instanceof Path);
 
-        assertEquals(input.toString(), ob.toString());
+        assertEquals(input.toAbsolutePath().toString(), ob.toString());
     }
 }


### PR DESCRIPTION
TestJava7Types fails on Windows due to absolute path starting with drive name.

Fix is to compare absolute paths.

It is just a small inconvenience on Windows - if it is even relevant for the project.

**Current behavior**
```
TestJava7Types.testPathRoundtrip(TestJava7Types.java:25)

junit.framework.AssertionFailedError: 
Expected :\tmp\foo.txt
Actual   :D:\tmp\foo.txt
```

```
TestJava7Types.testPolymorphicPath(TestJava7Types.java:44)

junit.framework.ComparisonFailure: 
Expected :\tmp\foo.txt
Actual   :D:\tmp\foo.txt
```


