### PR TITLE
[2.13.x] Add check in primitive value deserializers to avoid deep wrapper array nesting wrt UNWRAP_SINGLE_VALUE_ARRAYS [CVE-2022-42003]

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,62 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.14.0 (not yet released)
+
+#1980: Add method(s) in `JsonNode` that works like combination of `at()`
+  and `with()`: `withObject(...)` and `withArray(...)`
+#2541: Cannot merge polymorphic objects
+ (reported by Matthew A)
+ (fix contributed by James W)
+#3311: Add serializer-cache size limit to avoid Metaspace issues from
+  caching Serializers
+ (requested by mcolemanNOW@github)
+#3338: `configOverride.setMergeable(false)` not supported by `ArrayNode`
+ (requested by Ernst-Jan vdL)
+#3357: `@JsonIgnore` does not if together with `@JsonProperty` or `@JsonFormat`
+ (reported by lizongbo@github)
+#3373: Change `TypeSerializerBase` to skip `generator.writeTypePrefix()`
+  for `null` typeId
+#3394: Allow use of `JsonNode` field for `@JsonAnySetter`
+ (requested by @sixcorners)
+#3405: Create DataTypeFeature abstraction (for JSTEP-7) with placeholder features
+#3417: Allow (de)serializing records using Bean(De)SerializerModifier even when
+  reflection is unavailable
+ (contributed by Jonas K)
+#3419: Improve performance of `UnresolvedForwardReference` for forward reference
+ resolution
+(contributed by Gary M)
+#3421: Implement `JsonNodeFeature.READ_NULL_PROPERTIES` to allow skipping of
+  JSON `null` values on reading
+#3443: Do not strip generic type from `Class<C>` when resolving `JavaType`
+ (contributed by Jan J)
+#3447: Deeply nested JsonNode throws StackOverflowError for toString()
+ (reported by Deniz H)
+#3475: Support use of fast double parse
+ (contributed by @pjfanning)
+#3476: Implement `JsonNodeFeature.WRITE_NULL_PROPERTIES` to allow skipping
+  JSON `null` values on writing
+#3481: Filter method only got called once if the field is null when using
+  `@JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = SomeFieldFilter.class)`
+ (contributed by AmiDavidW@github)
+#3497: Deserialization of Throwables with PropertyNamingStrategy does not work
+#3500: Add optional explicit `JsonSubTypes` repeated names check
+ (contributed by Igor S)
+#3503: `StdDeserializer` coerces ints to floats even if configured to fail
+ (contributed by Jordi O-A)
+#3528: `TokenBuffer` defaults for parser/stream-read features neither passed
+  from parser nor use real defaults
+#3530: Change LRUMap to just evict one entry when maxEntries reached
+ (contributed by @pjfanning)
+#3533: Deserialize missing value of `EXTERNAL_PROPERTY` type using
+  custom `NullValueProvider`
+#3535: Replace `JsonNode.with()` with `JsonNode.withObject()`
+#3559: Support `null`-valued `Map` fields with "any setter"
+#3568: Change `JsonNode.with(String)` and `withArray(String)` to consider
+  argument as `JsonPointer` if valid expression
+#3590: Add check in primitive value deserializers to avoid deep wrapper array
+  nesting wrt `UNWRAP_SINGLE_VALUE_ARRAYS`
+
 2.13.4 (03-Sep-2022)
 
 #3275: JDK 16 Illegal reflective access for `Throwable.setCause()` with

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,61 +4,10 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
-2.14.0 (not yet released)
+2.13.4.1 (not yet released)
 
