### PR TITLE
Flush readonly map together with shared on serialization cache flush

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/SerializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/SerializerCache.java
@@ -217,5 +217,6 @@ public final class SerializerCache
      */
     public synchronized void flush() {
         _sharedMap.clear();
+        _readOnlyMap.set(null);
     }
 }


### PR DESCRIPTION
Without these flushing the cache may be not enough - for example if a new subtype for existing interface is added by a new provider, serialization cache  will still return old serializer for an interface.