### PR TITLE
#3876 Fix TypeFactory cache performance degradation with `constructSpecializedType`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JavaType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JavaType.java
@@ -86,7 +86,7 @@ public abstract class JavaType
             Object valueHandler, Object typeHandler, boolean asStatic)
     {
         _class = raw;
-        _hash =  31 * (31 + additionalHash) + raw.getName().hashCode();
+        _hash =  31 * additionalHash + raw.hashCode();
         _valueHandler = valueHandler;
         _typeHandler = typeHandler;
         _asStatic = asStatic;

--- a/src/main/java/com/fasterxml/jackson/databind/JavaType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JavaType.java
@@ -645,5 +645,5 @@ public abstract class JavaType
     public abstract boolean equals(Object o);
 
     @Override
-    public final int hashCode() { return _hash; }
+    public int hashCode() { return _hash; }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/JavaType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JavaType.java
@@ -86,7 +86,7 @@ public abstract class JavaType
             Object valueHandler, Object typeHandler, boolean asStatic)
     {
         _class = raw;
-        _hash = raw.getName().hashCode() + additionalHash;
+        _hash =  31 * (31 + additionalHash) + raw.getName().hashCode();
         _valueHandler = valueHandler;
         _typeHandler = typeHandler;
         _asStatic = asStatic;

--- a/src/main/java/com/fasterxml/jackson/databind/type/IdentityEqualityType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/IdentityEqualityType.java
@@ -1,0 +1,35 @@
+package com.fasterxml.jackson.databind.type;
+
+import com.fasterxml.jackson.databind.JavaType;
+
+/**
+ * Internal abstract type representing {@link TypeBase} implementations which use reference equality.
+ */
+abstract class IdentityEqualityType extends TypeBase {
+    protected IdentityEqualityType(
+            Class<?> raw,
+            TypeBindings bindings,
+            JavaType superClass,
+            JavaType[] superInts,
+            int hash,
+            Object valueHandler,
+            Object typeHandler,
+            boolean asStatic) {
+        super(raw, bindings, superClass, superInts, hash, valueHandler, typeHandler, asStatic);
+    }
+
+    protected IdentityEqualityType(TypeBase base) {
+        super(base);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        return o == this;
+    }
+
+    @Override
+    public final int hashCode() {
+        // The identity hashCode must be used otherwise all instances will have colliding hashCodes.
+        return System.identityHashCode(this);
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/type/IdentityEqualityType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/IdentityEqualityType.java
@@ -18,10 +18,6 @@ abstract class IdentityEqualityType extends TypeBase {
         super(raw, bindings, superClass, superInts, hash, valueHandler, typeHandler, asStatic);
     }
 
-    protected IdentityEqualityType(TypeBase base) {
-        super(base);
-    }
-
     @Override
     public final boolean equals(Object o) {
         return o == this;

--- a/src/main/java/com/fasterxml/jackson/databind/type/MapLikeType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/MapLikeType.java
@@ -36,8 +36,9 @@ public class MapLikeType extends TypeBase {
             JavaType superClass, JavaType[] superInts, JavaType keyT,
             JavaType valueT, Object valueHandler, Object typeHandler,
             boolean asStatic) {
-        super(mapType, bindings, superClass, superInts, keyT.hashCode()
-                ^ valueT.hashCode(), valueHandler, typeHandler, asStatic);
+        super(mapType, bindings, superClass, superInts,
+                31 * (31 + keyT.hashCode()) + valueT.hashCode(),
+                valueHandler, typeHandler, asStatic);
         _keyType = keyT;
         _valueType = valueT;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/type/MapLikeType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/MapLikeType.java
@@ -37,7 +37,7 @@ public class MapLikeType extends TypeBase {
             JavaType valueT, Object valueHandler, Object typeHandler,
             boolean asStatic) {
         super(mapType, bindings, superClass, superInts,
-                31 * (31 + keyT.hashCode()) + valueT.hashCode(),
+                31 * keyT.hashCode() + valueT.hashCode(),
                 valueHandler, typeHandler, asStatic);
         _keyType = keyT;
         _valueType = valueT;

--- a/src/main/java/com/fasterxml/jackson/databind/type/PlaceholderForType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/PlaceholderForType.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.JavaType;
  *
  * @since 2.8.11
  */
-public class PlaceholderForType extends TypeBase
+public class PlaceholderForType extends IdentityEqualityType
 {
     private static final long serialVersionUID = 1L;
 
@@ -97,11 +97,6 @@ public class PlaceholderForType extends TypeBase
     @Override
     public String toString() {
         return getErasedSignature(new StringBuilder()).toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return (o == this);
     }
 
     private <T> T _unsupported() {

--- a/src/main/java/com/fasterxml/jackson/databind/type/ResolvedRecursiveType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/ResolvedRecursiveType.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.JavaType;
  *
  * @since 2.7
  */
-public class ResolvedRecursiveType extends TypeBase
+public class ResolvedRecursiveType extends IdentityEqualityType
 {
     private static final long serialVersionUID = 1L;
 
@@ -126,16 +126,16 @@ public class ResolvedRecursiveType extends TypeBase
         return sb.toString();
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) return true;
-        if (o == null) return false;
-        if (o.getClass() == getClass()) {
+    //@Override
+    //public boolean equals(Object o) {
+        //if (o == this) return true;
+        //if (o == null) return false;
+        //if (o.getClass() == getClass()) {
             // 16-Jun-2017, tatu: as per [databind#1658], cannot do recursive call since
             //    there is likely to be a cycle...
 
             // but... true or false?
-            return false;
+            //return false;
 
             /*
             // Do NOT ever match unresolved references
@@ -145,7 +145,7 @@ public class ResolvedRecursiveType extends TypeBase
             return (o.getClass() == getClass()
                     && _referencedType.equals(((ResolvedRecursiveType) o).getSelfReferencedType()));
                     */
-        }
-        return false;
-    }
+        //}
+        //return false;
+    //}
 }

--- a/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
@@ -52,8 +52,18 @@ public class SimpleType // note: until 2.6 was final
             JavaType superClass, JavaType[] superInts,
             Object valueHandler, Object typeHandler, boolean asStatic)
     {
-        super(cls, bindings, superClass, superInts,
-                SimpleType.class.hashCode(), valueHandler, typeHandler, asStatic);
+        super(
+                cls,
+                bindings,
+                superClass,
+                superInts,
+                // Arbitrary additional hash component as a defensive measure against
+                // hash collisions with other JavaType implementations wrapping the
+                // same class.
+                474675244,
+                valueHandler,
+                typeHandler,
+                asStatic);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
@@ -53,7 +53,7 @@ public class SimpleType // note: until 2.6 was final
             Object valueHandler, Object typeHandler, boolean asStatic)
     {
         super(cls, bindings, superClass, superInts,
-                0, valueHandler, typeHandler, asStatic);
+                SimpleType.class.hashCode(), valueHandler, typeHandler, asStatic);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/SimpleType.java
@@ -57,10 +57,9 @@ public class SimpleType // note: until 2.6 was final
                 bindings,
                 superClass,
                 superInts,
-                // Arbitrary additional hash component as a defensive measure against
-                // hash collisions with other JavaType implementations wrapping the
-                // same class.
-                474675244,
+                // TypeBase normalizes null bindings to the singleton returned by TypeBindings.emptyBindings()
+                // so we must compute the same hashCode in both cases.
+                (bindings == null ? TypeBindings.emptyBindings() : bindings).hashCode(),
                 valueHandler,
                 typeHandler,
                 asStatic);

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -457,7 +457,7 @@ name, i, t.getRawClass()));
         public AsKey(Class<?> raw, JavaType[] params, int hash) {
             _raw = raw ;
             _params = params;
-            _hash = raw == null ? hash : 31 * raw.hashCode() + hash;
+            _hash = 31 * Objects.hashCode(raw) + hash;
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -56,11 +56,9 @@ public class TypeBindings
         if (_names.length != _types.length) {
             throw new IllegalArgumentException("Mismatching names ("+_names.length+"), types ("+_types.length+")");
         }
-        int h = Arrays.hashCode(uvars);
-        h = 31 * h + Arrays.hashCode(names);
-        h = 31 * h + Arrays.hashCode(types);
         _unboundVariables = uvars;
-        _hashCode = h;
+        // hashCode and equality are based solely on _types.
+        _hashCode = Arrays.hashCode(types);
     }
 
     public static TypeBindings emptyBindings() {
@@ -365,10 +363,8 @@ name, i, t.getRawClass()));
             return false;
         }
         TypeBindings other = (TypeBindings) o;
