### PR TITLE
Fix : Case insensitive and number based enum deserialization

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -353,7 +353,8 @@ public class EnumDeserializer
                 if (match != null) {
                     return match;
                 }
-            } else if (!ctxt.isEnabled(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
+            }
+            if (!ctxt.isEnabled(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS)
                     && !_isFromIntValue) {
                 // [databind#149]: Allow use of 'String' indexes as well -- unless prohibited (as per above)
                 char c = name.charAt(0);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserialization3638Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserialization3638Test.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.databind.deser.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EnumDeserialization3638Test extends BaseMapTest
+{
+    /*
+    /**********************************************************
+    /* Set up
+    /**********************************************************
+     */
+
+    protected final ObjectMapper MAPPER = new ObjectMapper();
+
+    static enum Member
+    {
+        FIRST_MEMBER(0),
+        SECOND_MEMBER(1);
+
+        private int index;
+
+        private Member(int index) {
+            this.index = index;
+        }
+    }
+
+    static class SensitiveBean
+    {
+        @JsonFormat(without = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+        public Member enumValue;
+    }
+
+    static class InsensitiveBean
+    {
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+        public Member enumValue;
+    }
+
+    /*
+    /**********************************************************
+    /* Tests
+    /**********************************************************
+     */
+
+    public void testCaseSensitive() throws JsonProcessingException {
+        String json = a2q("{'enumValue':'1'}");
+
+        SensitiveBean sensitiveBean = MAPPER.readValue(json, SensitiveBean.class);
+
+        assertEquals(Member.SECOND_MEMBER, sensitiveBean.enumValue);
+    }
+
+
+    public void testCaseInsensitive() throws JsonProcessingException {
+        String json = a2q("{'enumValue':'1'}");
+
+        InsensitiveBean insensitiveBean = MAPPER.readValue(json, InsensitiveBean.class);
+
+        assertEquals(Member.SECOND_MEMBER, insensitiveBean.enumValue);
+    }
+}


### PR DESCRIPTION
### Summary
- resolves #3638 

### Description
- **action** : move `if (!ctxt.isEnabled(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS) && !_isFromIntValue) {`  part to outer.
- **pros** : From code quality and future maintenance perspective, looks cleaner.
- **cons** : Backward compatibility, we cannot assume how many systems rely on this issue-turned-into-specification.