### PR TITLE
add testSerializeMapWithAsProperty

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
@@ -188,6 +188,42 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
     @JsonTypeName("implB")
     static class Factory1311ImplB implements Factory1311 { }
 
+
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value=Cat.class, name="cat"),
+            @JsonSubTypes.Type(value=Dog.class, name="dog")
+    })
+    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "__type")
+    interface Animal {
+        String getBreed();
+    }
+
+    static class Cat implements Animal {
+        private final String breed;
+
+        Cat(String breed) {
+            this.breed = breed;
+        }
+
+        @Override
+        public String getBreed() {
+            return breed;
+        }
+    }
+
+    static class Dog implements Animal {
+        private final String breed;
+
+        Dog(String breed) {
+            this.breed = breed;
+        }
+
+        @Override
+        public String getBreed() {
+            return breed;
+        }
+    }
+
     /*
     /**********************************************************
     /* Unit tests
@@ -440,4 +476,14 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
         assertEquals(5, impl.b);
         assertEquals(9, impl.def);
     }
+
+    public void testSerializeMapWithAsProperty() throws Exception {
+        Map<String, Animal> map = new HashMap<>();
+        map.put("a", new Dog("Golden Retriever"));
+        map.put("b", new Cat("Devon Rex"));
+        String result = MAPPER.writeValueAsString(map);
+        // the result is incorrect, the `__type` field is not written
+        assertEquals("{\"a\":{\"breed\":\"Golden Retriever\"},\"b\":{\"breed\":\"Devon Rex\"}}", result);
+    }
+
 }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestSubtypes.java
@@ -198,6 +198,19 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
         String getBreed();
     }
 
+    class AnimalMap {
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value=Cat.class, name="cat"),
+                @JsonSubTypes.Type(value=Dog.class, name="dog")
+        })
+        @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "__type")
+        private Map<String, Animal> map = new HashMap<>();
+
+        void addAnimal(String key, Animal value) {
+            map.put(key, value);
+        }
+    }
+
     static class Cat implements Animal {
         private final String breed;
 
@@ -484,6 +497,15 @@ public class TestSubtypes extends com.fasterxml.jackson.databind.BaseMapTest
         String result = MAPPER.writeValueAsString(map);
         // the result is incorrect, the `__type` field is not written
         assertEquals("{\"a\":{\"breed\":\"Golden Retriever\"},\"b\":{\"breed\":\"Devon Rex\"}}", result);
+    }
+
+    public void testSerializeAnimalMap() throws Exception {
+        AnimalMap map = new AnimalMap();
+        map.addAnimal("a", new Dog("Golden Retriever"));
+        map.addAnimal("b", new Cat("Devon Rex"));
+        String result = MAPPER.writeValueAsString(map);
+        assertEquals("{\"map\":{\"a\":{\"__type\":\"dog\",\"breed\":\"Golden Retriever\"},\"b\":{\"__type\":\"cat\",\"breed\":\"Devon Rex\"}}}",
+                result);
     }
 
 }


### PR DESCRIPTION
demonstrates a possible issue - where serializing a Map that has a Map Value type that is an interface with JsonType annotating 
* the `__type` field that the annotation says should be added does not appear when we serialize the map
* I have also seen similar behaviour with `List<Animal>` (that no `__type` field is written)
* it does look like I can workaround this by creating an AnimalMap class that wraps the HashMap.
* relates to https://github.com/FasterXML/jackson-module-scala/issues/623
* if this is regarded as an issue, it is probably something that has been like this for a while and I doubt whether we should delay v2.15.0 for a fix for this 