### PR TITLE
Implement empty string coercion for StringCollectionDeserializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -305,12 +305,10 @@ _containerType,
         if (value.isEmpty()) {
             CoercionAction act = ctxt.findCoercionAction(logicalType(), rawTargetType,
                     CoercionInputShape.EmptyString);
-            act = _checkCoercionFail(ctxt, act, rawTargetType, value,
-                    "empty String (\"\")");
-            if (act != null) {
-                    // handleNonArray may successfully deserialize the result (if
-                    // ACCEPT_SINGLE_VALUE_AS_ARRAY is enabled, for example) otherwise it
-                    // is capable of failing just as well as _deserializeFromEmptyString.
+            // handleNonArray may successfully deserialize the result (if
+            // ACCEPT_SINGLE_VALUE_AS_ARRAY is enabled, for example) otherwise it
+            // is capable of failing just as well as _deserializeFromEmptyString.
+            if (act != null && act != CoercionAction.Fail) {
                 return (Collection<Object>) _deserializeFromEmptyString(
                         p, ctxt, act, rawTargetType, "empty String (\"\")");
             }
@@ -320,8 +318,10 @@ _containerType,
         else if (_isBlank(value)) {
             final CoercionAction act = ctxt.findCoercionFromBlankString(logicalType(), rawTargetType,
                     CoercionAction.Fail);
-            return (Collection<Object>) _deserializeFromEmptyString(
-                    p, ctxt, act, rawTargetType, "blank String (all whitespace)");
+            if (act != CoercionAction.Fail) {
+                return (Collection<Object>) _deserializeFromEmptyString(
+                        p, ctxt, act, rawTargetType, "blank String (all whitespace)");
+            }
         }
         return handleNonArray(p, ctxt, createDefaultInstance(ctxt));
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -300,25 +300,27 @@ public final class StringCollectionDeserializer
             }
             value = (String) _nullProvider.getNullValue(ctxt);
         } else {
+            if (p.hasToken(JsonToken.VALUE_STRING)) {
+                String textValue = p.getText();
+                // https://github.com/FasterXML/jackson-dataformat-xml/issues/513
+                if (textValue.isEmpty()) {
+                    final CoercionAction act = ctxt.findCoercionAction(logicalType(), handledType(),
+                            CoercionInputShape.EmptyString);
+                    return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
+                            "empty String (\"\")");
+                }
+                if (_isBlank(textValue)) {
+                    final CoercionAction act = ctxt.findCoercionFromBlankString(logicalType(), handledType(),
+                            CoercionAction.Fail);
+                    return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
+                            "blank String (all whitespace)");
+                }
+            }
+
             try {
                 value = (valueDes == null) ? _parseString(p, ctxt) : valueDes.deserialize(p, ctxt);
             } catch (Exception e) {
                 throw JsonMappingException.wrapWithPath(e, result, result.size());
-            }
-        }
-        if (value != null) {
-            // https://github.com/FasterXML/jackson-dataformat-xml/issues/513
-            if (value.isEmpty()) {
-                final CoercionAction act = ctxt.findCoercionAction(logicalType(), handledType(),
-                        CoercionInputShape.EmptyString);
-                return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
-                        "empty String (\"\")");
-            }
-            if (_isBlank(value)) {
-                final CoercionAction act = ctxt.findCoercionFromBlankString(logicalType(), handledType(),
-                        CoercionAction.Fail);
-                return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
-                        "blank String (all whitespace)");
             }
         }
         result.add(value);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -306,15 +306,19 @@ public final class StringCollectionDeserializer
                 if (textValue.isEmpty()) {
                     final CoercionAction act = ctxt.findCoercionAction(logicalType(), handledType(),
                             CoercionInputShape.EmptyString);
-                    return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
-                            "empty String (\"\")");
-                }
-                if (_isBlank(textValue)) {
+                    if (act != CoercionAction.Fail) {
+                        return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
+                                "empty String (\"\")");
+                    }
+                } else if (_isBlank(textValue)) {
                     final CoercionAction act = ctxt.findCoercionFromBlankString(logicalType(), handledType(),
                             CoercionAction.Fail);
-                    return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
-                            "blank String (all whitespace)");
+                    if (act != CoercionAction.Fail) {
+                        return (Collection<String>) _deserializeFromEmptyString(p, ctxt, act, handledType(),
+                                "blank String (all whitespace)");
+                    }
                 }
