### PR TITLE
Implement #3394: allow `JsonNode` valued Fields for `@JsonAnySetter`

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -20,6 +20,8 @@ Project: jackson-databind
  (reported by lizongbo@github)
 #3373: Change `TypeSerializerBase` to skip `generator.writeTypePrefix()`
   for `null` typeId
+#3394: Allow use of `JsonNode` field for `@JsonAnySetter`
+ (requested by @sixcorners)
 #3405: Create DataTypeFeature abstraction (for JSTEP-7) with placeholder features
 #3417: Allow (de)serializing records using Bean(De)SerializerModifier even when
   reflection is unavailable

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 /**
  * Class that represents a "wildcard" set method which can be used
  * to generically set values of otherwise unmapped (aka "unknown")
- * properties read from Json content.
+ * properties read from JSON content.
  *<p>
  * !!! Note: might make sense to refactor to share some code
  * with {@link SettableBeanProperty}?
@@ -34,10 +34,10 @@ public class SettableAnyProperty
     /**
      * Annotated variant is needed for JDK serialization only
      */
-    final protected AnnotatedMember _setter;
+    protected final AnnotatedMember _setter;
 
-    final boolean _setterIsField;
-    
+    protected final boolean _setterIsField;
+
     protected final JavaType _type;
 
     protected JsonDeserializer<Object> _valueDeserializer;
@@ -68,13 +68,6 @@ public class SettableAnyProperty
         _setterIsField = setter instanceof AnnotatedField;
     }
 
-    @Deprecated // since 2.9
-    public SettableAnyProperty(BeanProperty property, AnnotatedMember setter, JavaType type,
-            JsonDeserializer<Object> valueDeser, TypeDeserializer typeDeser)
-    {
-        this(property, setter, type, null, valueDeser, typeDeser);
-    }
-
     public SettableAnyProperty withValueDeserializer(JsonDeserializer<Object> deser) {
         return new SettableAnyProperty(_property, _setter, _type,
                 _keyDeserializer, deser, _valueTypeDeserializer);
@@ -97,7 +90,7 @@ public class SettableAnyProperty
     Object readResolve() {
         // sanity check...
         if (_setter == null || _setter.getAnnotated() == null) {
-            throw new IllegalArgumentException("Missing method (broken JDK (de)serialization?)");
+            throw new IllegalArgumentException("Missing method/field (broken JDK (de)serialization?)");
         }
         return this;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -1,14 +1,10 @@
 package com.fasterxml.jackson.databind.deser.impl;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import com.fasterxml.jackson.core.JsonLocation;
+
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/BasicBeanDescription.java
@@ -322,9 +322,10 @@ anyMethod.getName(), type.getName()));
                 // For now let's require a Map; in future can add support for other
                 // types like perhaps Iterable<Map.Entry>?
                 Class<?> type = anyField.getRawType();
