### PR TITLE
added functionality for PropertyNamingStrategies.UPPER_SNAKE_CASE

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -263,6 +263,7 @@ public abstract class PropertyNamingStrategies
      * A {@link PropertyNamingStrategy} that translates an input to the equivalent upper case snake
      * case. The class extends {@link PropertyNamingStrategies.SnakeCaseStrategy} to retain the
      * snake case conversion functionality offered by the strategy.
+     * @since 2.13
      */
     public static class UpperSnakeCaseStrategy extends SnakeCaseStrategy {
 

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -56,6 +56,7 @@ public abstract class PropertyNamingStrategies
     /**
      * Naming convention in which the words are in upper-case letters, separated by underscores.
      * See {@link UpperSnakeCaseStrategy} for details.
+     * @since 2.13
      * <p>
      */
     public static final PropertyNamingStrategy UPPER_SNAKE_CASE = new UpperSnakeCaseStrategy();

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -54,6 +54,13 @@ public abstract class PropertyNamingStrategies
     public static final PropertyNamingStrategy SNAKE_CASE = new SnakeCaseStrategy();
 
     /**
+     * Naming convention in which the words are in upper-case letters, separated by underscores.
+     * See {@link UpperSnakeCaseStrategy} for details.
+     * <p>
+     */
+    public static final PropertyNamingStrategy UPPER_SNAKE_CASE = new UpperCamelCaseStrategy();
+
+    /**
      * Naming convention in which all words of the logical name are in lower case, and
      * no separator is used between words.
      * See {@link LowerCaseStrategy} for details.
@@ -79,7 +86,7 @@ public abstract class PropertyNamingStrategies
      * Example external property names would be "number.value", "naming.strategy", "the.definite.proof".
      */
     public static final PropertyNamingStrategy LOWER_DOT_CASE = new LowerDotCaseStrategy();
-    
+
     /*
     /**********************************************************************
     /* Public base class for simple implementations
@@ -159,7 +166,7 @@ public abstract class PropertyNamingStrategies
 
     /*
     /**********************************************************************
-    /* Standard implementations 
+    /* Standard implementations
     /**********************************************************************
      */
     
@@ -207,7 +214,7 @@ public abstract class PropertyNamingStrategies
      * <li>&quot;USER&quot; is translated to &quot;user&quot;</li>
      * <li>&quot;_user&quot; is translated to &quot;user&quot;</li>
      * <li>&quot;_User&quot; is translated to &quot;user&quot;</li>
-     * <li>&quot;__user&quot; is translated to &quot;_user&quot; 
+     * <li>&quot;__user&quot; is translated to &quot;_user&quot;
      * (the first of two underscores was removed)</li>
      * <li>&quot;user__name&quot; is translated to &quot;user__name&quot;
      * (unchanged, with two underscores)</li></ul>
@@ -248,6 +255,22 @@ public abstract class PropertyNamingStrategies
                 }
             }
             return resultLength > 0 ? result.toString() : input;
