### PR TITLE
use getNumberValueDeferred() to avoid over-eager number parsing in TokenBuffer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1863,6 +1863,11 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             return getNumberValue(false);
         }
 
+        public Object getNumberValueDeferred() throws IOException {
+            _checkIsNumber();
+            return _currentObject();
+        }
+
         private Number getNumberValue(final boolean preferBigNumbers) throws IOException {
             _checkIsNumber();
             Object value = _currentObject();

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1840,7 +1840,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         @Override
         public NumberType getNumberType() throws IOException
         {
-            Number n = getNumberValue();
+            Object n = getNumberValueDeferred();
             if (n instanceof Integer) return NumberType.INT;
             if (n instanceof Long) return NumberType.LONG;
             if (n instanceof Double) return NumberType.DOUBLE;
@@ -1848,6 +1848,9 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             if (n instanceof BigInteger) return NumberType.BIG_INTEGER;
             if (n instanceof Float) return NumberType.FLOAT;
             if (n instanceof Short) return NumberType.INT;       // should be SHORT
+            if (n instanceof String) {
+                return ((String) n).contains(".") ? NumberType.BIG_DECIMAL : NumberType.BIG_INTEGER;
+            }
             return null;
         }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1242,14 +1242,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             }
             break;
         case VALUE_NUMBER_FLOAT:
-            if (_forceBigDecimal) {
-                writeLazyDecimal(p.getNumberValueDeferred());
-            } else {
-                // 09-Jul-2020, tatu: Used to just copy using most optimal method, but
-                //  issues like [databind#2644] force to use exact, not optimal type
-                final Number n = p.getNumberValueExact();
-                _appendValue(JsonToken.VALUE_NUMBER_FLOAT, n);
-            }
+            writeLazyDecimal(p.getNumberValueDeferred());
             break;
         case VALUE_TRUE:
             writeBoolean(true);

--- a/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java
@@ -1863,6 +1863,7 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             return getNumberValue(false);
         }
 
+        @Override
         public Object getNumberValueDeferred() throws IOException {
             _checkIsNumber();
             return _currentObject();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/UnknownPropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/UnknownPropertiesTest.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+public class UnknownPropertiesTest extends BaseMapTest
+{
+
+    static class ExtractFieldsNoDefaultConstructor {
+        private final String s;
+        private final int i;
+
+        @JsonCreator
+        public ExtractFieldsNoDefaultConstructor(@JsonProperty("s") String s, @JsonProperty("i") int i) {
+            this.s = s;
+            this.i = i;
+        }
+
+        public String getS() {
+            return s;
+        }
+
+        public int getI() {
+            return i;
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    public void testIgnoreProperty() throws Exception
+    {
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
+                .build();
+        ObjectMapper objectMapper = JsonMapper.builder(jsonFactory)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 1000000; i++) {
+            stringBuilder.append(7);
+        }
+        final String test1000000 = stringBuilder.toString();
+        ExtractFieldsNoDefaultConstructor ef =
+                objectMapper.readValue(genJson(test1000000), ExtractFieldsNoDefaultConstructor.class);
+    }
+
+    private String genJson(String num) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder
+                .append("{\"s\":\"s\",\"n\":")
+                .append(num)
+                .append(",\"i\":1}");
+        return stringBuilder.toString();
+    }
+}


### PR DESCRIPTION
* the test case shows that BigInteger parsing no longer happens for the unexpected large integer field
* this change breaks 2 tests in NumberDeserWithYAMLTest (jackson-dataformats-text) - YAMLParser needs to override getNumberValueDeferred
* jackson-dataformats-binary and jackson-dataformat-xml seem to work ok with the changes in this PR
* if we want to avoid over-eager number parsing in other Jackson projects, it is likely that some getNumberValueDeferred implementations will need to be done in those projects 

With YAMLParser, this version is too eager but makes all the tests pass:
```
    @Override
    public Object getNumberValueDeferred() throws IOException {
        return getDecimalValue();
    }
```

YAMLParser inherits the getNumberValueDeferred from ParserBase and that has a relatively complicated implementation that doesn't seem to work well for YAMLParser.

`return getNumberValue();` leads to small rounding issues that affect tests
