### PR TITLE
Optimize: Replace TreeMap with ConcurrentSkipListMap

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.introspect;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -1179,7 +1180,7 @@ public class POJOPropertiesCollector
 
         // Second (starting with 2.11): index, if any:
         if (indexed) {
-            Map<Integer,POJOPropertyBuilder> byIndex = new TreeMap<>();
+            Map<Integer,POJOPropertyBuilder> byIndex = new ConcurrentSkipListMap<>();
             Iterator<Map.Entry<String,POJOPropertyBuilder>> it = all.entrySet().iterator();
             while (it.hasNext()) {
                 Map.Entry<String,POJOPropertyBuilder> entry = it.next();


### PR DESCRIPTION
ConcurrentSkipListMap is a newer data structure than TreeMap and generally performs better.
https://www.javacodegeeks.com/2017/04/simple-map-iterator-performance-test.html

This is my first code contribution to jackson-databind, please excuse any steps I may have missed, I will gladly make changes to fulfill the process to commit code.   I did run the unit tests multiple times and they succeeded every time.

Thank you very much,
Larry Diamond