### PR TITLE
Doc :  Improve JavaDoc of `TypeFactory.constructMapLikeType` methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1020,7 +1020,8 @@ public class TypeFactory // note: was final in 2.9, removed from 2.10
      * Map-like types are only meant for supporting things that do not implement Map interface
      * and as such cannot use standard Map handlers.
      * </p>
-     * <p>     * NOTE: type modifiers are NOT called on constructed type itself.
+     * <p>
+     * NOTE: type modifiers are NOT called on constructed type itself.
      */
     public MapLikeType constructMapLikeType(Class<?> mapClass, JavaType keyType, JavaType valueType) {
         // 19-Oct-2015, tatu: Allow case of no-type-variables, since it seems likely to be

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -997,8 +997,13 @@ public class TypeFactory // note: was final in 2.9, removed from 2.10
     }
 
     /**
-     * Method for constructing a {@link MapLikeType} instance
-     *<p>
+     * Method for constructing a {@link MapLikeType} instance.
+     * <p>
+     * Do not use this method to create a true Map type -- use {@link #constructMapType} instead.
+     * Map-like types are only meant for supporting things that do not implement Map interface
+     * and as such cannot use standard Map handlers.
+     * </p>
+     * <p>
      * NOTE: type modifiers are NOT called on constructed type itself; but are called
      * for contained types.
      */
@@ -1010,8 +1015,12 @@ public class TypeFactory // note: was final in 2.9, removed from 2.10
 
     /**
      * Method for constructing a {@link MapLikeType} instance
-     *<p>
-     * NOTE: type modifiers are NOT called on constructed type itself.
+     * <p>
+     * Do not use this method to create a true Map type -- use {@link #constructMapType} instead.
+     * Map-like types are only meant for supporting things that do not implement Map interface
+     * and as such cannot use standard Map handlers.
+     * </p>
+     * <p>     * NOTE: type modifiers are NOT called on constructed type itself.
      */
     public MapLikeType constructMapLikeType(Class<?> mapClass, JavaType keyType, JavaType valueType) {
         // 19-Oct-2015, tatu: Allow case of no-type-variables, since it seems likely to be


### PR DESCRIPTION
## Description

- from [a comment](https://github.com/FasterXML/jackson-databind/issues/3089#issuecomment-808350678) in #3089 
- This PR improves  JavaDoc of `TypeFactory.constructMapLikeType`, to guide the usage of `TypeFactory.constructMapLikeType`