### PR TITLE
Support strict Type ID handling.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -328,6 +328,15 @@ public enum MapperFeature implements ConfigFeature
      */
     INFER_BUILDER_TYPE_BINDINGS(true),
 
+    /**
+     * Feature that determines what happens when deserializing to a registered sub-type, but no
+     * type information has been provided. If enabled, then an {@link InvalidTypeIdException}
+     * will be thrown, if disabled then the deserialization will proceed without the type information.
+     *
+     * @since 2.15
+     */
+    STRICT_TYPE_ID_HANDLING(false),
+
     /*
     /******************************************************
     /* View-related features

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -335,7 +335,7 @@ public enum MapperFeature implements ConfigFeature
      *
      * @since 2.15
      */
-    STRICT_TYPE_ID_HANDLING(false),
+    REQUIRE_TYPE_ID_FOR_SUBTYPES(true),
 
     /*
     /******************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
@@ -29,11 +29,11 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
     protected final As _inclusion;
 
     /**
-     * Indicates if the current class has a TypeResolver attached or not.
+     * Indicates that we should be strict about handling missing type information.
      *
      * @since 2.15
      */
-    protected final boolean _hasTypeResolver;
+    protected final boolean _strictTypeIdHandling;
 
     // @since 2.12.2 (see [databind#3055]
     protected final String _msgForMissingId = (_property == null)
@@ -58,13 +58,13 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
     {
         super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl);
         _inclusion = inclusion;
-        _hasTypeResolver = true;
+        _strictTypeIdHandling = false;
     }
 
     public AsPropertyTypeDeserializer(AsPropertyTypeDeserializer src, BeanProperty property) {
         super(src, property);
         _inclusion = src._inclusion;
-        _hasTypeResolver = src._hasTypeResolver;
+        _strictTypeIdHandling = src._strictTypeIdHandling;
     }
 
     /**
@@ -72,11 +72,11 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
      */
     public AsPropertyTypeDeserializer(JavaType bt, TypeIdResolver idRes,
             String typePropertyName, boolean typeIdVisible, JavaType defaultImpl,
-            As inclusion, boolean hasTypeResolver)
+            As inclusion, boolean strictTypeIdHandling)
     {
         super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl);
         _inclusion = inclusion;
-        _hasTypeResolver = hasTypeResolver;
+        _strictTypeIdHandling = strictTypeIdHandling;
     }
 
     @Override
@@ -203,8 +203,7 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
         // genuine, or faked for "dont fail on bad type id")
         JsonDeserializer<Object> deser = _findDefaultImplDeserializer(ctxt);
         if (deser == null) {
-            JavaType t = _hasTypeResolver
-                ? _handleMissingTypeId(ctxt, priorFailureMsg) : _baseType;
+            JavaType t = _strictTypeIdHandling ? _handleMissingTypeId(ctxt, priorFailureMsg): _baseType;
 
             if (t == null) {
                 // 09-Mar-2017, tatu: Is this the right thing to do?

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -177,7 +177,7 @@ public class StdTypeResolverBuilder
         case EXISTING_PROPERTY: // as per [#528] same class as PROPERTY
             return new AsPropertyTypeDeserializer(baseType, idRes,
                     _typeProperty, _typeIdVisible, defaultImpl, _includeAs,
-                    _hasTypeResolver(config, baseType));
+                    _strictTypeIdHandling(config, baseType));
         case WRAPPER_OBJECT:
             return new AsWrapperTypeDeserializer(baseType, idRes,
                     _typeProperty, _typeIdVisible, defaultImpl);
@@ -404,18 +404,23 @@ public class StdTypeResolverBuilder
     }
 
     /**
-     * Checks whether the given class has annotations indicating some type resolver
-     * is applied, for example {@link com.fasterxml.jackson.annotation.JsonSubTypes}.
-     * Only initializes {@link #_hasTypeResolver} once if its value is null.
+     * Determines whether strict type ID handling should be used for this type or not.
+     * This will be enabled when either the type has type resolver annotations or if
+     * {@link com.fasterxml.jackson.databind.DeserializationFeature#FAIL_ON_MISSING_TYPE_NAME}
+     * is enabled.
      *
      * @param config the deserialization configuration to use
      * @param baseType the base type to check for type resolver annotations
      *
-     * @return true if the class has type resolver annotations, false otherwise
+     * @return {@code true} if the class has type resolver annotations, or the strict
+     * handling feature is enabled, {@code false} otherwise.
      *
      * @since 2.15
      */
