### PR TITLE
avoid hardcoded dependence on StreamReadConstraints.defaults

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -616,6 +616,21 @@ public abstract class JsonNode
      */
     public BigInteger bigIntegerValue() { return BigInteger.ZERO; }
 
+    /**
+     * Returns integer value for this node (as {@link BigInteger}), <b>if and only if</b>
+     * this node is numeric ({@link #isNumber} returns true). For other
+     * types returns <code>BigInteger.ZERO</code>.
+     *<p>
+     * NOTE: In Jackson 2.x MAY throw {@link com.fasterxml.jackson.core.exc.StreamConstraintsException}
+     *   if the scale of the underlying {@link BigDecimal} is too large to convert (NOTE: thrown
+     *   "sneakily" in Jackson 2.x due to API compatibility restrictions)
+     *
+     * @param streamReadConstraints the constraints to apply to the conversion
+     * @return {@link BigInteger} value this node contains, if numeric node; <code>BigInteger.ZERO</code> for non-number nodes.
+     * @since 2.15
+     */
+    public BigInteger bigIntegerValue(final StreamReadConstraints streamReadConstraints) { return BigInteger.ZERO; }
+
     /*
     /**********************************************************
     /* Public API, value access with conversion(s)/coercion(s)

--- a/src/main/java/com/fasterxml/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BaseJsonNode.java
@@ -274,9 +274,9 @@ public abstract class BaseJsonNode
    }
 
    // @since 2.15
-   protected BigInteger _bigIntFromBigDec(BigDecimal value) {
+   protected BigInteger _bigIntFromBigDec(StreamReadConstraints streamReadConstraints, BigDecimal value) {
        try {
-           StreamReadConstraints.defaults().validateBigIntegerScale(value.scale());
+           streamReadConstraints.validateBigIntegerScale(value.scale());
        } catch (StreamConstraintsException e) {
            // 06-Apr-2023, tatu: Since `JsonNode` does not generally expose Jackson
            //    exceptions, we need to either wrap possible `StreamConstraintsException`

--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -86,7 +86,12 @@ public class DecimalNode
 
     @Override
     public BigInteger bigIntegerValue() {
-        return _bigIntFromBigDec(_value);
+        return _bigIntFromBigDec(StreamReadConstraints.defaults(), _value);
+    }
+
+    @Override
+    public BigInteger bigIntegerValue(StreamReadConstraints streamReadConstraints) {
+        return _bigIntFromBigDec(streamReadConstraints, _value);
     }
 
     @Override


### PR DESCRIPTION
* may be a bit much since the limit for big int scale is hardcoded
* still seems best to allow users some control