### PR TITLE
Fix std deserializeer rejects blank strings for ints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
       <version>0.9.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.functions.invoker</groupId>
+      <artifactId>java-function-invoker</artifactId>
+      <version>1.0.1</version>
+    </dependency>
   </dependencies>
 
   <!-- Alas, need to include snapshot reference since otherwise can not find

--- a/pom.xml
+++ b/pom.xml
@@ -104,11 +104,6 @@
       <version>0.9.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.cloud.functions.invoker</groupId>
-      <artifactId>java-function-invoker</artifactId>
-      <version>1.0.1</version>
-    </dependency>
   </dependencies>
 
   <!-- Alas, need to include snapshot reference since otherwise can not find

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -1367,7 +1367,7 @@ public abstract class StdDeserializer<T>
             return _checkCoercionFail(ctxt, act, rawTargetType, value,
                     "empty String (\"\")");
         } else if (_isBlank(value)) {
-            act = ctxt.findCoercionFromBlankString(logicalType, rawTargetType, CoercionAction.Fail);
+            act = ctxt.findCoercionFromBlankString(logicalType, rawTargetType, CoercionAction.AsEmpty);
             return _checkCoercionFail(ctxt, act, rawTargetType, value,
                     "blank String (all whitespace)");
         } else {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/Jack.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/Jack.java
@@ -1,0 +1,23 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize
+public class Jack {
+    private int j;
+
+    @JsonCreator
+    public Jack(@JsonProperty("J") int j) {
+        this.j = j;
+    }
+
+    public int getJ() {
+        return j;
+    }
+
+    public void setJ(int j) {
+        this.j = j;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
@@ -3,10 +3,8 @@ package com.fasterxml.jackson.databind.deser;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.junit.Assert;
 
 public class TestObjectOrArrayDeserialization extends BaseMapTest
@@ -33,14 +31,40 @@ public class TestObjectOrArrayDeserialization extends BaseMapTest
     }
 
 
-    public void testCoercionOfBlankStrings() {
-        String s =  " ";
+    public void testCoercionOfBlankString() {
+        assertCoercion(" ");//, "0", "0 ", " 0 ", "", "    ", "\\n"});
+    }
 
+    public void testCoercionOfBlankStringWith0() {
+        assertCoercion("0");
+    }
+
+    public void testCoercionOfBlankStringWith0AndSpace() {
+        assertCoercion( "0 ");
+    }
+
+    public void testCoercion0withSpaces() {
+        assertCoercion(" 0 ");
+    }
+
+    public void testCoercionOfEmptyString() {
+        assertCoercion("");
+    }
+
+    public void testCoercionOfLongerBlankString() {
+        assertCoercion("    ");
+    }
+
+    public void testCoercionOfEndlineCharacter() {
+        assertCoercion("\\n");
+    }
+
+    private void assertCoercion (String s){
         final String json = "{ \"J\" : \"" + s + "\" }";
         try {
             final Jack jack = new ObjectMapper().readValue(json, Jack.class);
             System.out.println("j=" + jack.getJ());
-            Assert.assertEquals(0, jack.getJ());
+            Assert.assertEquals("Coercion failed for " + s, 0, jack.getJ());
         } catch (Throwable t) {
             t.printStackTrace();
             fail();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/TestObjectOrArrayDeserialization.java
@@ -3,8 +3,11 @@ package com.fasterxml.jackson.databind.deser;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Assert;
 
 public class TestObjectOrArrayDeserialization extends BaseMapTest
 {
@@ -26,6 +29,21 @@ public class TestObjectOrArrayDeserialization extends BaseMapTest
         public ArrayOrObject(SomeObject object) {
             this.objects = null;
             this.object = object;
+        }
+    }
+
+
+    public void testCoercionOfBlankStrings() {
+        String s =  " ";
+
+        final String json = "{ \"J\" : \"" + s + "\" }";
+        try {
+            final Jack jack = new ObjectMapper().readValue(json, Jack.class);
+            System.out.println("j=" + jack.getJ());
+            Assert.assertEquals(0, jack.getJ());
+        } catch (Throwable t) {
+            t.printStackTrace();
+            fail();
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/FasterXML/jackson-databind/issues/3234

I just jumped in.

I dont know if I put tests in the right place.

Also 56 tests were failing, but they were failing on branch 2.13 even before I started.