### PR TITLE
Change Records deserialization to use the same mechanism as POJO deserialization.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -280,16 +280,6 @@ public abstract class BasicDeserializerFactory
 
         // constructors only usable on concrete types:
         if (beanDesc.getType().isConcrete()) {
-            // [databind#2709]: Record support
-            if (beanDesc.getType().isRecordType()) {
-                final List<String> names = new ArrayList<>();
-                // NOTE: this does verify that there is no explicitly annotated alternatives
-                AnnotatedConstructor canonical = JDK14Util.findRecordConstructor(ctxt, beanDesc, names);
-                if (canonical != null) {
-                    _addRecordConstructor(ctxt, ccState, canonical, names);
-                    return ccState.creators.constructValueInstantiator(ctxt);
-                }
-            }
             // 25-Jan-2017, tatu: As per [databind#1501], [databind#1502], [databind#1503], best
             //     for now to skip attempts at using anything but no-args constructor (see
             //     `InnerClassProperty` construction for that)
@@ -400,7 +390,10 @@ index, owner, defs[index], propDef);
      * constructor is to be used: if so, we have implicit names to consider.
      *
      * @since 2.12
+     * @deprecated since 2.15 - no longer used, but kept because this protected method might have been overridden/used
+     * elsewhere
      */
+    @Deprecated
     protected void _addRecordConstructor(DeserializationContext ctxt, CreatorCollectionState ccState,
             AnnotatedConstructor canonical, List<String> implicitNames)
                     throws JsonMappingException
@@ -547,7 +540,9 @@ index, owner, defs[index], propDef);
                 JacksonInject.Value injectable = intr.findInjectableValue(param);
                 final PropertyName name = (propDef == null) ? null : propDef.getFullName();
 
