### PR TITLE
check for DUPLICATE_PROPERTIES in MapperDeserializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -613,7 +613,19 @@ public class MapDeserializer
                 if (useObjectId) {
                     referringAccumulator.put(key, value);
                 } else {
-                    result.put(key, value);
+                    if (result.containsKey(key) && ctxt.isEnabled(StreamReadCapability.DUPLICATE_PROPERTIES)) {
+                        Object oldValue = result.get(key);
+                        if (oldValue instanceof List) {
+                            ((List<Object>) oldValue).add(value);
+                        } else {
+                            List<Object> newValue = new ArrayList<>();
+                            newValue.add(oldValue);
+                            newValue.add(value);
+                            result.put(key, newValue);
+                        }
+                    } else {
+                        result.put(key, value);
+                    }
                 }
             } catch (UnresolvedForwardReference reference) {
                 handleUnresolvedReference(ctxt, referringAccumulator, key, reference);


### PR DESCRIPTION
Check for DUPLICATE_PROPERTIES in MapperDeserializer to replace found…

For https://github.com/FasterXML/jackson-databind/issues/3484
Only so far I had trouble building a testcase. The JsonMapper builder does not support `StreamReadCapability` features, as they also have no mapped `JsonParser.Feature`. Do you know an elegent way to solve this?