### PR TITLE
TestJava7Types fails on Windows. Fix for 2.12

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
@@ -20,9 +20,9 @@ public class TestJava7Types extends BaseMapTest
 
         Path p = mapper.readValue(json, Path.class);
         assertNotNull(p);
-        
+
         assertEquals(input.toUri(), p.toUri());
-        assertEquals(input, p);
+        assertEquals(input.toAbsolutePath(), p.toAbsolutePath());
     }
 
     // [databind#1688]:
@@ -41,6 +41,6 @@ public class TestJava7Types extends BaseMapTest
         Object ob = obs[0];
         assertTrue(ob instanceof Path);
 
-        assertEquals(input.toString(), ob.toString());
+        assertEquals(input.toAbsolutePath().toString(), ob.toString());
     }
 }


### PR DESCRIPTION
TestJava7Types fails on Windows due to absolute path starting with drive name.

This is #3162 chery picked and commited into 2.12 branch.
