### PR TITLE
Allow non-boolean return type for "is-getters" with `MapperFeature.ALLOW_IS_GETTERS_FOR_NON_BOOLEAN`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -486,6 +486,15 @@ public enum MapperFeature implements ConfigFeature
      */
     ALLOW_EXPLICIT_PROPERTY_RENAMING(false),
 
+    /**
+     * Feature that when enabled will allow getters with is-Prefix also for non-boolean return types.
+     * <p>
+     * Feature is disabled by default.
+     *
+     * @since 2.14
+     */
+    ALLOW_IS_GETTERS_FOR_NON_BOOLEAN(false),
+
     /*
     /******************************************************
     /* Coercion features

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
@@ -41,6 +41,7 @@ public class DefaultAccessorNamingStrategy
     protected final BaseNameValidator _baseNameValidator;
 
     protected final boolean _stdBeanNaming;
+    protected final boolean _isGettersNonBoolean;
 
     protected final String _getterPrefix;
     protected final String _isGetterPrefix;
@@ -59,6 +60,7 @@ public class DefaultAccessorNamingStrategy
         _forClass = forClass;
 
         _stdBeanNaming = config.isEnabled(MapperFeature.USE_STD_BEAN_NAMING);
+        _isGettersNonBoolean = config.isEnabled(MapperFeature.ALLOW_IS_GETTERS_FOR_NON_BOOLEAN);
         _mutatorPrefix = mutatorPrefix;
         _getterPrefix = getterPrefix;
         _isGetterPrefix = isGetterPrefix;
@@ -69,10 +71,13 @@ public class DefaultAccessorNamingStrategy
     public String findNameForIsGetter(AnnotatedMethod am, String name)
     {
         if (_isGetterPrefix != null) {
-            if (name.startsWith(_isGetterPrefix)) {
-                return _stdBeanNaming
-                        ? stdManglePropertyName(name, 2)
-                        : legacyManglePropertyName(name, 2);
+            final Class<?> rt = am.getRawType();
+            if (_isGettersNonBoolean || rt == Boolean.class || rt == Boolean.TYPE) {
+                if (name.startsWith(_isGetterPrefix)) {
+                    return _stdBeanNaming
+                            ? stdManglePropertyName(name, 2)
+                            : legacyManglePropertyName(name, 2);
+                }
             }
         }
         return null;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
@@ -69,13 +69,10 @@ public class DefaultAccessorNamingStrategy
     public String findNameForIsGetter(AnnotatedMethod am, String name)
     {
         if (_isGetterPrefix != null) {
-            final Class<?> rt = am.getRawType();
-            if (rt == Boolean.class || rt == Boolean.TYPE) {
-                if (name.startsWith(_isGetterPrefix)) {
-                    return _stdBeanNaming
-                            ? stdManglePropertyName(name, 2)
-                            : legacyManglePropertyName(name, 2);
-                }
+            if (name.startsWith(_isGetterPrefix)) {
+                return _stdBeanNaming
+                        ? stdManglePropertyName(name, 2)
+                        : legacyManglePropertyName(name, 2);
             }
         }
         return null;

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/IsGetterBoolean3609Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/IsGetterBoolean3609Test.java
@@ -1,0 +1,57 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static com.fasterxml.jackson.databind.MapperFeature.ALLOW_IS_GETTERS_FOR_NON_BOOLEAN;
+
+public class IsGetterBoolean3609Test extends BaseMapTest {
+
+    static class POJO3609 {
+        int isEnabled;
+
+        protected POJO3609() { }
+        public POJO3609(int b) {
+            isEnabled = b;
+        }
+
+        public int isEnabled() { return isEnabled; }
+        public void setEnabled(int b) { isEnabled = b; }
+    }
+
+    public void testAllowIntIsGetter() throws Exception
+    {
+        ObjectMapper MAPPER = jsonMapperBuilder()
+                .enable(ALLOW_IS_GETTERS_FOR_NON_BOOLEAN)
+                .build();
+
+        POJO3609 input = new POJO3609(12);
+        final String json = MAPPER.writeValueAsString(input);
+
+        Map<?, ?> props = MAPPER.readValue(json, Map.class);
+        assertEquals(Collections.singletonMap("enabled", 12),
+                props);
+
+        POJO3609 output = MAPPER.readValue(json, POJO3609.class);
+        assertEquals(input.isEnabled, output.isEnabled);
+    }
+
+    public void testDisallowIntIsGetter() throws Exception
+    {
+        ObjectMapper MAPPER = jsonMapperBuilder()
+                .disable(ALLOW_IS_GETTERS_FOR_NON_BOOLEAN)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .build();
+
+        POJO3609 input = new POJO3609(12);
+        final String json = MAPPER.writeValueAsString(input);
+
+        assertEquals("{}", json);
+
+    }
+}


### PR DESCRIPTION
On https://github.com/FasterXML/jackson-module-kotlin/issues/575 we discovered, that through filtering of the returntype we got into the situation of completely skipping serializing a field.

Although its common to only have the syntax on writing `is` only in front of boolean getters, this seems to be a bit too heavy. I would propose, to get rid of this restriction.