### PR TITLE
Add tests and JavaDoc to `SimpleFilterProvider`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
@@ -157,7 +157,7 @@ public class SimpleFilterProvider
      * a new filter with the same {@code id} will always override the previously added filter.
      *
      * <p>
-     * WARNING: Binding binding {@code id} or {@code filter} with {@code null} value will not
+     * WARNING: Binding {@code id} or {@code filter} with {@code null} value will not
      * be validated within this method, but during serialization of target class annotated
      * with {@link com.fasterxml.jackson.annotation.JsonFilter}.
      *

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
@@ -157,7 +157,7 @@ public class SimpleFilterProvider
      * a new filter with the same {@code id} will always override the previously added filter.
      *
      * <p>
-     * WARNING: Accidentally binding {@code id} or {@code filter} with {@code null} value will not
+     * WARNING: Binding binding {@code id} or {@code filter} with {@code null} value will not
      * be validated within this method, but during serialization of target class annotated
      * with {@link com.fasterxml.jackson.annotation.JsonFilter}.
      *
@@ -180,7 +180,7 @@ public class SimpleFilterProvider
      * a new filter with the same {@code id} will always override the previously added filter.
      *
      * <p>
-     * WARNING: Accidentally binding {@code id} or {@code filter} with {@code null} value will not
+     * WARNING: Binding {@code id} or {@code filter} with {@code null} value will not
      * be validated within this method, but during serialization of target class annotated
      * with {@link com.fasterxml.jackson.annotation.JsonFilter}.
      *

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleFilterProvider.java
@@ -151,6 +151,21 @@ public class SimpleFilterProvider
         return this;
     }
 
+    /**
+     * Adds an instance of {@link PropertyFilter} associated with the given {@code id} parameter.
+     * Note that there can always only be one filter associated with a single {@code id} parameter, meaning
+     * a new filter with the same {@code id} will always override the previously added filter.
+     *
+     * <p>
+     * WARNING: Accidentally binding {@code id} or {@code filter} with {@code null} value will not
+     * be validated within this method, but during serialization of target class annotated
+     * with {@link com.fasterxml.jackson.annotation.JsonFilter}.
+     *
+     * @param id The id to associate the filter with.
+     * @param filter The filter to add;
+     *
+     * @return This provider instance, for call-chaining
+     */
     public SimpleFilterProvider addFilter(String id, PropertyFilter filter) {
         _filtersById.put(id, filter);
         return this;
@@ -158,6 +173,21 @@ public class SimpleFilterProvider
 
     /**
      * Overloaded variant just to resolve "ties" when using {@link SimpleBeanPropertyFilter}.
+     * 
+     * <p>
+     * Adds an instance of {@link SimpleBeanPropertyFilter} associated with the given {@code id} parameter.
+     * Note that there can always only be one filter associated with a single {@code id} parameter, meaning
+     * a new filter with the same {@code id} will always override the previously added filter.
+     *
+     * <p>
+     * WARNING: Accidentally binding {@code id} or {@code filter} with {@code null} value will not
+     * be validated within this method, but during serialization of target class annotated
+     * with {@link com.fasterxml.jackson.annotation.JsonFilter}.
+     *
+     * @param id The id to associate the filter with.
+     * @param filter The filter to add;
+     *
+     * @return This provider instance, for call-chaining
      */
     public SimpleFilterProvider addFilter(String id, SimpleBeanPropertyFilter filter) {
         _filtersById.put(id, filter);

--- a/src/test/java/com/fasterxml/jackson/databind/ser/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/SimpleFilterProviderTest.java
@@ -114,7 +114,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
             writer.writeValueAsString(beanD);
             fail("Should not have passed");
         } catch (JsonMappingException e) {
-            verifyException(e, "No filter configured with id 'notExist'");
+            verifyException(e, "No filter configured with id 'filterD'");
         } catch (Exception e) {
             fail("Should not have passed");
         }
@@ -130,7 +130,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
             writer.writeValueAsString(beanD);
             fail("Should not have passed");
         } catch (JsonMappingException e) {
-            verifyException(e, "No filter configured with id 'notExist'");
+            verifyException(e, "No filter configured with id 'filterD'");
         } catch (Exception e) {
             fail("Should not have passed");
         }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/SimpleFilterProviderTest.java