+                // if coercion failed, we can still add it to a list
             }
 
             try {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/std/EmptyStringAsSingleValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/std/EmptyStringAsSingleValueTest.java
@@ -1,0 +1,115 @@
+package com.fasterxml.jackson.databind.deser.std;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+public class EmptyStringAsSingleValueTest {
+    private static ObjectMapper normalMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        return mapper;
+    }
+
+    private static ObjectMapper coercionMapper() {
+        ObjectMapper mapper = normalMapper();
+        // same as XmlMapper
+        mapper.coercionConfigDefaults()
+                .setAcceptBlankAsEmpty(true)
+                .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsEmpty);
+        return mapper;
+    }
+
+    @Test
+    public void emptyToList() throws JsonProcessingException {
+        // NO coercion + empty string input + StringCollectionDeserializer
+        Assert.assertEquals(Collections.singletonList(""), normalMapper().readValue("\"\"", new TypeReference<List<String>>() {}));
+    }
+
+    @Test
+    public void emptyToListWrapper() throws JsonProcessingException {
+        // NO coercion + empty string input + normal CollectionDeserializer
+        Assert.assertEquals(Collections.singletonList(new StringWrapper("")), normalMapper().readValue("\"\"", new TypeReference<List<StringWrapper>>() {}));
+    }
+
+    @Test
+    public void coercedEmptyToList() throws JsonProcessingException {
+        // YES coercion + empty string input + StringCollectionDeserializer
+        Assert.assertEquals(Collections.emptyList(), coercionMapper().readValue("\"\"", new TypeReference<List<String>>() {}));
+    }
+
+    @Test
+    public void coercedEmptyToListWrapper() throws JsonProcessingException {
+        // YES coercion + empty string input + normal CollectionDeserializer
+        Assert.assertEquals(Collections.emptyList(), coercionMapper().readValue("\"\"", new TypeReference<List<StringWrapper>>() {}));
+    }
+
+    @Test
+    public void coercedListToList() throws JsonProcessingException {
+        // YES coercion + empty LIST input + StringCollectionDeserializer
+        Assert.assertEquals(Collections.emptyList(), coercionMapper().readValue("[]", new TypeReference<List<String>>() {}));
+    }
+
+    @Test
+    public void coercedListToListWrapper() throws JsonProcessingException {
+        // YES coercion + empty LIST input + normal CollectionDeserializer
+        Assert.assertEquals(Collections.emptyList(), coercionMapper().readValue("[]", new TypeReference<List<StringWrapper>>() {}));
+    }
+
+    @Test
+    public void blankToList() throws JsonProcessingException {
+        // NO coercion + empty string input + StringCollectionDeserializer
+        Assert.assertEquals(Collections.singletonList(" "), normalMapper().readValue("\" \"", new TypeReference<List<String>>() {}));
+    }
+
+    @Test
+    public void blankToListWrapper() throws JsonProcessingException {
+        // NO coercion + empty string input + normal CollectionDeserializer
+        Assert.assertEquals(Collections.singletonList(new StringWrapper(" ")), normalMapper().readValue("\" \"", new TypeReference<List<StringWrapper>>() {}));
+    }
+
+    @Test
+    public void coercedBlankToList() throws JsonProcessingException {
+        // YES coercion + empty string input + StringCollectionDeserializer
+        Assert.assertEquals(Collections.emptyList(), coercionMapper().readValue("\" \"", new TypeReference<List<String>>() {}));
+    }
+
+    @Test
+    public void coercedBlankToListWrapper() throws JsonProcessingException {
+        // YES coercion + empty string input + normal CollectionDeserializer
+        Assert.assertEquals(Collections.emptyList(), coercionMapper().readValue("\" \"", new TypeReference<List<StringWrapper>>() {}));
+    }
+
+    private static final class StringWrapper {
+        private final String s;
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public StringWrapper(String s) {
+            this.s = s;
+        }
+
+        @Override
+        public String toString() {
+            return "StringWrapper{" + s + "}";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof StringWrapper && ((StringWrapper) obj).s.equals(s);
+        }
+
+        @Override
+        public int hashCode() {
+            return s.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/FasterXML/jackson-dataformat-xml/issues/513 .

@cowtowncoder how can I test this PR? I can't do it in jackson-databind, because the XML JsonParser impl is not available. Making a custom impl that behaves the same way as XML just for this test would be pretty complicated.

The test case is:

```java
public class StringCollectionDeserializerTest extends TestCase {
    @Test
    public void testEmptyXml() throws IOException {
        ObjectMapper mapper = new XmlMapper()
                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                ;
        List<?> strings = mapper.readValue("<items></items>", new TypeReference<List<String>>() {});
        Assert.assertEquals(0, strings.size());
    }
}
```