### PR TITLE
refactor: Use `Collections#isEmpty()` instead of comparing `size()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -239,7 +239,7 @@ public class MapDeserializer
     }
 
     public void setIgnorableProperties(Set<String> ignorable) {
-        _ignorableProperties = (ignorable == null || ignorable.size() == 0) ?
+        _ignorableProperties = (ignorable == null || ignorable.isEmpty()) ?
                 null : ignorable;
         _inclusionChecker = IgnorePropertiesUtil.buildCheckerIfNeeded(_ignorableProperties, _includableProperties);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StaticListSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StaticListSerializerBase.java
@@ -103,7 +103,7 @@ public abstract class StaticListSerializerBase<T extends Collection<?>>
 
     @Override
     public boolean isEmpty(SerializerProvider provider, T value) {
-        return (value == null) || (value.size() == 0);
+        return (value == null) || (value.isEmpty());
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/databind/ser/TestCustomSerializers.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/TestCustomSerializers.java
@@ -216,7 +216,7 @@ public class TestCustomSerializers extends BaseMapTest
             public void serialize(Collection value, JsonGenerator gen, SerializerProvider provider)
                     throws IOException
             {
-                if (value.size() != 0) {
+                if (!value.isEmpty()) {
                     collectionSerializer.serialize(value, gen, provider);
                 } else {
                     gen.writeNull();


### PR DESCRIPTION
Non functional change to improve the code quality. See https://rules.sonarsource.com/java/RSPEC-1155

This is the result of running the recipe `org.openrewrite.java.cleanup.IsEmptyCallOnCollections` from the OpenRewrite project

Read more : https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections



Created with: [Moderne](https://app.moderne.io)