### PR TITLE
Chore : fix pom.xml configuration for test sources directory of java17 Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,7 @@
                 <configuration>
                   <sources>
                     <source>src/test-jdk14/java</source>
+                    <source>src/test-jdk17/java</source>
                   </sources>
                 </configuration>
               </execution>


### PR DESCRIPTION
This change has already been made by https://github.com/FasterXML/jackson-databind/commit/05cb9a68e3899405b6ae06b93eaf4a08bce3c7c3 of PR #3817  in the past, but reverted by https://github.com/FasterXML/jackson-databind/commit/822d323b03284a48c6889b465b948bcc91716dce of PR #3803. 

I suppose conflict happened during merge into 2.15 branch.