### PR TITLE
fix some of the tests broken with Java17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,16 @@
               <release>17</release>
               <compilerArgs>
                 <arg>-parameters</arg>
+                <arg>--add-opens=java.base/java.lang=ALL-UNNAMED</arg>
+                <arg>--add-opens=java.base/java.util=ALL-UNNAMED</arg>
               </compilerArgs>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Relates to #3469

The remaining broken tests are related to java.lang.Record

The pom change is borrowed from #3549 (thanks to @sigpwned) - seems best to grab the pom change while rest of the PR is discussed.

See https://github.com/FasterXML/jackson-databind/pull/3549#issue-1318997468 for list of broken tests (ones not fixed by this change - this change fixes about a dozen other test failures).

#3102 seems to be the issue that is breaking the Record tests. According to this [medium article](https://medium.com/@atdsqdjyfkyziqkezu/java-15-breaks-deserialization-of-records-902fcc81253d), this reflection support was hardened in Java 15. So the reflection field setter might have worked in Java 14 but has been broken since.