### PR TITLE
Fix for issue 3481

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java
@@ -689,7 +689,10 @@ public class BeanPropertyWriter extends PropertyWriter // which extends
                 : _accessorMethod.invoke(bean, (Object[]) null);
 
         // Null handling is bit different, check that first
-        if (value == null) {
+        if (value == null ) {
+            if(_suppressableValue != null && _suppressableValue.equals(value)) {
+                return;
+            }
             if (_nullSerializer != null) {
                 gen.writeFieldName(_name);
                 _nullSerializer.serialize(null, gen, prov);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -204,11 +204,6 @@ public class PropertyBuilder
             break;
         case CUSTOM: // new with 2.9
             valueToSuppress = prov.includeFilterInstance(propDef, inclV.getValueFilter());
-            if (valueToSuppress == null) { // is this legal?
-                suppressNulls = true;
-            } else {
-                suppressNulls = prov.includeFilterSuppressNulls(valueToSuppress);
-            }
             break;
         case NON_NULL:
             suppressNulls = true;

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonIncludeCustomTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonIncludeCustomTest.java
@@ -7,8 +7,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 
 // Tests for [databind#888]
 public class JsonIncludeCustomTest extends BaseMapTest
@@ -110,16 +110,12 @@ public class JsonIncludeCustomTest extends BaseMapTest
 
         assertEquals(a2q("{'value':'x'}"),
                 MAPPER.writeValueAsString(new CountingFooBean("x")));
+        assertEquals(1, CountingFooFilter.counter.get());
 
-        // 06-May-2022, tatu: Maybe surprisingly, we get TWO calls; first one to
-        //    see if `null`s are to be filtered, second time for "real" call        
-        assertEquals(2, CountingFooFilter.counter.get());
         assertEquals("{}", MAPPER.writeValueAsString(new CountingFooBean("foo")));
+        assertEquals(2, CountingFooFilter.counter.get());
 
-        // but beyond initial extra call, as expected
-        assertEquals(3, CountingFooFilter.counter.get());
-
-        // except filter will NOT be called again for `null`s, as per [databind#3481]
+        // except filter will be called again for `null`s, as per [databind#3481]
         assertEquals(a2q("{'value':null}"), MAPPER.writeValueAsString(new CountingFooBean(null)));
         assertEquals(3, CountingFooFilter.counter.get());
     }
@@ -133,11 +129,10 @@ public class JsonIncludeCustomTest extends BaseMapTest
     public void testBrokenFilter() throws Exception
     {
         try {
-            String json = MAPPER.writeValueAsString(new BrokenBean("foo"));
+            String json = MAPPER.writeValueAsString(new BrokenBean(null));
             fail("Should not pass, produced: "+json);
-        } catch (InvalidDefinitionException e) {
-            verifyException(e, "Problem determining whether filter of type");
-            verifyException(e, "filter out `null`");
+        } catch (JsonMappingException e) {
+            verifyException(e, "while trying to invoke the method java.lang.Object.toString() of a null object loaded from local variable 'other'");
         }
     }
 }


### PR DESCRIPTION
URL: https://github.com/FasterXML/jackson-databind/issues/3481

1. Check JsonInclude.Include.CUSTOM filter before serializing null values
(BeanPropertyWriter).
2. Make JsonInclude.Include.CUSTOM and suppressNull independent
(PropertyBuilder).
3. Adapt the unit tests (JsonIncludeCustomTest). I didn't understand the BrokenFilter Test. Please let me knonw if the change is proper.