### PR TITLE
Test : Add more test cases to @JsonAlias for taking "an array of String" as value

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/PropertyAliasTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/PropertyAliasTest.java
@@ -142,4 +142,76 @@ public class PropertyAliasTest extends BaseMapTest
         assertNotNull(pojo);
         assertEquals("test", pojo.getName());
     }
+
+    static class FixedOrderAliasBean {
+        @JsonAlias({"a", "b", "c"})
+        public String value;
+    }
+
+    public void testDeserializedToLastMatchingKey_ascendingKeys() throws Exception {
+        String ascendingOrderInput = a2q(
+            "{\"a\": \"a-value\", " +
+                "\"b\": \"b-value\", " +
+                "\"c\": \"c-value\"}");
+
+        FixedOrderAliasBean ascObj = MAPPER.readValue(ascendingOrderInput, FixedOrderAliasBean.class);
+        assertEquals("c-value", ascObj.value);
+    }
+
+    public void testDeserializedToLastMatchingKey_descendingKeys() throws Exception {
+        String descendingOrderInput = a2q(
+            "{\"c\": \"c-value\", " +
+                "\"b\": \"b-value\", " +
+                "\"a\": \"a-value\"}");
+
+        FixedOrderAliasBean descObj = MAPPER.readValue(descendingOrderInput, FixedOrderAliasBean.class);
+        assertEquals("a-value", descObj.value);
+    }
+
+    static class AscendingOrderAliasBean {
+        @JsonAlias({"a", "b", "c"})
+        public String value;
+    }
+
+    public void testDeserializedToLastMatchingKey_ascendingAliases() throws Exception {
+        String input = a2q(
+                "{\"a\": \"a-value\", " +
+                "\"b\": \"b-value\", " +
+                "\"c\": \"c-value\"}");
+
+        AscendingOrderAliasBean ascObj = MAPPER.readValue(input, AscendingOrderAliasBean.class);
+        assertEquals("c-value", ascObj.value);
+    }
+
+    static class DescendingOrderAliasBean {
+        @JsonAlias({"c", "b", "a"})
+        public String value;
+    }
+
+    public void testDeserializedToLastMatchingKey_descendingAliases() throws Exception {
+        String input = a2q(
+            "{\"a\": \"a-value\", " +
+                "\"b\": \"b-value\", " +
+                "\"c\": \"c-value\"}");
+
+        DescendingOrderAliasBean descObj = MAPPER.readValue(input, DescendingOrderAliasBean.class);
+        assertEquals("c-value", descObj.value);
+    }
+
+    static class AliasTestBeanA {
+        @JsonAlias({"fullName"})
+        public String name;
+
+        @JsonAlias({"fullName"})
+        public String fullName;
+    }
+
+    public void testAliasFallBackToField() throws Exception {
+        AliasTestBeanA obj = MAPPER.readValue(a2q(
+            "{\"fullName\": \"Faster Jackson\", \"name\":\"Jackson\"}"
+        ), AliasTestBeanA.class);
+
+        assertEquals("Jackson", obj.name);
+        assertEquals("Faster Jackson", obj.fullName);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/PropertyAliasTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/PropertyAliasTest.java
@@ -148,7 +148,7 @@ public class PropertyAliasTest extends BaseMapTest
         public String value;
     }
 
-    public void testDeserializedToLastMatchingKey_ascendingKeys() throws Exception {
+    public void testAliasDeserializedToLastMatchingKey_ascendingKeys() throws Exception {
         String ascendingOrderInput = a2q(
             "{\"a\": \"a-value\", " +
                 "\"b\": \"b-value\", " +
@@ -158,7 +158,7 @@ public class PropertyAliasTest extends BaseMapTest
         assertEquals("c-value", ascObj.value);
     }
 
-    public void testDeserializedToLastMatchingKey_descendingKeys() throws Exception {
+    public void testAliasDeserializedToLastMatchingKey_descendingKeys() throws Exception {
         String descendingOrderInput = a2q(
             "{\"c\": \"c-value\", " +
                 "\"b\": \"b-value\", " +
@@ -173,7 +173,7 @@ public class PropertyAliasTest extends BaseMapTest
         public String value;
     }
 
-    public void testDeserializedToLastMatchingKey_ascendingAliases() throws Exception {
+    public void testAliasDeserializedToLastMatchingKey_ascendingAliases() throws Exception {
         String input = a2q(
                 "{\"a\": \"a-value\", " +
                 "\"b\": \"b-value\", " +
@@ -188,7 +188,7 @@ public class PropertyAliasTest extends BaseMapTest
         public String value;
     }
 
-    public void testDeserializedToLastMatchingKey_descendingAliases() throws Exception {
+    public void testAliasDeserializedToLastMatchingKey_descendingAliases() throws Exception {
         String input = a2q(
             "{\"a\": \"a-value\", " +
                 "\"b\": \"b-value\", " +


### PR DESCRIPTION
### Motivation

- described as the title.

### Description

- Taking `String[]` as an input can lead to issues regarding "ordering, overriding, overlapping, etc" in the future.
- These test cases will prevent unintended creation of **backward compatibility issues**

### ANOTHER PROPOSAL

- If you agree, I will add the workings of this PR's test cases to the java doc of [JsonAlias.java](https://github.com/FasterXML/jackson-annotations/blob/85965247ff2c19bf16e0ab68c607108ec0ba1c1c/src/main/java/com/fasterxml/jackson/annotation/JsonAlias.java) in [FasterXML/jackson-annotations](https://github.com/FasterXML/jackson-annotations) 