-                if (!Map.class.isAssignableFrom(type)) {
+                if (!Map.class.isAssignableFrom(type)
+                        && !JsonNode.class.isAssignableFrom(type)) {
                     throw new IllegalArgumentException(String.format(
-"Invalid 'any-setter' annotation on field '%s': type is not instance of java.util.Map",
+"Invalid 'any-setter' annotation on field '%s': type is not instance of `java.util.Map` or `JsonNode`",
 anyField.getName()));
                 }
                 return anyField;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter3394Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter3394Test.java
@@ -1,15 +1,26 @@
 package com.fasterxml.jackson.databind.deser;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 // for [databind#3394]
 public class AnySetter3394Test extends BaseMapTest
 {
     static class AnySetter3394Bean {
         @JsonAnySetter
-        public JsonNode extraData;
+        public JsonNode extraData = new ObjectNode(null);
+    }
+
+    private static class JsonAnySetterOnMapXXX {
+        public int id;
+
+        @JsonAnySetter
+        public Map<String, String> other;
     }
 
     /*
@@ -22,8 +33,19 @@ public class AnySetter3394Test extends BaseMapTest
 
     public void testAnySetterWithJsonNode() throws Exception
     {
-        final String DOC = a2q("{'test': 3}");
+        final String DOC = a2q("{'test':3,'value':true}");
         AnySetter3394Bean bean = MAPPER.readValue(DOC, AnySetter3394Bean.class);
         assertEquals(DOC, ""+bean.extraData);
     }
+
+    /*
+    public void testJsonAnySetterOnMap() throws Exception {
+        JsonAnySetterOnMapXXX result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
+                JsonAnySetterOnMapXXX.class);
+        assertEquals(2, result.id);
+        assertNotNull(result.other);
+        assertEquals("Joe", result.other.get("name"));
+        assertEquals("New Jersey", result.other.get("city"));
+    }
+    */
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter3394Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter3394Test.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import com.fasterxml.jackson.databind.*;
+
+// for [databind#3394]
+public class AnySetter3394Test extends BaseMapTest
+{
+    static class AnySetter3394Bean {
+        @JsonAnySetter
+        public JsonNode extraData;
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    public void testAnySetterWithJsonNode() throws Exception
+    {
+        final String DOC = a2q("{'test': 3}");
+        AnySetter3394Bean bean = MAPPER.readValue(DOC, AnySetter3394Bean.class);
+        assertEquals(DOC, ""+bean.extraData);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter3394Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/AnySetter3394Test.java
@@ -1,8 +1,5 @@
 package com.fasterxml.jackson.databind.deser;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 
 import com.fasterxml.jackson.databind.*;
@@ -12,15 +9,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class AnySetter3394Test extends BaseMapTest
 {
     static class AnySetter3394Bean {
-        @JsonAnySetter
-        public JsonNode extraData = new ObjectNode(null);
-    }
-
-    private static class JsonAnySetterOnMapXXX {
         public int id;
 
         @JsonAnySetter
-        public Map<String, String> other;
+        public JsonNode extraData = new ObjectNode(null);
     }
 
     /*
@@ -33,19 +25,10 @@ public class AnySetter3394Test extends BaseMapTest
 
     public void testAnySetterWithJsonNode() throws Exception
     {
-        final String DOC = a2q("{'test':3,'value':true}");
+        final String DOC = a2q("{'test':3,'nullable':null,'id':42,'value':true}");
         AnySetter3394Bean bean = MAPPER.readValue(DOC, AnySetter3394Bean.class);
-        assertEquals(DOC, ""+bean.extraData);
+        assertEquals(a2q("{'test':3,'nullable':null,'value':true}"),
+                ""+bean.extraData);
+        assertEquals(42, bean.id);
     }
-
-    /*
-    public void testJsonAnySetterOnMap() throws Exception {
-        JsonAnySetterOnMapXXX result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
-                JsonAnySetterOnMapXXX.class);
-        assertEquals(2, result.id);
-        assertNotNull(result.other);
-        assertEquals("Joe", result.other.get("name"));
-        assertEquals("New Jersey", result.other.get("city"));
-    }
-    */
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/AnySetterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/AnySetterTest.java
@@ -146,7 +146,7 @@ public class AnySetterTest
             props.put(name, value);
         }
     }
-    
+
     static class JsonAnySetterOnMap {
         public int id;
 
@@ -344,20 +344,20 @@ public class AnySetterTest
         assertTrue(ob instanceof Impl);
         assertEquals("xyz", ((Impl) ob).value);
     }
-    
-	public void testJsonAnySetterOnMap() throws Exception {
-		JsonAnySetterOnMap result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
-		        JsonAnySetterOnMap.class);
-		assertEquals(2, result.id);
-		assertEquals("Joe", result.other.get("name"));
-		assertEquals("New Jersey", result.other.get("city"));
-	}
 
-	public void testJsonAnySetterOnNullMap() throws Exception {
-		JsonAnySetterOnNullMap result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
-		        JsonAnySetterOnNullMap.class);
-		assertEquals(2, result.id);
-		assertNull(result.other);
+    public void testJsonAnySetterOnMap() throws Exception {
+        JsonAnySetterOnMap result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
+                JsonAnySetterOnMap.class);
+        assertEquals(2, result.id);
+        assertEquals("Joe", result.other.get("name"));
+        assertEquals("New Jersey", result.other.get("city"));
+    }
+
+    public void testJsonAnySetterOnNullMap() throws Exception {
+        JsonAnySetterOnNullMap result = MAPPER.readValue("{\"id\":2,\"name\":\"Joe\", \"city\":\"New Jersey\"}",
+                JsonAnySetterOnNullMap.class);
+        assertEquals(2, result.id);
+        assertNull(result.other);
     }
 
     final static String UNWRAPPED_JSON_349 = a2q(


### PR DESCRIPTION
Had to refactor `SettableAnyProperty` so it's now `abstract`: this is technically backwards-incompatible change of internal API, but not for public API. During Release Candidate phase we hopefully get indicate if someone somewhere was constructing instances directly (they shouldn't) and/or other possible non-supported but nonetheless existing use cases.