### PR TITLE
Use Constructor#getParameterCount() instead of getParameterTypes().length

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedConstructor.java
@@ -87,7 +87,7 @@ public final class AnnotatedConstructor
 
     @Override
     public int getParameterCount() {
-        return _constructor.getParameterTypes().length;
+        return _constructor.getParameterCount();
     }
 
     @Override


### PR DESCRIPTION

The issue with `Constructor#getParameterTypes` that each time it creates a new array by calling `clone` on existing one. It does not make sense for the cases when only knowledge about array size is required