### PR TITLE
Java7 classes should no longer need reflection

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.databind.ext;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.util.ClassUtil;
 
 /**
  * To support Java7-incomplete platforms, we will offer support for JDK 7
@@ -15,22 +14,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
  */
 public abstract class Java7Handlers
 {
-    private final static Java7Handlers IMPL;
-
-    static {
-        Java7Handlers impl = null;
-        try {
-            Class<?> cls = Class.forName("com.fasterxml.jackson.databind.ext.Java7HandlersImpl");
-            impl = (Java7Handlers) ClassUtil.createInstance(cls, false);
-        } catch (Throwable t) {
-            // 09-Sep-2019, tatu: Could choose not to log this, but since this is less likely
-            //    to miss (than annotations), do it
-            // 02-Nov-2020, Xakep_SDK: Remove java.logging module dependency
-//            java.util.logging.Logger.getLogger(Java7Handlers.class.getName())
-//                .warning("Unable to load JDK7 types (java.nio.file.Path): no Java7 type support added");
-        }
-        IMPL = impl;
-    }
+    private final static Java7Handlers IMPL = new Java7HandlersImpl();
 
     public static Java7Handlers instance() {
         return IMPL;

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.databind.ext;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
-import com.fasterxml.jackson.databind.util.ClassUtil;
 
 /**
  * To support Java7-incomplete platforms, we will offer support for JDK 7
@@ -14,20 +13,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
  */
 public abstract class Java7Support
 {
-    private final static Java7Support IMPL;
-
-    static {
-        Java7Support impl = null;
-        try {
-            Class<?> cls = Class.forName("com.fasterxml.jackson.databind.ext.Java7SupportImpl");
-            impl = (Java7Support) ClassUtil.createInstance(cls, false);
-        } catch (Throwable t) {
-            // 09-Sep-2019, tatu: Used to log earlier, but with 2.10.0 let's not log
-//            java.util.logging.Logger.getLogger(Java7Support.class.getName())
-//                .warning("Unable to load JDK7 annotations (@ConstructorProperties, @Transient): no Java7 annotation support added");
-        }
-        IMPL = impl;
-    }
+    private final static Java7Support IMPL = new Java7SupportImpl();
 
     public static Java7Support instance() {
         return IMPL;

--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -68,15 +68,8 @@ public class OptionalHandlerFactory implements java.io.Serializable
     // // (note: also assume it comes from JDK so that ClassLoader issues with OSGi
     // // can, I hope, be avoided?)
 
-    private static final Java7Handlers _jdk7Helper;
-    static {
-        Java7Handlers x = null;
-        try {
-            x = Java7Handlers.instance();
-        } catch (Throwable t) { }
-        _jdk7Helper = x;
-    }
-    
+    private static final Java7Handlers _jdk7Helper = Java7Handlers.instance();
+
     public final static OptionalHandlerFactory instance = new OptionalHandlerFactory();
 
     // classes from java.sql module, this module may or may not be present at runtime

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -59,17 +59,9 @@ public class JacksonAnnotationIntrospector
         JsonMerge.class // since 2.9
     };
 
-    // NOTE: loading of Java7 dependencies is encapsulated by handlers in Java7Support,
-    //  here we do not really need any handling; but for extra-safety use try-catch
-    private static final Java7Support _java7Helper;
-    static {
-        Java7Support x = null;
-        try {
-            x = Java7Support.instance();
-        } catch (Throwable t) { }
-        _java7Helper = x;
-    }
-    
+    // NOTE: Since Jackson 2.14, Java 8 is required so we can safely assume Java 7 support will load ok
+    private static final Java7Support _java7Helper = Java7Support.instance();
+
     /**
      * Since introspection of annotation types is a performance issue in some
      * use cases (rare, but do exist), let's try a simple cache to reduce


### PR DESCRIPTION
* Since Jackson 2.14, Java 8 is minimum needed
* with newer Java releases, it is better to minimise the use of Java reflection
* In theory, we could roll this code into parent classes but removing classes might be regarded as a breaking change - in the unlikely scenario, that someone has subclassed this part of the code