-    protected boolean _hasTypeResolver(DeserializationConfig config, JavaType baseType) {
+    protected boolean _strictTypeIdHandling(DeserializationConfig config, JavaType baseType) {
+        if (config.isEnabled(MapperFeature.STRICT_TYPE_ID_HANDLING)) {
+            return true;
+        }
         AnnotatedClass ac = AnnotatedClassResolver.resolveWithoutSuperTypes(config,  baseType.getRawClass());
         AnnotationIntrospector ai = config.getAnnotationIntrospector();
         return ai.findTypeResolver(config, ac, baseType) != null;

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -406,7 +406,7 @@ public class StdTypeResolverBuilder
     /**
      * Determines whether strict type ID handling should be used for this type or not.
      * This will be enabled when either the type has type resolver annotations or if
-     * {@link com.fasterxml.jackson.databind.MapperFeature#STRICT_TYPE_ID_HANDLING}
+     * {@link com.fasterxml.jackson.databind.MapperFeature#REQUIRE_TYPE_ID_FOR_SUBTYPES}
      * is enabled.
      *
      * @param config the deserialization configuration to use
@@ -418,7 +418,7 @@ public class StdTypeResolverBuilder
      * @since 2.15
      */
     protected boolean _strictTypeIdHandling(DeserializationConfig config, JavaType baseType) {
-        if (config.isEnabled(MapperFeature.STRICT_TYPE_ID_HANDLING)) {
+        if (config.isEnabled(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)) {
             return true;
         }
         // Otherwise we will be strict if there's a type resolver

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -421,6 +421,23 @@ public class StdTypeResolverBuilder
         if (config.isEnabled(MapperFeature.STRICT_TYPE_ID_HANDLING)) {
             return true;
         }
+        // Otherwise we will be strict if there's a type resolver
+        return _hasTypeResolver(config, baseType);
+    }
+
+    /**
+     * Checks whether the given class has annotations indicating some type resolver
+     * is applied, for example {@link com.fasterxml.jackson.annotation.JsonSubTypes}.
+     * Only initializes {@link #_hasTypeResolver} once if its value is null.
+     *
+     * @param config the deserialization configuration to use
+     * @param baseType the base type to check for type resolver annotations
+     *
+     * @return true if the class has type resolver annotations, false otherwise
+     *
+     * @since 2.15
+     */
+    protected boolean _hasTypeResolver(DeserializationConfig config, JavaType baseType) {
         AnnotatedClass ac = AnnotatedClassResolver.resolveWithoutSuperTypes(config,  baseType.getRawClass());
         AnnotationIntrospector ai = config.getAnnotationIntrospector();
         return ai.findTypeResolver(config, ac, baseType) != null;

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -406,7 +406,7 @@ public class StdTypeResolverBuilder
     /**
      * Determines whether strict type ID handling should be used for this type or not.
      * This will be enabled when either the type has type resolver annotations or if
-     * {@link com.fasterxml.jackson.databind.DeserializationFeature#FAIL_ON_MISSING_TYPE_NAME}
+     * {@link com.fasterxml.jackson.databind.MapperFeature#STRICT_TYPE_ID_HANDLING}
      * is enabled.
      *
      * @param config the deserialization configuration to use

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/JsonTypeInfoIgnored2968Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/JsonTypeInfoIgnored2968Test.java
@@ -3,10 +3,12 @@ package com.fasterxml.jackson.databind.jsontype;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class JsonTypeInfoIgnored2968Test extends BaseMapTest {
     /*
@@ -15,7 +17,7 @@ public class JsonTypeInfoIgnored2968Test extends BaseMapTest {
     /**********************************************************
      */
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapper.builder().disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES).build();
 
     @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/StrictJsonTypeInfoHandling3853Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/StrictJsonTypeInfoHandling3853Test.java
@@ -19,7 +19,7 @@ public class StrictJsonTypeInfoHandling3853Test extends BaseMapTest {
     static class DoSomethingCommand implements Command {
     }
 
-    public void testDefaultNonStrictTypeHandling() throws Exception {
+    public void testDefaultHasStrictTypeHandling() throws Exception {
         ObjectMapper om = new ObjectMapper();
         om.registerSubtypes(DoSomethingCommand.class);
 
@@ -28,13 +28,13 @@ public class StrictJsonTypeInfoHandling3853Test extends BaseMapTest {
         // and throw an exception if the target was a super-type in all cases
         verifyInvalidTypeIdWithSuperclassTarget(om);
 
-        // Default is to allow the deserialization without a type if the target
+        // Default is to disallow the deserialization without a type if the target
         // is a concrete sub-type
-        verifyDeserializationWithConcreteTarget(om);
+        verifyInvalidTypeIdWithConcreteTarget(om);
     }
 
     public void testExplicitNonStrictTypeHandling() throws Exception {
-        ObjectMapper om = JsonMapper.builder().disable(MapperFeature.STRICT_TYPE_ID_HANDLING).build();
+        ObjectMapper om = JsonMapper.builder().disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES).build();
         om.registerSubtypes(DoSomethingCommand.class);
 
         // This should pass in all scenarios
@@ -48,7 +48,7 @@ public class StrictJsonTypeInfoHandling3853Test extends BaseMapTest {
     }
 
     public void testStrictTypeHandling() throws Exception {
-        ObjectMapper om = JsonMapper.builder().enable(MapperFeature.STRICT_TYPE_ID_HANDLING).build();
+        ObjectMapper om = JsonMapper.builder().enable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES).build();
         om.registerSubtypes(DoSomethingCommand.class);
 
         // This should pass in all scenarios

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/StrictJsonTypeInfoHandling3853Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/StrictJsonTypeInfoHandling3853Test.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
-public class StrictJsonTypeInfoHandlingTest extends BaseMapTest {
+public class StrictJsonTypeInfoHandling3853Test extends BaseMapTest {
 
     @JsonTypeInfo(use = Id.NAME)
     interface Command {

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/StrictJsonTypeInfoHandlingTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/StrictJsonTypeInfoHandlingTest.java
@@ -1,0 +1,94 @@
+package com.fasterxml.jackson.databind.jsontype;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+public class StrictJsonTypeInfoHandlingTest extends BaseMapTest {
+
+    @JsonTypeInfo(use = Id.NAME)
+    interface Command {
+    }
+
+    @JsonTypeName("do-something")
+    static class DoSomethingCommand implements Command {
+    }
+
+    public void testDefaultNonStrictTypeHandling() throws Exception {
+        ObjectMapper om = new ObjectMapper();
+        om.registerSubtypes(DoSomethingCommand.class);
+
+        // This should pass in all scenarios
+        verifyDeserializationWithFullTypeInfo(om);
+        // and throw an exception if the target was a super-type in all cases
+        verifyInvalidTypeIdWithSuperclassTarget(om);
+
+        // Default is to allow the deserialization without a type if the target
+        // is a concrete sub-type
+        verifyDeserializationWithConcreteTarget(om);
+    }
+
+    public void testExplicitNonStrictTypeHandling() throws Exception {
+        ObjectMapper om = JsonMapper.builder().disable(MapperFeature.STRICT_TYPE_ID_HANDLING).build();
+        om.registerSubtypes(DoSomethingCommand.class);
+
+        // This should pass in all scenarios
+        verifyDeserializationWithFullTypeInfo(om);
+        // and throw an exception if the target was a super-type in all cases
+        verifyInvalidTypeIdWithSuperclassTarget(om);
+
+        // Default is to allow the deserialization without a type if the target
+        // is a concrete sub-type
+        verifyDeserializationWithConcreteTarget(om);
+    }
+
+    public void testStrictTypeHandling() throws Exception {
+        ObjectMapper om = JsonMapper.builder().enable(MapperFeature.STRICT_TYPE_ID_HANDLING).build();
+        om.registerSubtypes(DoSomethingCommand.class);
+
+        // This should pass in all scenarios
+        verifyDeserializationWithFullTypeInfo(om);
+        // and throw an exception if the target was a super-type in all cases
+        verifyInvalidTypeIdWithSuperclassTarget(om);
+
+        // With strict mode enabled, fail if there's no type information on the
+        // JSON
+        verifyInvalidTypeIdWithConcreteTarget(om);
+
+    }
+
+    private void verifyInvalidTypeIdWithSuperclassTarget(ObjectMapper om) throws Exception {
+        try {
+            om.readValue("{}", Command.class);
+            fail("Should not pass");
+        } catch (InvalidTypeIdException e) {
+            verifyException(e, "missing type id property '@type'");
+        }
+    }
+
+    private void verifyInvalidTypeIdWithConcreteTarget(ObjectMapper om) throws Exception {
+        try {
+            om.readValue("{}", DoSomethingCommand.class);
+            fail("Should not pass");
+        } catch (InvalidTypeIdException e) {
+            verifyException(e, "missing type id property '@type'");
+        }
+    }
+
+    private void verifyDeserializationWithConcreteTarget(ObjectMapper om) throws Exception {
+        DoSomethingCommand cmd = om.readValue("{}", DoSomethingCommand.class);
+        assertType(cmd, DoSomethingCommand.class);
+    }
+
+    private void verifyDeserializationWithFullTypeInfo(ObjectMapper om) throws Exception {
+        Command cmd = om.readValue("{\"@type\":\"do-something\"}", Command.class);
+        assertType(cmd, DoSomethingCommand.class);
+        cmd = om.readValue("{\"@type\":\"do-something\"}", DoSomethingCommand.class);
+        assertType(cmd, DoSomethingCommand.class);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestBaseTypeAsDefault.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestBaseTypeAsDefault.java
@@ -40,6 +40,11 @@ public class TestBaseTypeAsDefault extends BaseMapTest
             .disable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
             .build();
 
+    protected ObjectMapper MAPPER_WITHOUT_BASE_OR_SUBTYPE_ID = jsonMapperBuilder()
+            .disable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
+            .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+            .build();
+
     public void testPositiveForParent() throws Exception {
         Object o = MAPPER_WITH_BASE.readerFor(Parent.class).readValue("{}");
         assertEquals(o.getClass(), Parent.class);
@@ -60,7 +65,16 @@ public class TestBaseTypeAsDefault extends BaseMapTest
     }
 
     public void testNegativeForChild() throws Exception {
-        Child child = MAPPER_WITHOUT_BASE.readerFor(Child.class).readValue("{}");
+        try {
+            /*Object o =*/ MAPPER_WITHOUT_BASE.readerFor(Child.class).readValue("{}");
+            fail("Should not pass");
+        } catch (InvalidTypeIdException ex) {
+            assertTrue(ex.getMessage().contains("missing type id property '@class'"));
+        }
+    }
+
+    public void testNegativeForChildWithoutRequiringTypeId() throws Exception {
+        Child child = MAPPER_WITHOUT_BASE_OR_SUBTYPE_ID.readerFor(Child.class).readValue("{}");
 
         assertEquals(Child.class, child.getClass());
     }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/deftyping/DeserDefaultTypedConcrete2968Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/deftyping/DeserDefaultTypedConcrete2968Test.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.jsontype.deftyping;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
@@ -28,6 +29,7 @@ public class DeserDefaultTypedConcrete2968Test extends BaseMapTest {
         ObjectMapper mapper = jsonMapperBuilder()
             .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL,
                     JsonTypeInfo.As.PROPERTY)
+            .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
             .build();
 
         final String concreteTypeJson = a2q("{'size': 42}");


### PR DESCRIPTION
Resolves https://github.com/FasterXML/jackson-databind/issues/3853 by adding support for strict handling of type information when deserializing into a registered subtype.