### PR TITLE
Flatten atomic arrays, add tests for LRUMap size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,13 @@
       <version>0.9.1</version>
       <scope>test</scope>
     </dependency>
+    <!-- For testing memory footprint -->
+    <dependency>
+      <groupId>org.openjdk.jol</groupId>
+      <artifactId>jol-core</artifactId>
+      <version>0.16</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- Alas, need to include snapshot reference since otherwise can not find

--- a/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
@@ -143,8 +143,11 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
     /** Mask value for indexing into the read buffers. */
     static final int READ_BUFFERS_MASK = NUMBER_OF_READ_BUFFERS - 1;
 
-    /** The number of pending read operations before attempting to drain. */
-    static final int READ_BUFFER_THRESHOLD = 32;
+    /**
+     * The number of pending read operations before attempting to drain.
+     * The threshold of 4 was introduced due to https://github.com/FasterXML/jackson-databind/issues/3665.
+     */
+    static final int READ_BUFFER_THRESHOLD = 4;
 
     /** The maximum number of read operations to perform per amortized drain. */
     static final int READ_BUFFER_DRAIN_THRESHOLD = 2 * READ_BUFFER_THRESHOLD;

--- a/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
@@ -35,7 +35,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -175,15 +177,19 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
 
     final Lock evictionLock;
     final Queue<Runnable> writeBuffer;
-    final AtomicLong[] readBufferWriteCount;
-    final AtomicLong[] readBufferDrainAtWriteCount;
-    final AtomicReference<Node<K, V>>[][] readBuffers;
+    final AtomicLongArray readBufferWriteCount;
+    final AtomicLongArray readBufferDrainAtWriteCount;
+    final AtomicReferenceArray<Node<K, V>> readBuffers;
 
     final AtomicReference<DrainStatus> drainStatus;
 
     transient Set<K> keySet;
     transient Collection<V> values;
     transient Set<Entry<K, V>> entrySet;
+
+    private static int readBufferIndex(int bufferIndex, int entryIndex) {
+        return READ_BUFFER_SIZE * bufferIndex + entryIndex;
+    }
 
     /**
      * Creates an instance based on the builder's configuration.
@@ -203,17 +209,9 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
         drainStatus = new AtomicReference<DrainStatus>(IDLE);
 
         readBufferReadCount = new long[NUMBER_OF_READ_BUFFERS];
-        readBufferWriteCount = new AtomicLong[NUMBER_OF_READ_BUFFERS];
-        readBufferDrainAtWriteCount = new AtomicLong[NUMBER_OF_READ_BUFFERS];
-        readBuffers = new AtomicReference[NUMBER_OF_READ_BUFFERS][READ_BUFFER_SIZE];
-        for (int i = 0; i < NUMBER_OF_READ_BUFFERS; i++) {
-            readBufferWriteCount[i] = new AtomicLong();
-            readBufferDrainAtWriteCount[i] = new AtomicLong();
-            readBuffers[i] = new AtomicReference[READ_BUFFER_SIZE];
-            for (int j = 0; j < READ_BUFFER_SIZE; j++) {
-                readBuffers[i][j] = new AtomicReference<Node<K, V>>();
-            }
-        }
+        readBufferWriteCount = new AtomicLongArray(NUMBER_OF_READ_BUFFERS);
+        readBufferDrainAtWriteCount = new AtomicLongArray(NUMBER_OF_READ_BUFFERS);
+        readBuffers = new AtomicReferenceArray<>(NUMBER_OF_READ_BUFFERS * READ_BUFFER_SIZE);
     }
 
     /** Ensures that the object is not null. */
@@ -330,12 +328,11 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
         // The location in the buffer is chosen in a racy fashion as the increment
         // is not atomic with the insertion. This means that concurrent reads can
         // overlap and overwrite one another, resulting in a lossy buffer.
-        final AtomicLong counter = readBufferWriteCount[bufferIndex];
-        final long writeCount = counter.get();
-        counter.lazySet(writeCount + 1);
+        final long writeCount = readBufferWriteCount.get(bufferIndex);
+        readBufferWriteCount.lazySet(bufferIndex, writeCount + 1);
 
         final int index = (int) (writeCount & READ_BUFFER_INDEX_MASK);
-        readBuffers[bufferIndex][index].lazySet(node);
+        readBuffers.lazySet(readBufferIndex(bufferIndex, index), node);
 
         return writeCount;
     }
