### PR TITLE
Add warning about unsupported reconfiguration of `ObjectMapper` using `configure()`, `disable()`, and `enable()` methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2558,7 +2558,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#configure(SerializationFeature, boolean)}.</strong>
      */
     public ObjectMapper configure(SerializationFeature f, boolean state) {
         _serializationConfig = state ?
@@ -2575,7 +2575,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#enable(SerializationFeature...)}.</strong>
      */
     public ObjectMapper enable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.with(f);
@@ -2591,7 +2591,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#isEnabled(SerializationFeature)}.</strong>
      */
     public ObjectMapper enable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2608,7 +2608,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#disable(SerializationFeature...)}.</strong>
      */
     public ObjectMapper disable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.without(f);
@@ -2624,7 +2624,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#disable(SerializationFeature...)}.</strong>
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2655,7 +2655,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#configure(DeserializationFeature, boolean)}.</strong>
      */
     public ObjectMapper configure(DeserializationFeature f, boolean state) {
         _deserializationConfig = state ?
@@ -2672,7 +2672,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#enable(DeserializationFeature...)}.</strong>
      */
     public ObjectMapper enable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.with(feature);
@@ -2688,7 +2688,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#enable(DeserializationFeature...)}.</strong>
      */
     public ObjectMapper enable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2705,7 +2705,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#disable(DeserializationFeature...)} instead.</strong>
      */
     public ObjectMapper disable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.without(feature);
@@ -2721,7 +2721,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#disable(DeserializationFeature...)} instead.</strong>
      */
     public ObjectMapper disable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2744,7 +2744,7 @@ public class ObjectMapper
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#configure(DatatypeFeature, boolean)} instead.</strong>
      */
     public ObjectMapper configure(DatatypeFeature f, boolean state) {
         if (state) {
@@ -2778,8 +2778,8 @@ public class ObjectMapper
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#with(JsonParser.Feature)} instead.
      * <p>
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * <strong>Also, this method will be removed in Jackson 3.0 due to unsafe usage and
+     * replaced by {@link MapperBuilder#configure(JsonParser.Feature, boolean)}.</strong>
      */
     public ObjectMapper configure(JsonParser.Feature f, boolean state) {
         _jsonFactory.configure(f, state);
@@ -2796,8 +2796,8 @@ public class ObjectMapper
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#with(JsonParser.Feature)} instead.
      * <p>
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * <strong>Also, this method will be removed in Jackson 3.0 due to unsafe usage and
+     * replaced by {@link MapperBuilder#enable(JsonParser.Feature...)}.</strong>
      *
      * @since 2.5
      */
@@ -2818,8 +2818,8 @@ public class ObjectMapper
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#without(JsonParser.Feature)} instead.
      * <p>
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * <strong>Also, this method will be removed in Jackson 3.0 due to unsafe usage and
+     * replaced by {@link MapperBuilder#disable(JsonParser.Feature...)}.</strong>
      *
      * @since 2.5
      */
@@ -2852,7 +2852,7 @@ public class ObjectMapper
      * this, use {@link ObjectWriter#with(JsonGenerator.Feature)} instead.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#configure(JsonGenerator.Feature, boolean)} instead.</strong>
      */
     public ObjectMapper configure(JsonGenerator.Feature f, boolean state) {
         _jsonFactory.configure(f,  state);
@@ -2870,7 +2870,7 @@ public class ObjectMapper
      * this, use {@link ObjectWriter#with(JsonGenerator.Feature)} instead.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#enable(JsonGenerator.Feature...)} instead.</strong>
      *
      * @since 2.5
      */
@@ -2892,7 +2892,7 @@ public class ObjectMapper
      * this, use {@link ObjectWriter#without(JsonGenerator.Feature)} instead.
      * <p>
      * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
-     * Configure using {@link MapperBuilder} instead.</strong>
+     * Configure using {@link MapperBuilder#disable(JsonGenerator.Feature...)} instead.</strong>
      *
      * @since 2.5
      */

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2611,10 +2611,12 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
-     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write)
+     * is not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>WARNING:</strong> This method will be removed in Jackson 3.0 due to potential unsafe usage.
+     * Use {@link MapperBuilder#configure(JsonParser.Feature, boolean)} and other overloads instead.
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2553,10 +2553,10 @@ public class ObjectMapper
      * Method for changing state of an on/off serialization feature for
      * this object mapper.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper configure(SerializationFeature f, boolean state) {
         _serializationConfig = state ?
@@ -2568,10 +2568,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} feature.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.with(f);
@@ -2582,10 +2582,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2597,10 +2597,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.without(f);
@@ -2611,10 +2611,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2640,10 +2640,10 @@ public class ObjectMapper
      * Method for changing state of an on/off deserialization feature for
      * this object mapper.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper configure(DeserializationFeature f, boolean state) {
         _deserializationConfig = state ?
@@ -2655,10 +2655,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.with(feature);
@@ -2669,10 +2669,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2684,10 +2684,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.without(feature);
@@ -2698,10 +2698,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2719,10 +2719,10 @@ public class ObjectMapper
      * Method for changing state of an on/off datatype-specific feature for
      * this object mapper.
      * <p>
-     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
-     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
-     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
-     * which fully support reconfiguration as new instances are constructed.
+     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper configure(DatatypeFeature f, boolean state) {
         if (state) {
@@ -2755,6 +2755,7 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#with(JsonParser.Feature)} instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
      */
     public ObjectMapper configure(JsonParser.Feature f, boolean state) {
         _jsonFactory.configure(f, state);
@@ -2770,6 +2771,7 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#with(JsonParser.Feature)} instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
      *
      * @since 2.5
      */
@@ -2789,6 +2791,7 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#without(JsonParser.Feature)} instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
      *
      * @since 2.5
      */
@@ -2819,6 +2822,7 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectWriter}s as well -- to avoid
      * this, use {@link ObjectWriter#with(JsonGenerator.Feature)} instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
      */
     public ObjectMapper configure(JsonGenerator.Feature f, boolean state) {
         _jsonFactory.configure(f,  state);
@@ -2834,6 +2838,7 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectWriter}s as well -- to avoid
      * this, use {@link ObjectWriter#with(JsonGenerator.Feature)} instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
      *
      * @since 2.5
      */
@@ -2853,6 +2858,7 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectWriter}s as well -- to avoid
      * this, use {@link ObjectWriter#without(JsonGenerator.Feature)} instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
      *
      * @since 2.5
      */

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2553,10 +2553,12 @@ public class ObjectMapper
      * Method for changing state of an on/off serialization feature for
      * this object mapper.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper configure(SerializationFeature f, boolean state) {
         _serializationConfig = state ?
@@ -2568,10 +2570,12 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} feature.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper enable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.with(f);
@@ -2582,10 +2586,12 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper enable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2597,10 +2603,12 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper disable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.without(f);
@@ -2611,12 +2619,12 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write)
-     * is not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
      * <p>
-     * <strong>WARNING:</strong> This method will be removed in Jackson 3.0 due to potential unsafe usage.
-     * Use {@link MapperBuilder#configure(JsonParser.Feature, boolean)} and other overloads instead.
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2642,10 +2650,12 @@ public class ObjectMapper
      * Method for changing state of an on/off deserialization feature for
      * this object mapper.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper configure(DeserializationFeature f, boolean state) {
         _deserializationConfig = state ?
@@ -2657,10 +2667,12 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper enable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.with(feature);
@@ -2671,10 +2683,12 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper enable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2686,10 +2700,12 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper disable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.without(feature);
@@ -2700,10 +2716,12 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper disable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2721,10 +2739,12 @@ public class ObjectMapper
      * Method for changing state of an on/off datatype-specific feature for
      * this object mapper.
      * <p>
-     * <strong>WARNING: This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
-     * Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
+     * Note: Changing the configuration of this {@link ObjectMapper} instance after its first use (read &amp; write) is
      * not safe and should not be attempted. Instead, use {@code with()} and {@code without()} methods of
      * {@link ObjectReader}/{@link ObjectWriter} which fully support reconfiguration as new instances are constructed.
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper configure(DatatypeFeature f, boolean state) {
         if (state) {
@@ -2757,7 +2777,9 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#with(JsonParser.Feature)} instead.
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper configure(JsonParser.Feature f, boolean state) {
         _jsonFactory.configure(f, state);
@@ -2773,7 +2795,9 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#with(JsonParser.Feature)} instead.
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      *
      * @since 2.5
      */
@@ -2793,7 +2817,9 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectReader}s as well -- to avoid
      * this, use {@link ObjectReader#without(JsonParser.Feature)} instead.
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      *
      * @since 2.5
      */
@@ -2824,7 +2850,9 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectWriter}s as well -- to avoid
      * this, use {@link ObjectWriter#with(JsonGenerator.Feature)} instead.
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      */
     public ObjectMapper configure(JsonGenerator.Feature f, boolean state) {
         _jsonFactory.configure(f,  state);
@@ -2840,7 +2868,9 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectWriter}s as well -- to avoid
      * this, use {@link ObjectWriter#with(JsonGenerator.Feature)} instead.
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      *
      * @since 2.5
      */
@@ -2860,7 +2890,9 @@ public class ObjectMapper
      * WARNING: since this method directly modifies state of underlying {@link JsonFactory},
      * it will change observed configuration by {@link ObjectWriter}s as well -- to avoid
      * this, use {@link ObjectWriter#without(JsonGenerator.Feature)} instead.
-     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.</strong>
+     * <p>
+     * <strong>This method will be removed in Jackson 3.0 due to unsafe usage.
+     * Configure using {@link MapperBuilder} instead.</strong>
      *
      * @since 2.5
      */

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2552,6 +2552,11 @@ public class ObjectMapper
     /**
      * Method for changing state of an on/off serialization feature for
      * this object mapper.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper configure(SerializationFeature f, boolean state) {
         _serializationConfig = state ?
@@ -2562,6 +2567,11 @@ public class ObjectMapper
     /**
      * Method for enabling specified {@link DeserializationConfig} feature.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper enable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.with(f);
@@ -2571,6 +2581,11 @@ public class ObjectMapper
     /**
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper enable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2581,6 +2596,11 @@ public class ObjectMapper
     /**
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper disable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.without(f);
@@ -2590,6 +2610,11 @@ public class ObjectMapper
     /**
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2614,6 +2639,11 @@ public class ObjectMapper
     /**
      * Method for changing state of an on/off deserialization feature for
      * this object mapper.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper configure(DeserializationFeature f, boolean state) {
         _deserializationConfig = state ?
@@ -2624,6 +2654,11 @@ public class ObjectMapper
     /**
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper enable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.with(feature);
@@ -2633,6 +2668,11 @@ public class ObjectMapper
     /**
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper enable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2643,6 +2683,11 @@ public class ObjectMapper
     /**
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper disable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.without(feature);
@@ -2652,6 +2697,11 @@ public class ObjectMapper
     /**
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper disable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2668,6 +2718,11 @@ public class ObjectMapper
     /**
      * Method for changing state of an on/off datatype-specific feature for
      * this object mapper.
+     * <p>
+     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
+     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
+     * (for which reconfiguration is fully supported as new instances are constructed) and
+     * their <code>with(...)</code> and <code>without(...)</code> methods.
      */
     public ObjectMapper configure(DatatypeFeature f, boolean state) {
         if (state) {

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2553,10 +2553,10 @@ public class ObjectMapper
      * Method for changing state of an on/off serialization feature for
      * this object mapper.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper configure(SerializationFeature f, boolean state) {
         _serializationConfig = state ?
@@ -2568,10 +2568,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} feature.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.with(f);
@@ -2582,10 +2582,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2597,10 +2597,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.without(f);
@@ -2611,10 +2611,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2640,10 +2640,10 @@ public class ObjectMapper
      * Method for changing state of an on/off deserialization feature for
      * this object mapper.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper configure(DeserializationFeature f, boolean state) {
         _deserializationConfig = state ?
@@ -2655,10 +2655,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.with(feature);
@@ -2669,10 +2669,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper enable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2684,10 +2684,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.without(feature);
@@ -2698,10 +2698,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper disable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2719,10 +2719,10 @@ public class ObjectMapper
      * Method for changing state of an on/off datatype-specific feature for
      * this object mapper.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
-     * These methods will be removed in Jackson 3.0.
-     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
-     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
+     * <strong>WARNING:</strong> Changing the configuration of this {@link ObjectMapper} instance after its first
+     * use (read &amp; write) is not safe and should not be attempted. These methods will be removed in Jackson 3.0.
+     * Instead, use {@link ObjectReader}, {@link ObjectWriter}, and their {@code with(...)} and {@code without(...)} methods,
+     * which fully support reconfiguration as new instances are constructed.
      */
     public ObjectMapper configure(DatatypeFeature f, boolean state) {
         if (state) {

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -2553,10 +2553,10 @@ public class ObjectMapper
      * Method for changing state of an on/off serialization feature for
      * this object mapper.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper configure(SerializationFeature f, boolean state) {
         _serializationConfig = state ?
@@ -2568,10 +2568,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} feature.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper enable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.with(f);
@@ -2582,10 +2582,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper enable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2597,10 +2597,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper disable(SerializationFeature f) {
         _serializationConfig = _serializationConfig.without(f);
@@ -2611,10 +2611,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper disable(SerializationFeature first,
             SerializationFeature... f) {
@@ -2640,10 +2640,10 @@ public class ObjectMapper
      * Method for changing state of an on/off deserialization feature for
      * this object mapper.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper configure(DeserializationFeature f, boolean state) {
         _deserializationConfig = state ?
@@ -2655,10 +2655,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper enable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.with(feature);
@@ -2669,10 +2669,10 @@ public class ObjectMapper
      * Method for enabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper enable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2684,10 +2684,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper disable(DeserializationFeature feature) {
         _deserializationConfig = _deserializationConfig.without(feature);
@@ -2698,10 +2698,10 @@ public class ObjectMapper
      * Method for disabling specified {@link DeserializationConfig} features.
      * Modifies and returns this instance; no new object is created.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper disable(DeserializationFeature first,
             DeserializationFeature... f) {
@@ -2719,10 +2719,10 @@ public class ObjectMapper
      * Method for changing state of an on/off datatype-specific feature for
      * this object mapper.
      * <p>
-     * WARNING: Changing configuration after first use (read &amp; write) is not supported and should not be attempted.
-     * For changing configuration, it is recommended to use {@link ObjectReader}/{@link ObjectWriter}
-     * (for which reconfiguration is fully supported as new instances are constructed) and
-     * their <code>with(...)</code> and <code>without(...)</code> methods.
+     * WARNING: Changing configuration after first use (read &amp; write) is not safe and should not be attempted.
+     * These methods will be removed in Jackson 3.0.
+     * Instead, {@link ObjectReader}, {@link ObjectWriter} and their <code>with(...)</code> and <code>without(...)</code>
+     * methods should be used instead -- for which reconfiguration is fully supported as new instances are constructed.
      */
     public ObjectMapper configure(DatatypeFeature f, boolean state) {
         if (state) {


### PR DESCRIPTION
This change was suggested during a discussion in issue #3886 and in comment https://github.com/FasterXML/jackson-databind/issues/3886#issuecomment-1512304407. `<strong>` tags are used on the important parts.