### PR TITLE
fix #3624 ALLOW_COERCION_OF_SCALARS allows int->float coercion

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/cfg/CoercionConfigs.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/CoercionConfigs.java
@@ -217,11 +217,14 @@ public class CoercionConfigs
         // scalar for this particular purpose
         final boolean baseScalar = _isScalarType(targetType);
 
-        if (baseScalar) {
-            // Default for setting in 2.x is true
-            if (!config.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS)) {
+        if (baseScalar
+                // Default for setting in 2.x is true
+                && !config.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+                // Coercion from integer-shaped data into a floating point type is not banned by the
+                // ALLOW_COERCION_OF_SCALARS feature because '1' is a valid JSON representation of
+                // '1.0' in a way that other types of coercion do not satisfy.
+                && (targetType != LogicalType.Float || inputShape != CoercionInputShape.Integer)) {
                 return CoercionAction.Fail;
-            }
         }
 
         if (inputShape == CoercionInputShape.EmptyString) {

--- a/src/test/java/com/fasterxml/jackson/databind/convert/CoerceIntToFloatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/CoerceIntToFloatTest.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.convert;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
@@ -32,6 +33,10 @@ public class CoerceIntToFloatTest extends BaseMapTest
     private final ObjectMapper MAPPER_TO_EMPTY = jsonMapperBuilder()
             .withCoercionConfig(LogicalType.Float, cfg ->
                     cfg.setCoercion(CoercionInputShape.Integer, CoercionAction.AsEmpty))
+            .build();
+
+    private final ObjectMapper LEGACY_SCALAR_COERCION_FAIL = jsonMapperBuilder()
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
             .build();
 
     public void testDefaultIntToFloatCoercion() throws JsonProcessingException
@@ -113,6 +118,11 @@ public class CoerceIntToFloatTest extends BaseMapTest
         _verifyCoerceFail(MAPPER_TO_FAIL, double[].class, "[ -2 ]", "element of `double[]`");
 
         _verifyCoerceFail(MAPPER_TO_FAIL, BigDecimal.class, "73455342");
+    }
+
+    public void testLegacyConfiguration() throws JsonProcessingException
+    {
+        assertSuccessfulIntToFloatConversionsWith(LEGACY_SCALAR_COERCION_FAIL);
     }
 
     /*


### PR DESCRIPTION
Issue reported here: #3624

Existing code which disables `MapperFeature.ALLOW_COERCION_OF_SCALARS` unexpectedly impacted by #3509 / #3503 which added support for coercionconfig converting from integer-shaped data into float-shaped data. I agree that the ability to control such facets of coercion is fantastic, but I'm not sure that the feature should impact `MapperFeature.ALLOW_COERCION_OF_SCALARS` for a case that can be considered a valid format in JSON (`1` vs `1.0`, I would argue both are valid representations of `(float) 1`).

In an ideal world, I would use the new coercion configuration type, however this is not always possible due to cross-version compatibility requirements. Dependency resolution from 2.13.x to 2.14.0 will potentially cause deserialization to fail unexpectedly.