@@ -1,0 +1,138 @@
+package com.fasterxml.jackson.databind.ser;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+/**
+ * Tests {@link SimpleFilterProvider} on registration of filters.
+ */
+public class SimpleFilterProviderTest extends BaseMapTest
+{
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @JsonFilter("bF")
+    public static class AnyBeanB
+    {
+        public String a;
+        public String b;
+
+        public AnyBeanB(String a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public void testAddFilterLastOneRemains() throws Exception {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter("bF", SimpleBeanPropertyFilter.serializeAll())
+                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept());
+        AnyBeanB beanB = new AnyBeanB("1a", "2b");
+
+        String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
+
+        assertEquals(a2q("{}"), jsonString);
+    }
+
+    public void testAddFilterLastOneRemainsFlip() throws Exception {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept("a"))
+                .addFilter("bF", SimpleBeanPropertyFilter.serializeAll());
+        AnyBeanB beanB = new AnyBeanB("1a", "2b");
+
+        String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
+
+        assertEquals(a2q("{'a':'1a','b':'2b'}"), jsonString);
+    }
+
+    public void testAddFilterNulls() throws Exception {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept(null, null));
+        AnyBeanB beanB = new AnyBeanB("1a", "2b");
+
+        String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
+
+        assertEquals(a2q("{}"), jsonString);
+    }
+
+    public void testAddFilterEmptyString() throws Exception {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept("", ""));
+        AnyBeanB anyBeanB = new AnyBeanB("1a", "2b");
+
+        String jsonString = MAPPER.writer(prov).writeValueAsString(anyBeanB);
+
+        assertEquals(a2q("{}"), jsonString);
+    }
+
+    @JsonFilter(value = "")
+    public static class AnyBeanC
+    {
+        public String c;
+        public String d;
+
+        public AnyBeanC(String c, String d) {
+            this.c = c;
+            this.d = d;
+        }
+    }
+
+    public void testAddFilterWithEmptyStringId() throws Exception {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter("", SimpleBeanPropertyFilter.filterOutAllExcept("d"));
+        AnyBeanC bean = new AnyBeanC(null, "D is filtered");
+
+        String jsonString = MAPPER.writer(prov).writeValueAsString(bean);
+
+        assertEquals(a2q("{'c':null,'d':'D is filtered'}"), jsonString);
+    }
+
+    @JsonFilter("notExist")
+    public static class AnyBeanD
+    {
+        public String a;
+        public String b;
+
+        public AnyBeanD(String a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public void testAddingNullFilter2ThrowsException() {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter("notExist", null);
+        ObjectWriter writer = MAPPER.writer(prov);
+        AnyBeanD beanD = new AnyBeanD("1a", "2b");
+
+        try {
+            writer.writeValueAsString(beanD);
+            fail("Should not have passed");
+        } catch (JsonMappingException e) {
+            verifyException(e, "No filter configured with id 'notExist'");
+        } catch (Exception e) {
+            fail("Should not have passed");
+        }
+    }
+
+    public void testAddingNullFilterIdThrowsException() {
+        FilterProvider prov = new SimpleFilterProvider()
+                .addFilter(null, SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"));
+        ObjectWriter writer = MAPPER.writer(prov);
+        AnyBeanD beanD = new AnyBeanD("1a", "2b");
+
+        try {
+            writer.writeValueAsString(beanD);
+            fail("Should not have passed");
+        } catch (JsonMappingException e) {
+            verifyException(e, "No filter configured with id 'notExist'");
+        } catch (Exception e) {
+            fail("Should not have passed");
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/ser/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/SimpleFilterProviderTest.java
@@ -16,7 +16,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    @JsonFilter("bF")
+    @JsonFilter("filterB")
     public static class AnyBeanB
     {
         public String a;
@@ -30,8 +30,8 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     public void testAddFilterLastOneRemains() throws Exception {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter("bF", SimpleBeanPropertyFilter.serializeAll())
-                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept());
+                .addFilter("filterB", SimpleBeanPropertyFilter.serializeAll())
+                .addFilter("filterB", SimpleBeanPropertyFilter.filterOutAllExcept());
         AnyBeanB beanB = new AnyBeanB("1a", "2b");
 
         String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
@@ -41,8 +41,8 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     public void testAddFilterLastOneRemainsFlip() throws Exception {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept("a"))
-                .addFilter("bF", SimpleBeanPropertyFilter.serializeAll());
+                .addFilter("filterB", SimpleBeanPropertyFilter.filterOutAllExcept("a"))
+                .addFilter("filterB", SimpleBeanPropertyFilter.serializeAll());
         AnyBeanB beanB = new AnyBeanB("1a", "2b");
 
         String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
@@ -52,7 +52,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     public void testAddFilterNulls() throws Exception {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept(null, null));
+                .addFilter("filterB", SimpleBeanPropertyFilter.filterOutAllExcept(null, null));
         AnyBeanB beanB = new AnyBeanB("1a", "2b");
 
         String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
@@ -62,7 +62,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     public void testAddFilterEmptyString() throws Exception {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter("bF", SimpleBeanPropertyFilter.filterOutAllExcept("", ""));
+                .addFilter("filterB", SimpleBeanPropertyFilter.filterOutAllExcept("", ""));
         AnyBeanB anyBeanB = new AnyBeanB("1a", "2b");
 
         String jsonString = MAPPER.writer(prov).writeValueAsString(anyBeanB);
@@ -92,7 +92,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
         assertEquals(a2q("{'c':null,'d':'D is filtered'}"), jsonString);
     }
 
-    @JsonFilter("notExist")
+    @JsonFilter("filterD")
     public static class AnyBeanD
     {
         public String a;
@@ -106,7 +106,7 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     public void testAddingNullFilter2ThrowsException() {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter("notExist", null);
+                .addFilter("filterD", null);
         ObjectWriter writer = MAPPER.writer(prov);
         AnyBeanD beanD = new AnyBeanD("1a", "2b");
 

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
@@ -47,18 +47,6 @@ public class SimpleFilterProviderTest extends BaseMapTest
         }
     }
 
-    @JsonFilter("filterD")
-    public static class AnyBeanD
-    {
-        public String a;
-        public String b;
-
-        public AnyBeanD(String a, String b) {
-            this.a = a;
-            this.b = b;
-        }
-    }
-
     /*
     /**********************************************************
     /* Tests
@@ -99,29 +87,29 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
     public void testAddingNullFilter2ThrowsException() throws JsonProcessingException {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter("filterD", null);
+                .addFilter("filterB", null);
         ObjectWriter writer = MAPPER.writer(prov);
-        AnyBeanD beanD = new AnyBeanD("1a", "2b");
+        AnyBeanB beanD = new AnyBeanB("1a", "2b");
 
         try {
             writer.writeValueAsString(beanD);
             fail("Should not have passed");
         } catch (JsonMappingException e) {
-            verifyException(e, "No filter configured with id 'filterD'");
+            verifyException(e, "No filter configured with id 'filterB'");
         }
     }
 
     public void testAddingNullFilterIdThrowsException() throws JsonProcessingException {
         FilterProvider prov = new SimpleFilterProvider()
-                .addFilter(null, SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"));
+                .addFilter(null, SimpleBeanPropertyFilter.serializeAll());
         ObjectWriter writer = MAPPER.writer(prov);
-        AnyBeanD beanD = new AnyBeanD("1a", "2b");
+        AnyBeanB beanD = new AnyBeanB("1a", "2b");
 
         try {
             writer.writeValueAsString(beanD);
             fail("Should not have passed");
         } catch (JsonMappingException e) {
-            verifyException(e, "No filter configured with id 'filterD'");
+            verifyException(e, "No filter configured with id 'filterB'");
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.ser;
+package com.fasterxml.jackson.databind.ser.filter;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -6,10 +6,7 @@ import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference;
-import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 


### PR DESCRIPTION
## Description

- Improve JavaDoc and add more tests around `SimpleFilterProvider addFilter()`.
- Below are cases that need to be tested.

### Tested cases

- Adding two filters with duplicate id are added, the filter later added will remain.
- Adding "weird filter" by `.addFilter("filterId", SimpleBeanPropertyFilter.filterOutAllExcept(null, null));` does not fail.
- Adding "weird filter" by `.addFilter("filterId", SimpleBeanPropertyFilter.filterOutAllExcept("", ""));` does not fail.
- Annotating `@JsonFilter("")` with empty string id and adding filter with an empty string id `.addFilter("", SimpleBeanPropertyFilter.filterOutAllExcept("d"));` will NOT work.
- Adding filter with `null` id `.addFilter(null, SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"));` throws an error during "serialization"
- Adding filter with `null` filter `.addFilter("someId",  null);` throws an error during "serialization"