@@ -348,7 +345,7 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
      * @param writeCount the number of writes on the chosen read buffer
      */
     void drainOnReadIfNeeded(int bufferIndex, long writeCount) {
-        final long pending = (writeCount - readBufferDrainAtWriteCount[bufferIndex].get());
+        final long pending = (writeCount - readBufferDrainAtWriteCount.get(bufferIndex));
         final boolean delayable = (pending < READ_BUFFER_THRESHOLD);
         final DrainStatus status = drainStatus.get();
         if (status.shouldDrainBuffers(delayable)) {
@@ -403,20 +400,20 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
     /** Drains the read buffer up to an amortized threshold. */
     //@GuardedBy("evictionLock")
     void drainReadBuffer(int bufferIndex) {
-        final long writeCount = readBufferWriteCount[bufferIndex].get();
+        final long writeCount = readBufferWriteCount.get(bufferIndex);
         for (int i = 0; i < READ_BUFFER_DRAIN_THRESHOLD; i++) {
             final int index = (int) (readBufferReadCount[bufferIndex] & READ_BUFFER_INDEX_MASK);
-            final AtomicReference<Node<K, V>> slot = readBuffers[bufferIndex][index];
-            final Node<K, V> node = slot.get();
+            final int arrayIndex = readBufferIndex(bufferIndex, index);
+            final Node<K, V> node = readBuffers.get(arrayIndex);
             if (node == null) {
                 break;
             }
 
-            slot.lazySet(null);
+            readBuffers.lazySet(arrayIndex, null);
             applyRead(node);
             readBufferReadCount[bufferIndex]++;
         }
-        readBufferDrainAtWriteCount[bufferIndex].lazySet(writeCount);
+        readBufferDrainAtWriteCount.lazySet(bufferIndex, writeCount);
     }
 
     /** Updates the node's location in the page replacement policy. */
@@ -579,10 +576,8 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
             }
 
             // Discard all pending reads
-            for (AtomicReference<Node<K, V>>[] buffer : readBuffers) {
-                for (AtomicReference<Node<K, V>> slot : buffer) {
-                    slot.lazySet(null);
-                }
+            for (int i = 0; i < readBuffers.length(); i++) {
+                readBuffers.lazySet(i, null);
             }
 
             // Apply all pending writes

--- a/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
@@ -134,8 +134,11 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
     /** The maximum capacity of the map. */
     static final long MAXIMUM_CAPACITY = Long.MAX_VALUE - Integer.MAX_VALUE;
 
-    /** The number of read buffers to use. */
-    static final int NUMBER_OF_READ_BUFFERS = ceilingNextPowerOfTwo(NCPU);
+    /**
+     * The number of read buffers to use.
+     * The max of 4 was introduced due to https://github.com/FasterXML/jackson-databind/issues/3665.
+     */
+    static final int NUMBER_OF_READ_BUFFERS = Math.min(4, ceilingNextPowerOfTwo(NCPU));
 
     /** Mask value for indexing into the read buffers. */
     static final int READ_BUFFERS_MASK = NUMBER_OF_READ_BUFFERS - 1;

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -2,11 +2,13 @@ package com.fasterxml.jackson.databind;
 
 import com.google.common.testing.GcFinalization;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jol.info.GraphLayout;
 
 public class MapperFootprintTest {
     @Test
+    @Ignore
     public void testMapperFootprint() throws InterruptedException {
         // memory footprint limit for the ObjectMapper
 

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -3,13 +3,14 @@ package com.fasterxml.jackson.databind;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jol.info.GraphLayout;
+import org.openjdk.jol.vm.VM;
 
 public class MapperFootprintTest {
     @Test
     public void testMapperFootprint() {
         // memory footprint limit for the ObjectMapper
         GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper());
-        Assert.assertTrue(mapperLayout.totalSize() < 50000);
         System.out.println(mapperLayout.toFootprint());
+        Assert.assertTrue(mapperLayout.totalSize() < 50000);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -14,8 +14,15 @@ public class MapperFootprintTest {
             System.gc();
             Thread.sleep(100);
         }
-        GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper())
+        // do this calculation twice. If there's a GC in one case, and the subtract call doesn't work well because of
+        // this, we can fall back to the other.
+        GraphLayout mapperLayoutA = GraphLayout.parseInstance(new ObjectMapper())
                 .subtract(GraphLayout.parseInstance(new ObjectMapper()));
+        GraphLayout mapperLayoutB = GraphLayout.parseInstance(new ObjectMapper())
+                .subtract(GraphLayout.parseInstance(new ObjectMapper()));
+        GraphLayout mapperLayout = mapperLayoutA.totalSize() > mapperLayoutB.totalSize() ?
+                mapperLayoutB : mapperLayoutA;
+
         Assert.assertTrue(
                 "ObjectMapper memory footprint exceeded limit. Footprint details: " + mapperLayout.toFootprint(),
                 mapperLayout.totalSize() < 10000);

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -1,18 +1,23 @@
 package com.fasterxml.jackson.databind;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jol.info.GraphLayout;
 
 public class MapperFootprintTest {
     @Test
-    @Ignore
-    public void testMapperFootprint() {
+    public void testMapperFootprint() throws InterruptedException {
         // memory footprint limit for the ObjectMapper
+
+        // force gc (see javadoc of GraphLayout.subtract)
+        for (int i = 0; i < 5; i++) {
+            System.gc();
+            Thread.sleep(100);
+        }
         GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper())
                 .subtract(GraphLayout.parseInstance(new ObjectMapper()));
-        System.out.println(mapperLayout.toFootprint());
-        Assert.assertTrue(mapperLayout.totalSize() < 50000);
+        Assert.assertTrue(
+                "ObjectMapper memory footprint exceeded limit. Footprint details: " + mapperLayout.toFootprint(),
+                mapperLayout.totalSize() < 10000);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -9,7 +9,7 @@ public class MapperFootprintTest {
     public void testMapperFootprint() {
         // memory footprint limit for the ObjectMapper
         GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper());
-        Assert.assertTrue(mapperLayout.totalSize() < 130000);
+        Assert.assertTrue(mapperLayout.totalSize() < 50000);
         System.out.println(mapperLayout.toFootprint());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.databind;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jol.info.GraphLayout;
+
+public class MapperFootprintTest {
+    @Test
+    public void testMapperFootprint() {
+        // memory footprint limit for the ObjectMapper
+        GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper());
+        Assert.assertTrue(mapperLayout.totalSize() < 130000);
+        System.out.println(mapperLayout.toFootprint());
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -1,15 +1,17 @@
 package com.fasterxml.jackson.databind;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jol.info.GraphLayout;
-import org.openjdk.jol.vm.VM;
 
 public class MapperFootprintTest {
     @Test
+    @Ignore
     public void testMapperFootprint() {
         // memory footprint limit for the ObjectMapper
-        GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper());
+        GraphLayout mapperLayout = GraphLayout.parseInstance(new ObjectMapper())
+                .subtract(GraphLayout.parseInstance(new ObjectMapper()));
         System.out.println(mapperLayout.toFootprint());
         Assert.assertTrue(mapperLayout.totalSize() < 50000);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -1,11 +1,13 @@
 package com.fasterxml.jackson.databind;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jol.info.GraphLayout;
 
 public class MapperFootprintTest {
     @Test
+    @Ignore
     public void testMapperFootprint() throws InterruptedException {
         // memory footprint limit for the ObjectMapper
 

--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -1,21 +1,17 @@
 package com.fasterxml.jackson.databind;
 
+import com.google.common.testing.GcFinalization;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jol.info.GraphLayout;
 
 public class MapperFootprintTest {
     @Test
-    @Ignore
     public void testMapperFootprint() throws InterruptedException {
         // memory footprint limit for the ObjectMapper
 
         // force gc (see javadoc of GraphLayout.subtract)
-        for (int i = 0; i < 5; i++) {
-            System.gc();
-            Thread.sleep(100);
-        }
+        GcFinalization.awaitFullGc();
         // do this calculation twice. If there's a GC in one case, and the subtract call doesn't work well because of
         // this, we can fall back to the other.
         GraphLayout mapperLayoutA = GraphLayout.parseInstance(new ObjectMapper())


### PR DESCRIPTION
See #3665

- Flatten `readBuffers` array to be one-dimensional, this should have no performance impact (if it does, probably positive)
- Move to Atomic\*Array to reduce footprint (similar to #3670 but also for the long arrays)
- Reduce NUMBER_OF_READ_BUFFERS and READ_BUFFER_THRESHOLD to match the values in #3670, this is required so that the test doesn't rely on the number of cores of the test runner
- Add a test based on [jol](https://github.com/openjdk/jol) to verify that the ObjectMapper doesn't have too large a footprint

Using the JOL test, I compared the footprints of various versions of this code. My machine has 24 cores, which influences some of the results.

```
2.13 (target)       4376
2.14                259240
+ flat ARefArray    60760
+ ALongArray        57016
+ READ_BUFFERS = 4  11992
+ THRESHOLD = 4     6616
```

The tests before `READ_BUFFERS = 4` depend on cpu count. As you can see, with all the changes in this PR, we are barely above the memory use of 2.13.