### PR TITLE
Restore FAIL_ON_NULL_FOR_PRIMITIVES behaviour with empty strings

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -596,7 +596,8 @@ public abstract class StdDeserializer<T>
         CoercionAction act = _checkFromStringCoercion(ctxt, text,
                 LogicalType.Integer, Byte.TYPE);
         if (act == CoercionAction.AsNull) {
-            return (byte) 0; // no need to check as does not come from `null`, explicit coercion
+            _verifyNullForPrimitiveCoercion(ctxt, text);
+            return (byte) 0;
         }
         if (act == CoercionAction.AsEmpty) {
             return (byte) 0;
@@ -663,7 +664,8 @@ public abstract class StdDeserializer<T>
         CoercionAction act = _checkFromStringCoercion(ctxt, text,
                 LogicalType.Integer, Short.TYPE);
         if (act == CoercionAction.AsNull) {
-            return (short) 0; // no need to check as does not come from `null`, explicit coercion
+            _verifyNullForPrimitiveCoercion(ctxt, text);
+            return (short) 0;
         }
         if (act == CoercionAction.AsEmpty) {
             return (short) 0;
@@ -728,7 +730,8 @@ public abstract class StdDeserializer<T>
         final CoercionAction act = _checkFromStringCoercion(ctxt, text,
                 LogicalType.Integer, Integer.TYPE);
         if (act == CoercionAction.AsNull) {
-            return 0; // no need to check as does not come from `null`, explicit coercion
+            _verifyNullForPrimitiveCoercion(ctxt, text);
+            return 0;
         }
         if (act == CoercionAction.AsEmpty) {
             return 0;
@@ -855,7 +858,8 @@ public abstract class StdDeserializer<T>
         final CoercionAction act = _checkFromStringCoercion(ctxt, text,
                 LogicalType.Integer, Long.TYPE);
         if (act == CoercionAction.AsNull) {
-            return 0L; // no need to check as does not come from `null`, explicit coercion
+            _verifyNullForPrimitiveCoercion(ctxt, text);
+            return 0L;
         }
         if (act == CoercionAction.AsEmpty) {
             return 0L;
@@ -976,7 +980,8 @@ public abstract class StdDeserializer<T>
         final CoercionAction act = _checkFromStringCoercion(ctxt, text,
                 LogicalType.Integer, Float.TYPE);
         if (act == CoercionAction.AsNull) {
-            return  0.0f; // no need to check as does not come from `null`, explicit coercion
+            _verifyNullForPrimitiveCoercion(ctxt, text);
+            return  0.0f;
         }
         if (act == CoercionAction.AsEmpty) {
             return  0.0f;
@@ -1081,7 +1086,8 @@ public abstract class StdDeserializer<T>
         final CoercionAction act = _checkFromStringCoercion(ctxt, text,
                 LogicalType.Integer, Double.TYPE);
         if (act == CoercionAction.AsNull) {
-            return  0.0; // no need to check as does not come from `null`, explicit coercion
+            _verifyNullForPrimitiveCoercion(ctxt, text);
+            return  0.0;
         }
         if (act == CoercionAction.AsEmpty) {
             return  0.0;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKScalarsDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKScalarsDeserTest.java
@@ -554,6 +554,42 @@ public class JDKScalarsDeserTest
         }
     }
 
+    public void testCoercedEmptyStringWhenNullForPrimitivesNotAllowed() throws IOException
+    {
+        final ObjectReader reader = MAPPER
+                .readerFor(PrimitivesBean.class)
+                .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+
+        try {
+            reader.readValue("{\"byteValue\":\"\"}");
+            fail("Expected failure for byte + null");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot coerce empty String (\"\") to Null value as `byte` value");
+            verifyPath(e, "byteValue");
+        }
+        try {
+            reader.readValue("{\"shortValue\":\"\"}");
+            fail("Expected failure for short + null");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot coerce empty String (\"\") to Null value as `short` value");
+            verifyPath(e, "shortValue");
+        }
+        try {
+            reader.readValue("{\"intValue\":\"\"}");
+            fail("Expected failure for int + null");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot coerce empty String (\"\") to Null value as `int` value");
+            verifyPath(e, "intValue");
+        }
+        try {
+            reader.readValue("{\"longValue\":\"\"}");
+            fail("Expected failure for long + null");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot coerce empty String (\"\") to Null value as `long` value");
+            verifyPath(e, "longValue");
+        }
+    }
+
     public void testNullForPrimitivesNotAllowedFP() throws IOException
     {
         final ObjectReader reader = MAPPER


### PR DESCRIPTION
Ensure that FAIL_ON_NULL_FOR_PRIMITIVES works as expected when coercing an empty string to null.

The test I added works on 2.11 (with a slightly different error message), but fails on 2.12. It is kind of odd that empty strings were coerced to null even though FAIL_ON_NULL_FOR_PRIMITIVES was enabled.