### PR TITLE
Add "missing" read-only top-level workflow permissions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -5,6 +5,9 @@ on:
     - "2.15"
     - "2.14"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }} @ ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -5,8 +5,7 @@ on:
     - "2.15"
     - "2.14"
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }} @ ${{ github.ref }}


### PR DESCRIPTION
## Description

Relates to security improvements made in https://github.com/FasterXML/jackson-core/pull/953, which caught my curious eyes. After digging further, found a missing piece in this project also.

### Changes Made

- Add "missing" read-only top-level workflow permissions in `cifuzz` workflow.
