### PR TITLE
Allow (de)serializing records using `Bean(De)SerializerModifier` even when reflection is unavailable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version.core}</version>
     </dependency>
-    <dependency>
-      <groupId>org.graalvm.sdk</groupId>
-      <artifactId>graal-sdk</artifactId>
-      <version>22.0.0.2</version>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- and for testing we need a few libraries
          libs for which we use reflection for code, but direct dep for testing

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version.core}</version>
     </dependency>
+    <dependency>
+      <groupId>org.graalvm.sdk</groupId>
+      <artifactId>graal-sdk</artifactId>
+      <version>22.0.0.2</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- and for testing we need a few libraries
          libs for which we use reflection for code, but direct dep for testing

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1412,6 +1412,10 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
             return ctxt.handleMissingInstantiator(raw, null, p,
 "non-static inner classes like this can only by instantiated using default, no-argument constructor");
         }
+        if (NativeImageUtil.needsReflectionConfiguration(raw)) {
+            return ctxt.handleMissingInstantiator(raw, null, p,
+                    "cannot deserialize from Object value (no delegate- or property-based Creator): this appears to be a native image, in which case you may need to configure reflection for the class that is to be deserialized");
+        }
         return ctxt.handleMissingInstantiator(raw, getValueInstantiator(), p,
 "cannot deserialize from Object value (no delegate- or property-based Creator)");
     }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.introspect;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -527,10 +529,10 @@ public class DefaultAccessorNamingStrategy
                     // trickier: regular fields are ok (handled differently), but should
                     // we also allow getter discovery? For now let's do so
                     "get", "is", null);
