### PR TITLE
Fix #3235 fix default type overridden in StdTypeResolverBuilder

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -260,6 +260,21 @@ public class ObjectMapper
             _subtypeValidator = _requireNonNull(ptv, "Can not pass `null` PolymorphicTypeValidator");
         }
 
+        /**
+         * copy constructor
+         */
+        protected DefaultTypeResolverBuilder(DefaultTypeResolverBuilder src) {
+            super(src);
+            this._appliesFor = src._appliesFor;
+            this._subtypeValidator = src._subtypeValidator;
+        }
+
+        @Override
+        protected DefaultTypeResolverBuilder copy() {
+            ClassUtil.verifyMustOverride(DefaultTypeResolverBuilder.class, this, "copy");
+            return new DefaultTypeResolverBuilder(this);
+        }
+
         // 20-Jan-2020: as per [databind#2599] Objects.requireNonNull() from JDK7 not in all Android so
         private static <T> T _requireNonNull(T value, String msg) {
             // Replacement for: return Objects.requireNonNull(t, msg);

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestBaseTypeAsDefault.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestBaseTypeAsDefault.java
@@ -6,8 +6,14 @@ import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class TestBaseTypeAsDefault extends BaseMapTest
 {
@@ -31,6 +37,14 @@ public class TestBaseTypeAsDefault extends BaseMapTest
     static class ChildOfChild extends ChildOfAbstract {
     }
 
+
+    static abstract class AbstractParentWithoutDefault {}
+
+    static class ChildOfParentWithoutDefault extends AbstractParentWithoutDefault {
+        public Map mapField;
+        public Parent objectField;
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -44,7 +58,27 @@ public class TestBaseTypeAsDefault extends BaseMapTest
     protected ObjectMapper MAPPER_WITHOUT_BASE = jsonMapperBuilder()
             .disable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
             .build();
-    
+
+    protected ObjectMapper MAPPER_WITH_RESOLVER_BUILDER_AND_DEFAULT;
+    {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .enable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
+                .addModule(new SimpleModule()
+                        .addAbstractTypeMapping(AbstractParentWithoutDefault.class, ChildOfParentWithoutDefault.class)
+                        .addAbstractTypeMapping(Map.class, TreeMap.class)
+                        .addAbstractTypeMapping(List.class, LinkedList.class)
+                )
+                .registerSubtypes(TreeMap.class, LinkedList.class, ChildOfParentWithoutDefault.class)
+                .build();
+        mapper.setDefaultTyping(
+                new ObjectMapper.DefaultTypeResolverBuilder(
+                        ObjectMapper.DefaultTyping.NON_FINAL, LaissezFaireSubTypeValidator.instance
+                ).init(JsonTypeInfo.Id.CLASS, null
+                ).inclusion(JsonTypeInfo.As.PROPERTY)
+        );
+        MAPPER_WITH_RESOLVER_BUILDER_AND_DEFAULT = mapper;
+    }
+
     public void testPositiveForParent() throws IOException {
         Object o = MAPPER_WITH_BASE.readerFor(Parent.class).readValue("{}");
         assertEquals(o.getClass(), Parent.class);
@@ -89,5 +123,20 @@ public class TestBaseTypeAsDefault extends BaseMapTest
         Object o = MAPPER_WITH_BASE.readerFor(ChildOfAbstract.class).readValue("{}");
 
         assertEquals(o.getClass(), ChildOfChild.class);
+    }
+
+    public void testForAbstractTypeMapping() throws IOException {
+        String t =
+                "{" +
+                "  'mapField': {" +
+                "    'a':'a'" +
+                "  }, " +
+                "  'objectField': {}" +
+                "}";
+        Object o = MAPPER_WITH_RESOLVER_BUILDER_AND_DEFAULT.readValue(a2q(t), AbstractParentWithoutDefault.class);
+        assertEquals(o.getClass(), ChildOfParentWithoutDefault.class);
+        ChildOfParentWithoutDefault ot = (ChildOfParentWithoutDefault) o;
+        assertEquals(ot.mapField.getClass(), TreeMap.class);
+        assertEquals(ot.objectField.getClass(), Parent.class);
     }
 }


### PR DESCRIPTION
**Issue:** [USE_BASE_TYPE_AS_DEFAULT_IMPL not working with DefaultTypeResolverBuilder](https://github.com/FasterXML/jackson-databind/issues/3235) #3235 

**Solution:**
Issue mainly caused by variable `_defaultImpl` is a shared in [`StdTypeResolverBuilder$defineDefaultImpl`](https://github.com/FasterXML/jackson-databind/blob/2.12/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java#L145).
defaultImpl will be setted only if previous value is null. In [BasicDeserializerFactory](https://github.com/FasterXML/jackson-databind/blob/2.12/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java#L1797)
```java
        if ((b.getDefaultImpl() == null) && baseType.isAbstract()) {
            JavaType defaultType = mapAbstractType(config, baseType);
            if ((defaultType != null) && !defaultType.hasRawClass(baseType.getRawClass())) {
                b = b.defaultImpl(defaultType.getRawClass());
            }
        }
```
So,  a newly constructed instance is returned if _defaultImpl is given a new value.

**Other ways to fix this issue:**
1. Change method `buildTypeDeserializer` in interface `TypeResolverBuilder`, adding `defaultImpl` as a method arg. this way will lead too many places need to be changed.
2. remove if condition `defaultType != null` in `BasicDeserializerFactory`. Because they will run in `synchronized` block, this will be ok in most cases. But default `TypeResolverBuilder` is a shared instance, may lead to bugs hard to find&fix.
3. move `mapAbstractType` to `TypeResolverBuilder`. ** May be this is the correct way.**, but changes is too big. 

