### PR TITLE
Do not catch and ignore fatal exceptions

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
@@ -26,9 +26,7 @@ public abstract class Java7Support
             // 09-Sep-2019, tatu: Used to log earlier, but with 2.10.0 let's not log
 //            java.util.logging.Logger.getLogger(Java7Support.class.getName())
 //                .warning("Unable to load JDK7 annotations (@ConstructorProperties, @Transient): no Java7 annotation support added");
-            if (ExceptionUtil.isFatal(t)) {
-                ExceptionUtil.rethrow(t);
-            }
+            ExceptionUtil.rethrowIfFatal(t);
         }
         IMPL = impl;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.ExceptionUtil;
 
 /**
  * To support Java7-incomplete platforms, we will offer support for JDK 7
@@ -25,6 +26,9 @@ public abstract class Java7Support
             // 09-Sep-2019, tatu: Used to log earlier, but with 2.10.0 let's not log
 //            java.util.logging.Logger.getLogger(Java7Support.class.getName())
 //                .warning("Unable to load JDK7 annotations (@ConstructorProperties, @Transient): no Java7 annotation support added");
+            if (ExceptionUtil.isFatal(t)) {
+                ExceptionUtil.rethrow(t);
+            }
         }
         IMPL = impl;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -56,9 +56,7 @@ public class OptionalHandlerFactory implements java.io.Serializable
             node = org.w3c.dom.Node.class;
             doc = org.w3c.dom.Document.class;
         } catch (Throwable e) {
-            if (ExceptionUtil.isFatal(e)) {
-                ExceptionUtil.rethrow(e);
-            }
+            ExceptionUtil.rethrowIfFatal(e);
             // not optimal but will do
             // 02-Nov-2020, Xakep_SDK: Remove java.logging module dependency
 //            Logger.getLogger(OptionalHandlerFactory.class.getName())
@@ -78,9 +76,7 @@ public class OptionalHandlerFactory implements java.io.Serializable
         try {
             x = Java7Handlers.instance();
         } catch (Throwable t) {
-            if (ExceptionUtil.isFatal(t)) {
-                ExceptionUtil.rethrow(t);
-            }
+            ExceptionUtil.rethrowIfFatal(t);
         }
         _jdk7Helper = x;
     }
@@ -240,9 +236,7 @@ public class OptionalHandlerFactory implements java.io.Serializable
         try {
             return instantiate(Class.forName(className), valueType);
         } catch (Throwable e) {
-            if (ExceptionUtil.isFatal(e)) {
-                ExceptionUtil.rethrow(e);
-            }
+            ExceptionUtil.rethrowIfFatal(e);
             throw new IllegalStateException("Failed to find class `"
 +className+"` for handling values of type "+ClassUtil.getTypeDescription(valueType)
 +", problem: ("+e.getClass().getName()+") "+e.getMessage());
@@ -254,9 +248,7 @@ public class OptionalHandlerFactory implements java.io.Serializable
         try {
             return ClassUtil.createInstance(handlerClass, false);
         } catch (Throwable e) {
-            if (ExceptionUtil.isFatal(e)) {
-                ExceptionUtil.rethrow(e);
-            }
+            ExceptionUtil.rethrowIfFatal(e);
             throw new IllegalStateException("Failed to create instance of `"
 +handlerClass.getName()+"` for handling values of type "+ClassUtil.getTypeDescription(valueType)
 +", problem: ("+e.getClass().getName()+") "+e.getMessage());

--- a/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/OptionalHandlerFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.fasterxml.jackson.databind.ser.Serializers;
 import com.fasterxml.jackson.databind.ser.std.DateSerializer;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.databind.util.ExceptionUtil;
 
 /**
  * Helper class used for isolating details of handling optional+external types
@@ -55,6 +56,9 @@ public class OptionalHandlerFactory implements java.io.Serializable
             node = org.w3c.dom.Node.class;
             doc = org.w3c.dom.Document.class;
         } catch (Throwable e) {
+            if (ExceptionUtil.isFatal(e)) {
+                ExceptionUtil.rethrow(e);
+            }
             // not optimal but will do
             // 02-Nov-2020, Xakep_SDK: Remove java.logging module dependency
 //            Logger.getLogger(OptionalHandlerFactory.class.getName())
@@ -73,7 +77,11 @@ public class OptionalHandlerFactory implements java.io.Serializable
         Java7Handlers x = null;
         try {
             x = Java7Handlers.instance();
-        } catch (Throwable t) { }
+        } catch (Throwable t) {
+            if (ExceptionUtil.isFatal(t)) {
+                ExceptionUtil.rethrow(t);
+            }
+        }
         _jdk7Helper = x;
     }
 
@@ -232,6 +240,9 @@ public class OptionalHandlerFactory implements java.io.Serializable
         try {
             return instantiate(Class.forName(className), valueType);
         } catch (Throwable e) {
+            if (ExceptionUtil.isFatal(e)) {
+                ExceptionUtil.rethrow(e);
+            }
             throw new IllegalStateException("Failed to find class `"
 +className+"` for handling values of type "+ClassUtil.getTypeDescription(valueType)
 +", problem: ("+e.getClass().getName()+") "+e.getMessage());
@@ -243,6 +254,9 @@ public class OptionalHandlerFactory implements java.io.Serializable
         try {
             return ClassUtil.createInstance(handlerClass, false);
         } catch (Throwable e) {
+            if (ExceptionUtil.isFatal(e)) {
+                ExceptionUtil.rethrow(e);
+            }
             throw new IllegalStateException("Failed to create instance of `"
 +handlerClass.getName()+"` for handling values of type "+ClassUtil.getTypeDescription(valueType)
 +", problem: ("+e.getClass().getName()+") "+e.getMessage());

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -66,7 +66,11 @@ public class JacksonAnnotationIntrospector
         Java7Support x = null;
         try {
             x = Java7Support.instance();
-        } catch (Throwable t) { }
+        } catch (Throwable t) {
+            if (ExceptionUtil.isFatal(t)) {
+                ExceptionUtil.rethrow(t);
+            }
+        }
         _java7Helper = x;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -67,9 +67,7 @@ public class JacksonAnnotationIntrospector
         try {
             x = Java7Support.instance();
         } catch (Throwable t) {
-            if (ExceptionUtil.isFatal(t)) {
-                ExceptionUtil.rethrow(t);
-            }
+            ExceptionUtil.rethrowIfFatal(t);
         }
         _java7Helper = x;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -1180,6 +1180,9 @@ se.getClass().getName(), se.getMessage()),
         try {
             return getJDKMajorVersion() >= 17;
         } catch (Throwable t) {
+            if (ExceptionUtil.isFatal(t)) {
+                ExceptionUtil.rethrow(t);
+            }
             System.err.println("Failed to determine JDK major version, assuming pre-JDK-17; problem: "+t);
             return false;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -1180,9 +1180,7 @@ se.getClass().getName(), se.getMessage()),
         try {
             return getJDKMajorVersion() >= 17;
         } catch (Throwable t) {
-            if (ExceptionUtil.isFatal(t)) {
-                ExceptionUtil.rethrow(t);
-            }
+            ExceptionUtil.rethrowIfFatal(t);
             System.err.println("Failed to determine JDK major version, assuming pre-JDK-17; problem: "+t);
             return false;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.databind.util;
+
+/**
+ * Utilitity methods for dealing with exceptions/throwables
+ *
+ * @since 2.15
+ */
+public class ExceptionUtil {
+    private ExceptionUtil() {}
+
+    /**
+     * It is important never to catch all <code>Throwable</code>s. Some like
+     * {@link InterruptedException} should be rethrown. Based on
+     * <a href="https://www.scala-lang.org/api/2.13.10/scala/util/control/NonFatal$.html">scala.util.control.NonFatal</a>.
+     *
+     * @param throwable to check
+     * @return whether the <code>Throwable</code> is a fatal error
+     */
+    public static boolean isFatal(Throwable throwable) {
+        return (throwable instanceof VirtualMachineError
+                || throwable instanceof ThreadDeath
+                || throwable instanceof InterruptedException
+                || throwable instanceof LinkageError);
+    }
+
+    /**
+     * Designed to be used in conjunction with {@link #isFatal(Throwable)}.
+     * This method should be used with care.
+     * <p>
+     *     The input throwable is thrown if it is an <code>Error</code> or <code>RuntimeException</code>.
+     *     Otherwise, the method wraps the throwable in a RuntimeException and rethrows that.
+     * </p>
+     *
+     * @param throwable to check
+     * @throws Error the input throwable if it is an <code>Error</code>.
+     * @throws RuntimeException the input throwable if it is an <code>RuntimeException</code>
+     * Otherwise wraps the throwable in a RuntimeException.
+     */
+    public static void rethrow(Throwable throwable) throws Error, RuntimeException {
+        if (throwable instanceof Error) {
+            throw (Error) throwable;
+        }
+        if (throwable instanceof RuntimeException) {
+            throw (RuntimeException) throwable;
+        }
+        throw new RuntimeException(throwable);
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
@@ -13,36 +13,42 @@ public class ExceptionUtil {
      * {@link InterruptedException} should be rethrown. Based on
      * <a href="https://www.scala-lang.org/api/2.13.10/scala/util/control/NonFatal$.html">scala.util.control.NonFatal</a>.
      *
+     * This method should be used with care.
+     * <p>
+     *     If the <code>Throwable</code> is fatal, it is rethrown, otherwise, this method just returns.
+     *     The input throwable is thrown if it is an <code>Error</code> or <code>RuntimeException</code>.
+     *     Otherwise, the method wraps the throwable in a RuntimeException and throws that.
+     * </p>
+     *
+     * @param throwable to check
+     * @throws Error the input throwable if it is fatal
+     * @throws RuntimeException the input throwable if it is fatal - throws the original throwable
+     * if is a <code>RuntimeException</code>. Otherwise, wraps the throwable in a RuntimeException.
+     */
+    public static void rethrowIfFatal(Throwable throwable) throws Error, RuntimeException {
+        if (isFatal(throwable)) {
+            if (throwable instanceof Error) {
+                throw (Error) throwable;
+            }
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            }
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    /**
+     * It is important never to catch all <code>Throwable</code>s. Some like
+     * {@link InterruptedException} should be rethrown. Based on
+     * <a href="https://www.scala-lang.org/api/2.13.10/scala/util/control/NonFatal$.html">scala.util.control.NonFatal</a>.
+     *
      * @param throwable to check
      * @return whether the <code>Throwable</code> is a fatal error
      */
-    public static boolean isFatal(Throwable throwable) {
+    private static boolean isFatal(Throwable throwable) {
         return (throwable instanceof VirtualMachineError
                 || throwable instanceof ThreadDeath
                 || throwable instanceof InterruptedException
                 || throwable instanceof LinkageError);
-    }
-
-    /**
-     * Designed to be used in conjunction with {@link #isFatal(Throwable)}.
-     * This method should be used with care.
-     * <p>
-     *     The input throwable is thrown if it is an <code>Error</code> or <code>RuntimeException</code>.
-     *     Otherwise, the method wraps the throwable in a RuntimeException and rethrows that.
-     * </p>
-     *
-     * @param throwable to check
-     * @throws Error the input throwable if it is an <code>Error</code>.
-     * @throws RuntimeException the input throwable if it is an <code>RuntimeException</code>
-     * Otherwise wraps the throwable in a RuntimeException.
-     */
-    public static void rethrow(Throwable throwable) throws Error, RuntimeException {
-        if (throwable instanceof Error) {
-            throw (Error) throwable;
-        }
-        if (throwable instanceof RuntimeException) {
-            throw (RuntimeException) throwable;
-        }
-        throw new RuntimeException(throwable);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
@@ -49,6 +49,12 @@ public class ExceptionUtil {
         return (throwable instanceof VirtualMachineError
                 || throwable instanceof ThreadDeath
                 || throwable instanceof InterruptedException
-                || throwable instanceof LinkageError);
+                || throwable instanceof ClassCircularityError
+                || throwable instanceof ClassFormatError
+                || throwable instanceof ExceptionInInitializerError
+                || throwable instanceof IncompatibleClassChangeError
+                || throwable instanceof BootstrapMethodError
+                || throwable instanceof VerifyError
+        );
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
@@ -51,7 +51,6 @@ public class ExceptionUtil {
                 || throwable instanceof InterruptedException
                 || throwable instanceof ClassCircularityError
                 || throwable instanceof ClassFormatError
-                || throwable instanceof ExceptionInInitializerError
                 || throwable instanceof IncompatibleClassChangeError
                 || throwable instanceof BootstrapMethodError
                 || throwable instanceof VerifyError

--- a/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ExceptionUtil.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.databind.util;
 
 /**
- * Utilitity methods for dealing with exceptions/throwables
+ * Utility methods for dealing with exceptions/throwables
  *
  * @since 2.15
  */
@@ -16,7 +16,7 @@ public class ExceptionUtil {
      * This method should be used with care.
      * <p>
      *     If the <code>Throwable</code> is fatal, it is rethrown, otherwise, this method just returns.
-     *     The input throwable is thrown if it is an <code>Error</code> or <code>RuntimeException</code>.
+     *     The input throwable is thrown if it is an <code>Error</code> or a <code>RuntimeException</code>.
      *     Otherwise, the method wraps the throwable in a RuntimeException and throws that.
      * </p>
      *

--- a/src/test/java/com/fasterxml/jackson/databind/util/ExceptionUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ExceptionUtilTest.java
@@ -1,0 +1,28 @@
+package com.fasterxml.jackson.databind.util;
+
+import com.fasterxml.jackson.databind.BaseTest;
+
+public class ExceptionUtilTest extends BaseTest {
+    public void testNoClassDefError() {
+        //next line should be a no-op
+        ExceptionUtil.rethrowIfFatal(new NoClassDefFoundError("fake"));
+    }
+
+    public void testOutOfMemoryError() {
+        try {
+            ExceptionUtil.rethrowIfFatal(new OutOfMemoryError("fake"));
+            fail("expected OutOfMemoryError");
+        } catch (OutOfMemoryError err) {
+            assertEquals("fake", err.getMessage());
+        }
+    }
+
+    public void testVerifyError() {
+        try {
+            ExceptionUtil.rethrowIfFatal(new VerifyError("fake"));
+            fail("expected VerifyError");
+        } catch (VerifyError err) {
+            assertEquals("fake", err.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/util/ExceptionUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ExceptionUtilTest.java
@@ -8,6 +8,11 @@ public class ExceptionUtilTest extends BaseTest {
         ExceptionUtil.rethrowIfFatal(new NoClassDefFoundError("fake"));
     }
 
+    public void testExceptionInInitializerError() {
+        //next line should be a no-op
+        ExceptionUtil.rethrowIfFatal(new ExceptionInInitializerError("fake"));
+    }
+
     public void testOutOfMemoryError() {
         try {
             ExceptionUtil.rethrowIfFatal(new OutOfMemoryError("fake"));


### PR DESCRIPTION
I was pitching for this in https://github.com/FasterXML/jackson-databind/pull/3826

I don't think it is a good idea to risk messing with fatal errors like OutOfMemoryErrors.

If this util seems ok, it could in theory be moved to jackson-core and used in other Jackson modules.

fyi @JooHyukKim