### PR TITLE
change TokenBuffer parser getDecimalValue to avoid using lossy double parsing

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1808,7 +1808,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         @Override
         public BigDecimal getDecimalValue() throws IOException
         {
-            Number n = getNumberValue();
+            Number n = getNumberValue(true);
             if (n instanceof BigDecimal) {
                 return (BigDecimal) n;
             } else if (n instanceof Integer) {
@@ -1869,6 +1869,10 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
 
         @Override
         public final Number getNumberValue() throws IOException {
+            return getNumberValue(false);
+        }
+
+        private Number getNumberValue(final boolean preferBigDecimal) throws IOException {
             _checkIsNumber();
             Object value = _currentObject();
             if (value instanceof Number) {
@@ -1880,6 +1884,10 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             if (value instanceof String) {
                 String str = (String) value;
                 if (str.indexOf('.') >= 0) {
+                    if (preferBigDecimal) {
+                        return NumberInput.parseBigDecimal(str,
+                                isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
+                    }
                     return NumberInput.parseDouble(str, isEnabled(StreamReadFeature.USE_FAST_DOUBLE_PARSER));
                 }
                 return NumberInput.parseLong(str);

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1795,7 +1795,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         @Override
         public BigInteger getBigIntegerValue() throws IOException
         {
-            Number n = getNumberValue();
+            Number n = getNumberValue(true);
             if (n instanceof BigInteger) {
                 return (BigInteger) n;
             } else if (n instanceof BigDecimal) {

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1872,7 +1872,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             return getNumberValue(false);
         }
 
-        private Number getNumberValue(final boolean preferBigDecimal) throws IOException {
+        private Number getNumberValue(final boolean preferBigNumbers) throws IOException {
             _checkIsNumber();
             Object value = _currentObject();
             if (value instanceof Number) {
@@ -1884,11 +1884,13 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             if (value instanceof String) {
                 String str = (String) value;
                 if (str.indexOf('.') >= 0) {
-                    if (preferBigDecimal) {
+                    if (preferBigNumbers) {
                         return NumberInput.parseBigDecimal(str,
                                 isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
                     }
                     return NumberInput.parseDouble(str, isEnabled(StreamReadFeature.USE_FAST_DOUBLE_PARSER));
+                } else if (preferBigNumbers) {
+                    return NumberInput.parseBigInteger(str, isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
                 }
                 return NumberInput.parseLong(str);
             }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
@@ -539,6 +539,25 @@ public class ExternalTypeIdTest extends BaseMapTest
             w.value.equals(w2.value));
     }
 
+    public void testBigDecimal965StringBased() throws Exception
+    {
+        Wrapper965 w = new Wrapper965();
+        w.typeEnum = Type965.BIG_DECIMAL;
+        final String NUM_STR = "-10000000000.0000000001";
+        w.value = new BigDecimal(NUM_STR);
+
+        String json = "{\"objectValue\":\"-10000000000.0000000001\",\"type\":\"BIG_DECIMAL\"}";
+
+        Wrapper965 w2 = MAPPER.readerFor(Wrapper965.class)
+                .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .readValue(json);
+
+        assertEquals(w.typeEnum, w2.typeEnum);
+        assertTrue(String.format("Expected %s = %s; got back %s = %s",
+                        w.value.getClass().getSimpleName(), w.value.toString(), w2.value.getClass().getSimpleName(), w2.value.toString()),
+                w.value.equals(w2.value));
+    }
+
     static class Box3008 {
         public String type;
         public Fruit3008 fruit;

--- a/src/test/java/com/fasterxml/jackson/databind/util/TokenBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/TokenBufferTest.java
@@ -194,6 +194,32 @@ public class TokenBufferTest extends BaseMapTest
         }
     }
 
+    public void testBigIntAsString() throws IOException
+    {
+        try (TokenBuffer buf = new TokenBuffer(null, false)) {
+            BigInteger big = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.valueOf(1));
+            buf.writeNumber(big.toString());
+            try (JsonParser p = buf.asParser()) {
+                // NOTE: oddity of buffering, no inspection of "real" type if given String...
+                assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+                assertEquals(big, p.getBigIntegerValue());
+            }
+        }
+    }
+
+    public void testBigDecimalAsString() throws IOException
+    {
+        final String num = "-10000000000.0000000001";
+        try (TokenBuffer buf = new TokenBuffer(null, false)) {
+            buf.writeNumber(num);
+            try (JsonParser p = buf.asParser()) {
+                // NOTE: oddity of buffering, no inspection of "real" type if given String...
+                assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+                assertEquals(new BigDecimal(num), p.getDecimalValue());
+            }
+        }
+    }
+
     public void testParentContext() throws IOException
     {
         TokenBuffer buf = new TokenBuffer(null, false); // no ObjectCodec


### PR DESCRIPTION
Double parsing can lead to rounding and if you ultimately want to get a BigDecimal, you need to avoid parsing as a double and the creating a BigDecimal from the double.

The current code might round inadvertently and be more expensive due to doing 2 conversions. 