-#1980: Add method(s) in `JsonNode` that works like combination of `at()`
-  and `with()`: `withObject(...)` and `withArray(...)`
-#2541: Cannot merge polymorphic objects
- (reported by Matthew A)
- (fix contributed by James W)
-#3311: Add serializer-cache size limit to avoid Metaspace issues from
-  caching Serializers
- (requested by mcolemanNOW@github)
-#3338: `configOverride.setMergeable(false)` not supported by `ArrayNode`
- (requested by Ernst-Jan vdL)
-#3357: `@JsonIgnore` does not if together with `@JsonProperty` or `@JsonFormat`
- (reported by lizongbo@github)
-#3373: Change `TypeSerializerBase` to skip `generator.writeTypePrefix()`
-  for `null` typeId
-#3394: Allow use of `JsonNode` field for `@JsonAnySetter`
- (requested by @sixcorners)
-#3405: Create DataTypeFeature abstraction (for JSTEP-7) with placeholder features
-#3417: Allow (de)serializing records using Bean(De)SerializerModifier even when
-  reflection is unavailable
- (contributed by Jonas K)
-#3419: Improve performance of `UnresolvedForwardReference` for forward reference
- resolution
-(contributed by Gary M)
-#3421: Implement `JsonNodeFeature.READ_NULL_PROPERTIES` to allow skipping of
-  JSON `null` values on reading
-#3443: Do not strip generic type from `Class<C>` when resolving `JavaType`
- (contributed by Jan J)
-#3447: Deeply nested JsonNode throws StackOverflowError for toString()
- (reported by Deniz H)
-#3475: Support use of fast double parse
- (contributed by @pjfanning)
-#3476: Implement `JsonNodeFeature.WRITE_NULL_PROPERTIES` to allow skipping
-  JSON `null` values on writing
-#3481: Filter method only got called once if the field is null when using
-  `@JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = SomeFieldFilter.class)`
- (contributed by AmiDavidW@github)
-#3497: Deserialization of Throwables with PropertyNamingStrategy does not work
-#3500: Add optional explicit `JsonSubTypes` repeated names check
- (contributed by Igor S)
-#3503: `StdDeserializer` coerces ints to floats even if configured to fail
- (contributed by Jordi O-A)
-#3528: `TokenBuffer` defaults for parser/stream-read features neither passed
-  from parser nor use real defaults
-#3530: Change LRUMap to just evict one entry when maxEntries reached
- (contributed by @pjfanning)
-#3533: Deserialize missing value of `EXTERNAL_PROPERTY` type using
-  custom `NullValueProvider`
-#3535: Replace `JsonNode.with()` with `JsonNode.withObject()`
-#3559: Support `null`-valued `Map` fields with "any setter"
-#3568: Change `JsonNode.with(String)` and `withArray(String)` to consider
-  argument as `JsonPointer` if valid expression
 #3590: Add check in primitive value deserializers to avoid deep wrapper array
-  nesting wrt `UNWRAP_SINGLE_VALUE_ARRAYS`
+  nesting wrt `UNWRAP_SINGLE_VALUE_ARRAYS` [CVE-2022-42003]
 
 2.13.4 (03-Sep-2022)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -2056,7 +2056,7 @@ handledType().getName());
      * Helper method called when detecting a deep(er) nesting of Arrays when trying
      * to unwrap value for {@code DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS}.
      *
-     * @since 2.14
+     * @since 2.13.4.1
      */
     protected Object handleNestedArrayForSingle(JsonParser p, DeserializationContext ctxt) throws IOException
     {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -357,12 +357,8 @@ public abstract class StdDeserializer<T>
         // 23-Mar-2017, tatu: Let's specifically block recursive resolution to avoid
         //   either supporting nested arrays, or to cause infinite looping.
         if (p.hasToken(JsonToken.START_ARRAY)) {
-            String msg = String.format(
-"Cannot deserialize instance of %s out of %s token: nested Arrays not allowed with %s",
-                    ClassUtil.nameOf(_valueClass), JsonToken.START_ARRAY,
-                    "DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS");
             @SuppressWarnings("unchecked")
-            T result = (T) ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p, msg);
+            T result = (T) handleNestedArrayForSingle(p, ctxt);
             return result;
         }
         return (T) deserialize(p, ctxt);
@@ -413,7 +409,9 @@ public abstract class StdDeserializer<T>
         case JsonTokenId.ID_START_ARRAY:
             // 12-Jun-2020, tatu: For some reason calling `_deserializeFromArray()` won't work so:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (boolean) handleNestedArrayForSingle(p, ctxt);
+                }
                 final boolean parsed = _parseBooleanPrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -582,7 +580,9 @@ public abstract class StdDeserializer<T>
         case JsonTokenId.ID_START_ARRAY: // unwrapping / from-empty-array coercion?
             // 12-Jun-2020, tatu: For some reason calling `_deserializeFromArray()` won't work so:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (byte) handleNestedArrayForSingle(p, ctxt);
+                }
                 final byte parsed = _parseBytePrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -652,7 +652,9 @@ public abstract class StdDeserializer<T>
         case JsonTokenId.ID_START_ARRAY:
             // 12-Jun-2020, tatu: For some reason calling `_deserializeFromArray()` won't work so:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (short) handleNestedArrayForSingle(p, ctxt);
+                }
                 final short parsed = _parseShortPrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -719,7 +721,9 @@ public abstract class StdDeserializer<T>
             break;
         case JsonTokenId.ID_START_ARRAY:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (int) handleNestedArrayForSingle(p, ctxt);
+                }
                 final int parsed = _parseIntPrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -870,7 +874,9 @@ public abstract class StdDeserializer<T>
             break;
         case JsonTokenId.ID_START_ARRAY:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (long) handleNestedArrayForSingle(p, ctxt);
+                }
                 final long parsed = _parseLongPrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -995,7 +1001,9 @@ public abstract class StdDeserializer<T>
             break;
         case JsonTokenId.ID_START_ARRAY:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (float) handleNestedArrayForSingle(p, ctxt);
