### PR TITLE
Doc : Fix broken link for JavaDoc `EnumNaming` feature and enhance documentation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
@@ -274,7 +274,7 @@ public class EnumSerializer
                 annotatedClass);
         EnumNamingStrategy enumNamingStrategy = EnumNamingStrategyFactory.createEnumNamingStrategyInstance(
             namingDef, config.canOverrideAccessModifiers());
-        return enumNamingStrategy == null ? null : EnumValues.constructUsingEnumNaming(
+        return enumNamingStrategy == null ? null : EnumValues.constructUsingEnumNamingStrategy(
             config, enumClass, enumNamingStrategy);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.EnumNamingStrategy;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 
 /**
@@ -153,6 +154,8 @@ public class EnumResolver implements java.io.Serializable
      * Factory method for constructing resolver that maps the name of enums converted to external property
      * names into Enum value using an implementation of {@link EnumNamingStrategy}.
      *
+     * The output {@link EnumResolver} should contain values that are symmetric to
+     * {@link EnumValues#constructUsingEnumNaming(MapperConfig, Class, EnumNamingStrategy)}.
      * @since 2.15
      */
     public static EnumResolver constructUsingEnumNamingStrategy(DeserializationConfig config,

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -155,7 +155,7 @@ public class EnumResolver implements java.io.Serializable
      * names into Enum value using an implementation of {@link EnumNamingStrategy}.
      *
      * The output {@link EnumResolver} should contain values that are symmetric to
-     * {@link EnumValues#constructUsingEnumNaming(MapperConfig, Class, EnumNamingStrategy)}.
+     * {@link EnumValues#constructUsingEnumNamingStrategy(MapperConfig, Class, EnumNamingStrategy)}.
      * @since 2.15
      */
     public static EnumResolver constructUsingEnumNamingStrategy(DeserializationConfig config,

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -81,8 +81,9 @@ public final class EnumValues
 
     /**
      * Returns String serializations of Enum name using an instance of {@link EnumNamingStrategy}.
+     *
      * The output {@link EnumValues} should contain values that are symmetric to
-     * {@link EnumResolver#constructUsingEnumNaming(DeserializationConfig, Class, EnumNamingStrategy)}.
+     * {@link EnumResolver#constructUsingEnumNamingStrategy(DeserializationConfig, Class, EnumNamingStrategy)}.
      *
      * @since 2.15
      */

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -87,7 +87,7 @@ public final class EnumValues
      *
      * @since 2.15
      */
-    public static EnumValues constructUsingEnumNaming(MapperConfig<?> config, Class<Enum<?>> enumClass, EnumNamingStrategy namingStrategy) {
+    public static EnumValues constructUsingEnumNamingStrategy(MapperConfig<?> config, Class<Enum<?>> enumClass, EnumNamingStrategy namingStrategy) {
         Class<? extends Enum<?>> cls = ClassUtil.findEnumType(enumClass);
         Enum<?>[] values = cls.getEnumConstants();
         if (values == null) {


### PR DESCRIPTION
## Description
This PR aims to improve the documentation and naming of methods introduced by `@EnumNaming` feature in #2667, specifically on the de/serialization symmetry.

### Changes Made

The following changes were made:

- The broken JavaDoc link {@link EnumResolver#constructUsingEnumNamingStrategy} was fixed.
- The JavaDoc in `EnumResolver` and `EnumValues` to reference each other, to better reflect the intended symmetry.