### PR TITLE
Deprecate classes in package jsonschema

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/DOMSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/DOMSerializer.java
@@ -51,6 +51,10 @@ public class DOMSerializer extends StdSerializer<Node>
         }
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, java.lang.reflect.Type typeHint) {
         // Well... it is serialized as String

--- a/src/main/java/com/fasterxml/jackson/databind/jsonschema/JsonSerializableSchema.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonschema/JsonSerializableSchema.java
@@ -17,10 +17,13 @@ import com.fasterxml.jackson.annotation.JacksonAnnotation;
  * 
  * @author Ryan Heaton
  * @author Tatu Saloranta
+ * @deprecated Since 2.15, we recommend use of external
+ * <a href="https://github.com/FasterXML/jackson-module-jsonSchema">JSON Schema generator module</a>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @JacksonAnnotation
+@Deprecated
 public @interface JsonSerializableSchema
 {
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/jsonschema/SchemaAware.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsonschema/SchemaAware.java
@@ -8,7 +8,11 @@ import java.lang.reflect.Type;
 
 /**
  * Marker interface for schema-aware serializers.
+ *
+ * @deprecated Since 2.15, we recommend use of external
+ * <a href="https://github.com/FasterXML/jackson-module-jsonSchema">JSON Schema generator module</a>
  */
+@Deprecated
 public interface SchemaAware
 {
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.impl.WritableObjectId;
@@ -583,8 +582,9 @@ filter.getClass().getName(), e.getClass().getName(), ClassUtil.exceptionMessage(
          * type information it needs is accessible via "untyped" serializer)
          */
         JsonSerializer<Object> ser = findValueSerializer(type, null);
-        JsonNode schemaNode = (ser instanceof SchemaAware) ?
-                ((SchemaAware) ser).getSchema(this, null) : com.fasterxml.jackson.databind.jsonschema.JsonSchema.getDefaultSchemaNode();
+        JsonNode schemaNode = (ser instanceof com.fasterxml.jackson.databind.jsonschema.SchemaAware)
+            ? ((com.fasterxml.jackson.databind.jsonschema.SchemaAware) ser).getSchema(this, null)
+            : com.fasterxml.jackson.databind.jsonschema.JsonSchema.getDefaultSchemaNode();
         if (!(schemaNode instanceof ObjectNode)) {
             throw new IllegalArgumentException("Class " + type.getName()
                     +" would not be serialized as a JSON object and therefore has no schema");

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/StringArraySerializer.java
@@ -210,6 +210,10 @@ public class StringArraySerializer
         }
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode("array", true).set("items", createSchemaNode("string"));

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.ContainerSerializer;
@@ -271,7 +270,10 @@ public abstract class AsArraySerializerBase<T>
     protected abstract void serializeContents(T value, JsonGenerator gen, SerializerProvider provider)
         throws IOException;
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         throws JsonMappingException
@@ -279,8 +281,9 @@ public abstract class AsArraySerializerBase<T>
         ObjectNode o = createSchemaNode("array", true);
         if (_elementSerializer != null) {
             JsonNode schemaNode = null;
-            if (_elementSerializer instanceof SchemaAware) {
-                schemaNode = ((SchemaAware) _elementSerializer).getSchema(provider, null);
+            if (_elementSerializer instanceof com.fasterxml.jackson.databind.jsonschema.SchemaAware) {
+                schemaNode = ((com.fasterxml.jackson.databind.jsonschema.SchemaAware) _elementSerializer)
+                    .getSchema(provider, null);
             }
             if (schemaNode == null) {
                 schemaNode = com.fasterxml.jackson.databind.jsonschema.JsonSchema.getDefaultSchemaNode();

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.jsonschema.JsonSerializableSchema;
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.*;
@@ -40,7 +39,7 @@ import com.fasterxml.jackson.databind.util.NameTransformer;
 public abstract class BeanSerializerBase
     extends StdSerializer<Object>
     implements ContextualSerializer, ResolvableSerializer,
-        JsonFormatVisitable, SchemaAware
+        JsonFormatVisitable
 {
     protected final static PropertyName NAME_FOR_OBJECT_REF = new PropertyName("#object-ref");
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.introspect.ObjectIdInfo;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
-import com.fasterxml.jackson.databind.jsonschema.JsonSerializableSchema;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.*;
@@ -848,7 +847,8 @@ public abstract class BeanSerializerBase
         ObjectNode o = createSchemaNode("object", true);
         // [JACKSON-813]: Add optional JSON Schema id attribute, if found
         // NOTE: not optimal, does NOT go through AnnotationIntrospector etc:
-        JsonSerializableSchema ann = _handledType.getAnnotation(JsonSerializableSchema.class);
+        com.fasterxml.jackson.databind.jsonschema.JsonSerializableSchema ann =
+            _handledType.getAnnotation(com.fasterxml.jackson.databind.jsonschema.JsonSerializableSchema.class);
         if (ann != null) {
             String id = ann.id();
             if (id != null && !id.isEmpty()) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BooleanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BooleanSerializer.java
@@ -75,6 +75,10 @@ public final class BooleanSerializer
         g.writeBoolean(Boolean.TRUE.equals(value));
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode("boolean", !_forPrimitive);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteArraySerializer.java
@@ -69,6 +69,10 @@ public class ByteArraySerializer extends StdSerializer<byte[]>
         */
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ClassSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ClassSerializer.java
@@ -27,6 +27,10 @@ public class ClassSerializer
         g.writeString(value.getName());
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/DateTimeSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/DateTimeSerializerBase.java
@@ -148,6 +148,10 @@ df0.getClass().getName()));
 
     protected abstract long _timestamp(T value);
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider serializers, Type typeHint) {
         //todo: (ryan) add a format for the date in the schema?

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
@@ -139,6 +139,10 @@ public class EnumSerializer
     /**********************************************************
      */
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/FileSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/FileSerializer.java
@@ -26,6 +26,10 @@ public class FileSerializer
         g.writeString(value.getAbsolutePath());
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode("string", true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.BeanSerializer;
@@ -41,7 +40,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 @JacksonStdImpl
 public class JsonValueSerializer
     extends StdSerializer<Object>
-    implements ContextualSerializer, JsonFormatVisitable, SchemaAware
+    implements ContextualSerializer, JsonFormatVisitable
 {
     /**
      * @since 2.9
@@ -302,13 +301,17 @@ public class JsonValueSerializer
     /**********************************************************
      */
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider ctxt, Type typeHint)
         throws JsonMappingException
     {
-        if (_valueSerializer instanceof SchemaAware) {
-            return ((SchemaAware)_valueSerializer).getSchema(ctxt, null);
+        if (_valueSerializer instanceof com.fasterxml.jackson.databind.jsonschema.SchemaAware) {
+            return ((com.fasterxml.jackson.databind.jsonschema.SchemaAware) _valueSerializer)
+                .getSchema(ctxt, null);
         }
         return com.fasterxml.jackson.databind.jsonschema.JsonSchema.getDefaultSchemaNode();
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
@@ -1102,6 +1102,10 @@ public class MapSerializer
     /**********************************************************
      */
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NullSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NullSerializer.java
@@ -43,7 +43,11 @@ public class NullSerializer
     {
         gen.writeNull();
     }
-    
+
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) throws JsonMappingException {
         return createSchemaNode("null");

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializer.java
@@ -91,6 +91,10 @@ public class NumberSerializer
         }
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode(_isInt ? "integer" : "number", true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/NumberSerializers.java
@@ -75,6 +75,10 @@ public class NumberSerializers {
                     || (numberType == JsonParser.NumberType.BIG_INTEGER);
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode(_schemaType, true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/RawSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/RawSerializer.java
@@ -41,7 +41,11 @@ public class RawSerializer<T>
         serialize(value, g, provider);
         typeSer.writeTypeSuffix(g, typeIdDef);
     }
-    
+
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/SqlTimeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/SqlTimeSerializer.java
@@ -22,6 +22,10 @@ public class SqlTimeSerializer
         g.writeString(value.toString());
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode("string", true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StaticListSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StaticListSerializerBase.java
@@ -106,6 +106,10 @@ public abstract class StaticListSerializerBase<T extends Collection<?>>
         return (value == null) || (value.isEmpty());
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode("array", true).set("items", contentSchema());

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdArraySerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdArraySerializers.java
@@ -155,6 +155,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         {
@@ -232,6 +236,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         {
@@ -307,6 +315,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         {
@@ -397,6 +409,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode("array", true).set("items", createSchemaNode("integer"));
@@ -469,6 +485,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         {
@@ -547,6 +567,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode("array", true).set("items", createSchemaNode("number"));
@@ -631,6 +655,10 @@ public class StdArraySerializers
             }
         }
 
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode("array", true).set("items", createSchemaNode("number"));

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdDelegatingSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdDelegatingSerializer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
@@ -29,7 +28,7 @@ import java.lang.reflect.Type;
 public class StdDelegatingSerializer
     extends StdSerializer<Object>
     implements ContextualSerializer, ResolvableSerializer,
-        JsonFormatVisitable, SchemaAware
+        JsonFormatVisitable
 {
     protected final Converter<Object,?> _converter;
 
@@ -201,22 +200,32 @@ public class StdDelegatingSerializer
     /**********************************************************
      */
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         throws JsonMappingException
     {
-        if (_delegateSerializer instanceof SchemaAware) {
-            return ((SchemaAware) _delegateSerializer).getSchema(provider, typeHint);
+        if (_delegateSerializer instanceof com.fasterxml.jackson.databind.jsonschema.SchemaAware) {
+            return ((com.fasterxml.jackson.databind.jsonschema.SchemaAware) _delegateSerializer)
+                .getSchema(provider, typeHint);
         }
         return super.getSchema(provider, typeHint);
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint,
         boolean isOptional) throws JsonMappingException
     {
-        if (_delegateSerializer instanceof SchemaAware) {
-            return ((SchemaAware) _delegateSerializer).getSchema(provider, typeHint, isOptional);
+        if (_delegateSerializer instanceof com.fasterxml.jackson.databind.jsonschema.SchemaAware) {
+            return ((com.fasterxml.jackson.databind.jsonschema.SchemaAware) _delegateSerializer)
+                .getSchema(provider, typeHint, isOptional);
         }
         return super.getSchema(provider, typeHint);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdJdkSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdJdkSerializers.java
@@ -66,7 +66,11 @@ public class StdJdkSerializers
         public void serialize(AtomicBoolean value, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeBoolean(value.get());
         }
-    
+
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode("boolean", true);
@@ -87,7 +91,11 @@ public class StdJdkSerializers
         public void serialize(AtomicInteger value, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeNumber(value.get());
         }
-    
+
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode("integer", true);
@@ -109,7 +117,11 @@ public class StdJdkSerializers
         public void serialize(AtomicLong value, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeNumber(value.get());
         }
-    
+
+        /**
+         * @deprecated Since 2.15
+         */
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return createSchemaNode("integer", true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdScalarSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdScalarSerializer.java
@@ -58,6 +58,10 @@ public abstract class StdScalarSerializer<T>
         typeSer.writeTypeSuffix(g, typeIdDef);
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         throws JsonMappingException

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdSerializer.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -27,11 +26,11 @@ import com.fasterxml.jackson.databind.util.Converter;
  * Base class used by all standard serializers, and can also
  * be used for custom serializers (in fact, this is the recommended
  * base class to use).
- * Provides convenience methods for implementing {@link SchemaAware}
  */
+@SuppressWarnings("deprecation")
 public abstract class StdSerializer<T>
     extends JsonSerializer<T>
-    implements JsonFormatVisitable, SchemaAware, java.io.Serializable
+    implements JsonFormatVisitable, com.fasterxml.jackson.databind.jsonschema.SchemaAware, java.io.Serializable
 {
     private static final long serialVersionUID = 1L;
 
@@ -120,7 +119,11 @@ public abstract class StdSerializer<T>
     /**
      * Default implementation simply claims type is "string"; usually
      * overriden by custom serializers.
+     *
+     * @deprecated Since 2.15, we recommend use of external
+     * <a href="https://github.com/FasterXML/jackson-module-jsonSchema">JSON Schema generator module</a>
      */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) throws JsonMappingException
     {
@@ -130,7 +133,11 @@ public abstract class StdSerializer<T>
     /**
      * Default implementation simply claims type is "string"; usually
      * overriden by custom serializers.
+     *
+     * @deprecated Since 2.15, we recommend use of external
+     * <a href="https://github.com/FasterXML/jackson-module-jsonSchema">JSON Schema generator module</a>
      */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint, boolean isOptional)
         throws JsonMappingException

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StringSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StringSerializer.java
@@ -49,6 +49,10 @@ public final class StringSerializer
         gen.writeString((String) value);
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
         return createSchemaNode("string", true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java
@@ -57,6 +57,10 @@ public class ToEmptyObjectSerializer
         return true;
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
             throws JsonMappingException {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ToStringSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ToStringSerializerBase.java
@@ -59,6 +59,10 @@ public abstract class ToStringSerializerBase
         typeSer.writeTypeSuffix(g, typeIdDef);
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint) throws JsonMappingException {
         return createSchemaNode("string", true);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/TokenBufferSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/TokenBufferSerializer.java
@@ -56,6 +56,10 @@ public class TokenBufferSerializer
         typeSer.writeTypeSuffix(g, typeIdDef);
     }
 
+    /**
+     * @deprecated Since 2.15
+     */
+    @Deprecated
     @Override
     public JsonNode getSchema(SerializerProvider provider, Type typeHint)
     {

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/NewSchemaTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/NewSchemaTest.java
@@ -148,7 +148,9 @@ public class NewSchemaTest extends BaseMapTest
                     }
                     // and this just for bit of extra coverage...
                     if (ser instanceof StdSerializer) {
-                        assertNotNull(((StdSerializer<?>) ser).getSchema(prov, prop.getType()));
+                        @SuppressWarnings("deprecation")
+                        JsonNode schemaNode = ((StdSerializer<?>) ser).getSchema(prov, prop.getType());
+                        assertNotNull(schemaNode);
                     }
                     JsonFormatVisitorWrapper visitor = new JsonFormatVisitorWrapper.Base(getProvider());
                     ser.acceptJsonFormatVisitor(visitor, prop.getType());

--- a/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/module/SimpleModuleTest.java
@@ -44,6 +44,7 @@ public class SimpleModuleTest extends BaseMapTest
             jgen.writeString(value.str + "|" + value.num);
         }
 
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return null;
@@ -78,6 +79,7 @@ public class SimpleModuleTest extends BaseMapTest
             jgen.writeString(value.name().toLowerCase());
         }
 
+        @Deprecated
         @Override
         public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
             return null;


### PR DESCRIPTION
The package `com.fasterxml.jackson.databind.jsonschema` has moved to an external module [JSON Schema generator module](https://github.com/FasterXML/jackson-module-jsonSchema) and all classes in this package should be marked with `@Deprecated`.

This PR deprecated classes and methods in package jsonschema. Programmers implementing `interface SchemaAware` or override method `public JsonNode getSchema(SerializerProvider provider, Type typeHint)` will get a deprecation warning.