### PR TITLE
Add test cases for `ObjectReader` reading from file

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
@@ -809,7 +809,6 @@ public class ObjectReaderTest extends BaseMapTest
         }
     }
 
-
     public void testReadValueFromFile() throws Exception {
         File file = _createFileWithNameAndJson(
             "testReadValueFromFile",


### PR DESCRIPTION
## Description

 This PR adds test cases for the `ObjectReader` class that cover cases when reading from files. The test cases are relatively simple, but I do not think that is necessarily a bad thing. Simple test cases can be very effective in identifying basic functionality issues. Thank you in advance! 🙏🏼

### Changes Made 

The test cases cover scenarios such as
- reading from invalid or non-existent files
- reading from files with empty content
- reading from files as `MappingIterator<T>`.