+                }
                 final float parsed = _parseFloatPrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -1102,7 +1110,9 @@ public abstract class StdDeserializer<T>
             break;
         case JsonTokenId.ID_START_ARRAY:
             if (ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                p.nextToken();
+                if (p.nextToken() == JsonToken.START_ARRAY) {
+                    return (double) handleNestedArrayForSingle(p, ctxt);
+                }
                 final double parsed = _parseDoublePrimitive(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -1259,6 +1269,9 @@ public abstract class StdDeserializer<T>
                 default:
                 }
             } else if (unwrap) {
+                if (t == JsonToken.START_ARRAY) {
+                    return (java.util.Date) handleNestedArrayForSingle(p, ctxt);
+                }
                 final Date parsed = _parseDate(p, ctxt);
                 _verifyEndArrayForSingle(p, ctxt);
                 return parsed;
@@ -2037,6 +2050,21 @@ inputDesc, _coercedTypeDesc());
 handledType().getName());
         // 05-May-2016, tatu: Should recover somehow (maybe skip until END_ARRAY);
         //     but for now just fall through
+    }
+
+    /**
+     * Helper method called when detecting a deep(er) nesting of Arrays when trying
+     * to unwrap value for {@code DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS}.
+     *
+     * @since 2.14
+     */
+    protected Object handleNestedArrayForSingle(JsonParser p, DeserializationContext ctxt) throws IOException
+    {
+        String msg = String.format(
+"Cannot deserialize instance of %s out of %s token: nested Arrays not allowed with %s",
+                ClassUtil.nameOf(_valueClass), JsonToken.START_ARRAY,
+                "DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS");
+        return ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p, msg);
     }
 
     protected void _verifyEndArrayForSingle(JsonParser p, DeserializationContext ctxt) throws IOException

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepArrayWrappingForDeser3590Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepArrayWrappingForDeser3590Test.java
@@ -1,0 +1,95 @@
+package com.fasterxml.jackson.databind.deser.dos;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+public class DeepArrayWrappingForDeser3590Test extends BaseMapTest
+{
+    // 05-Sep-2022, tatu: Before fix, failed with 5000
+    private final static int TOO_DEEP_NESTING = 9999;
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+            .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+            .build();
+
+    private final static String TOO_DEEP_DOC = _nestedDoc(TOO_DEEP_NESTING, "[ ", "] ", "123");
+
+    public void testArrayWrappingForBoolean() throws Exception
+    {
+        _testArrayWrappingFor(Boolean.class);
+        _testArrayWrappingFor(Boolean.TYPE);
+    }
+
+    public void testArrayWrappingForByte() throws Exception
+    {
+        _testArrayWrappingFor(Byte.class);
+        _testArrayWrappingFor(Byte.TYPE);
+    }
+
+    public void testArrayWrappingForShort() throws Exception
+    {
+        _testArrayWrappingFor(Short.class);
+        _testArrayWrappingFor(Short.TYPE);
+    }
+
+    public void testArrayWrappingForInt() throws Exception
+    {
+        _testArrayWrappingFor(Integer.class);
+        _testArrayWrappingFor(Integer.TYPE);
+    }
+
+    public void testArrayWrappingForLong() throws Exception
+    {
+        _testArrayWrappingFor(Long.class);
+        _testArrayWrappingFor(Long.TYPE);
+    }
+
+    public void testArrayWrappingForFloat() throws Exception
+    {
+        _testArrayWrappingFor(Float.class);
+        _testArrayWrappingFor(Float.TYPE);
+    }
+
+    public void testArrayWrappingForDouble() throws Exception
+    {
+        _testArrayWrappingFor(Double.class);
+        _testArrayWrappingFor(Double.TYPE);
+    }
+
+    public void testArrayWrappingForDate() throws Exception
+    {
+        _testArrayWrappingFor(Date.class);
+    }
+
+    private void _testArrayWrappingFor(Class<?> cls) throws Exception
+    {
+        try {
+            MAPPER.readValue(TOO_DEEP_DOC, cls);
+            fail("Should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot deserialize");
+            verifyException(e, "nested Arrays not allowed");
+        }
+    }
+
+    private static String _nestedDoc(int nesting, String open, String close, String content) {
+        StringBuilder sb = new StringBuilder(nesting * (open.length() + close.length()));
+        for (int i = 0; i < nesting; ++i) {
+            sb.append(open);
+            if ((i & 31) == 0) {
+                sb.append("\n");
+            }
+        }
+        sb.append("\n").append(content).append("\n");
+        for (int i = 0; i < nesting; ++i) {
+            sb.append(close);
+            if ((i & 31) == 0) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
# What does this PR do?

As discussed in https://github.com/FasterXML/jackson-databind/issues/3590 

Here is a PR with 

- a cherry pick of the related changes 
- updates release notes for a potential 2.13.4.1