### PR TITLE
Test : Ordering of deserializing unknown enum value "Using default" or "As null"

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -405,14 +405,18 @@ public enum DeserializationFeature implements ConfigFeature
     READ_ENUMS_USING_TO_STRING(false),
 
     /**
-     * Feature that allows unknown Enum values to be parsed as null values.
+     * Feature that allows unknown Enum values to be parsed as {@code null} values.
      * If disabled, unknown Enum values will throw exceptions.
-     *<p>
-     * Note that in some cases this will in effect ignore unknown {@code Enum} values,
+     * <p>
+     * Note that in some cases this will effectively ignore unknown {@code Enum} values,
      * e.g. when the unknown values are used as keys of {@link java.util.EnumMap}
-     * or values of {@link java.util.EnumSet}: this because these data structures cannot
+     * or values of {@link java.util.EnumSet}: this is because these data structures cannot
      * store {@code null} values.
-     *<p>
+     * <p>
+     * Also note that this feature has lower precedence than
+     * {@link DeserializationFeature#READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE},
+     * meaning this feature will work only if latter feature is disabled.
+     * <p>
      * Feature is disabled by default.
      *
      * @since 2.0
@@ -420,11 +424,13 @@ public enum DeserializationFeature implements ConfigFeature
     READ_UNKNOWN_ENUM_VALUES_AS_NULL(false),
 
     /**
-     * Feature that allows unknown Enum values to be ignored and a predefined value specified through
+     * Feature that allows unknown Enum values to be ignored and replaced by a predefined value specified through
      * {@link com.fasterxml.jackson.annotation.JsonEnumDefaultValue @JsonEnumDefaultValue} annotation.
      * If disabled, unknown Enum values will throw exceptions.
      * If enabled, but no predefined default Enum value is specified, an exception will be thrown as well.
-     *<p>
+     * <p>
+     * Note that this feature has higher precedence than {@link DeserializationFeature#READ_UNKNOWN_ENUM_VALUES_AS_NULL}.
+     * <p>
      * Feature is disabled by default.
      *
      * @since 2.8

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserilizationFeatureOrderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserilizationFeatureOrderTest.java
@@ -1,0 +1,154 @@
+package com.fasterxml.jackson.databind.deser.enums;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class EnumDeserilizationFeatureOrderTest extends BaseMapTest
+{
+    /*
+    /**********************************************************
+    /* Set up
+    /**********************************************************
+     */
+
+    private final ObjectMapper MAPPER = new ObjectMapper();
+
+    enum EnumFruit
+    {
+        APPLE,
+        BANANA,
+        @JsonEnumDefaultValue
+        LEMON
+    }
+
+    enum EnumLetter
+    {
+        A,
+        @JsonEnumDefaultValue
+        @JsonAlias({"singleAlias"})
+        B,
+        @JsonAlias({"multipleAliases1", "multipleAliases2"})
+        C
+    }
+
+    /*
+    /**********************************************************
+    /* Tests
+    /**********************************************************
+     */
+
+
+    public void testDeserUnknownUsingDefaultBeforeAsNull() throws Exception {
+        ObjectReader reader = MAPPER
+                .readerFor(EnumFruit.class)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        EnumFruit simpleEnumA = reader.readValue(q(""));
+
+        assertEquals(EnumFruit.LEMON, simpleEnumA);
+    }
+
+    public void testDeserUnknownUsingDefaultBeforeAsNullFlip() throws Exception {
+        ObjectReader reader = MAPPER
+                .readerFor(EnumFruit.class)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumFruit simpleEnumA = reader.readValue(q(""));
+
+        assertEquals(EnumFruit.LEMON, simpleEnumA);
+    }
+
+    public void testDeserUnknownAsNull() throws Exception {
+        ObjectReader reader = MAPPER
+                .readerFor(EnumFruit.class)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        EnumFruit simpleEnumA = reader.readValue(q(""));
+
+        assertEquals(null, simpleEnumA);
+    }
+
+    public void testDeserWithAliasUsingDefault() throws Exception {
+        ObjectReader reader = MAPPER
+                .readerFor(EnumLetter.class)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumLetter defaulted = reader.readValue(q("unknownValue"));
+
+        assertEquals(EnumLetter.B, defaulted);
+    }
+
+    public void testDeserWithAliasAsNull() throws Exception {
+        ObjectReader reader = MAPPER
+                .readerFor(EnumLetter.class)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        EnumLetter defaulted = reader.readValue(q("unknownValue"));
+
+        assertEquals(null, defaulted);
+    }
+
+    public void testDeserUnknownEnumMapKeyUsingDefault() throws Exception {
+        String JSON = a2q("{ 'UNknownWhatEver': 'fresh!'}");
+        ObjectReader reader = MAPPER
+                .readerFor(new TypeReference<EnumMap<EnumFruit, String>>() {})
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+
+        EnumMap<EnumFruit, String> result = reader.readValue(JSON);
+
+        assertTrue(result.containsKey(EnumFruit.LEMON));
+        assertEquals("fresh!", result.get(EnumFruit.LEMON));
+    }
+
+    public void testDeserUnknownEnumMapKeyAsNull() throws Exception {
+        String JSON = a2q("{ 'UNknownWhatEver': 'fresh!'}");
+        ObjectReader reader = MAPPER
+                .readerFor(new TypeReference<EnumMap<EnumFruit, String>>() {})
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        EnumMap<EnumFruit, String> result = reader.readValue(JSON);
+
+        // EnumMap cannot have null as key
+        assertEquals(EnumMap.class, result.getClass());
+        assertTrue(result.isEmpty());
+    }
+
+    public void testDeserUnknownMapKeyUsingDefault() throws Exception {
+        String JSON = a2q("{ 'UNknownWhatEver': 'fresh!'}");
+        ObjectReader reader = MAPPER
+                .readerFor(new TypeReference<Map<EnumFruit, String>>() {})
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        Map<EnumFruit, String> result = reader.readValue(JSON);
+
+        assertTrue(result.containsKey(EnumFruit.LEMON));
+        assertEquals("fresh!", result.get(EnumFruit.LEMON));
+    }
+
+    public void testDeserUnknownMapKeyAsNull() throws Exception {
+        // Arrange
+        String JSON = a2q("{ 'UNknownWhatEver': 'fresh!'}");
+        ObjectReader reader = MAPPER
+                .readerFor(new TypeReference<Map<EnumFruit, String>>() {})
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        Map<EnumFruit, String> result = reader.readValue(JSON);
+
+        assertFalse(result.containsKey(EnumFruit.LEMON));
+        assertTrue(result.containsKey(null));
+        assertEquals("fresh!", result.get(null));
+    }
+}


### PR DESCRIPTION
## Description

This PR clarifies the "ordered" behavior of `READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` and `READ_UNKNOWN_ENUM_VALUES_AS_NULL` in `DeserializationFeature` when handling unknown enum values. It adds explicit JavaDoc and test cases to validate the behavior.

### Changes Made
- Clarified the ordered workings of DeserializationFeature in handling unknown enum values.
- Added explicit JavaDoc to describe the behavior.
- Added test cases to validate the behavior.
- Would Improve user experience by providing a better understanding of the handling unknown enum values.

### Covered parts

Currently, the following cases are covered:
https://github.com/FasterXML/jackson-databind/blob/b090d9d1d6308994a533569ae62c8a117d2a3aa4/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java#L321-L328

https://github.com/FasterXML/jackson-databind/blob/b090d9d1d6308994a533569ae62c8a117d2a3aa4/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java#L378-L383

https://github.com/FasterXML/jackson-databind/blob/b090d9d1d6308994a533569ae62c8a117d2a3aa4/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java#L409-L420