### PR TITLE
Fix #3419 do not generate stack trace for UnresolvedForwardReference …

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
@@ -168,7 +168,7 @@ public abstract class DefaultDeserializationContext
                 continue;
             }
             if (exception == null) {
-                exception = new UnresolvedForwardReference(getParser(), "Unresolved forward references for: ");
+                exception = new UnresolvedForwardReference(getParser(), "Unresolved forward references for: ")._fillInStackTrace();
             }
             Object key = roid.getKey().key;
             for (Iterator<Referring> iterator = roid.referringProperties(); iterator.hasNext(); ) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/UnresolvedForwardReference.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/UnresolvedForwardReference.java
@@ -97,4 +97,14 @@ public class UnresolvedForwardReference extends JsonMappingException {
         sb.append('.');
         return sb.toString();
     }
+
+    @Override
+    public synchronized UnresolvedForwardReference fillInStackTrace() {
+        return this;
+    }
+
+    public synchronized UnresolvedForwardReference _fillInStackTrace() {
+        super.fillInStackTrace();
+        return this;
+    }
 }


### PR DESCRIPTION
…thrown internally.


Also merge this into 2.13.