-        return _hashCode == other._hashCode
-                && Arrays.equals(_types, other._types)
-                && Arrays.equals(_names, other._names)
-                && Arrays.equals(_unboundVariables, other._unboundVariables);
+        // hashCode and equality are based solely on _types.
+        return _hashCode == other._hashCode && Arrays.equals(_types, other._types);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -250,7 +250,7 @@ name, i, t.getRawClass()));
         return null;
     }
 
-    boolean containsPlaceholders() {
+    private boolean containsPlaceholders() {
         for (JavaType type : _types) {
             if (type instanceof PlaceholderForType) {
                 return true;

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -56,10 +56,9 @@ public class TypeBindings
         if (_names.length != _types.length) {
             throw new IllegalArgumentException("Mismatching names ("+_names.length+"), types ("+_types.length+")");
         }
-        int h = 1;
+        int h = Arrays.hashCode(uvars);
         h = 31 * h + Arrays.hashCode(names);
         h = 31 * h + Arrays.hashCode(types);
-        h = 31 * h + Arrays.hashCode(uvars);
         _unboundVariables = uvars;
         _hashCode = h;
     }
@@ -458,7 +457,7 @@ name, i, t.getRawClass()));
         public AsKey(Class<?> raw, JavaType[] params, int hash) {
             _raw = raw ;
             _params = params;
-            _hash = 31 * (31 + (raw == null ? 0 : raw.hashCode())) + hash;
+            _hash = raw == null ? hash : 31 * raw.hashCode() + hash;
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -58,7 +58,7 @@ public class TypeBindings
         }
         _unboundVariables = uvars;
         // hashCode and equality are based solely on _types.
-        _hashCode = Arrays.hashCode(types);
+        _hashCode = Arrays.hashCode(_types);
     }
 
     public static TypeBindings emptyBindings() {

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -457,7 +457,7 @@ name, i, t.getRawClass()));
         public AsKey(Class<?> raw, JavaType[] params, int hash) {
             _raw = raw ;
             _params = params;
-            _hash = 31 * Objects.hashCode(raw) + hash;
+            _hash = 31 * raw.hashCode() + hash;
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1465,7 +1465,7 @@ ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
         } else {
             key = bindings.asKey(rawType);
         }
