### PR TITLE
Feature : convenience method `SimpleBeanPropertyFilter.filterOutAll()` as symmetric counterpart of `serializeAll()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleBeanPropertyFilter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleBeanPropertyFilter.java
@@ -304,7 +304,7 @@ public class SimpleBeanPropertyFilter
     {
         private static final long serialVersionUID = 1L;
 
-        static final SerializeExceptFilter INCLUDE_ALL = new SerializeExceptFilter();
+        final static SerializeExceptFilter INCLUDE_ALL = new SerializeExceptFilter();
 
         /**
          * Set of property names to filter out.

--- a/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleBeanPropertyFilter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/impl/SimpleBeanPropertyFilter.java
@@ -42,6 +42,16 @@ public class SimpleBeanPropertyFilter
     }
 
     /**
+     * Convenience factory method that will return a filter that will
+     * simply filter out everything.
+     *
+     * @since 2.15
+     */
+    public static SimpleBeanPropertyFilter filterOutAll() {
+        return FilterExceptFilter.EXCLUDE_ALL;
+    }
+
+    /**
      * Factory method that was accidentally added in 2.5 with arguments; basically
      * works just as an alias of {@link #filterOutAllExcept(Set)} which is not
      * very useful. Instead, see {@link #serializeAll()} for intended signature.
@@ -258,10 +268,16 @@ public class SimpleBeanPropertyFilter
     {
         private static final long serialVersionUID = 1L;
 
+        static final FilterExceptFilter EXCLUDE_ALL = new FilterExceptFilter();
+
         /**
          * Set of property names to serialize.
          */
         protected final Set<String> _propertiesToInclude;
+
+        FilterExceptFilter() {
+            _propertiesToInclude = Collections.emptySet();
+        }
 
         public FilterExceptFilter(Set<String> properties) {
             _propertiesToInclude = properties;
@@ -288,7 +304,7 @@ public class SimpleBeanPropertyFilter
     {
         private static final long serialVersionUID = 1L;
 
-        final static SerializeExceptFilter INCLUDE_ALL = new SerializeExceptFilter();
+        static final SerializeExceptFilter INCLUDE_ALL = new SerializeExceptFilter();
 
         /**
          * Set of property names to filter out.

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.*;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -219,22 +221,22 @@ public class JsonFilterTest extends BaseMapTest
     public void testAllFiltersWithSameOutput() throws Exception
     {
         List<SimpleBeanPropertyFilter> allPossibleFilters = List.of(
-            // Parent class
+            // Parent class : SimpleBeanPropertyFilter
             SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"),
-            SimpleBeanPropertyFilter.filterOutAllExcept(Set.of("a", "b")),
+            SimpleBeanPropertyFilter.filterOutAllExcept(setOf("a", "b")),
             SimpleBeanPropertyFilter.serializeAllExcept("c"),
-            SimpleBeanPropertyFilter.serializeAllExcept(Set.of("c")),
-            // Subclass
-            new SimpleBeanPropertyFilter.SerializeExceptFilter(Set.of("c")),
+            SimpleBeanPropertyFilter.serializeAllExcept(setOf("c")),
+            // Subclass : SerializeExceptFilter
+            new SimpleBeanPropertyFilter.SerializeExceptFilter(setOf("c")),
             SimpleBeanPropertyFilter.SerializeExceptFilter.serializeAllExcept("c"),
-            SimpleBeanPropertyFilter.SerializeExceptFilter.serializeAllExcept(Set.of("c")),
+            SimpleBeanPropertyFilter.SerializeExceptFilter.serializeAllExcept(setOf("c")),
             SimpleBeanPropertyFilter.SerializeExceptFilter.filterOutAllExcept("a", "b"),
-            SimpleBeanPropertyFilter.SerializeExceptFilter.filterOutAllExcept(Set.of("a", "b")),
-            // Subclass
-            new SimpleBeanPropertyFilter.FilterExceptFilter(Set.of("a", "b")),
+            SimpleBeanPropertyFilter.SerializeExceptFilter.filterOutAllExcept(setOf("a", "b")),
+            // Subclass : FilterExceptFilter
+            new SimpleBeanPropertyFilter.FilterExceptFilter(setOf("a", "b")),
             SimpleBeanPropertyFilter.FilterExceptFilter.serializeAllExcept("c"),
-            SimpleBeanPropertyFilter.FilterExceptFilter.serializeAllExcept(Set.of("c")),
-            SimpleBeanPropertyFilter.FilterExceptFilter.filterOutAllExcept(Set.of("a", "b")),
+            SimpleBeanPropertyFilter.FilterExceptFilter.serializeAllExcept(setOf("c")),
+            SimpleBeanPropertyFilter.FilterExceptFilter.filterOutAllExcept(setOf("a", "b")),
             SimpleBeanPropertyFilter.FilterExceptFilter.filterOutAllExcept("a", "b")
         );
 
@@ -247,5 +249,11 @@ public class JsonFilterTest extends BaseMapTest
 
             assertEquals(a2q("{'a':'aa','b':'bb'}"), jsonStr);
         }
+    }
+
+    private Set<String> setOf(String... properties) {
+        Set<String> set = new HashSet<>(properties.length);
+        set.addAll(Arrays.asList(properties));
+        return set;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.*;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -150,6 +149,13 @@ public class JsonFilterTest extends BaseMapTest
         assertEquals("{\"a\":\"a\",\"b\":\"b\"}", MAPPER.writer(prov).writeValueAsString(new Bean()));
     }
 
+    public void testExcludeAllFilter() throws Exception
+    {
+        FilterProvider prov = new SimpleFilterProvider().addFilter("RootFilter",
+            SimpleBeanPropertyFilter.filterOutAll());
+        assertEquals("{}", MAPPER.writer(prov).writeValueAsString(new Bean()));
+    }
+
     public void testSimpleExclusionFilter() throws Exception
     {
         FilterProvider prov = new SimpleFilterProvider().addFilter("RootFilter",
@@ -210,21 +216,21 @@ public class JsonFilterTest extends BaseMapTest
                 MAPPER.writer(prov).writeValueAsString(new FilteredProps()));
     }
 
-    public void testFiltersWithSameOutput() throws Exception
+    public void testAllFiltersWithSameOutput() throws Exception
     {
         List<SimpleBeanPropertyFilter> allPossibleFilters = List.of(
-            // Main-class
+            // Parent class
             SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"),
             SimpleBeanPropertyFilter.filterOutAllExcept(Set.of("a", "b")),
             SimpleBeanPropertyFilter.serializeAllExcept("c"),
             SimpleBeanPropertyFilter.serializeAllExcept(Set.of("c")),
-            // Sub-class
+            // Subclass
             new SimpleBeanPropertyFilter.SerializeExceptFilter(Set.of("c")),
             SimpleBeanPropertyFilter.SerializeExceptFilter.serializeAllExcept("c"),
             SimpleBeanPropertyFilter.SerializeExceptFilter.serializeAllExcept(Set.of("c")),
             SimpleBeanPropertyFilter.SerializeExceptFilter.filterOutAllExcept("a", "b"),
             SimpleBeanPropertyFilter.SerializeExceptFilter.filterOutAllExcept(Set.of("a", "b")),
-            // Sub-class
+            // Subclass
             new SimpleBeanPropertyFilter.FilterExceptFilter(Set.of("a", "b")),
             SimpleBeanPropertyFilter.FilterExceptFilter.serializeAllExcept("c"),
             SimpleBeanPropertyFilter.FilterExceptFilter.serializeAllExcept(Set.of("c")),

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
@@ -219,6 +219,7 @@ public class JsonFilterTest extends BaseMapTest
 
     public void testAllFiltersWithSameOutput() throws Exception
     {
+        // Setup
         SimpleBeanPropertyFilter[] allPossibleFilters = new SimpleBeanPropertyFilter[]{
             // Parent class : SimpleBeanPropertyFilter
             SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"),
@@ -239,12 +240,12 @@ public class JsonFilterTest extends BaseMapTest
             SimpleBeanPropertyFilter.FilterExceptFilter.filterOutAllExcept("a", "b")
         };
 
+        // Tests
         for (SimpleBeanPropertyFilter filter : allPossibleFilters) {
             BeanB beanB = new BeanB("aa", "bb", "cc");
+            SimpleFilterProvider prov = new SimpleFilterProvider().addFilter("filterB", filter);
 
-            String jsonStr = MAPPER
-                .writer(new SimpleFilterProvider().addFilter("filterB", filter))
-                .writeValueAsString(beanB);
+            String jsonStr = MAPPER.writer(prov).writeValueAsString(beanB);
 
             assertEquals(a2q("{'a':'aa','b':'bb'}"), jsonStr);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonFilterTest.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.ser.impl.*;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -220,7 +219,7 @@ public class JsonFilterTest extends BaseMapTest
 
     public void testAllFiltersWithSameOutput() throws Exception
     {
-        List<SimpleBeanPropertyFilter> allPossibleFilters = List.of(
+        SimpleBeanPropertyFilter[] allPossibleFilters = new SimpleBeanPropertyFilter[]{
             // Parent class : SimpleBeanPropertyFilter
             SimpleBeanPropertyFilter.filterOutAllExcept("a", "b"),
             SimpleBeanPropertyFilter.filterOutAllExcept(setOf("a", "b")),
@@ -238,7 +237,7 @@ public class JsonFilterTest extends BaseMapTest
             SimpleBeanPropertyFilter.FilterExceptFilter.serializeAllExcept(setOf("c")),
             SimpleBeanPropertyFilter.FilterExceptFilter.filterOutAllExcept(setOf("a", "b")),
             SimpleBeanPropertyFilter.FilterExceptFilter.filterOutAllExcept("a", "b")
-        );
+        };
 
         for (SimpleBeanPropertyFilter filter : allPossibleFilters) {
             BeanB beanB = new BeanB("aa", "bb", "cc");


### PR DESCRIPTION
## Description

 This PR adds a new convenience method to `SimpleBeanPropertyFilter` class, called `filterOutAll()`. The purpose of this method is to provide a symmetric counterpart to the already-existing `serializeAll()`, making it easier for developers to use `SimpleBeanPropertyFilter` class in a more intuitive way.

### Changes Made

- Implemented the `filterOutAll()` method in `SimpleBeanPropertyFilter.
- Added test cases for all possible `filterOutAllExcept(String...)` and `serializeAllExcept(String...)` methods of `SimpleBeanPropertyFilter` and its subclasses to ensure that they output the same JSON string.