### PR TITLE
Chore : fix `pom.xml` configuration for test sources directory of `java17` Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,7 @@
                 </goals>
                 <configuration>
                   <sources>
+                    <source>src/test-jdk14/java</source>
                     <source>src/test-jdk17/java</source>
                   </sources>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
                 </goals>
                 <configuration>
                   <sources>
-                    <source>src/test-jdk14/java</source>
+                    <source>src/test-jdk17/java</source>
                   </sources>
                 </configuration>
               </execution>


### PR DESCRIPTION
both maven profiles `java14` and `java17` were pointing to `src/test-jdk14/java`