### PR TITLE
Throw JsonMappingException for deeply nested JSON (#2816, CVE-2020-36518)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
@@ -695,64 +695,67 @@ public class UntypedObjectDeserializer
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException
         {
-            switch (p.currentTokenId()) {
-            case JsonTokenId.ID_START_OBJECT:
-                {
-                    JsonToken t = p.nextToken();
-                    if (t == JsonToken.END_OBJECT) {
-                        return new LinkedHashMap<String,Object>(2);
-                    }
-                }
-            case JsonTokenId.ID_FIELD_NAME:
-                return mapObject(p, ctxt);
-            case JsonTokenId.ID_START_ARRAY:
-                {
-                    JsonToken t = p.nextToken();
-                    if (t == JsonToken.END_ARRAY) { // and empty one too
-                        if (ctxt.isEnabled(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
-                            return NO_OBJECTS;
+            try {
+                switch (p.currentTokenId()) {
+                    case JsonTokenId.ID_START_OBJECT: {
+                        JsonToken t = p.nextToken();
+                        if (t == JsonToken.END_OBJECT) {
+                            return new LinkedHashMap<String, Object>(2);
                         }
-                        return new ArrayList<Object>(2);
                     }
+                    case JsonTokenId.ID_FIELD_NAME:
+                        return mapObject(p, ctxt);
+                    case JsonTokenId.ID_START_ARRAY: {
+                        JsonToken t = p.nextToken();
+                        if (t == JsonToken.END_ARRAY) { // and empty one too
+                            if (ctxt.isEnabled(
+                                DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
+                                return NO_OBJECTS;
+                            }
+                            return new ArrayList<Object>(2);
+                        }
+                    }
+                    if (ctxt.isEnabled(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
+                        return mapArrayToArray(p, ctxt);
+                    }
+                    return mapArray(p, ctxt);
+                    case JsonTokenId.ID_EMBEDDED_OBJECT:
+                        return p.getEmbeddedObject();
+                    case JsonTokenId.ID_STRING:
+                        return p.getText();
+
+                    case JsonTokenId.ID_NUMBER_INT:
+                        if (ctxt.hasSomeOfFeatures(F_MASK_INT_COERCIONS)) {
+                            return _coerceIntegral(p, ctxt);
+                        }
+                        return p.getNumberValue(); // should be optimal, whatever it is
+
+                    case JsonTokenId.ID_NUMBER_FLOAT:
+                        if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
+                            return p.getDecimalValue();
+                        }
+                        return p.getNumberValue();
+
+                    case JsonTokenId.ID_TRUE:
+                        return Boolean.TRUE;
+                    case JsonTokenId.ID_FALSE:
+                        return Boolean.FALSE;
+
+                    case JsonTokenId.ID_END_OBJECT:
+                        // 28-Oct-2015, tatu: [databind#989] We may also be given END_OBJECT (similar to FIELD_NAME),
+                        //    if caller has advanced to the first token of Object, but for empty Object
+                        return new LinkedHashMap<String, Object>(2);
+
+                    case JsonTokenId.ID_NULL: // 08-Nov-2016, tatu: yes, occurs
+                        return null;
+
+                    //case JsonTokenId.ID_END_ARRAY: // invalid
+                    default:
                 }
-                if (ctxt.isEnabled(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
-                    return mapArrayToArray(p, ctxt);
-                }
-                return mapArray(p, ctxt);
-            case JsonTokenId.ID_EMBEDDED_OBJECT:
-                return p.getEmbeddedObject();
-            case JsonTokenId.ID_STRING:
-                return p.getText();
-
-            case JsonTokenId.ID_NUMBER_INT:
-                if (ctxt.hasSomeOfFeatures(F_MASK_INT_COERCIONS)) {
-                    return _coerceIntegral(p, ctxt);
-                }
-                return p.getNumberValue(); // should be optimal, whatever it is
-
-            case JsonTokenId.ID_NUMBER_FLOAT:
-                if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-                    return p.getDecimalValue();
-                }
-                return p.getNumberValue();
-
-            case JsonTokenId.ID_TRUE:
-                return Boolean.TRUE;
-            case JsonTokenId.ID_FALSE:
-                return Boolean.FALSE;
-
-            case JsonTokenId.ID_END_OBJECT:
-                // 28-Oct-2015, tatu: [databind#989] We may also be given END_OBJECT (similar to FIELD_NAME),
-                //    if caller has advanced to the first token of Object, but for empty Object
-                return new LinkedHashMap<String,Object>(2);
-
-            case JsonTokenId.ID_NULL: // 08-Nov-2016, tatu: yes, occurs
-                return null;
-
-            //case JsonTokenId.ID_END_ARRAY: // invalid
-            default:
+                return ctxt.handleUnexpectedToken(Object.class, p);
+            } catch (StackOverflowError soe) {
+                throw new JsonMappingException("JSON is too deeply nested.", soe);
             }
-            return ctxt.handleUnexpectedToken(Object.class, p);
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
@@ -661,6 +661,10 @@ public class UntypedObjectDeserializer
     {
         private static final long serialVersionUID = 1L;
 
+        // Arbitrarily chosen.
+        // Introduced to resolve CVE-2020-36518 and as a temporary hotfix for #2816
+        private static final int MAX_DEPTH = 256;
+
         public final static Vanilla std = new Vanilla();
 
         // @since 2.9
@@ -693,69 +697,78 @@ public class UntypedObjectDeserializer
         }
 
         @Override
-        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return deserialize(p, ctxt, 0);
+        }
+
+        private Object deserialize(JsonParser p, DeserializationContext ctxt, int depth) throws IOException
         {
-            try {
-                switch (p.currentTokenId()) {
-                    case JsonTokenId.ID_START_OBJECT: {
-                        JsonToken t = p.nextToken();
-                        if (t == JsonToken.END_OBJECT) {
-                            return new LinkedHashMap<String, Object>(2);
-                        }
-                    }
-                    case JsonTokenId.ID_FIELD_NAME:
-                        return mapObject(p, ctxt);
-                    case JsonTokenId.ID_START_ARRAY: {
-                        JsonToken t = p.nextToken();
-                        if (t == JsonToken.END_ARRAY) { // and empty one too
-                            if (ctxt.isEnabled(
-                                DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
-                                return NO_OBJECTS;
-                            }
-                            return new ArrayList<Object>(2);
-                        }
-                    }
-                    if (ctxt.isEnabled(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
-                        return mapArrayToArray(p, ctxt);
-                    }
-                    return mapArray(p, ctxt);
-                    case JsonTokenId.ID_EMBEDDED_OBJECT:
-                        return p.getEmbeddedObject();
-                    case JsonTokenId.ID_STRING:
-                        return p.getText();
-
-                    case JsonTokenId.ID_NUMBER_INT:
-                        if (ctxt.hasSomeOfFeatures(F_MASK_INT_COERCIONS)) {
-                            return _coerceIntegral(p, ctxt);
-                        }
-                        return p.getNumberValue(); // should be optimal, whatever it is
-
-                    case JsonTokenId.ID_NUMBER_FLOAT:
-                        if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-                            return p.getDecimalValue();
-                        }
-                        return p.getNumberValue();
-
-                    case JsonTokenId.ID_TRUE:
-                        return Boolean.TRUE;
-                    case JsonTokenId.ID_FALSE:
-                        return Boolean.FALSE;
-
-                    case JsonTokenId.ID_END_OBJECT:
-                        // 28-Oct-2015, tatu: [databind#989] We may also be given END_OBJECT (similar to FIELD_NAME),
-                        //    if caller has advanced to the first token of Object, but for empty Object
+            switch (p.currentTokenId()) {
+                case JsonTokenId.ID_START_OBJECT: {
+                    JsonToken t = p.nextToken();
+                    if (t == JsonToken.END_OBJECT) {
                         return new LinkedHashMap<String, Object>(2);
-
-                    case JsonTokenId.ID_NULL: // 08-Nov-2016, tatu: yes, occurs
-                        return null;
-
-                    //case JsonTokenId.ID_END_ARRAY: // invalid
-                    default:
+                    }
                 }
-                return ctxt.handleUnexpectedToken(Object.class, p);
-            } catch (StackOverflowError soe) {
-                throw new JsonMappingException("JSON is too deeply nested.", soe);
+                case JsonTokenId.ID_FIELD_NAME:
+                    if (depth > MAX_DEPTH) {
+                        throw new JsonParseException(p, "JSON is too deeply nested.");
+                    }
+
+                    return mapObject(p, ctxt, depth);
+                case JsonTokenId.ID_START_ARRAY: {
+                    JsonToken t = p.nextToken();
+                    if (t == JsonToken.END_ARRAY) { // and empty one too
+                        if (ctxt.isEnabled(
+                            DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
+                            return NO_OBJECTS;
+                        }
+                        return new ArrayList<Object>(2);
+                    }
+                }
+
+                if (depth > MAX_DEPTH) {
+                    throw new JsonParseException(p, "JSON is too deeply nested.");
+                }
+
+                if (ctxt.isEnabled(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY)) {
+                    return mapArrayToArray(p, ctxt, depth);
+                }
+                return mapArray(p, ctxt, depth);
+                case JsonTokenId.ID_EMBEDDED_OBJECT:
+                    return p.getEmbeddedObject();
+                case JsonTokenId.ID_STRING:
+                    return p.getText();
+
+                case JsonTokenId.ID_NUMBER_INT:
+                    if (ctxt.hasSomeOfFeatures(F_MASK_INT_COERCIONS)) {
+                        return _coerceIntegral(p, ctxt);
+                    }
+                    return p.getNumberValue(); // should be optimal, whatever it is
+
+                case JsonTokenId.ID_NUMBER_FLOAT:
+                    if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
+                        return p.getDecimalValue();
+                    }
+                    return p.getNumberValue();
+
+                case JsonTokenId.ID_TRUE:
+                    return Boolean.TRUE;
+                case JsonTokenId.ID_FALSE:
+                    return Boolean.FALSE;
+
+                case JsonTokenId.ID_END_OBJECT:
+                    // 28-Oct-2015, tatu: [databind#989] We may also be given END_OBJECT (similar to FIELD_NAME),
+                    //    if caller has advanced to the first token of Object, but for empty Object
+                    return new LinkedHashMap<String, Object>(2);
+
+                case JsonTokenId.ID_NULL: // 08-Nov-2016, tatu: yes, occurs
+                    return null;
+
+                //case JsonTokenId.ID_END_ARRAY: // invalid
+                default:
             }
+            return ctxt.handleUnexpectedToken(Object.class, p);
         }
 
         @Override
@@ -861,15 +874,15 @@ public class UntypedObjectDeserializer
             return deserialize(p, ctxt);
         }
 
-        protected Object mapArray(JsonParser p, DeserializationContext ctxt) throws IOException
+        protected Object mapArray(JsonParser p, DeserializationContext ctxt, int depth) throws IOException
         {
-            Object value = deserialize(p, ctxt);
+            Object value = deserialize(p, ctxt, depth + 1);
             if (p.nextToken()  == JsonToken.END_ARRAY) {
                 ArrayList<Object> l = new ArrayList<Object>(2);
                 l.add(value);
                 return l;
             }
-            Object value2 = deserialize(p, ctxt);
+            Object value2 = deserialize(p, ctxt, depth + 1);
             if (p.nextToken()  == JsonToken.END_ARRAY) {
                 ArrayList<Object> l = new ArrayList<Object>(2);
                 l.add(value);
@@ -883,7 +896,7 @@ public class UntypedObjectDeserializer
             values[ptr++] = value2;
             int totalSize = ptr;
             do {
-                value = deserialize(p, ctxt);
+                value = deserialize(p, ctxt, depth + 1);
                 ++totalSize;
                 if (ptr >= values.length) {
                     values = buffer.appendCompletedChunk(values);
@@ -900,12 +913,12 @@ public class UntypedObjectDeserializer
         /**
          * Method called to map a JSON Array into a Java Object array (Object[]).
          */
-        protected Object[] mapArrayToArray(JsonParser p, DeserializationContext ctxt) throws IOException {
+        protected Object[] mapArrayToArray(JsonParser p, DeserializationContext ctxt, int depth) throws IOException {
             ObjectBuffer buffer = ctxt.leaseObjectBuffer();
             Object[] values = buffer.resetAndStart();
             int ptr = 0;
             do {
-                Object value = deserialize(p, ctxt);
+                Object value = deserialize(p, ctxt, depth + 1);
                 if (ptr >= values.length) {
                     values = buffer.appendCompletedChunk(values);
                     ptr = 0;
@@ -918,13 +931,13 @@ public class UntypedObjectDeserializer
         /**
          * Method called to map a JSON Object into a Java value.
          */
-        protected Object mapObject(JsonParser p, DeserializationContext ctxt) throws IOException
+        protected Object mapObject(JsonParser p, DeserializationContext ctxt, int depth) throws IOException
         {
             // will point to FIELD_NAME at this point, guaranteed
             // 19-Jul-2021, tatu: Was incorrectly using "getText()" before 2.13, fixed for 2.13.0
             String key1 = p.currentName();
             p.nextToken();
-            Object value1 = deserialize(p, ctxt);
+            Object value1 = deserialize(p, ctxt, depth + 1);
 
             String key2 = p.nextFieldName();
             if (key2 == null) { // single entry; but we want modifiable
@@ -933,7 +946,7 @@ public class UntypedObjectDeserializer
                 return result;
             }
             p.nextToken();
-            Object value2 = deserialize(p, ctxt);
+            Object value2 = deserialize(p, ctxt, depth + 1);
 
             String key = p.nextFieldName();
             if (key == null) {
@@ -955,7 +968,7 @@ public class UntypedObjectDeserializer
 
             do {
                 p.nextToken();
-                final Object newValue = deserialize(p, ctxt);
+                final Object newValue = deserialize(p, ctxt, depth + 1);
                 final Object oldValue = result.put(key, newValue);
                 if (oldValue != null) {
                     return _mapObjectWithDups(p, ctxt, result, key, oldValue, newValue,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UntypedObjectDeserializer.java
@@ -663,7 +663,7 @@ public class UntypedObjectDeserializer
 
         // Arbitrarily chosen.
         // Introduced to resolve CVE-2020-36518 and as a temporary hotfix for #2816
-        private static final int MAX_DEPTH = 256;
+        private static final int MAX_DEPTH = 1000;
 
         public final static Vanilla std = new Vanilla();
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/DeepNestingUntypedDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/DeepNestingUntypedDeserTest.java
@@ -1,0 +1,55 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+
+public class DeepNestingUntypedDeserTest extends BaseMapTest
+{
+  // 28-Mar-2021, tatu: Currently 3000 fails for untyped/Object,
+  //     4000 for untyped/Array
+  private final static int TOO_DEEP_NESTING = 4000;
+
+  private final ObjectMapper MAPPER = newJsonMapper();
+
+  public void testUntypedWithArray() throws Exception
+  {
+    final String doc = _nestedDoc(TOO_DEEP_NESTING, "[ ", "] ");
+    try {
+      Object ob = MAPPER.readValue(doc, Object.class);
+      assertTrue(ob instanceof List<?>);
+    } catch (JsonMappingException jme) {
+      assertEquals("JSON is too deeply nested.", jme.getMessage());
+    }
+  }
+
+  public void testUntypedWithObject() throws Exception
+  {
+    final String doc = "{"+_nestedDoc(TOO_DEEP_NESTING, "\"x\":{", "} ") + "}";
+    try {
+      Object ob = MAPPER.readValue(doc, Object.class);
+      assertTrue(ob instanceof Map<?, ?>);
+    } catch (JsonMappingException jme) {
+      assertEquals("JSON is too deeply nested.", jme.getMessage());
+    }
+  }
+
+  private String _nestedDoc(int nesting, String open, String close) {
+    StringBuilder sb = new StringBuilder(nesting * (open.length() + close.length()));
+    for (int i = 0; i < nesting; ++i) {
+      sb.append(open);
+      if ((i & 31) == 0) {
+        sb.append("\n");
+      }
+    }
+    for (int i = 0; i < nesting; ++i) {
+      sb.append(close);
+      if ((i & 31) == 0) {
+        sb.append("\n");
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/DeepNestingUntypedDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/DeepNestingUntypedDeserTest.java
@@ -10,8 +10,8 @@ public class DeepNestingUntypedDeserTest extends BaseMapTest
 {
   // 28-Mar-2021, tatu: Currently 3000 fails for untyped/Object,
   //     4000 for untyped/Array
-  private final static int TOO_DEEP_NESTING = 300;
-  private final static int NOT_TOO_DEEP = 250;
+  private final static int TOO_DEEP_NESTING = 4000;
+  private final static int NOT_TOO_DEEP = 1000;
 
   private final ObjectMapper MAPPER = newJsonMapper();
 
@@ -19,7 +19,7 @@ public class DeepNestingUntypedDeserTest extends BaseMapTest
   {
     final String doc = _nestedDoc(TOO_DEEP_NESTING, "[ ", "] ");
     try {
-      Object ob = MAPPER.readValue(doc, Object.class);
+      MAPPER.readValue(doc, Object.class);
       fail("Should have thrown an exception.");
     } catch (JsonParseException jpe) {
       assertTrue(jpe.getMessage().startsWith("JSON is too deeply nested."));
@@ -37,7 +37,7 @@ public class DeepNestingUntypedDeserTest extends BaseMapTest
   {
     final String doc = "{"+_nestedDoc(TOO_DEEP_NESTING, "\"x\":{", "} ") + "}";
     try {
-      Object ob = MAPPER.readValue(doc, Object.class);
+      MAPPER.readValue(doc, Object.class);
       fail("Should have thrown an exception.");
     } catch (JsonParseException jpe) {
       assertTrue(jpe.getMessage().startsWith("JSON is too deeply nested."));


### PR DESCRIPTION
By throwing a checked exception instead of a runtime exception, it's less likely that Jackson's issues will bring down the caller's code in unexpected ways. I think this might be good enough to consider the CVE resolved.

I copied over the existing failing test and modified it so that it passes if either the original assertion passes or if the test throws a JsonMappingException.