### PR TITLE
check for fast parser flag in more places

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -1030,7 +1030,7 @@ public abstract class StdDeserializer<T>
             _verifyNullForPrimitiveCoercion(ctxt, text);
             return  0.0f;
         }
-        return _parseFloatPrimitive(ctxt, text);
+        return _parseFloatPrimitive(p, ctxt, text);
 }
 
     /**
@@ -1041,6 +1041,20 @@ public abstract class StdDeserializer<T>
     {
         try {
             return NumberInput.parseFloat(text);
+        } catch (IllegalArgumentException iae) { }
+        Number v = (Number) ctxt.handleWeirdStringValue(Float.TYPE, text,
+                "not a valid `float` value");
+        return _nonNullNumber(v).floatValue();
+    }
+
+    /**
+     * @since 2.14
+     */
+    protected final float _parseFloatPrimitive(JsonParser p, DeserializationContext ctxt, String text)
+            throws IOException
+    {
+        try {
+            return NumberInput.parseFloat(text, p.isEnabled(StreamReadFeature.USE_FAST_DOUBLE_PARSER));
         } catch (IllegalArgumentException iae) { }
         Number v = (Number) ctxt.handleWeirdStringValue(Float.TYPE, text,
                 "not a valid `float` value");
@@ -1137,7 +1151,7 @@ public abstract class StdDeserializer<T>
             _verifyNullForPrimitiveCoercion(ctxt, text);
             return  0.0;
         }
-        return _parseDoublePrimitive(ctxt, text);
+        return _parseDoublePrimitive(p, ctxt, text);
     }
 
     /**
@@ -1148,6 +1162,20 @@ public abstract class StdDeserializer<T>
     {
         try {
             return _parseDouble(text);
+        } catch (IllegalArgumentException iae) { }
+        Number v = (Number) ctxt.handleWeirdStringValue(Double.TYPE, text,
+                "not a valid `double` value (as String to convert)");
+        return _nonNullNumber(v).doubleValue();
+    }
+
+    /**
+     * @since 2.14
+     */
+    protected final double _parseDoublePrimitive(JsonParser p, DeserializationContext ctxt, String text)
+            throws IOException
+    {
+        try {
+            return _parseDouble(text, p.isEnabled(StreamReadFeature.USE_FAST_DOUBLE_PARSER));
         } catch (IllegalArgumentException iae) { }
         Number v = (Number) ctxt.handleWeirdStringValue(Double.TYPE, text,
                 "not a valid `double` value (as String to convert)");


### PR DESCRIPTION
Follow up to #3475

I'm not sure why the _parse methods are protected as opposed to private. That's why I made the new methods protected too. I could mark the old methods as deprecated.