-        result = _typeCache.get(key); // ok, cache object is synced
+        result = key == null ? null : _typeCache.get(key); // ok, cache object is synced
         if (result != null) {
             return result;
         }
@@ -1529,7 +1529,7 @@ ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
         context.resolveSelfReferences(result);
         // 16-Jul-2016, tatu: [databind#1302] is solved different way, but ideally we shouldn't
         //     cache anything with partially resolved `ResolvedRecursiveType`... so maybe improve
-        if (!result.hasHandlers()) {
+        if (key != null && !result.hasHandlers()) {
             _typeCache.putIfAbsent(key, result); // cache object syncs
         }
         return result;

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
@@ -5,6 +5,8 @@ import java.util.*;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.JavaType;
 
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Simple tests to verify for generic type binding functionality
  * implemented by {@link TypeBindings} class.
@@ -86,5 +88,30 @@ public class TestTypeBindings
             verifyException(e, "Cannot create TypeBindings");
             verifyException(e, "class expects 2");
         }
+    }
+
+    public void testEqualityAndHashCode()
+    {
+        JavaType stringType = DEFAULT_TF.constructType(String.class);
+        TypeBindings listStringBindings = TypeBindings.create(List.class, stringType);
+        TypeBindings listStringBindingsWithUnbound = listStringBindings.withUnboundVariable("X");
+        TypeBindings iterableStringBindings = TypeBindings.create(Iterable.class, stringType);
+        // Ensure that type variable names used by List and Iterable do not change in future java versions
+        assertEquals("E", listStringBindings.getBoundName(0));
+        assertEquals("T", iterableStringBindings.getBoundName(0));
+        // These TypeBindings should differ:
+        assertNotEquals(listStringBindings, iterableStringBindings);
+        assertNotEquals(listStringBindings.hashCode(), iterableStringBindings.hashCode());
+        // Type bindings which differ by an unbound variable still differ:
+        assertNotEquals(listStringBindingsWithUnbound, listStringBindings);
+        assertNotEquals(listStringBindingsWithUnbound.hashCode(), listStringBindings.hashCode());
+
+        Object iterableStringBaseList = iterableStringBindings.asKey(List.class);
+        Object listStringBaseList = listStringBindings.asKey(List.class);
+        Object listStringBindingsWithUnboundBaseList = listStringBindingsWithUnbound.asKey(List.class);
+        assertNotEquals(iterableStringBaseList, listStringBaseList);
+        assertNotEquals(iterableStringBaseList.hashCode(), listStringBaseList.hashCode());
+        assertNotEquals(listStringBindingsWithUnboundBaseList, listStringBaseList);
+        assertNotEquals(listStringBindingsWithUnboundBaseList.hashCode(), listStringBaseList.hashCode());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
@@ -90,6 +90,7 @@ public class TestTypeBindings
         }
     }
 
