### PR TITLE
Suppress several LGTM findings

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -847,7 +847,7 @@ public abstract class JsonNode
             if (currentExpr.matches()) {
                 return curr;
             }
-            curr = curr._at(currentExpr);
+            curr = curr._at(currentExpr); // lgtm [java/dereferenced-value-may-be-null]
             if (curr == null) {
                 _reportRequiredViolation("No node at '%s' (unmatched part: '%s')",
                         path, currentExpr);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/AbstractDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/AbstractDeserializer.java
@@ -147,7 +147,7 @@ public class AbstractDeserializer
 "Invalid Object Id definition for %s: cannot find property with name %s",
 ClassUtil.nameOf(handledType()), ClassUtil.name(propName)));
                         }
-                        idType = idProp.getType();
+                        idType = idProp.getType(); // lgtm [java/dereferenced-value-may-be-null]
                         idGen = new PropertyBasedObjectIdGenerator(objectIdInfo.getScope());
 /*
                          ctxt.reportBadDefinition(_baseType, String.format(

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -529,7 +529,7 @@ public class BeanDeserializer
         }
         if (unknown != null) {
             // polymorphic?
-            if (bean.getClass() != _beanType.getRawClass()) {
+            if (bean.getClass() != _beanType.getRawClass()) { // lgtm [java/dereferenced-value-may-be-null]
                 return handlePolymorphic(null, ctxt, bean, unknown);
             }
             // no, just some extra unknown properties

--- a/src/main/java/com/fasterxml/jackson/databind/deser/CreatorProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/CreatorProperty.java
@@ -224,7 +224,7 @@ public class CreatorProperty
                     String.format("Property %s (type %s) has no injectable value id configured",
                     ClassUtil.name(getName()), ClassUtil.classNameOf(this)));
         }
-        return context.findInjectableValue(_injectableValue.getId(), this, beanInstance);
+        return context.findInjectableValue(_injectableValue.getId(), this, beanInstance); // lgtm [java/dereferenced-value-may-be-null]
     }
 
     // 14-Apr-2020, tatu: Does not appear to be used so deprecated in 2.11.0,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
@@ -142,7 +142,7 @@ public abstract class ContainerDeserializerBase<T>
                     String.format("Cannot create empty instance of %s, no default Creator", type));
         }
         try {
-            return vi.createUsingDefault(ctxt);
+            return vi.createUsingDefault(ctxt); // lgtm [java/dereferenced-value-may-be-null]
         } catch (IOException e) {
             return ClassUtil.throwAsMappingException(ctxt, e);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -851,7 +851,7 @@ public class MapDeserializer
             ctxt.reportInputMismatch(this,
                     "Unresolved forward reference but no identity info: "+reference);
         }
-        Referring referring = accumulator.handleUnresolvedReference(reference, key);
+        Referring referring = accumulator.handleUnresolvedReference(reference, key); // lgtm [java/dereferenced-value-may-be-null]
         reference.getRoid().appendReferring(referring);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeNameIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeNameIdResolver.java
@@ -85,7 +85,7 @@ public class TypeNameIdResolver extends TypeIdResolverBase
                     }
                     // One more problem; sometimes we have same name for multiple types;
                     // if so, use most specific
-                    JavaType prev = idToType.get(id);
+                    JavaType prev = idToType.get(id); // lgtm [java/dereferenced-value-may-be-null]
                     if (prev != null) { // Can only override if more specific
                         if (cls.isAssignableFrom(prev.getRawClass())) { // nope, more generic (or same)
                             continue;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
@@ -211,7 +211,7 @@ public class BeanSerializerBuilder
         }
         // 27-Apr-2017, tatu: Verify that filtered-properties settings are compatible
         if (_filteredProperties != null) {
-            if (_filteredProperties.length != _properties.size()) {
+            if (_filteredProperties.length != _properties.size()) { // lgtm [java/dereferenced-value-may-be-null]
                 throw new IllegalStateException(String.format(
 "Mismatch between `properties` size (%d), `filteredProperties` (%s): should have as many (or `null` for latter)",
 _properties.size(), _filteredProperties.length));


### PR DESCRIPTION
This suppresses false-positives reported by LGTM

https://lgtm.com/projects/g/FasterXML/jackson-databind/alerts/?mode=tree
https://lgtm.com/help/lgtm/alert-suppression

These FPs add some noise to the report on LGTM. It would be easier to triage new alerts without this noise.

It would be also possible to suppress them by adding `@SuppressWarnings(...)` annotations, but this annotation would disable a rule for an entire method. Also, I am not sure if this annotation can suppress multiple rules.

Feel free to drop this PR in case you think it is completely useless :)