### PR TITLE
Test Failures on NonDex Issue-3693

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/format/MapEntryFormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/format/MapEntryFormatTest.java
@@ -177,7 +177,6 @@ public class MapEntryFormatTest extends BaseMapTest
                     cfg.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.OBJECT)))
                 .build();
         Map.Entry<String,String> input = new BeanWithMapEntry("foo", "bar").entry;
-        assertEquals(a2q("{'key':'foo','value':'bar'}"),
-                mapper.writeValueAsString(input));
+        assertTrue(mapper.writeValueAsString(input).equals(a2q("{'key':'foo','value':'bar'}")) || mapper.writeValueAsString(input).equals(a2q("{'value':'bar','key':'foo'}")));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
@@ -101,8 +101,8 @@ public class TestObjectIdWithEquals extends BaseMapTest
         foo.otherBars.add(bar2);
 
         String json = mapper.writeValueAsString(foo);
-        assertEquals("{\"id\":1,\"bars\":[{\"id\":1},{\"id\":2}],\"otherBars\":[1,2]}", json);
-
+        assertTrue(json.equals("{\"id\":1,\"bars\":[{\"id\":1},{\"id\":2}],\"otherBars\":[1,2]}")
+                || json.equals("{\"id\":1,\"otherBars\":[{\"id\":1},{\"id\":2}],\"bars\":[1,2]}"));
         Foo foo2 = mapper.readValue(json, Foo.class);       
         assertNotNull(foo2);
         assertEquals(foo.id, foo2.id);

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/TestObjectIdWithEquals.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.*;
 
 public class TestObjectIdWithEquals extends BaseMapTest
 {
+    @JsonPropertyOrder({"id","bars","otherBars"})
     @JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property="id", scope=Foo.class)
     static class Foo {
         public int id;
@@ -101,8 +102,7 @@ public class TestObjectIdWithEquals extends BaseMapTest
         foo.otherBars.add(bar2);
 
         String json = mapper.writeValueAsString(foo);
-        assertTrue(json.equals("{\"id\":1,\"bars\":[{\"id\":1},{\"id\":2}],\"otherBars\":[1,2]}")
-                || json.equals("{\"id\":1,\"otherBars\":[{\"id\":1},{\"id\":2}],\"bars\":[1,2]}"));
+        assertEquals("{\"id\":1,\"bars\":[{\"id\":1},{\"id\":2}],\"otherBars\":[1,2]}", json);
         Foo foo2 = mapper.readValue(json, Foo.class);       
         assertNotNull(foo2);
         assertEquals(foo.id, foo2.id);


### PR DESCRIPTION
Tests in MapEntryFormatTest and TestObjectIdWithEquals.java express non-deterministic behavior and change the order of the attributes. The fix is checking for all possible ways of permutations that could happen.

[Issue] (https://github.com/FasterXML/jackson-databind/issues/3693)

After resolving the issues successfully, the tests pass with NonDex - 

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/52324780/206803777-2bbae723-4f16-4b88-b920-f7fa1105f22c.png">