+    // for [databind#3876]
     public void testEqualityAndHashCode()
     {
         JavaType stringType = DEFAULT_TF.constructType(String.class);

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeBindings.java
@@ -93,25 +93,35 @@ public class TestTypeBindings
     public void testEqualityAndHashCode()
     {
         JavaType stringType = DEFAULT_TF.constructType(String.class);
+        JavaType integerType = DEFAULT_TF.constructType(Integer.class);
         TypeBindings listStringBindings = TypeBindings.create(List.class, stringType);
         TypeBindings listStringBindingsWithUnbound = listStringBindings.withUnboundVariable("X");
         TypeBindings iterableStringBindings = TypeBindings.create(Iterable.class, stringType);
+        TypeBindings mapStringInt = TypeBindings.create(Map.class, stringType, integerType);
+        TypeBindings mapIntString = TypeBindings.create(Map.class, integerType, stringType);
         // Ensure that type variable names used by List and Iterable do not change in future java versions
         assertEquals("E", listStringBindings.getBoundName(0));
         assertEquals("T", iterableStringBindings.getBoundName(0));
-        // These TypeBindings should differ:
-        assertNotEquals(listStringBindings, iterableStringBindings);
-        assertNotEquals(listStringBindings.hashCode(), iterableStringBindings.hashCode());
-        // Type bindings which differ by an unbound variable still differ:
-        assertNotEquals(listStringBindingsWithUnbound, listStringBindings);
-        assertNotEquals(listStringBindingsWithUnbound.hashCode(), listStringBindings.hashCode());
+        // These TypeBindings bind the same types in the same order
+        assertEquals(listStringBindings, iterableStringBindings);
+        assertEquals(listStringBindings.hashCode(), iterableStringBindings.hashCode());
+        // Type bindings which differ by an unbound variable still evaluate to equal
+        assertEquals(listStringBindingsWithUnbound, listStringBindings);
+        assertEquals(listStringBindingsWithUnbound.hashCode(), listStringBindings.hashCode());
+        // However type bindings for the same types in different order must differ:
+        assertNotEquals(mapStringInt, mapIntString);
+        assertNotEquals(mapStringInt.hashCode(), mapIntString.hashCode());
 
         Object iterableStringBaseList = iterableStringBindings.asKey(List.class);
         Object listStringBaseList = listStringBindings.asKey(List.class);
         Object listStringBindingsWithUnboundBaseList = listStringBindingsWithUnbound.asKey(List.class);
-        assertNotEquals(iterableStringBaseList, listStringBaseList);
-        assertNotEquals(iterableStringBaseList.hashCode(), listStringBaseList.hashCode());
-        assertNotEquals(listStringBindingsWithUnboundBaseList, listStringBaseList);
-        assertNotEquals(listStringBindingsWithUnboundBaseList.hashCode(), listStringBaseList.hashCode());
+        Object mapStringIntBaseMap = mapStringInt.asKey(Map.class);
+        Object mapIntStringBaseMap = mapIntString.asKey(Map.class);
+        assertEquals(iterableStringBaseList, listStringBaseList);
+        assertEquals(iterableStringBaseList.hashCode(), listStringBaseList.hashCode());
+        assertEquals(listStringBindingsWithUnboundBaseList, listStringBaseList);
+        assertEquals(listStringBindingsWithUnboundBaseList.hashCode(), listStringBaseList.hashCode());
+        assertNotEquals(mapStringIntBaseMap, mapIntStringBaseMap);
+        assertNotEquals(mapStringIntBaseMap.hashCode(), mapIntStringBaseMap.hashCode());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
@@ -7,6 +7,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Simple tests to verify that the {@link TypeFactory} constructs
  * type information as expected.
@@ -355,6 +357,16 @@ public class TestTypeFactory
         assertEquals(AbstractList.class, superType.getRawClass());
     }
 
+    @SuppressWarnings("rawtypes")
+    public void testCollectionsHashCode()
+    {
+        TypeFactory tf = newTypeFactory();
+        JavaType listOfCollection = tf.constructType(new TypeReference<List<Collection>>() { });
+        JavaType collectionOfList = tf.constructType(new TypeReference<Collection<List>>() { });
+        assertNotEquals(listOfCollection, collectionOfList);
+        assertNotEquals(listOfCollection.hashCode(), collectionOfList.hashCode());
+    }
+
     /*
     /**********************************************************
     /* Unit tests: map type parameter resolution
@@ -395,6 +407,23 @@ public class TestTypeFactory
         MapType mapType = (MapType) type;
         assertEquals(tf.constructType(String.class), mapType.getKeyType());
         assertEquals(tf.constructType(Boolean.class), mapType.getContentType());
+    }
+
+    public void testMapsHashCode()
+    {
+        TypeFactory tf = newTypeFactory();
+        JavaType mapStringInt = tf.constructType(new TypeReference<Map<String,Integer>>() {});
+        JavaType mapIntString = tf.constructType(new TypeReference<Map<Integer,String>>() {});
+        assertNotEquals(mapStringInt, mapIntString);
+        assertNotEquals(
+                "hashCode should depend on parameter order",
+                mapStringInt.hashCode(),
+                mapIntString.hashCode());
+
+        JavaType mapStringString = tf.constructType(new TypeReference<Map<String,String>>() {});
+        JavaType mapIntInt = tf.constructType(new TypeReference<Map<Integer,Integer>>() {});
+        assertNotEquals(mapStringString, mapIntInt);
+        assertNotEquals(mapStringString.hashCode(), mapIntInt.hashCode());
     }
 
     // since 2.7

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
@@ -357,6 +357,7 @@ public class TestTypeFactory
         assertEquals(AbstractList.class, superType.getRawClass());
     }
 
+    // for [databind#3876]
     @SuppressWarnings("rawtypes")
     public void testCollectionsHashCode()
     {
@@ -409,6 +410,7 @@ public class TestTypeFactory
         assertEquals(tf.constructType(Boolean.class), mapType.getContentType());
     }
 
+    // for [databind#3876]
     public void testMapsHashCode()
     {
         TypeFactory tf = newTypeFactory();
@@ -699,5 +701,21 @@ public class TestTypeFactory
         assertEquals(SimpleType.class, t.getClass());
         assertEquals(1, t.containedTypeCount());
         assertEquals(CharSequence.class, t.containedType(0).getRawClass());
+    }
+
+    // for [databind#3876]
+    public void testParameterizedSimpleType() {
+        TypeFactory tf = TypeFactory.defaultInstance();
+
+        JavaType charSequenceClass = tf.constructType(new TypeReference<Class<? extends CharSequence>>() { });
+        JavaType numberClass = tf.constructType(new TypeReference<Class<? extends Number>>() { });
+
+        assertEquals(SimpleType.class, charSequenceClass.getClass());
+        assertEquals(SimpleType.class, numberClass.getClass());
+
+        assertNotEquals(charSequenceClass, numberClass);
+        assertNotEquals(
+                "hash values should be distributed",
+                charSequenceClass.hashCode(), numberClass.hashCode());
     }
 }


### PR DESCRIPTION
This would result in cache interactions taking seconds in real-world scenarios under heavy load (e.g. Jersey ProviderBase, where 'constructSpecializedType' is used) where the operation itself takes microseconds.

`TypeFactory.constructSpecializedType` adds elements to the cache which contain `PlaceholderForType` type arguments. These type arguments all have the same hashCode (based on Object.class plus a hard-coded value for all placeholders) while overriding `equals` to perform reference equality. Each time that `constructSpecializedType` is called, more data is added to the cache with the same hash code, but equality never succeeds due to instances differing, not only reducing cache hit probability, but making it increasingly difficult to find the values we want due to following pointers on heavy cache collisoins where the data structure degenerates into a linked list.
I've committed a change which bypasses the cache in cases where PlaceholderForType is used. I don't know if this is an ideal solution, but it improves the case where I've encountered this edge case.

Secondly, the hashCode implementations in several components lead to hash collisions due to commutativity (summation and bitwise-xor). Take MapLikeType, for example: Map<A, B> would always have the same hashCode as Map<B, A> due to using `A.hashCode ^ B.hashCode`. Furthermore, all maps using the same type as a key and value have the same hashCode due to `A.hashCode ^ A.hashCode` evaluating to zero.

~~Lastly (and I would really appreciate feedback on the details here because I don't entirely understand the TypeBindings semantics!), TypeBindings equals and hashCode only took into account `_types`, but not `_names` or `_unboundVariables`. I've updated equals and hashCode to include these additional pieces of data, and to include a fast-path checking the memoized _hashCode first to avoid unnecessary computation when we can quickly rule out equality.~~

Edit: I've created a PR into jackson-benchmarks which should allow you to reproduce the issue: https://github.com/FasterXML/jackson-benchmarks/pull/5