### PR TITLE
set transformer factory attributes to improve protection against XXE

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/DOMSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/DOMSerializer.java
@@ -28,6 +28,8 @@ public class DOMSerializer extends StdSerializer<Node>
         try {
             transformerFactory = TransformerFactory.newInstance();
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            setTransformerFactoryAttribute(transformerFactory, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            setTransformerFactoryAttribute(transformerFactory, XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         } catch (Exception e) {
             throw new IllegalStateException("Could not instantiate `TransformerFactory`: "+e.getMessage(), e);
         }
@@ -64,5 +66,14 @@ public class DOMSerializer extends StdSerializer<Node>
     @Override
     public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) throws JsonMappingException {
         if (visitor != null) visitor.expectAnyFormat(typeHint);
+    }
+
+    private static void setTransformerFactoryAttribute(final TransformerFactory transformerFactory,
+                                                       final String name, final Object value) {
+        try {
+            transformerFactory.setAttribute(name, value);
+        } catch (Exception e) {
+            System.err.println("[DOMSerializer] Failed to set TransformerFactory attribute: " + name);
+        }
     }
 }


### PR DESCRIPTION
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html recommends these attributes.

Wrapped the setAttribute because some old implementations of the JAXP interfaces are liable to throw exceptions when you set attributes that they don't recognise.

Relates to #3387 - which has a new comment today