+        }
+    }
+
+    /**
+     * A {@link PropertyNamingStrategy} that translates an input to the equivalent upper case snake
+     * case. The class extends {@link PropertyNamingStrategies.SnakeCaseStrategy} to retain the
+     * snake case conversion functionality offered by the strategy.
+     */
+    public static class UpperSnakeCaseStrategy extends SnakeCaseStrategy {
+
+        @Override
+        public String translate(String input) {
+            String output = super.translate(input);
+            if (output == null)
+                return null;
+            return super.translate(input).toUpperCase();
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -58,7 +58,7 @@ public abstract class PropertyNamingStrategies
      * See {@link UpperSnakeCaseStrategy} for details.
      * <p>
      */
-    public static final PropertyNamingStrategy UPPER_SNAKE_CASE = new UpperCamelCaseStrategy();
+    public static final PropertyNamingStrategy UPPER_SNAKE_CASE = new UpperSnakeCaseStrategy();
 
     /**
      * Naming convention in which all words of the logical name are in lower case, and

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
@@ -364,7 +364,8 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testUpperSnakeCaseTranslations() throws Exception
     {
         // First serialize
-        String json = _ucWithUnderscoreMapper.writeValueAsString(new PersonBean("Joe", "Sixpack", 42));
+        String json = _ucWithUnderscoreMapper
+            .writeValueAsString(new PersonBean("Joe", "Sixpack", 42));
         assertEquals("{\"FIRST_NAME\":\"Joe\",\"LAST_NAME\":\"Sixpack\",\"AGE\":42}", json);
 
         // then deserialize

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
@@ -24,7 +24,7 @@ public class TestNamingStrategyStd extends BaseMapTest
         public String WWW;
         public String someURL;
         public String someURIs;
-        
+
         public Acronyms() {this(null, null, null);}
         public Acronyms(String WWW, String someURL, String someURIs)
         {
@@ -33,7 +33,7 @@ public class TestNamingStrategyStd extends BaseMapTest
             this.someURIs = someURIs;
         }
     }
-    
+
     @JsonPropertyOrder({"from_user", "user", "from$user", "from7user", "_x"})
     static class UnchangedNames
     {
@@ -43,7 +43,7 @@ public class TestNamingStrategyStd extends BaseMapTest
         public String from7user;
         // Used to test "_", but it's explicitly deprecated in JDK8 so...
         public String _x;
-        
+
         public UnchangedNames() {this(null, null, null, null, null);}
         public UnchangedNames(String from_user, String _user, String from$user, String from7user, String _x)
         {
@@ -84,7 +84,7 @@ public class TestNamingStrategyStd extends BaseMapTest
         public String firstName = "Bob";
         public String lastName = "Burger";
     }
- 
+
     public static class ClassWithObjectNodeField {
         public String id;
         public ObjectNode json;
@@ -278,8 +278,8 @@ public class TestNamingStrategyStd extends BaseMapTest
      */
 
     /**
-     * Unit test to verify translations of 
-     * {@link PropertyNamingStrategies#SNAKE_CASE} 
+     * Unit test to verify translations of
+     * {@link PropertyNamingStrategies#SNAKE_CASE}
      * outside the context of an ObjectMapper.
      */
     public void testLowerCaseStrategyStandAlone()
@@ -296,7 +296,7 @@ public class TestNamingStrategyStd extends BaseMapTest
         // First serialize
         String json = _lcWithUnderscoreMapper.writeValueAsString(new PersonBean("Joe", "Sixpack", 42));
         assertEquals("{\"first_name\":\"Joe\",\"last_name\":\"Sixpack\",\"age\":42}", json);
-        
+
         // then deserialize
         PersonBean result = _lcWithUnderscoreMapper.readValue(json, PersonBean.class);
         assertEquals("Joe", result.firstName);
@@ -309,7 +309,7 @@ public class TestNamingStrategyStd extends BaseMapTest
         // First serialize
         String json = _lcWithUnderscoreMapper.writeValueAsString(new Acronyms("world wide web", "http://jackson.codehaus.org", "/path1/,/path2/"));
         assertEquals("{\"www\":\"world wide web\",\"some_url\":\"http://jackson.codehaus.org\",\"some_uris\":\"/path1/,/path2/\"}", json);
-        
+
         // then deserialize
         Acronyms result = _lcWithUnderscoreMapper.readValue(json, Acronyms.class);
         assertEquals("world wide web", result.WWW);
@@ -322,7 +322,7 @@ public class TestNamingStrategyStd extends BaseMapTest
         // First serialize
         String json = _lcWithUnderscoreMapper.writeValueAsString(new OtherNonStandardNames("Results", "_User", "___", "$User"));
         assertEquals("{\"results\":\"Results\",\"user\":\"_User\",\"__\":\"___\",\"$_user\":\"$User\"}", json);
-        
+
         // then deserialize
         OtherNonStandardNames result = _lcWithUnderscoreMapper.readValue(json, OtherNonStandardNames.class);
         assertEquals("Results", result.Results);
@@ -352,13 +352,26 @@ public class TestNamingStrategyStd extends BaseMapTest
     /**********************************************************
      */
 
-    public void testUpperCaseStrategyStandAlone()
+    public void testUpperSnakeCaseStrategyStandAlone()
     {
         for (Object[] pair : UPPER_SNAKE_CASE_NAME_TRANSLATIONS) {
             String translatedJavaName = PropertyNamingStrategies.UPPER_SNAKE_CASE
                 .nameForField(null, null, (String) pair[0]);
             assertEquals((String) pair[1], translatedJavaName);
         }
+    }
+
+    public void testUpperSnakeCaseTranslations() throws Exception
+    {
+        // First serialize
+        String json = _ucWithUnderscoreMapper.writeValueAsString(new PersonBean("Joe", "Sixpack", 42));
+        assertEquals("{\"FIRST_NAME\":\"Joe\",\"LAST_NAME\":\"Sixpack\",\"AGE\":42}", json);
+
+        // then deserialize
+        PersonBean result = _ucWithUnderscoreMapper.readValue(json, PersonBean.class);
+        assertEquals("Joe", result.firstName);
+        assertEquals("Sixpack", result.lastName);
+        assertEquals(42, result.age);
     }
 
 
@@ -369,8 +382,8 @@ public class TestNamingStrategyStd extends BaseMapTest
      */
 
     /**
-     * Unit test to verify translations of 
-     * {@link PropertyNamingStrategies#UPPER_CAMEL_CASE } 
+     * Unit test to verify translations of
+     * {@link PropertyNamingStrategies#UPPER_CAMEL_CASE }
      * outside the context of an ObjectMapper.
      */
     public void testPascalCaseStandAlone()

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
@@ -206,11 +206,70 @@ public class TestNamingStrategyStd extends BaseMapTest
                 {"xCoordinate", "x_coordinate" },
     });
 
