### PR TITLE
Fix #3262: catch exceptions for `POJONode` when serializing, produce `TextNode` with failure

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/InternalNodeMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/InternalNodeMapper.java
@@ -134,6 +134,14 @@ final class InternalNodeMapper {
                         stack.push(currIt);
                         currIt = value.elements();
                         g.writeStartArray(value, value.size());
+                    } else if (value instanceof POJONode) {
+                        // [databind#3262] Problematic case, try to handle
+                        try {
+                            value.serialize(g, _context);
+                        } catch (IOException | RuntimeException e) {
+                            g.writeString(String.format("[ERROR: (%s) %s]",
+                                    e.getClass().getName(), e.getMessage()));
+                        }
                     } else {
                         value.serialize(g, _context);
                     }

--- a/src/test/java/com/fasterxml/jackson/failing/POJONode3262Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/POJONode3262Test.java
@@ -4,11 +4,11 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.*;
 
-// [databind#3262]: not sure what could be done here. The issue is that
+// [databind#3262]: The issue is that
 // `JsonNode.toString()` will use internal "default" ObjectMapper which
 // does not (and cannot) have modules for external datatypes, such as
-// Java 8 Date/Time types. One possibility would be catch IOException for
-// POJONode, produce something like "ERROR: <ExceptionClass>" TextNode for that case?
+// Java 8 Date/Time types. So we'll catch IOException/RuntimeException for
+// POJONode, produce something like "[ERROR: (type) [msg]" TextNode for that case?
 public class POJONode3262Test extends BaseMapTest
 {
     private final ObjectMapper MAPPER = newJsonMapper();
@@ -17,7 +17,13 @@ public class POJONode3262Test extends BaseMapTest
     {
         JsonNode node = MAPPER.createObjectNode().putPOJO("test", LocalDateTime.now());
         String json = node.toString();
-
         assertNotNull(json);
+
+        JsonNode result = MAPPER.readTree(json);
+        String msg = result.path("test").asText();
+        assertTrue("Wrong fail message: "+msg,
+                msg.startsWith("[ERROR:"));
+        assertTrue("Wrong fail message: "+msg,
+                msg.contains("InvalidDefinitionException"));
     }
 }


### PR DESCRIPTION
…TextNode with failure