### PR TITLE
Fix : Not thread-safe singleton factory methods on EnumResolver and  StdKeyDeserializer class

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -404,7 +404,7 @@ public class EnumDeserializer
             synchronized (this) {
                 lookup = _lookupByToString;
                 if (lookup == null) {
-                    _lookupByToString = EnumResolver.constructUsingToString(ctxt.getConfig(), _enumClass())
+                    lookup = EnumResolver.constructUsingToString(ctxt.getConfig(), _enumClass())
                         .constructLookup();
                     _lookupByToString = lookup;
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -403,7 +403,7 @@ public class EnumDeserializer
             synchronized (this) {
                 if (_lookupByToString == null) {
                     _lookupByToString = EnumResolver.constructUsingToString(ctxt.getConfig(), _enumClass())
-                       .constructLookup();
+                        .constructLookup();
                 }
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -397,8 +397,7 @@ public class EnumDeserializer
         return handledType();
     }
 
-    protected CompactStringObjectMap _getToStringLookup(DeserializationContext ctxt)
-    {
+    protected CompactStringObjectMap _getToStringLookup(DeserializationContext ctxt) {
         CompactStringObjectMap lookup = _lookupByToString;
         if (lookup == null) {
             synchronized (this) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -50,7 +50,7 @@ public class EnumDeserializer
      *
      * @since 2.7.3
      */
-    protected CompactStringObjectMap _lookupByToString;
+    protected volatile CompactStringObjectMap _lookupByToString;
 
     protected final Boolean _caseInsensitive;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -399,15 +399,18 @@ public class EnumDeserializer
 
     protected CompactStringObjectMap _getToStringLookup(DeserializationContext ctxt)
     {
-        if (_lookupByToString == null) {
+        CompactStringObjectMap lookup = _lookupByToString;
+        if (lookup == null) {
             synchronized (this) {
-                if (_lookupByToString == null) {
+                lookup = _lookupByToString;
+                if (lookup == null) {
                     _lookupByToString = EnumResolver.constructUsingToString(ctxt.getConfig(), _enumClass())
                         .constructLookup();
+                    _lookupByToString = lookup;
                 }
             }
         }
-        return _lookupByToString;
+        return lookup;
     }
 
     // @since 2.15

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -399,17 +399,15 @@ public class EnumDeserializer
 
     protected CompactStringObjectMap _getToStringLookup(DeserializationContext ctxt)
     {
-        CompactStringObjectMap lookup = _lookupByToString;
-        // note: exact locking not needed; all we care for here is to try to
-        // reduce contention for the initial resolution
-        if (lookup == null) {
+        if (_lookupByToString == null) {
             synchronized (this) {
-                lookup = EnumResolver.constructUsingToString(ctxt.getConfig(), _enumClass())
-                    .constructLookup();
+                if (_lookupByToString == null) {
+                    _lookupByToString = EnumResolver.constructUsingToString(ctxt.getConfig(), _enumClass())
+                       .constructLookup();
+                }
             }
-            _lookupByToString = lookup;
         }
-        return lookup;
+        return _lookupByToString;
     }
 
     // @since 2.15

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -407,15 +407,18 @@ public class StdKeyDeserializer extends KeyDeserializer
 
         private EnumResolver _getToStringResolver(DeserializationContext ctxt)
         {
-            if (_byToStringResolver == null) {
+            EnumResolver res = _byToStringResolver;
+            if (res == null) {
                 synchronized (this) {
-                    if (_byToStringResolver == null) {
-                        _byToStringResolver = EnumResolver.constructUsingToString(ctxt.getConfig(),
+                    res = _byToStringResolver;
+                    if (res == null) {
+                        res = EnumResolver.constructUsingToString(ctxt.getConfig(),
                             _byNameResolver.getEnumClass());
+                        _byToStringResolver = res;
                     }
                 }
             }
-            return _byToStringResolver;
+            return res;
         }
     }
     

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -368,7 +368,7 @@ public class StdKeyDeserializer extends KeyDeserializer
          *
          * @since 2.7.3
          */
-        protected EnumResolver _byToStringResolver;
+        protected volatile EnumResolver _byToStringResolver;
 
         protected final Enum<?> _enumDefaultValue;
         
@@ -410,9 +410,11 @@ public class StdKeyDeserializer extends KeyDeserializer
             EnumResolver res = _byToStringResolver;
             if (res == null) {
                 synchronized (this) {
-                    res = EnumResolver.constructUsingToString(ctxt.getConfig(),
-                            _byNameResolver.getEnumClass());
-                    _byToStringResolver = res;
+                    if (res == null){
+                        res = EnumResolver.constructUsingToString(ctxt.getConfig(),
+                           _byNameResolver.getEnumClass());
+                        _byToStringResolver = res;
+                    }
                 }
             }
             return res;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -410,9 +410,9 @@ public class StdKeyDeserializer extends KeyDeserializer
             EnumResolver res = _byToStringResolver;
             if (res == null) {
                 synchronized (this) {
-                    if (res == null){
+                    if (res == null) {
                         res = EnumResolver.constructUsingToString(ctxt.getConfig(),
-                           _byNameResolver.getEnumClass());
+                            _byNameResolver.getEnumClass());
                         _byToStringResolver = res;
                     }
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -407,17 +407,15 @@ public class StdKeyDeserializer extends KeyDeserializer
 
         private EnumResolver _getToStringResolver(DeserializationContext ctxt)
         {
-            EnumResolver res = _byToStringResolver;
-            if (res == null) {
+            if (_byToStringResolver == null) {
                 synchronized (this) {
-                    if (res == null) {
-                        res = EnumResolver.constructUsingToString(ctxt.getConfig(),
+                    if (_byToStringResolver == null) {
+                        _byToStringResolver = EnumResolver.constructUsingToString(ctxt.getConfig(),
                             _byNameResolver.getEnumClass());
-                        _byToStringResolver = res;
                     }
                 }
             }
-            return res;
+            return _byToStringResolver;
         }
     }
     


### PR DESCRIPTION
## Summary

- thanks to @yawkat, whiling reviewing my PR #3764 , I found unthread-safe `StdKeyDeserializer._getToStringResolver()` method

## Details on the bug

> this form of double-checked locking is not thread-safe, see https://shipilev.net/blog/2014/safe-public-construction/

-  should be volatile and double-checked before and after locking