+    final static List<Object[]> UPPER_SNAKE_CASE_NAME_TRANSLATIONS = Arrays.asList(new Object[][] {
+        {null, null},
+        {"", ""},
+        {"a", "A"},
+        {"abc", "ABC"},
+        {"1", "1"},
+        {"123", "123"},
+        {"1a", "1A"},
+        {"a1", "A1"},
+        {"$", "$"},
+        {"$a", "$A"},
+        {"a$", "A$"},
+        {"$_a", "$_A"},
+        {"a_$", "A_$"},
+        {"a$a", "A$A"},
+        {"$A", "$_A"},
+        {"$_A", "$_A"},
+        {"_", "_"},
+        {"__", "_"},
+        {"___", "__"},
+        {"A", "A"},
+        {"A1", "A1"},
+        {"1A", "1_A"},
+        {"_a", "A"},
+        {"_A", "A"},
+        {"a_a", "A_A"},
+        {"a_A", "A_A"},
+        {"A_A", "A_A"},
+        {"A_a", "A_A"},
+        {"WWW", "WWW"},
+        {"someURI", "SOME_URI"},
+        {"someURIs", "SOME_URIS"},
+        {"Results", "RESULTS"},
+        {"_Results", "RESULTS"},
+        {"_results", "RESULTS"},
+        {"__results", "_RESULTS"},
+        {"__Results", "_RESULTS"},
+        {"___results", "__RESULTS"},
+        {"___Results", "__RESULTS"},
+        {"userName", "USER_NAME"},
+        {"user_name", "USER_NAME"},
+        {"user__name", "USER__NAME"},
+        {"UserName", "USER_NAME"},
+        {"User_Name", "USER_NAME"},
+        {"User__Name", "USER__NAME"},
+        {"_user_name", "USER_NAME"},
+        {"_UserName", "USER_NAME"},
+        {"_User_Name", "USER_NAME"},
+        {"USER_NAME", "USER_NAME"},
+        {"_Bars", "BARS" },
+        {"usId", "US_ID" },
+        {"uId", "U_ID" },
+        {"xCoordinate", "X_COORDINATE" },
+    });
+
     private final ObjectMapper VANILLA_MAPPER = newJsonMapper();
 
-    private final ObjectMapper _lcWithUndescoreMapper = JsonMapper.builder()
+    private final ObjectMapper _lcWithUnderscoreMapper = JsonMapper.builder()
             .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .build();
