### PR TITLE
Refactor : test BigDecimalNormalization separately, default and non-default setting

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/node/JsonNodeFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/JsonNodeFactoryTest.java
@@ -80,17 +80,17 @@ public class JsonNodeFactoryTest extends NodeTestBase
                MAPPER.writeValueAsString(mapper.readTree(BIGGER_INPUT)));
    }
 
-	public void testBigDecimalNormalization_enabled_by_default() throws Exception
-	{
-		final BigDecimal NON_NORMALIZED = new BigDecimal("12.5000");
-		final BigDecimal NORMALIZED = NON_NORMALIZED.stripTrailingZeros();
+   public void testBigDecimalNormalization_enabled_by_default() throws Exception
+   {
+      final BigDecimal NON_NORMALIZED = new BigDecimal("12.5000");
+      final BigDecimal NORMALIZED = NON_NORMALIZED.stripTrailingZeros();
 
-		// By default, 2.x WILL normalize
-		JsonNode n1 = MAPPER.readTree(String.valueOf(NON_NORMALIZED));
-		assertEquals(NORMALIZED, n1.decimalValue());
-	}
+      // By default, 2.x WILL normalize
+      JsonNode n1 = MAPPER.readTree(String.valueOf(NON_NORMALIZED));
+      assertEquals(NORMALIZED, n1.decimalValue());
+   }
 
-	// 06-Nov-2022, tatu: Wasn't being tested, oddly enough
+   // 06-Nov-2022, tatu: Wasn't being tested, oddly enough
    public void testBigDecimalNormalization_when_disabled() throws Exception
    {
        final BigDecimal NON_NORMALIZED = new BigDecimal("12.5000");

--- a/src/test/java/com/fasterxml/jackson/databind/node/JsonNodeFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/JsonNodeFactoryTest.java
@@ -61,7 +61,7 @@ public class JsonNodeFactoryTest extends NodeTestBase
    public void testSortingObjectNode() throws Exception
    {
        final String SIMPLE_INPUT = "{\"b\":2,\"a\":1}";
-       
+
        // First, by default, ordering retained:
        assertEquals(SIMPLE_INPUT,
                MAPPER.writeValueAsString(MAPPER.readTree(SIMPLE_INPUT)));
@@ -80,15 +80,20 @@ public class JsonNodeFactoryTest extends NodeTestBase
                MAPPER.writeValueAsString(mapper.readTree(BIGGER_INPUT)));
    }
 
-   // 06-Nov-2022, tatu: Wasn't being tested, oddly enough
-   public void testBigDecimalNormalization() throws Exception
+	public void testBigDecimalNormalization_enabled_by_default() throws Exception
+	{
+		final BigDecimal NON_NORMALIZED = new BigDecimal("12.5000");
+		final BigDecimal NORMALIZED = NON_NORMALIZED.stripTrailingZeros();
+
+		// By default, 2.x WILL normalize
+		JsonNode n1 = MAPPER.readTree(String.valueOf(NON_NORMALIZED));
+		assertEquals(NORMALIZED, n1.decimalValue());
+	}
+
+	// 06-Nov-2022, tatu: Wasn't being tested, oddly enough
+   public void testBigDecimalNormalization_when_disabled() throws Exception
    {
        final BigDecimal NON_NORMALIZED = new BigDecimal("12.5000");
-       final BigDecimal NORMALIZED = NON_NORMALIZED.stripTrailingZeros();
-
-       // By default, 2.x WILL normalize
-       JsonNode n1 = MAPPER.readTree(String.valueOf(NON_NORMALIZED));
-       assertEquals(NORMALIZED, n1.decimalValue());
 
        // But can change
        ObjectMapper nonNormMapper = JsonMapper.builder()


### PR DESCRIPTION
### Summary 

Just separating two assertions in `JsonNodeFactoryTest.testBigDecimalNormalization()`

### Reason

testing two actions in one will cause failure in one to affect the other.
