### PR TITLE
switch from bundle to jar packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <artifactId>jackson-databind</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <name>jackson-databind</name>
-  <packaging>bundle</packaging>
+
   <description>General data-binding functionality for Jackson: works on core streaming API</description>
   <url>https://github.com/FasterXML/jackson</url>
   <inceptionYear>2008</inceptionYear>
@@ -159,6 +159,29 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
fixes #3680 by still using Felix maven-bundle-plugin to create the `META-INF/MANIFEST.MF` with OSGi configuration  as usual, but letting `maven-jar-plugin` create the jar output