### PR TITLE
Fix #3311: essentially backporting #1994 from 3.0 to establish limits on serializer cache

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -9,6 +9,9 @@ Project: jackson-databind
 #2541: Cannot merge polymorphic objects
  (reported by Matthew A)
  (fix contributed by James W)
+#3311: Add serializer-cache size limit to avoid Metaspace issues from
+  caching Serializers
+ (requested by mcolemanNOW@github)
 #3338: `configOverride.setMergeable(false)` not supported by `ArrayNode`
  (requested by Ernst-Jan vdL)
 #3357: `@JsonIgnore` does not if together with `@JsonProperty` or `@JsonFormat`

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/ReadOnlyClassToSerializerMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/ReadOnlyClassToSerializerMap.java
@@ -1,9 +1,8 @@
 package com.fasterxml.jackson.databind.ser.impl;
 
-import java.util.*;
-
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.util.LRUMap;
 import com.fasterxml.jackson.databind.util.TypeKey;
 
 /**
@@ -23,17 +22,15 @@ public final class ReadOnlyClassToSerializerMap
 
     private final int _mask;
 
-    public ReadOnlyClassToSerializerMap(Map<TypeKey,JsonSerializer<Object>> serializers)
+    public ReadOnlyClassToSerializerMap(LRUMap<TypeKey,JsonSerializer<Object>> src)
     {
-        int size = findSize(serializers.size());
-        _size = size;
-        _mask = (size-1);
-        Bucket[] buckets = new Bucket[size];
-        for (Map.Entry<TypeKey,JsonSerializer<Object>> entry : serializers.entrySet()) {
-            TypeKey key = entry.getKey();
+        _size = findSize(src.size());
+        _mask = (_size-1);
+        Bucket[] buckets = new Bucket[_size];
+        src.contents((key, value) -> {
             int index = key.hashCode() & _mask;
-            buckets[index] = new Bucket(buckets[index], key, entry.getValue());
-        }
+            buckets[index] = new Bucket(buckets[index], key, value);
+        });
         _buckets = buckets;
     }
     
@@ -51,7 +48,7 @@ public final class ReadOnlyClassToSerializerMap
     /**
      * Factory method for constructing an instance.
      */
-    public static ReadOnlyClassToSerializerMap from(HashMap<TypeKey, JsonSerializer<Object>> src) {
+    public static ReadOnlyClassToSerializerMap from(LRUMap<TypeKey, JsonSerializer<Object>> src) {
         return new ReadOnlyClassToSerializerMap(src);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/LRUMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/LRUMap.java
@@ -1,5 +1,8 @@
 package com.fasterxml.jackson.databind.util;
 
+import java.util.Map;
+import java.util.function.BiConsumer;
+
 import com.fasterxml.jackson.databind.util.internal.PrivateMaxEntriesMap;
 
 /**
@@ -61,9 +64,21 @@ public class LRUMap<K,V>
     public int size() { return _map.size(); }
 
     /*
-    /**********************************************************
+    /**********************************************************************
+    /* Extended API (2.14)
+    /**********************************************************************
+     */
+
+    public void contents(BiConsumer<K,V> consumer) {
+        for (Map.Entry<K,V> entry : _map.entrySet()) {
+            consumer.accept(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /*
+    /**********************************************************************
     /* Serializable overrides
-    /**********************************************************
+    /**********************************************************************
      */
 
     protected Object readResolve() {


### PR DESCRIPTION
Note: uses new and improved `LRUMap` (see #3530). Limit is 4000 entries (which may translate to fewer types), which is rather high; but the idea is to try to avoid possibility of regression from former unlimited case.