### PR TITLE
seems like java.nio.file.Path is safe for Android API level 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,26 +242,22 @@
               mvn animal-sniffer:check
 	-->
       <plugin>
-	<groupId>org.codehaus.mojo</groupId>
-	<artifactId>animal-sniffer-maven-plugin</artifactId>
-	<version>1.22</version>
-	<configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.22</version>
+        <configuration>
           <signature>
             <groupId>com.toasttab.android</groupId>
             <artifactId>gummy-bears-api-${version.android.sdk}</artifactId>
             <version>${version.android.sdk.signature}</version>
           </signature>
-	  <ignores>
+          <ignores>
             <!-- These are only accessed (safely) via "Java7SupportImpl.java" so ignore
               -->
-	    <ignore>java.beans.ConstructorProperties</ignore>
-	    <ignore>java.beans.Transient</ignore>
-	    <ignore>java.nio.file.FileSystemNotFoundException</ignore>
-	    <ignore>java.nio.file.Path</ignore>
-	    <ignore>java.nio.file.Paths</ignore>
-	    <ignore>java.nio.file.spi.FileSystemProvider</ignore>
-	  </ignores>
-	</configuration>
+            <ignore>java.beans.ConstructorProperties</ignore>
+            <ignore>java.beans.Transient</ignore>
+          </ignores>
+        </configuration>
       </plugin>
 
      </plugins>

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.databind.ext;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.util.ClassUtil;
 
 /**
  * To support Java7-incomplete platforms, we will offer support for JDK 7
@@ -15,22 +14,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
  */
 public abstract class Java7Handlers
 {
-    private final static Java7Handlers IMPL;
-
-    static {
-        Java7Handlers impl = null;
-        try {
-            Class<?> cls = Class.forName("com.fasterxml.jackson.databind.ext.Java7HandlersImpl");
-            impl = (Java7Handlers) ClassUtil.createInstance(cls, false);
-        } catch (Throwable t) {
-            // 09-Sep-2019, tatu: Could choose not to log this, but since this is less likely
-            //    to miss (than annotations), do it
-            // 02-Nov-2020, Xakep_SDK: Remove java.logging module dependency
-//            java.util.logging.Logger.getLogger(Java7Handlers.class.getName())
-//                .warning("Unable to load JDK7 types (java.nio.file.Path): no Java7 type support added");
-        }
-        IMPL = impl;
-    }
+    private final static Java7Handlers IMPL = new Java7HandlersImpl();
 
     public static Java7Handlers instance() {
         return IMPL;

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Handlers.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 
 /**
- * To support Java7-incomplete platforms, we will offer support for JDK 7
- * datatype(s) (that is, {@link java.nio.file.Path} through this class, loaded
- * dynamically; if loading fails, support will be missing.
- * This class is the non-JDK-7-dependent API, and {@link Java7HandlersImpl} is
- * JDK7-dependent implementation of functionality.
+ * Since v2.15, {@link Java7HandlersImpl} is no longer loaded via reflection.
+ * <p>
+ *     Prior to v2.15, this class supported Java7-incomplete platforms, specifically
+ *     platforms that do not support {@link java.nio.file.Path}.
+ * </p>
  *
  * @since 2.10 (cleaved off of {@link Java7Support})
  */

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7HandlersImpl.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7HandlersImpl.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 
 /**
+ * Since v2.15, this is no longer loaded via reflection.
+ *
  * @since 2.10
  */
 public class Java7HandlersImpl extends Java7Handlers


### PR DESCRIPTION
* Jackson 2.14 now requires Java 8 and Android API level 26 or above
* this changes saves some reflection lookups but doesn't change the jackson API