### PR TITLE
cifuzz does not work on master due to package name change

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,8 +2,8 @@ name: CIFuzz
 on:
   pull_request:
     branches:
-    - "master"
-    - "3.0"
+    - "2.15"
+    - "2.14"
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* we can always re-enable if and when the ci-fuzz jobs are cloned to work with tools.jackson packages