-                if (propDef != null && propDef.isExplicitlyNamed()) {
+                if (propDef != null
+                        // NOTE: Record canonical constructor will have implicitly named propDef
+                        && (propDef.isExplicitlyNamed() || beanDesc.getType().isRecordType())) {
                     ++explicitNameCount;
                     properties[i] = constructCreatorProperty(ctxt, beanDesc, name, i, param, injectable);
                     continue;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -466,7 +466,12 @@ public class BeanDeserializer
             }
             // regular property? needs buffering
             SettableBeanProperty prop = _beanProperties.find(propName);
-            if (prop != null) {
+            // Special handling because Records' ignored creator props weren't removed (to help in creating
+            // constructor-backed PropertyCreator) so they ended up in _beanProperties, unlike POJO (whose ignored
+            // props are removed)
+            boolean isClassWithoutMutator = _beanType.isRecordType();
+
+            if (prop != null && !isClassWithoutMutator) {
                 try {
                     buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
                 } catch (UnresolvedForwardReference reference) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.jdk14.JDK14Util;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
 /**
@@ -610,23 +611,53 @@ public class POJOPropertiesCollector
     protected void _addCreators(Map<String, POJOPropertyBuilder> props)
     {
         // can be null if annotation processing is disabled...
-        if (!_useAnnotations) {
-            return;
+        if (_useAnnotations) {
+            for (AnnotatedConstructor ctor : _classDef.getConstructors()) {
+                if (_creatorProperties == null) {
+                    _creatorProperties = new LinkedList<POJOPropertyBuilder>();
+                }
+                for (int i = 0, len = ctor.getParameterCount(); i < len; ++i) {
+                    _addCreatorParam(props, ctor.getParameter(i));
+                }
+            }
+            for (AnnotatedMethod factory : _classDef.getFactoryMethods()) {
+                if (_creatorProperties == null) {
+                    _creatorProperties = new LinkedList<POJOPropertyBuilder>();
+                }
+                for (int i = 0, len = factory.getParameterCount(); i < len; ++i) {
+                    _addCreatorParam(props, factory.getParameter(i));
+                }
+            }
         }
-        for (AnnotatedConstructor ctor : _classDef.getConstructors()) {
-            if (_creatorProperties == null) {
-                _creatorProperties = new LinkedList<POJOPropertyBuilder>();
-            }
-            for (int i = 0, len = ctor.getParameterCount(); i < len; ++i) {
-                _addCreatorParam(props, ctor.getParameter(i));
-            }
-        }
-        for (AnnotatedMethod factory : _classDef.getFactoryMethods()) {
-            if (_creatorProperties == null) {
-                _creatorProperties = new LinkedList<POJOPropertyBuilder>();
-            }
-            for (int i = 0, len = factory.getParameterCount(); i < len; ++i) {
-                _addCreatorParam(props, factory.getParameter(i));
+        if (_classDef.getType().isRecordType()) {
+            List<String> recordComponentNames = new ArrayList<String>();
+            AnnotatedConstructor canonicalCtor = JDK14Util.findRecordConstructor(
+                    _classDef, _annotationIntrospector, _config, recordComponentNames);
+
+            if (canonicalCtor != null) {
+                if (_creatorProperties == null) {
+                    _creatorProperties = new LinkedList<POJOPropertyBuilder>();
+                }
+
+                Set<AnnotatedParameter> registeredParams = new HashSet<AnnotatedParameter>();
+                for (POJOPropertyBuilder creatorProperty : _creatorProperties) {
+                    Iterator<AnnotatedParameter> iter = creatorProperty.getConstructorParameters();
+                    while (iter.hasNext()) {
+                        AnnotatedParameter param = iter.next();
+                        if (param.getOwner().equals(canonicalCtor)) {
+                            registeredParams.add(param);
+                        }
+                    }
+                }
+
+                if (_creatorProperties.isEmpty() || !registeredParams.isEmpty()) {
+                    for (int i = 0; i < canonicalCtor.getParameterCount(); i++) {
+                        AnnotatedParameter param = canonicalCtor.getParameter(i);
+                        if (!registeredParams.contains(param)) {
+                            _addCreatorParam(props, param, recordComponentNames.get(i));
+                        }
+                    }
+                }
             }
         }
     }
@@ -637,11 +668,23 @@ public class POJOPropertiesCollector
     protected void _addCreatorParam(Map<String, POJOPropertyBuilder> props,
             AnnotatedParameter param)
     {
-        // JDK 8, paranamer, Scala can give implicit name
-        String impl = _annotationIntrospector.findImplicitPropertyName(param);
-        if (impl == null) {
-            impl = "";
+        _addCreatorParam(props, param, null);
+    }
+
+    private void _addCreatorParam(Map<String, POJOPropertyBuilder> props,
+            AnnotatedParameter param, String recordComponentName)
+    {
+        String impl;
+        if (recordComponentName != null) {
+            impl = recordComponentName;
+        } else {
+            // JDK 8, paranamer, Scala can give implicit name
+            impl = _annotationIntrospector.findImplicitPropertyName(param);
+            if (impl == null) {
+                impl = "";
+            }
         }
+
         PropertyName pn = _annotationIntrospector.findNameForDeserialization(param);
         boolean expl = (pn != null && !pn.isEmpty());
         if (!expl) {
@@ -650,10 +693,13 @@ public class POJOPropertiesCollector
                 // this creator parameter -- may or may not be a problem, verified at a later point.
                 return;
             }
-            // Also: if this occurs, there MUST be explicit annotation on creator itself
-            JsonCreator.Mode creatorMode = _annotationIntrospector.findCreatorAnnotation(_config,
-                    param.getOwner());
-            if ((creatorMode == null) || (creatorMode == JsonCreator.Mode.DISABLED)) {
+
+            // Also: if this occurs, there MUST be explicit annotation on creator itself...
+            JsonCreator.Mode creatorMode = _annotationIntrospector.findCreatorAnnotation(_config, param.getOwner());
+            // ...or is a Records canonical constructor
+            boolean isCanonicalConstructor = recordComponentName != null;
+
+            if ((creatorMode == null || creatorMode == JsonCreator.Mode.DISABLED) && !isCanonicalConstructor) {
                 return;
             }
             pn = PropertyName.construct(impl);

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -948,6 +948,17 @@ public class POJOPropertiesCollector
             }
             // Otherwise, check ignorals
             if (prop.anyIgnorals()) {
+                // Special handling for Records, as they do not have mutators so relying on constructors with (mostly)
+                // implicitly-named parameters...
+                if (_classDef.getType().isRecordType()) {
+                    // ...so can only remove ignored field and/or accessors, not constructor parameters that are needed
+                    // for instantiation...
+                    prop.removeIgnored();
+                    // ...which will then be ignored (the incoming property value) during deserialization
+                    _collectIgnorals(prop.getName());
+                    continue;
+                }
+
                 // first: if one or more ignorals, and no explicit markers, remove the whole thing
                 // 16-May-2022, tatu: NOTE! As per [databind#3357] need to consider
                 //    only explicit inclusion by accessors OTHER than ones with ignoral marker

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/Jdk8ConstructorParameterNameAnnotationIntrospector.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/Jdk8ConstructorParameterNameAnnotationIntrospector.java
@@ -1,0 +1,28 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+class Jdk8ConstructorParameterNameAnnotationIntrospector extends JacksonAnnotationIntrospector {
+
+    @Override
+    public String findImplicitPropertyName(AnnotatedMember member) {
+        if (!(member instanceof AnnotatedParameter)) {
+            return null;
+        }
+        AnnotatedParameter parameter = (AnnotatedParameter) member;
+        if (!(parameter.getOwner() instanceof AnnotatedConstructor)) {
+            return null;
+        }
+        AnnotatedConstructor constructor = (AnnotatedConstructor) parameter.getOwner();
+        String parameterName = constructor.getAnnotated().getParameters()[parameter.getIndex()].getName();
+
+        if (parameterName == null || parameterName.isBlank()) {
+            throw new IllegalArgumentException("Unable to extract constructor parameter name for: " + member);
+        }
+
+        return parameterName;
+    }
+}

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordBasicsTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordBasicsTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.ClassUtil;
@@ -22,8 +21,6 @@ public class RecordBasicsTest extends BaseMapTest
     record SimpleRecord(int id, String name) { }
 
     record RecordOfRecord(SimpleRecord record) { }
-
-    record RecordWithIgnore(int id, @JsonIgnore String name) { }
 
     record RecordWithRename(int id, @JsonProperty("rename")String name) { }
 
@@ -56,7 +53,6 @@ public class RecordBasicsTest extends BaseMapTest
 
         assertTrue(ClassUtil.isRecordType(SimpleRecord.class));
         assertTrue(ClassUtil.isRecordType(RecordOfRecord.class));
-        assertTrue(ClassUtil.isRecordType(RecordWithIgnore.class));
         assertTrue(ClassUtil.isRecordType(RecordWithRename.class));
     }
 
@@ -65,7 +61,6 @@ public class RecordBasicsTest extends BaseMapTest
 
         assertTrue(MAPPER.constructType(SimpleRecord.class).isRecordType());
         assertTrue(MAPPER.constructType(RecordOfRecord.class).isRecordType());
-        assertTrue(MAPPER.constructType(RecordWithIgnore.class).isRecordType());
         assertTrue(MAPPER.constructType(RecordWithRename.class).isRecordType());
     }
 
@@ -131,36 +126,9 @@ public class RecordBasicsTest extends BaseMapTest
 
     /*
     /**********************************************************************
-    /* Test methods, ignorals, renames, injects
+    /* Test methods, renames, injects
     /**********************************************************************
      */
-
-    public void testSerializeJsonIgnoreRecord() throws Exception {
-        String json = MAPPER.writeValueAsString(new RecordWithIgnore(123, "Bob"));
-        assertEquals("{\"id\":123}", json);
-    }
-
-    /**
-     * This test-case is just for documentation purpose:
-     * Because unlike JavaBean where the setter can be ignored, the Record's constructor argument must
-     * have value.
-     * <p/>
-     * You can make a constructor parameter optional by {@link JacksonInject}-ing a value, or by creating an alternative
-     * JsonCreator.mode=PROPERTIES constructor that excludes the ignored parameter.
-     *
-     * @see #testDeserializeConstructorInjectRecord()
-     * @see RecordCreatorsTest#testDeserializeWithAltCtor()
-     */
-    public void testDeserializeJsonIgnoreRecord_WillFail() throws Exception {
-        try {
-            MAPPER.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithIgnore.class);
-
-            fail("should not pass");
-        } catch (InvalidDefinitionException e) {
-            verifyException(e, "Argument #1 of constructor");
-            verifyException(e, "must have name when multiple-parameter constructor annotated as Creator");
-        }
-    }
 
     public void testSerializeJsonRename() throws Exception {
         String json = MAPPER.writeValueAsString(new RecordWithRename(123, "Bob"));

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordBasicsTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordBasicsTest.java
@@ -1,17 +1,20 @@
-package com.fasterxml.jackson.databind.failing;
+package com.fasterxml.jackson.databind.records;
 
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.Converter;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-// 01-Dec-2022, tatu: Alas, fails on JDK 17
 public class RecordBasicsTest extends BaseMapTest
 {
     record EmptyRecord() { }
@@ -24,9 +27,21 @@ public class RecordBasicsTest extends BaseMapTest
 
     record RecordWithRename(int id, @JsonProperty("rename")String name) { }
 
+    record RecordWithHeaderInject(int id, @JacksonInject String name) { }
+
+    record RecordWithConstructorInject(int id, String name) {
+
+        RecordWithConstructorInject(int id, @JacksonInject String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
     // [databind#2992]
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     record SnakeRecord(String myId, String myValue){}
+
+    record RecordWithJsonDeserialize(int id, @JsonDeserialize(converter = StringTrimmer.class) String name) { }
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
@@ -116,13 +131,35 @@ public class RecordBasicsTest extends BaseMapTest
 
     /*
     /**********************************************************************
-    /* Test methods, ignorals, renames
+    /* Test methods, ignorals, renames, injects
     /**********************************************************************
      */
 
     public void testSerializeJsonIgnoreRecord() throws Exception {
         String json = MAPPER.writeValueAsString(new RecordWithIgnore(123, "Bob"));
         assertEquals("{\"id\":123}", json);
+    }
+
+    /**
+     * This test-case is just for documentation purpose:
+     * Because unlike JavaBean where the setter can be ignored, the Record's constructor argument must
+     * have value.
+     * <p/>
+     * You can make a constructor parameter optional by {@link JacksonInject}-ing a value, or by creating an alternative
+     * JsonCreator.mode=PROPERTIES constructor that excludes the ignored parameter.
+     *
+     * @see #testDeserializeConstructorInjectRecord()
+     * @see RecordCreatorsTest#testDeserializeWithAltCtor()
+     */
+    public void testDeserializeJsonIgnoreRecord_WillFail() throws Exception {
+        try {
+            MAPPER.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithIgnore.class);
+
+            fail("should not pass");
+        } catch (InvalidDefinitionException e) {
+            verifyException(e, "Argument #1 of constructor");
+            verifyException(e, "must have name when multiple-parameter constructor annotated as Creator");
+        }
     }
 
     public void testSerializeJsonRename() throws Exception {
@@ -137,6 +174,32 @@ public class RecordBasicsTest extends BaseMapTest
         assertEquals(new RecordWithRename(123, "Bob"), value);
     }
 
+    /**
+     * This test-case is just for documentation purpose:
+     * GOTCHA: Annotations on header will be propagated to the field, leading to this failure.
+     *
+     * @see #testDeserializeConstructorInjectRecord()
+     */
+    public void testDeserializeHeaderInjectRecord_WillFail() throws Exception {
+        MAPPER.setInjectableValues(new InjectableValues.Std().addValue(String.class, "Bob"));
+
+        try {
+            MAPPER.readValue("{\"id\":123}", RecordWithHeaderInject.class);
+
+            fail("should not pass");
+        } catch (IllegalArgumentException e) {
+            verifyException(e, "RecordWithHeaderInject#name");
+            verifyException(e, "Can not set final java.lang.String field");
+        }
+    }
+
+    public void testDeserializeConstructorInjectRecord() throws Exception {
+        MAPPER.setInjectableValues(new InjectableValues.Std().addValue(String.class, "Bob"));
+
+        RecordWithConstructorInject value = MAPPER.readValue("{\"id\":123}", RecordWithConstructorInject.class);
+        assertEquals(new RecordWithConstructorInject(123, "Bob"), value);
+    }
+
     /*
     /**********************************************************************
     /* Test methods, naming strategy
@@ -147,9 +210,24 @@ public class RecordBasicsTest extends BaseMapTest
     public void testNamingStrategy() throws Exception
     {
         SnakeRecord input = new SnakeRecord("123", "value");
+
         String json = MAPPER.writeValueAsString(input);
+        assertEquals("{\"my_id\":\"123\",\"my_value\":\"value\"}", json);
+
         SnakeRecord output = MAPPER.readValue(json, SnakeRecord.class);
         assertEquals(input, output);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, JsonDeserialize
+    /**********************************************************************
+     */
+
+    public void testDeserializeJsonDeserializeRecord() throws Exception {
+        RecordWithJsonDeserialize value = MAPPER.readValue("{\"id\":123,\"name\":\"   Bob   \"}", RecordWithJsonDeserialize.class);
+
+        assertEquals(new RecordWithJsonDeserialize(123, "Bob"), value);
     }
 
     /*
@@ -164,5 +242,23 @@ public class RecordBasicsTest extends BaseMapTest
         result.put(key1, value1);
         result.put(key2, value2);
         return result;
+    }
+
+    public static class StringTrimmer implements Converter<String, String> {
+
+        @Override
+        public String convert(String value) {
+            return value.trim();
+        }
+
+        @Override
+        public JavaType getInputType(TypeFactory typeFactory) {
+            return typeFactory.constructType(String.class);
+        }
+
+        @Override
+        public JavaType getOutputType(TypeFactory typeFactory) {
+            return typeFactory.constructType(String.class);
+        }
     }
 }

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordCreatorsTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordCreatorsTest.java
@@ -57,6 +57,17 @@ public class RecordCreatorsTest extends BaseMapTest
                 RecordWithAltCtor.class);
         assertEquals(2812, value.id());
         assertEquals("name2", value.name());
+
+        // "Implicit" canonical constructor can no longer be used when there's explicit constructor
+        try {
+            MAPPER.readValue("{\"id\":2812,\"name\":\"Bob\"}",
+                    RecordWithAltCtor.class);
+
+            fail("should not pass");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Can not set final java.lang.String field");
+            verifyException(e, "RecordWithAltCtor.name");
+        }
     }
 
     // [databind#2980]

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordExplicitCreatorsTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordExplicitCreatorsTest.java
@@ -1,0 +1,326 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+import java.math.BigDecimal;
+
+public class RecordExplicitCreatorsTest extends BaseMapTest
+{
+    record RecordWithOneJsonPropertyWithoutJsonCreator(int id, String name) {
+
+        public RecordWithOneJsonPropertyWithoutJsonCreator(@JsonProperty("id_only") int id) {
+            this(id, "JsonPropertyConstructor");
+        }
+
+        public static RecordWithOneJsonPropertyWithoutJsonCreator valueOf(int id) {
+            return new RecordWithOneJsonPropertyWithoutJsonCreator(id);
+        }
+    }
+
+    record RecordWithTwoJsonPropertyWithoutJsonCreator(int id, String name, String email) {
+
+        public RecordWithTwoJsonPropertyWithoutJsonCreator(@JsonProperty("the_id") int id, @JsonProperty("the_email") String email) {
+            this(id, "TwoJsonPropertyConstructor", email);
+        }
+
+        public static RecordWithTwoJsonPropertyWithoutJsonCreator valueOf(int id) {
+            return new RecordWithTwoJsonPropertyWithoutJsonCreator(id, "factory@example.com");
+        }
+    }
+
+    record RecordWithJsonPropertyAndImplicitPropertyWithoutJsonCreator(int id, String name, String email) {
+
+        public RecordWithJsonPropertyAndImplicitPropertyWithoutJsonCreator(@JsonProperty("id_only") int id, String email) {
+            this(id, "JsonPropertyConstructor", email);
+        }
+    }
+
+    record RecordWithJsonPropertyWithJsonCreator(int id, String name) {
+
+        @JsonCreator
+        public RecordWithJsonPropertyWithJsonCreator(@JsonProperty("id_only") int id) {
+            this(id, "JsonCreatorConstructor");
+        }
+
+        public static RecordWithJsonPropertyWithJsonCreator valueOf(int id) {
+            return new RecordWithJsonPropertyWithJsonCreator(id);
+        }
+    }
+
+    record RecordWithJsonPropertyAndImplicitPropertyWithJsonCreator(int id, String name, String email) {
+
+        @JsonCreator
+        public RecordWithJsonPropertyAndImplicitPropertyWithJsonCreator(@JsonProperty("id_only") int id, String email) {
+            this(id, "JsonPropertyConstructor", email);
+        }
+    }
+
+    record RecordWithMultiExplicitDelegatingConstructor(int id, String name) {
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public RecordWithMultiExplicitDelegatingConstructor(int id) {
+            this(id, "IntConstructor");
+        }
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public RecordWithMultiExplicitDelegatingConstructor(String id) {
+            this(Integer.parseInt(id), "StringConstructor");
+        }
+    }
+
+    record RecordWithDisabledJsonCreator(int id, String name) {
+
+        @JsonCreator(mode = JsonCreator.Mode.DISABLED)
+        RecordWithDisabledJsonCreator {
+        }
+    }
+
+    record RecordWithExplicitFactoryMethod(BigDecimal id, String name) {
+
+        @JsonCreator
+        public static RecordWithExplicitFactoryMethod valueOf(int id) {
+            return new RecordWithExplicitFactoryMethod(BigDecimal.valueOf(id), "IntFactoryMethod");
+        }
+
+        public static RecordWithExplicitFactoryMethod valueOf(double id) {
+            return new RecordWithExplicitFactoryMethod(BigDecimal.valueOf(id), "DoubleFactoryMethod");
+        }
+
+        @JsonCreator
+        public static RecordWithExplicitFactoryMethod valueOf(String id) {
+            return new RecordWithExplicitFactoryMethod(BigDecimal.valueOf(Double.parseDouble(id)), "StringFactoryMethod");
+        }
+    }
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+            .disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS) // So that test cases don't have to assert weird error messages
+            .build();
+
+    /*
+    /**********************************************************************
+    /* Test methods, "implicit" (?) constructor with JsonProperty without JsonCreator
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingJsonPropertyConstructor_WithoutJsonCreator() throws Exception {
+        RecordWithOneJsonPropertyWithoutJsonCreator oneJsonPropertyValue = MAPPER.readValue(
+                "{\"id_only\":123}",
+                RecordWithOneJsonPropertyWithoutJsonCreator.class);
+        assertEquals(new RecordWithOneJsonPropertyWithoutJsonCreator(123), oneJsonPropertyValue);
+
+        RecordWithTwoJsonPropertyWithoutJsonCreator twoJsonPropertyValue = MAPPER.readValue(
+                "{\"the_id\":123,\"the_email\":\"bob@example.com\"}",
+                RecordWithTwoJsonPropertyWithoutJsonCreator.class);
+        assertEquals(new RecordWithTwoJsonPropertyWithoutJsonCreator(123, "bob@example.com"), twoJsonPropertyValue);
+    }
+
+    /**
+     * Only 1 properties-based creator allowed, so can no longer use the (un-annotated) canonical constructor.
+     */
+    public void testDeserializeUsingCanonicalConstructor_WhenJsonPropertyConstructorExists_WillFail() throws Exception {
+        try {
+            MAPPER.readValue(
+                    "{\"id\":123,\"name\":\"Bobby\"}",
+                    RecordWithOneJsonPropertyWithoutJsonCreator.class);
+
+            fail("should not pass");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Unrecognized field \"id\"");
+            verifyException(e, "RecordWithOneJsonPropertyWithoutJsonCreator");
+            verifyException(e, "one known property: \"id_only\"");
+        }
+
+        try {
+            MAPPER.readValue(
+                    "{\"id\":123,\"name\":\"Bobby\",\"email\":\"bobby@example.com\"}",
+                    RecordWithTwoJsonPropertyWithoutJsonCreator.class);
+
+            fail("should not pass");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Unrecognized field \"id\"");
+            verifyException(e, "RecordWithTwoJsonPropertyWithoutJsonCreator");
+            verifyException(e, "2 known properties: \"the_id\", \"the_email\"");
+        }
+    }
+
+    public void testDeserializeUsingImplicitFactoryMethod_WhenJsonPropertyConstructorExists() throws Exception {
+        RecordWithOneJsonPropertyWithoutJsonCreator oneJsonPropertyValue = MAPPER.readValue(
+                "123",
+                RecordWithOneJsonPropertyWithoutJsonCreator.class);
+        assertEquals(RecordWithOneJsonPropertyWithoutJsonCreator.valueOf(123), oneJsonPropertyValue);
+
+        RecordWithTwoJsonPropertyWithoutJsonCreator twoJsonPropertyValue = MAPPER.readValue(
+                "123",
+                RecordWithTwoJsonPropertyWithoutJsonCreator.class);
+        assertEquals(RecordWithTwoJsonPropertyWithoutJsonCreator.valueOf(123), twoJsonPropertyValue);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, explicit constructor with JsonProperty with JsonCreator
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingJsonCreatorConstructor() throws Exception {
+        RecordWithJsonPropertyWithJsonCreator value = MAPPER.readValue("{\"id_only\":123}", RecordWithJsonPropertyWithJsonCreator.class);
+
+        assertEquals(new RecordWithJsonPropertyWithJsonCreator(123), value);
+    }
+
+    /**
+     * Only 1 properties-based creator allowed, so can no longer use the (un-annotated) canonical constructor
+     */
+    public void testDeserializeUsingCanonicalConstructor_WhenJsonCreatorConstructorExists_WillFail() throws Exception {
+        try {
+            MAPPER.readValue("{\"id\":123,\"name\":\"Bobby\"}", RecordWithJsonPropertyWithJsonCreator.class);
+
+            fail("should not pass");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Unrecognized field \"id\"");
+            verifyException(e, "RecordWithJsonPropertyWithJsonCreator");
+            verifyException(e, "one known property: \"id_only\"");
+        }
+    }
+
+    public void testDeserializeUsingImplicitFactoryMethod_WhenJsonCreatorConstructorExists_WillFail() throws Exception {
+        try {
+            MAPPER.readValue("123", RecordWithJsonPropertyWithJsonCreator.class);
+
+            fail("should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithJsonPropertyWithJsonCreator");
+            verifyException(e, "although at least one Creator exists");
+            verifyException(e, "no int/Int-argument constructor/factory method");
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, multiple explicit delegating constructors
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingExplicitDelegatingConstructors() throws Exception {
+        RecordWithMultiExplicitDelegatingConstructor intConstructorValue = MAPPER.readValue("123", RecordWithMultiExplicitDelegatingConstructor.class);
+        assertEquals(new RecordWithMultiExplicitDelegatingConstructor(123, "IntConstructor"), intConstructorValue);
+
+        RecordWithMultiExplicitDelegatingConstructor stringConstructorValue = MAPPER.readValue("\"123\"", RecordWithMultiExplicitDelegatingConstructor.class);
+        assertEquals(new RecordWithMultiExplicitDelegatingConstructor(123, "StringConstructor"), stringConstructorValue);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, JsonCreator.mode=DISABLED
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingDisabledConstructors_WillFail() throws Exception {
+        try {
+            MAPPER.readValue("{\"id\":123,\"name\":\"Bobby\"}", RecordWithDisabledJsonCreator.class);
+
+            fail("should not pass");
+        } catch (InvalidDefinitionException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithDisabledJsonCreator");
+            verifyException(e, "no Creators, like default constructor, exist");
+            verifyException(e, "cannot deserialize from Object value");
+        }
+
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, explicit factory methods
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingExplicitFactoryMethods() throws Exception {
+        RecordWithExplicitFactoryMethod intFactoryValue = MAPPER.readValue("123", RecordWithExplicitFactoryMethod.class);
+        assertEquals(new RecordWithExplicitFactoryMethod(BigDecimal.valueOf(123), "IntFactoryMethod"), intFactoryValue);
+
+        RecordWithExplicitFactoryMethod stringFactoryValue = MAPPER.readValue("\"123.4\"", RecordWithExplicitFactoryMethod.class);
+        assertEquals(new RecordWithExplicitFactoryMethod(BigDecimal.valueOf(123.4), "StringFactoryMethod"), stringFactoryValue);
+    }
+
+    /**
+     * Implicit factory methods detection is only activated when there's no explicit (i.e. annotated
+     * with {@link JsonCreator}) factory methods.
+     */
+    public void testDeserializeUsingImplicitFactoryMethods_WhenExplicitFactoryMethodsExist_WillFail() throws Exception {
+        try {
+            MAPPER.readValue("123.4", RecordWithExplicitFactoryMethod.class);
+
+            fail("should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithExplicitFactoryMethod");
+            verifyException(e, "although at least one Creator exists");
+            verifyException(e, "no double/Double-argument constructor/factory");
+        }
+    }
+
+    /**
+     * Just like how no-arg constructor + setters will still be used to deserialize JSON Object even when
+     * there's JsonCreator factory method(s) in the JavaBean class.
+     */
+    public void testDeserializeUsingImplicitCanonicalConstructor_WhenFactoryMethodsExist() throws Exception {
+        RecordWithExplicitFactoryMethod value = MAPPER.readValue("{\"id\":123.4,\"name\":\"CanonicalConstructor\"}", RecordWithExplicitFactoryMethod.class);
+
+        assertEquals(new RecordWithExplicitFactoryMethod(BigDecimal.valueOf(123.4), "CanonicalConstructor"), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, implicit parameter names
+    /**********************************************************************
+     */
+
+    public void testDeserializeMultipleConstructorsRecord_WithExplicitAndImplicitParameterNames_WithJsonCreator() throws Exception {
+        MAPPER.setAnnotationIntrospector(new Jdk8ConstructorParameterNameAnnotationIntrospector());
+
+        RecordWithJsonPropertyAndImplicitPropertyWithJsonCreator value = MAPPER.readValue(
+                "{\"id_only\":123,\"email\":\"bob@example.com\"}",
+                RecordWithJsonPropertyAndImplicitPropertyWithJsonCreator.class);
+        assertEquals(new RecordWithJsonPropertyAndImplicitPropertyWithJsonCreator(123, "bob@example.com"), value);
+    }
+
+    /**
+     * This test-case is just for documentation purpose:
+     * GOTCHA: The problem is there are two usable constructors:
+     * <ol>
+     *   <li>Canonical constructor</li>
+     *   <li>Non-canonical constructor with JsonProperty parameter</li>
+     * </ol>
+     * ...so Jackson-Databind decided NOT to choose any.  To overcome this, annotate JsonCreator on the non-canonical
+     * constructor.
+     * <p/>
+     * Similar behaviour is observed if a JavaBean has two usable constructors.
+     *
+     * @see #testDeserializeUsingJsonCreatorConstructor()
+     * @see #testDeserializeUsingCanonicalConstructor_WhenJsonCreatorConstructorExists_WillFail()
+     */
+    public void testDeserializeMultipleConstructorsRecord_WithExplicitAndImplicitParameterNames() throws Exception {
+        MAPPER.setAnnotationIntrospector(new Jdk8ConstructorParameterNameAnnotationIntrospector());
+
+        try {
+            MAPPER.readValue(
+                    "{\"id_only\":123,\"email\":\"bob@example.com\"}",
+                    RecordWithJsonPropertyAndImplicitPropertyWithoutJsonCreator.class);
+
+            fail("should not pass");
+        } catch (InvalidDefinitionException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithJsonPropertyAndImplicitPropertyWithoutJsonCreator");
+            verifyException(e, "no Creators, like default constructor, exist");
+            verifyException(e, "cannot deserialize from Object value");
+        }
+    }
+}

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordImplicitCreatorsTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordImplicitCreatorsTest.java
@@ -1,0 +1,241 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+import java.math.BigDecimal;
+
+public class RecordImplicitCreatorsTest extends BaseMapTest
+{
+    record RecordWithImplicitFactoryMethods(BigDecimal id, String name) {
+
+        public static RecordWithImplicitFactoryMethods valueOf(int id) {
+            return new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(id), "IntFactoryMethod");
+        }
+
+        public static RecordWithImplicitFactoryMethods valueOf(double id) {
+            return new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(id), "DoubleFactoryMethod");
+        }
+
+        public static RecordWithImplicitFactoryMethods valueOf(String id) {
+            return new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(Double.parseDouble(id)), "StringFactoryMethod");
+        }
+    }
+
+    record RecordWithSingleValueConstructor(int id) {
+    }
+
+    record RecordWithNonCanonicalConstructor(int id, String name, String email) {
+
+        public RecordWithNonCanonicalConstructor(int id, String email) {
+            this(id, "NonCanonicalConstructor", email);
+        }
+    }
+
+    /**
+     * Similar to:
+     * <pre>
+     *   public class MyBean {
+     *       ...
+     *       // Single-arg constructor used by delegating creator.
+     *       public MyBean(int id) { ... }
+     *
+     *       // No-arg constructor used by properties-based creator.
+     *       public MyBean() {}
+     *
+     *       // Setters used by properties-based creator.
+     *       public void setId(int id) { ... }
+     *       public void setName(String name) { ... }
+     *   }
+     * </pre>
+     */
+    record RecordWithAltSingleValueConstructor(int id, String name) {
+
+        public RecordWithAltSingleValueConstructor(int id) {
+            this(id, "SingleValueConstructor");
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    /*
+    /**********************************************************************
+    /* Test methods, implicit factory methods & "implicit" canonical constructor
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingImplicitIntegerFactoryMethod() throws Exception {
+        RecordWithImplicitFactoryMethods factoryMethodValue = MAPPER.readValue("123", RecordWithImplicitFactoryMethods.class);
+
+        assertEquals(new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(123), "IntFactoryMethod"), factoryMethodValue);
+    }
+
+    public void testDeserializeUsingImplicitDoubleFactoryMethod() throws Exception {
+        RecordWithImplicitFactoryMethods value = MAPPER.readValue("123.4", RecordWithImplicitFactoryMethods.class);
+
+        assertEquals(new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(123.4), "DoubleFactoryMethod"), value);
+    }
+
+    public void testDeserializeUsingImplicitStringFactoryMethod() throws Exception {
+        RecordWithImplicitFactoryMethods value = MAPPER.readValue("\"123.4\"", RecordWithImplicitFactoryMethods.class);
+
+        assertEquals(new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(123.4), "StringFactoryMethod"), value);
+    }
+
+    public void testDeserializeUsingImplicitCanonicalConstructor_WhenImplicitFactoryMethodsExist() throws Exception {
+        RecordWithImplicitFactoryMethods value = MAPPER.readValue(
+                "{\"id\":123.4,\"name\":\"CanonicalConstructor\"}",
+                RecordWithImplicitFactoryMethods.class);
+
+        assertEquals(new RecordWithImplicitFactoryMethods(BigDecimal.valueOf(123.4), "CanonicalConstructor"), value);
+    }
+
+    public void testDeserializeUsingImplicitFactoryMethod_WithAutoDetectCreatorsDisabled_WillFail() throws Exception {
+        MAPPER.disable(MapperFeature.AUTO_DETECT_CREATORS);
+
+        try {
+            MAPPER.readValue("123", RecordWithImplicitFactoryMethods.class);
+
+            fail("should not pass");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithImplicitFactoryMethod");
+            verifyException(e, "no int/Int-argument constructor/factory method");
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, implicit single-value constructor
+    /**********************************************************************
+     */
+
+    /**
+     * This test-case is just for documentation purpose:
+     * GOTCHA: For JavaBean, only having single-value constructor results in implicit delegating creator.  But for
+     * Records, the CANONICAL single-value constructor results in properties-based creator.
+     * <p/>
+     * Only when there's NON-CANONICAL single-value constructor will there be implicit delegating creator - see
+     * {@link #testDeserializeUsingImplicitDelegatingConstructor()}.
+     * <p/>
+     * yihtserns: maybe we can change this to adopt JavaBean's behaviour, but I prefer to not break existing behaviour
+     * until and unless there's a discussion on this.
+     */
+    public void testDeserializeUsingImplicitSingleValueConstructor() throws Exception {
+        try {
+            // Cannot use delegating creator, unlike when dealing with JavaBean
+            MAPPER.readValue("123", RecordWithSingleValueConstructor.class);
+
+            fail("should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithSingleValueConstructor");
+            verifyException(e, "at least one Creator exists");
+            verifyException(e, "no int/Int-argument constructor/factory method");
+        }
+
+        // Can only use properties-based creator
+        RecordWithSingleValueConstructor value = MAPPER.readValue("{\"id\":123}", RecordWithSingleValueConstructor.class);
+        assertEquals(new RecordWithSingleValueConstructor(123), value);
+    }
+
+    /**
+     * This test-case is just for documentation purpose:
+     * See {@link #testDeserializeUsingImplicitSingleValueConstructor}
+     */
+    public void testDeserializeSingleValueConstructor_WithDelegatingConstructorDetector_WillFail() throws Exception {
+        MAPPER.setConstructorDetector(ConstructorDetector.USE_DELEGATING);
+
+        try {
+            // Fail, no delegating creator
+            MAPPER.readValue("123", RecordWithSingleValueConstructor.class);
+
+            fail("should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithSingleValueConstructor");
+            verifyException(e, "at least one Creator exists");
+            verifyException(e, "no int/Int-argument constructor/factory method");
+        }
+
+        // Only have properties-based creator
+        RecordWithSingleValueConstructor value = MAPPER.readValue("{\"id\":123}", RecordWithSingleValueConstructor.class);
+        assertEquals(new RecordWithSingleValueConstructor(123), value);
+    }
+
+    /**
+     * This is just to catch any potential regression.
+     */
+    public void testDeserializeSingleValueConstructor_WithPropertiesBasedConstructorDetector_WillFail() throws Exception {
+        MAPPER.setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED);
+
+        try {
+            // This should fail
+            MAPPER.readValue("123", RecordWithSingleValueConstructor.class);
+
+            fail("should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot construct instance");
+            verifyException(e, "RecordWithSingleValueConstructor");
+            verifyException(e, "at least one Creator exists");
+            verifyException(e, "no int/Int-argument constructor/factory method");
+        }
+
+        // This should work
+        RecordWithSingleValueConstructor value = MAPPER.readValue("{\"id\":123}", RecordWithSingleValueConstructor.class);
+        assertEquals(new RecordWithSingleValueConstructor(123), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, implicit properties-based + delegating constructor
+    /**********************************************************************
+     */
+
+    public void testDeserializeUsingImplicitPropertiesBasedConstructor() throws Exception {
+        RecordWithAltSingleValueConstructor value = MAPPER.readValue(
+                "{\"id\":123,\"name\":\"PropertiesBasedConstructor\"}",
+                RecordWithAltSingleValueConstructor.class);
+
+        assertEquals(new RecordWithAltSingleValueConstructor(123, "PropertiesBasedConstructor"), value);
+    }
+
+    /**
+     * @see #testDeserializeUsingImplicitSingleValueConstructor()
+     */
+    public void testDeserializeUsingImplicitDelegatingConstructor() throws Exception {
+        RecordWithAltSingleValueConstructor value = MAPPER.readValue("123", RecordWithAltSingleValueConstructor.class);
+
+        assertEquals(new RecordWithAltSingleValueConstructor(123, "SingleValueConstructor"), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, implicit parameter names
+    /**********************************************************************
+     */
+
+    public void testDeserializeMultipleConstructorsRecord_WithImplicitParameterNames_WillUseCanonicalConstructor() throws Exception {
+        MAPPER.setAnnotationIntrospector(new Jdk8ConstructorParameterNameAnnotationIntrospector());
+
+        RecordWithNonCanonicalConstructor value = MAPPER.readValue(
+                "{\"id\":123,\"name\":\"Bob\",\"email\":\"bob@example.com\"}",
+                RecordWithNonCanonicalConstructor.class);
+
+        assertEquals(new RecordWithNonCanonicalConstructor(123, "Bob", "bob@example.com"), value);
+    }
+
+    public void testDeserializeMultipleConstructorsRecord_WithImplicitParameterNames_WillIgnoreNonCanonicalConstructor() throws Exception {
+        MAPPER.setAnnotationIntrospector(new Jdk8ConstructorParameterNameAnnotationIntrospector());
+
+        RecordWithNonCanonicalConstructor value = MAPPER.readValue(
+                "{\"id\":123,\"email\":\"bob@example.com\"}",
+                RecordWithNonCanonicalConstructor.class);
+
+        assertEquals(new RecordWithNonCanonicalConstructor(123, null, "bob@example.com"), value);
+    }
+}

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordNamingStrategy2992Test.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordNamingStrategy2992Test.java
@@ -1,11 +1,10 @@
-package com.fasterxml.jackson.databind.failing;
+package com.fasterxml.jackson.databind.records;
 
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-// 01-Dec-2022, tatu: Alas, fails on JDK 17
 public class RecordNamingStrategy2992Test extends BaseMapTest
 {
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordTypeInfo3342Test.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordTypeInfo3342Test.java
@@ -1,0 +1,58 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// [databind#3102]
+public class RecordTypeInfo3342Test extends BaseMapTest
+{
+    public enum SpiceLevel {
+        LOW,
+        HIGH
+    }
+
+    public interface SpiceTolerance {
+    }
+
+    public record LowSpiceTolerance(String food) implements SpiceTolerance {
+    }
+
+    public record HighSpiceTolerance(String food) implements SpiceTolerance {
+    }
+
+    public record Example(
+            SpiceLevel level,
+            @JsonTypeInfo(
+                    use = JsonTypeInfo.Id.NAME,
+                    include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                    property = "level")
+            @JsonSubTypes({
+                    @JsonSubTypes.Type(value = LowSpiceTolerance.class, name = "LOW"),
+                    @JsonSubTypes.Type(value = HighSpiceTolerance.class, name = "HIGH")
+            })
+            SpiceTolerance tolerance) { }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    public void testSerializeDeserializeJsonSubType_LOW() throws Exception {
+        Example record = new Example(SpiceLevel.LOW, new LowSpiceTolerance("Tomato"));
+
+        String json = MAPPER.writeValueAsString(record);
+        assertEquals("{\"level\":\"LOW\",\"tolerance\":{\"food\":\"Tomato\"}}", json);
+
+        Example value = MAPPER.readValue(json, Example.class);
+        assertEquals(record, value);
+    }
+
+    public void testSerializeDeserializeJsonSubType_HIGH() throws Exception {
+        Example record = new Example(SpiceLevel.HIGH, new HighSpiceTolerance("Chilli"));
+
+        String json = MAPPER.writeValueAsString(record);
+        assertEquals("{\"level\":\"HIGH\",\"tolerance\":{\"food\":\"Chilli\"}}", json);
+
+        Example value = MAPPER.readValue(json, Example.class);
+        assertEquals(record, value);
+    }
+}

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordWithJsonIgnoreTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordWithJsonIgnoreTest.java
@@ -1,0 +1,93 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RecordWithJsonIgnoreTest extends BaseMapTest
+{
+    record RecordWithIgnore(int id, @JsonIgnore String name) {
+    }
+
+    record RecordWithIgnoreJsonProperty(int id, @JsonIgnore @JsonProperty("name") String name) {
+    }
+
+    record RecordWithIgnoreAccessor(int id, String name) {
+
+        @JsonIgnore
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+
+    record RecordWithIgnorePrimitiveType(@JsonIgnore int id, String name) {
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    /*
+    /**********************************************************************
+    /* Test methods, JsonIgnore
+    /**********************************************************************
+     */
+
+    public void testSerializeJsonIgnoreRecord() throws Exception {
+        String json = MAPPER.writeValueAsString(new RecordWithIgnore(123, "Bob"));
+        assertEquals("{\"id\":123}", json);
+    }
+
+    public void testDeserializeJsonIgnoreRecord() throws Exception {
+        RecordWithIgnore value = MAPPER.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithIgnore.class);
+        assertEquals(new RecordWithIgnore(123, null), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, JsonIgnore + JsonProperty
+    /**********************************************************************
+     */
+
+    public void testSerializeJsonIgnoreAndJsonPropertyRecord() throws Exception {
+        String json = MAPPER.writeValueAsString(new RecordWithIgnoreJsonProperty(123, "Bob"));
+        assertEquals("{\"id\":123}", json);
+    }
+
+    public void testDeserializeJsonIgnoreAndJsonPropertyRecord() throws Exception {
+        RecordWithIgnoreJsonProperty value = MAPPER.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithIgnoreJsonProperty.class);
+        assertEquals(new RecordWithIgnoreJsonProperty(123, "Bob"), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, JsonIgnore accessor
+    /**********************************************************************
+     */
+
+    public void testSerializeJsonIgnoreAccessorRecord() throws Exception {
+        String json = MAPPER.writeValueAsString(new RecordWithIgnoreAccessor(123, "Bob"));
+        assertEquals("{\"id\":123}", json);
+    }
+
+    public void testDeserializeJsonIgnoreAccessorRecord() throws Exception {
+        RecordWithIgnoreAccessor value = MAPPER.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithIgnoreAccessor.class);
+        assertEquals(new RecordWithIgnoreAccessor(123, null), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, JsonIgnore parameter of primitive type
+    /**********************************************************************
+     */
+
+    public void testSerializeJsonIgnorePrimitiveTypeRecord() throws Exception {
+        String json = MAPPER.writeValueAsString(new RecordWithIgnorePrimitiveType(123, "Bob"));
+        assertEquals("{\"name\":\"Bob\"}", json);
+    }
+
+    public void testDeserializeJsonIgnorePrimitiveTypeRecord() throws Exception {
+        RecordWithIgnorePrimitiveType value = MAPPER.readValue("{\"id\":123,\"name\":\"Bob\"}", RecordWithIgnorePrimitiveType.class);
+        assertEquals(new RecordWithIgnorePrimitiveType(0, "Bob"), value);
+    }
+}

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordWithJsonNaming3102Test.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordWithJsonNaming3102Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.failing;
+package com.fasterxml.jackson.databind.records;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-// [databind#3102]: fails on JDK 16 which finally blocks mutation
-// of Record fields.
 public class RecordWithJsonNaming3102Test extends BaseMapTest
 {
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordWithJsonSetter2974Test.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordWithJsonSetter2974Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.failing;
+package com.fasterxml.jackson.databind.records;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
### New
- Supports `@JsonCreator.mode=DISABLED` on canonical constructor.
- Supports deserialization using "implicit" (i.e. without `@JsonCreator` annotation) non-canonical constructor when 1/more of its parameter is/are annotated with `@JsonProperty`.
- Supports "implicit" (i.e. without `@JsonCreator` annotation) 1-arg delegating constructor.
- Supports "implicit" (i.e. without `@JsonCreator` annotation) 1-arg delegating factory method.
- Supports disabling "implicit" (i.e. without `@JsonCreator` annotation) constructor/factory method detection via `MapperFeature.AUTO_DETECT_CREATORS`.

This is a non-exhaustive list - I don't have full knowledge of existing JavaBeans deserialization capabilities.

### Fixes
- Fixes #2992
- Fixes #2974
- Fixes #3297
- Fixes #3342
- Resolves #3180 (via "implicit" 1-arg delegating factory method)
