### PR TITLE
Use Method.getParameterCount() where possible

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -961,8 +961,8 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
                 // and is inner class of the bean class...
                 if ((enclosing != null) && (enclosing == _beanType.getRawClass())) {
                     for (Constructor<?> ctor : valueClass.getConstructors()) {
-                        Class<?>[] paramTypes = ctor.getParameterTypes();
-                        if (paramTypes.length == 1) {
+                        if (ctor.getParameterCount() == 1) {
+                            Class<?>[] paramTypes = ctor.getParameterTypes();
                             if (enclosing.equals(paramTypes[0])) {
                                 if (ctxt.canOverrideAccessModifiers()) {
                                     ClassUtil.checkAndFixAccess(ctor, ctxt.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
@@ -87,14 +87,15 @@ public final class AnnotatedConstructor
 
     @Override
     public int getParameterCount() {
-        return _constructor.getParameterTypes().length;
+        return _constructor.getParameterCount();
     }
 
     @Override
-    public Class<?> getRawParameterType(int index)
-    {
-        Class<?>[] types = _constructor.getParameterTypes();
-        return (index >= types.length) ? null : types[index];
+    public Class<?> getRawParameterType(int index) {
+        if (index >= _constructor.getParameterCount()) {
+            return null;
+        }
+        return _constructor.getParameterTypes()[index];
     }
 
     @Override
@@ -169,8 +170,7 @@ public final class AnnotatedConstructor
 
     @Override
     public String toString() {
-        // 03-Nov-2020 ckozak: This can use _constructor.getParameterCount() once java 8 is required.
-        final int argCount = _constructor.getParameterTypes().length;
+        final int argCount = _constructor.getParameterCount();
         return String.format("[constructor for %s (%d arg%s), annotations: %s",
                 ClassUtil.nameOf(_constructor.getDeclaringClass()), argCount,
                 (argCount == 1) ? "" : "s", _annotations);

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedCreatorCollector.java
@@ -352,7 +352,7 @@ ctor.getDeclaringClass().getName(), paramCount, paramAnns.length));
     protected AnnotatedMethod constructFactoryCreator(Method m,
             TypeResolutionContext typeResCtxt, Method mixin)
     {
-        final int paramCount = m.getParameterTypes().length;
+        final int paramCount = m.getParameterCount();
         if (_intr == null) { // when annotation processing is disabled
             return new AnnotatedMethod(typeResCtxt, m, _emptyAnnotationMap(),
                     _emptyAnnotationMaps(paramCount));

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedMethodCollector.java
@@ -184,7 +184,7 @@ public class AnnotatedMethodCollector
         }
         // also, for now we have no use for methods with more than 2 arguments:
         // (2 argument methods for "any setter", fwtw)
-        int pcount = m.getParameterTypes().length;
+        int pcount = m.getParameterCount();
         return (pcount <= 2);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -339,8 +339,7 @@ public final class ClassUtil
             return false;
         }
         // Must take no args
-        Class<?>[] pts = m.getParameterTypes();
-        if (pts != null && pts.length != 0) {
+        if (m.getParameterCount() != 0) {
             return false;
         }
         // Can't be a void method
@@ -1446,7 +1445,7 @@ cls.getName(), rootCause.getClass().getName(), rootCause.getMessage()),
         public int getParamCount() {
             int c = _paramCount;
             if (c < 0) {
-                c = _ctor.getParameterTypes().length;
+                c = _ctor.getParameterCount();
                 _paramCount = c;
             }
             return c;


### PR DESCRIPTION
Hi,

since the minimum version was lifted to JDK 8 in 2.13 we can make use of `Method.getParameterCount()` to avoid cloning the underlying parameter array unnecessarily.

Let me know what you think. Also - as this is my first contribution to the project - let me know if I should have done anything different.

Cheers,
Christoph