### PR TITLE
#3314 - Fix Flaky Test

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyCustom.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyCustom.java
@@ -103,7 +103,7 @@ public class TestNamingStrategyCustom extends BaseMapTest
         public FieldBean(int v) { key = v; }
     }
 
-    @JsonPropertyOrder({"first_name", "last_name"})
+    @JsonPropertyOrder({"firstName", "lastName", "age"})
     static class PersonBean {
         public String firstName;
         public String lastName;


### PR DESCRIPTION
Upon closer examination, I found that most of the flaky tests in the issue has been fixed and com.fasterxml.jackson.databind.introspect.TestNamingStrategyStd#testUpperSnakeCaseTranslations was the remaining unfixed one. The fix used annotation to specify JSON serialization order and did not introduce any performance regression.
