### PR TITLE
Declare missing fields explicitly as `null` in copy constructors

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -254,6 +254,7 @@ public abstract class DeserializationContext
         _readCapabilities = src._readCapabilities;
         _view = src._view;
         _injectableValues = null;
+        _currentType = null;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -249,6 +249,7 @@ public abstract class SerializerProvider
         _serializationView = null;
         _serializerFactory = null;
         _knownSerializers = null;
+        _dateFormat = null;
 
         // and others initialized to default empty state
         _serializerCache = new SerializerCache();

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DefaultDeserializationContext.java
@@ -66,6 +66,7 @@ public abstract class DefaultDeserializationContext
      */
     protected DefaultDeserializationContext(DefaultDeserializationContext src) {
         super(src);
+        _objectIdResolvers = null;
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -197,6 +197,7 @@ public abstract class SettableBeanProperty
     protected SettableBeanProperty(SettableBeanProperty src)
     {
         super(src);
+        _objectIdInfo = null;
         _propName = src._propName;
         _type = src._type;
         _wrapperName = src._wrapperName;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -208,7 +208,6 @@ public abstract class SettableBeanProperty
         _propertyIndex = src._propertyIndex;
         _viewMatcher = src._viewMatcher;
         _nullProvider = src._nullProvider;
-        _objectIdInfo = null;
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
@@ -81,6 +81,12 @@ public class BeanSerializerBuilder
      * Copy-constructor that may be used for sub-classing
      */
     protected BeanSerializerBuilder(BeanSerializerBuilder src) {
+        // empty state
+        _config = null;
+        _typeId = null;
+        _objectIdWriter = null;
+
+        // copy fields
         _beanDesc = src._beanDesc;
         _properties = src._properties;
         _filteredProperties = src._filteredProperties;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializerBuilder.java
@@ -92,11 +92,6 @@ public class BeanSerializerBuilder
         _filteredProperties = src._filteredProperties;
         _anyGetter = src._anyGetter;
         _filterId = src._filterId;
-
-        // empty state
-        _config = null;
-        _typeId = null;
-        _objectIdWriter = null;
     }
 
     /**


### PR DESCRIPTION
## Description

 This PR declares missing fields in copy constructors to prevent confusion and potential bugs. It's important for maintenance to explicitly declare null values, rather than ignoring the declaration altogether.

### Further Actions

- There seems to be one field in `SettableBeanProperty` that might not have to be `null`. Let me know so I can fix 🙏🏼