### PR TITLE
Add test cases for circular registration of mix-ins

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/mixins/MixinsCircularTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/mixins/MixinsCircularTest.java
@@ -1,0 +1,79 @@
+package com.fasterxml.jackson.databind.mixins;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class MixinsCircularTest extends BaseMapTest {
+
+    static class First {
+        @JsonProperty("first-mixin")
+        public String value;
+    }
+
+    static class Second {
+        @JsonProperty("second-mixin")
+        public String value;
+
+    }
+
+    static class Third {
+        @JsonProperty("third-mixin")
+        public String value;
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    protected final ObjectMapper MAPPER = jsonMapperBuilder().build();
+
+    public void testPojoMixinDeserialization() throws Exception {
+        ObjectMapper mxMapper = MAPPER
+            .addMixIn(First.class, Second.class)
+            .addMixIn(Second.class, Third.class)
+            .addMixIn(Third.class, First.class);
+
+        // first deserialized from second
+        First first = mxMapper.readValue(a2q("{'second-mixin':'second-mixin'}"), First.class);
+        assertEquals("second-mixin", first.value);
+
+        // second deserialized from third
+        Second second = mxMapper.readValue(a2q("{'third-mixin':'third-mixin'}"), Second.class);
+        assertEquals("third-mixin", second.value);
+
+        // third deserialized from first
+        Third third = mxMapper.readValue(a2q("{'first-mixin':'first-mixin'}"), Third.class);
+        assertEquals("first-mixin", third.value);
+    }
+
+    public void testPojoMixinSerialization() throws Exception {
+        ObjectMapper mxMapper = MAPPER
+            .addMixIn(First.class, Second.class)
+            .addMixIn(Second.class, Third.class)
+            .addMixIn(Third.class, First.class);
+
+        // first serialized as second
+        First firstBean = new First();
+        firstBean.value = "value";
+        assertEquals(
+            a2q("{'second-mixin':'value'}"),
+            mxMapper.writeValueAsString(firstBean));
+
+        // second serialized as third
+        Second secondBean = new Second();
+        secondBean.value = "value";
+        assertEquals(
+            a2q("{'third-mixin':'value'}"),
+            mxMapper.writeValueAsString(secondBean));
+
+        // third serialized as first
+        Third thirdBean = new Third();
+        thirdBean.value = "value";
+        assertEquals(
+            a2q("{'first-mixin':'value'}"),
+            mxMapper.writeValueAsString(thirdBean));
+    }
+}


### PR DESCRIPTION
## Description 

This PR adds test cases to ensure circular mix-in registration does not propagate and remains unaffected by future library changes or refactoring.