### PR TITLE
Add failing test for order-dependent resolution of `JsonSubTypes` declared on multiple interfaces

### DIFF
--- a/src/test/java/com/fasterxml/jackson/failing/JsonTypeIdConflict3681Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/JsonTypeIdConflict3681Test.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+// [databind#3681]: JsonSubTypes declared on multiple interfaces of a class
+// results in order-dependent resolution and outcome
 public class JsonTypeIdConflict3681Test extends BaseMapTest {
 
     /*

--- a/src/test/java/com/fasterxml/jackson/failing/JsonTypeIdConflict3681Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/JsonTypeIdConflict3681Test.java
@@ -50,13 +50,17 @@ public class JsonTypeIdConflict3681Test extends BaseMapTest {
     private final ObjectMapper MAPPER = newJsonMapper();
 
     /**
-     * Type resolution fails due to a conflict between the types.
+     * Type resolution fails due to a conflict between the types --check the exception message below this test case.
      * <p>
-     * NOTE: This only pass when {@code C} extends {@code A} first.
-     * For example, {@code private interface C extends A, B}
+     * This will only pass when we modify {@code C} to extend {@code A} first, like so:
+     * <pre>
+     *  private interface C extends A, B {}
+     * </pre>
      */
     public void testFailureWithTypeIdConflict() throws Exception {
         WrapperC c = MAPPER.readValue(a2q("{'c': {'type': 'c_impl'}}"), WrapperC.class);
         assertNotNull(c);
     }
+    // com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'c_impl' as a subtype
+    // of `com.fasterxml.jackson.failing.JsonTypeIdConflict3681Test$C`: known type ids = [b_impl] (for POJO property 'c')
 }

--- a/src/test/java/com/fasterxml/jackson/failing/JsonTypeIdConflict3681Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/JsonTypeIdConflict3681Test.java
@@ -1,0 +1,61 @@
+package com.fasterxml.jackson.failing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+
+public class JsonTypeIdConflict3681Test extends BaseMapTest {
+
+    /*
+    /**********************************************************
+    /* Set up
+    /**********************************************************
+    */
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(name = "c_impl", value = C_Impl.class)
+    })
+    private interface A {}
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(name = "b_impl", value = B_impl.class),
+    })
+    private interface B {}
+
+    /***
+     * Note the order of declarations on inherited interfaces - it makes
+     * the difference in how types are resolved here.
+     */
+    private interface C extends A, B {}
+
+    private static class C_Impl implements C {}
+
+    private static class B_impl implements B {}
+
+    private static class Clazz {
+        @JsonProperty
+        public C c;
+    }
+
+    /*
+    /**********************************************************
+    /* Tests
+    /**********************************************************
+    */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    public void testCheckSanity() throws Exception {
+        try {
+
+            MAPPER.readValue(a2q("{'c': {'type': 'c_impl'}}"), Clazz.class);
+        } catch (InvalidTypeIdException e) {
+            verifyException(e, "Cannot resolve type id 'c_impl' as a subtype of");
+        }
+    }
+}


### PR DESCRIPTION
Regarding issue #3681, this PR is intended to provide a repeatable test case that can enable developers to reproduce and diagnose the problem more easily. 