### PR TITLE
Add isEmpty for TextNode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -89,7 +89,12 @@ e.getMessage()),
         return getBinaryValue(Base64Variants.getDefaultVariant());
     }
 
-    /* 
+    @Override
+    public boolean isEmpty() {
+        return _value == null || _value.isEmpty();
+    }
+
+    /*
     /**********************************************************
     /* General type coercions
     /**********************************************************

--- a/src/test/java/com/fasterxml/jackson/databind/node/NodeTestBase.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NodeTestBase.java
@@ -30,7 +30,5 @@ abstract class NodeTestBase extends BaseMapTest
         assertEquals((long) expInt, n.asLong(19L));
         assertEquals(expDouble, n.asDouble());
         assertEquals(expDouble, n.asDouble(-19.25));
-
-        assertTrue(n.isEmpty());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/NumberNodesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NumberNodesTest.java
@@ -30,6 +30,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals("1", n.asText());
 
         assertNodeNumbers(n, 1, 1.0);
+        assertTrue(n.isEmpty());
 
         assertTrue(ShortNode.valueOf((short) 0).canConvertToInt());
         assertTrue(ShortNode.valueOf(Short.MAX_VALUE).canConvertToInt());
@@ -85,6 +86,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals("1", n.asText("foo"));
         
         assertNodeNumbers(n, 1, 1.0);
+        assertTrue(n.isEmpty());
 
         assertTrue(IntNode.valueOf(0).canConvertToInt());
         assertTrue(IntNode.valueOf(Integer.MAX_VALUE).canConvertToInt());
@@ -110,6 +112,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals("1", n.asText());
 
         assertNodeNumbers(n, 1, 1.0);
+        assertTrue(n.isEmpty());
 
         // ok if contains small enough value
         assertTrue(LongNode.valueOf(0).canConvertToInt());
@@ -167,6 +170,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals("0.25", n.asText());
 
         assertNodeNumbers(DoubleNode.valueOf(4.5), 4, 4.5);
+        assertTrue(n.isEmpty());
 
         assertTrue(DoubleNode.valueOf(0).canConvertToInt());
         assertTrue(DoubleNode.valueOf(Integer.MAX_VALUE).canConvertToInt());
@@ -240,6 +244,7 @@ public class NumberNodesTest extends NodeTestBase
 
         // 1.6:
         assertNodeNumbers(FloatNode.valueOf(4.5f), 4, 4.5f);
+        assertTrue(n.isEmpty());
 
         assertTrue(FloatNode.valueOf(0).canConvertToInt());
         assertTrue(FloatNode.valueOf(Integer.MAX_VALUE).canConvertToInt());
@@ -272,6 +277,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals("1", n.asText());
 
         assertNodeNumbers(n, 1, 1.0);
+        assertTrue(n.isEmpty());
 
         assertTrue(DecimalNode.valueOf(BigDecimal.ZERO).canConvertToInt());
         assertTrue(DecimalNode.valueOf(BigDecimal.valueOf(Integer.MAX_VALUE)).canConvertToInt());
@@ -352,6 +358,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals(BigInteger.ONE, n.bigIntegerValue());
         assertEquals("1", n.asText());
         assertNodeNumbers(n, 1, 1.0);
+        assertTrue(n.isEmpty());
 
         BigInteger maxLong = BigInteger.valueOf(Long.MAX_VALUE);
         

--- a/src/test/java/com/fasterxml/jackson/databind/node/TestJsonNode.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestJsonNode.java
@@ -45,7 +45,9 @@ public class TestJsonNode extends NodeTestBase
         assertEquals(JsonToken.VALUE_TRUE, t.asToken());
 
         assertNodeNumbers(f, 0, 0.0);
+        assertTrue(f.isEmpty());
         assertNodeNumbers(t, 1, 1.0);
+        assertTrue(t.isEmpty());
     
         JsonNode result = objectMapper().readTree("true\n");
         assertFalse(result.isNull());
@@ -102,7 +104,9 @@ public class TestJsonNode extends NodeTestBase
         // default; non-numeric
         assertNodeNumbersForNonNumeric(n);
         // but if wrapping actual number, use it
-        assertNodeNumbers(new POJONode(Integer.valueOf(123)), 123, 123.0);
+        POJONode pojoNode = new POJONode(Integer.valueOf(123));
+        assertNodeNumbers(pojoNode, 123, 123.0);
+        assertTrue(pojoNode.isEmpty());
     }
 
     // [databind#743]

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.node;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class TextNodeTest extends NodeTestBase
 {
     public void testText()
@@ -35,5 +37,16 @@ public class TextNodeTest extends NodeTestBase
         assertTrue(TextNode.valueOf("true").asBoolean(false));
         assertFalse(TextNode.valueOf("false").asBoolean(true));
         assertFalse(TextNode.valueOf("false").asBoolean(false));
+    }
+
+    // Test to check conversions, coercions
+    protected void assertNodeNumbers(JsonNode n, int expInt, double expDouble)
+    {
+        assertEquals(expInt, n.asInt());
+        assertEquals(expInt, n.asInt(-42));
+        assertEquals((long) expInt, n.asLong());
+        assertEquals((long) expInt, n.asLong(19L));
+        assertEquals(expDouble, n.asDouble());
+        assertEquals(expDouble, n.asDouble(-19.25));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -29,6 +29,7 @@ public class TextNodeTest extends NodeTestBase
         // and then with non-numeric input
         n = TextNode.valueOf("foobar");
         assertNodeNumbersForNonNumeric(n);
+        assertFalse(n.isEmpty());
 
         assertEquals("foobar", n.asText("barf"));
         assertEquals("", empty.asText("xyz"));
@@ -39,14 +40,4 @@ public class TextNodeTest extends NodeTestBase
         assertFalse(TextNode.valueOf("false").asBoolean(false));
     }
 
-    // Test to check conversions, coercions
-    protected void assertNodeNumbers(JsonNode n, int expInt, double expDouble)
-    {
-        assertEquals(expInt, n.asInt());
-        assertEquals(expInt, n.asInt(-42));
-        assertEquals((long) expInt, n.asLong());
-        assertEquals((long) expInt, n.asLong(19L));
-        assertEquals(expDouble, n.asDouble());
-        assertEquals(expDouble, n.asDouble(-19.25));
-    }
 }


### PR DESCRIPTION
I think its very simple and usefull. Can we use default `String` methods?

Main problem - tests. We can move `isEmpty` assert to tests where `assertNodeNumbers` executed.