-            _fieldNames = new HashSet<>();
-            for (String name : JDK14Util.getRecordFieldNames(forClass.getRawType())) {
-                _fieldNames.add(name);
-            }
+            String[] recordFieldNames = JDK14Util.getRecordFieldNames(forClass.getRawType());
+            _fieldNames = recordFieldNames == null ?
+                    Collections.emptySet() :
+                    new HashSet<>(Arrays.asList(recordFieldNames));
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/jdk14/JDK14Util.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jdk14/JDK14Util.java
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.databind.jdk14;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +12,7 @@ import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.NativeImageUtil;
 
 /**
  * Helper class to support some of JDK 14 (and later) features
@@ -129,7 +129,7 @@ i, components.length, ClassUtil.nameOf(recordType)), e);
             try {
                 return (Object[]) RECORD_GET_RECORD_COMPONENTS.invoke(recordType);
             } catch (Exception e) {
-                if (isGraalUnsupportedFeatureError(e)) {
+                if (NativeImageUtil.isUnsupportedFeatureError(e)) {
                     return null;
                 }
                 throw new IllegalArgumentException("Failed to access RecordComponents of type "
@@ -137,12 +137,6 @@ i, components.length, ClassUtil.nameOf(recordType)), e);
             }
         }
 
-        private boolean isGraalUnsupportedFeatureError(Throwable e) {
-            if (e instanceof InvocationTargetException) {
-                e = e.getCause();
-            }
-            return e.getClass().getName().equals("com.oracle.svm.core.jdk.UnsupportedFeatureError");
-        }
     }
 
     static class RawTypeName {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerFactory.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.util.BeanUtil;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.databind.util.Converter;
 import com.fasterxml.jackson.databind.util.IgnorePropertiesUtil;
+import com.fasterxml.jackson.databind.util.NativeImageUtil;
 
 /**
  * Factory class that can provide serializers for any regular Java beans
@@ -476,7 +477,10 @@ public class BeanSerializerFactory
         }
         if (ser == null) { // Means that no properties were found
             // 21-Aug-2020, tatu: Empty Records should be fine tho
-            if (type.isRecordType()) {
+            // 18-Mar-2022, yawkat: Record will also appear empty when missing reflection info.
+            // needsReflectionConfiguration will check that a constructor is present, else we fall back to the empty
+            // bean error msg
+            if (type.isRecordType() && !NativeImageUtil.needsReflectionConfiguration(type.getRawClass())) {
                 return builder.createDummy();
             }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnknownSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnknownSerializer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.ToEmptyObjectSerializer;
+import com.fasterxml.jackson.databind.util.NativeImageUtil;
 
 @SuppressWarnings("serial")
 public class UnknownSerializer
@@ -43,8 +44,15 @@ public class UnknownSerializer
 
     protected void failForEmpty(SerializerProvider prov, Object value)
             throws JsonMappingException {
-        prov.reportBadDefinition(handledType(), String.format(
-                "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)",
-                value.getClass().getName()));
+        Class<?> cl = value.getClass();
+        if (NativeImageUtil.needsReflectionConfiguration(cl)) {
+            prov.reportBadDefinition(handledType(), String.format(
+                    "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS). This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized",
+                    cl.getName()));
+        } else {
+            prov.reportBadDefinition(handledType(), String.format(
+                    "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)",
+                    cl.getName()));
+        }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -1,7 +1,5 @@
 package com.fasterxml.jackson.databind.util;
 
-import org.graalvm.nativeimage.ImageInfo;
-
 import java.lang.reflect.InvocationTargetException;
 
 /**
@@ -11,15 +9,7 @@ public class NativeImageUtil {
     private static final boolean RUNNING_IN_SVM;
 
     static {
-        boolean runningInSvm;
-        try {
-            // check whether ImageInfo is available
-            ImageInfo.inImageCode();
-            runningInSvm = true;
-        } catch (NoClassDefFoundError ignored) {
-            runningInSvm = false;
-        }
-        RUNNING_IN_SVM = runningInSvm;
+        RUNNING_IN_SVM = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     }
 
     private NativeImageUtil() {
@@ -30,7 +20,7 @@ public class NativeImageUtil {
      * the static initializer may run early during build time
      */
     private static boolean isRunningInNativeImage() {
-        return RUNNING_IN_SVM && ImageInfo.inImageRuntimeCode();
+        return RUNNING_IN_SVM && System.getProperty("org.graalvm.nativeimage.imagecode").equals("runtime");
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.databind.util;
+
+import org.graalvm.nativeimage.ImageInfo;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Utilities for graal native image support.
+ */
+public class NativeImageUtil {
+    private static final boolean RUNNING_IN_SVM;
+
+    static {
+        boolean runningInSvm;
+        try {
+            // check whether ImageInfo is available
+            ImageInfo.inImageCode();
+            runningInSvm = true;
+        } catch (NoClassDefFoundError ignored) {
+            runningInSvm = false;
+        }
+        RUNNING_IN_SVM = runningInSvm;
+    }
+
+    private NativeImageUtil() {
+    }
+
+    /**
+     * Check whether we're running in substratevm native image runtime mode. This check cannot be a constant, because
+     * the static initializer may run early during build time
+     */
+    private static boolean isRunningInNativeImage() {
+        return RUNNING_IN_SVM && ImageInfo.inImageRuntimeCode();
+    }
+
+    /**
+     * Check whether the given error is a substratevm UnsupportedFeatureError
+     */
+    public static boolean isUnsupportedFeatureError(Throwable e) {
+        if (!isRunningInNativeImage()) {
+            return false;
+        }
+        if (e instanceof InvocationTargetException) {
+            e = e.getCause();
+        }
+        return e.getClass().getName().equals("com.oracle.svm.core.jdk.UnsupportedFeatureError");
+    }
+
+    /**
+     * Check whether the given class is likely missing reflection configuration (running in native image, and no
+     * members visible in reflection).
+     */
+    public static boolean needsReflectionConfiguration(Class<?> cl) {
+        if (!isRunningInNativeImage()) {
+            return false;
+        }
+        // records list their fields but not other members
+        return (cl.getDeclaredFields().length == 0 || ClassUtil.isRecordType(cl)) &&
+                cl.getDeclaredMethods().length == 0 &&
+                cl.getDeclaredConstructors().length == 0;
+    }
+}


### PR DESCRIPTION
First of all, apologies for not reporting this issue separately before making a PR. I had to write the patch anyway for internal bureaucracy reasons, so I couldn't wait for more feedback on whether this is the right approach to fix this issue.

---

With graal native image, reflection information for records is opt-in. When it is missing, jackson will report a bad definition:

```
Failures (1):
  JUnit Jupiter:RecordTest:test()
    MethodSource [className = 'RecordTest', methodName = 'test', methodParameterTypes = '']
    => com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Failed to access RecordComponents of type `Rec`
       com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1300)
       com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1447)
       com.fasterxml.jackson.databind.SerializerProvider.findValueSerializer(SerializerProvider.java:544)
       com.fasterxml.jackson.databind.SerializerProvider.findTypedValueSerializer(SerializerProvider.java:822)
       com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:308)
       com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4568)
       com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3821)
       RecordTest.test(RecordTest.java:41)
       java.lang.reflect.Method.invoke(Method.java:568)
       org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
       [...]
```

(similar for deserialization)

This is usually fine, but when the `ObjectMapper` is configured with a `BeanDeserializerModifier` and `BeanSerializerModifier` that implement access to the record components on their own, this is an issue. The error will happen even if the modifiers could (de)serialize a record. A very simple test case is available here, just run `./gradlew nativeTest`: https://github.com/yawkat/graal-record-jackson/blob/master/src/test/java/RecordTest.java 

---

This PR changes `JDK14Util` `recordComponents` to instead return `null` if the call fails due to a graal native image error. It compares the error class, which is unfortunately the only way to do this right now, according to the graal team at oracle. Downstream users of this class are also changed to account for this.

However I see two issues with this PR. First, the errors people get when they *don't* use a modifier are now worse. For serialization: 

```
Failures (1):
  JUnit Jupiter:RecordTest:test()
    MethodSource [className = 'RecordTest', methodName = 'test', methodParameterTypes = '']
    => org.opentest4j.AssertionFailedError: expected: <{"foo":"bar"}> but was: <{}>
       org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
       org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
       org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
       org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
       org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141)
       RecordTest.test(RecordTest.java:41)
       java.lang.reflect.Method.invoke(Method.java:568)
       org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
       org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
       org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
       [...]
```

For deserialization:

```
Failures (1):
  JUnit Jupiter:RecordTest:test()
    MethodSource [className = 'RecordTest', methodName = 'test', methodParameterTypes = '']
    => com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `Rec` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (String)"{"foo":"bar"}"; line: 1, column: 2]
       com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1904)
       com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:400)
       com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1349)
       com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1415)
       com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:351)
       com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:184)
       com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
       com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4674)
       com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3629)
       com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3597)
       [...]
```

iirc this is consistent with what happens with non-record beans when reflection information is unavailable. But the failure mode is certainly more confusing than it is without this patch, which may lead to users not realizing they have to enable reflection for the record classes.

The second issue is testing this. I don't see a sensible way to add native image tests to jackson-databind, so this patch does not have a unit test. This also means it's very easy to introduce a regression here, should this code be touched again.