+
+    private final ObjectMapper _ucWithUnderscoreMapper = JsonMapper.builder()
+        .propertyNamingStrategy(PropertyNamingStrategies.UPPER_SNAKE_CASE)
+        .build();
 
     /*
     /**********************************************************
@@ -235,11 +294,11 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testLowerCaseTranslations() throws Exception
     {
         // First serialize
-        String json = _lcWithUndescoreMapper.writeValueAsString(new PersonBean("Joe", "Sixpack", 42));
+        String json = _lcWithUnderscoreMapper.writeValueAsString(new PersonBean("Joe", "Sixpack", 42));
         assertEquals("{\"first_name\":\"Joe\",\"last_name\":\"Sixpack\",\"age\":42}", json);
         
         // then deserialize
-        PersonBean result = _lcWithUndescoreMapper.readValue(json, PersonBean.class);
+        PersonBean result = _lcWithUnderscoreMapper.readValue(json, PersonBean.class);
         assertEquals("Joe", result.firstName);
         assertEquals("Sixpack", result.lastName);
         assertEquals(42, result.age);
@@ -248,11 +307,11 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testLowerCaseAcronymsTranslations() throws Exception
     {
         // First serialize
-        String json = _lcWithUndescoreMapper.writeValueAsString(new Acronyms("world wide web", "http://jackson.codehaus.org", "/path1/,/path2/"));
+        String json = _lcWithUnderscoreMapper.writeValueAsString(new Acronyms("world wide web", "http://jackson.codehaus.org", "/path1/,/path2/"));
         assertEquals("{\"www\":\"world wide web\",\"some_url\":\"http://jackson.codehaus.org\",\"some_uris\":\"/path1/,/path2/\"}", json);
         
         // then deserialize
-        Acronyms result = _lcWithUndescoreMapper.readValue(json, Acronyms.class);
+        Acronyms result = _lcWithUnderscoreMapper.readValue(json, Acronyms.class);
         assertEquals("world wide web", result.WWW);
         assertEquals("http://jackson.codehaus.org", result.someURL);
         assertEquals("/path1/,/path2/", result.someURIs);
@@ -261,11 +320,11 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testLowerCaseOtherNonStandardNamesTranslations() throws Exception
     {
         // First serialize
-        String json = _lcWithUndescoreMapper.writeValueAsString(new OtherNonStandardNames("Results", "_User", "___", "$User"));
+        String json = _lcWithUnderscoreMapper.writeValueAsString(new OtherNonStandardNames("Results", "_User", "___", "$User"));
         assertEquals("{\"results\":\"Results\",\"user\":\"_User\",\"__\":\"___\",\"$_user\":\"$User\"}", json);
         
         // then deserialize
-        OtherNonStandardNames result = _lcWithUndescoreMapper.readValue(json, OtherNonStandardNames.class);
+        OtherNonStandardNames result = _lcWithUnderscoreMapper.readValue(json, OtherNonStandardNames.class);
         assertEquals("Results", result.Results);
         assertEquals("_User", result._User);
         assertEquals("___", result.___);
@@ -275,17 +334,33 @@ public class TestNamingStrategyStd extends BaseMapTest
     public void testLowerCaseUnchangedNames() throws Exception
     {
         // First serialize
-        String json = _lcWithUndescoreMapper.writeValueAsString(new UnchangedNames("from_user", "_user", "from$user", "from7user", "_x"));
+        String json = _lcWithUnderscoreMapper.writeValueAsString(new UnchangedNames("from_user", "_user", "from$user", "from7user", "_x"));
         assertEquals("{\"from_user\":\"from_user\",\"user\":\"_user\",\"from$user\":\"from$user\",\"from7user\":\"from7user\",\"x\":\"_x\"}", json);
 
         // then deserialize
-        UnchangedNames result = _lcWithUndescoreMapper.readValue(json, UnchangedNames.class);
+        UnchangedNames result = _lcWithUnderscoreMapper.readValue(json, UnchangedNames.class);
         assertEquals("from_user", result.from_user);
         assertEquals("_user", result._user);
         assertEquals("from$user", result.from$user);
         assertEquals("from7user", result.from7user);
         assertEquals("_x", result._x);
     }
+
+    /*
+    /**********************************************************
+    /* Test methods for UPPER_SNAKE_CASE
+    /**********************************************************
+     */
+
+    public void testUpperCaseStrategyStandAlone()
+    {
+        for (Object[] pair : UPPER_SNAKE_CASE_NAME_TRANSLATIONS) {
+            String translatedJavaName = PropertyNamingStrategies.UPPER_SNAKE_CASE
+                .nameForField(null, null, (String) pair[0]);
+            assertEquals((String) pair[1], translatedJavaName);
+        }
+    }
+
 
     /*
     /**********************************************************


### PR DESCRIPTION
## Changes

1. Issue: #3238 
2. A new strategy namely `UpperSnakeCaseStrategy`.

## Design

1. We had a `SnakeCaseStrategy` inside the `PropertyNamingStrategies` which had the functionality of translating any input into a proper lower case snake case.
2. Using this to the issue's benefit the `UpperSnakeCaseStrategy` has been extended which internally calls the super class (i.e `SnakeCaseStrategy` translate method.
