### PR TITLE
Only avoid Records fields detection for deserialization.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -440,7 +440,8 @@ public class POJOPropertiesCollector
 
         // 15-Jan-2023, tatu: [databind#3736] Let's avoid detecting fields of Records
         //   altogether (unless we find a good reason to detect them)
-        if (!isRecordType()) {
+        // 17-Apr-2023: Need Records' fields for serialization for cases like [databind#3895] & [databind#3628]
+        if (!isRecordType() || _forSerialization) {
             _addFields(props); // note: populates _fieldRenameMappings
         }
         _addMethods(props);

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordIgnoreNonAccessorGetterTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordIgnoreNonAccessorGetterTest.java
@@ -1,0 +1,54 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RecordIgnoreNonAccessorGetterTest extends BaseMapTest {
+
+    // [databind#3628]
+    interface InterfaceWithGetter {
+
+        String getId();
+
+        String getName();
+    }
+
+    @JsonPropertyOrder({"id", "name", "count"}) // easier to assert when JSON field ordering is always the same
+    record RecordWithInterfaceWithGetter(String name) implements InterfaceWithGetter {
+
+        @Override
+        public String getId() {
+            return "ID:" + name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        // [databind#3895]
+        public int getCount() {
+            return 999;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    public void testSerializeIgnoreInterfaceGetter_WithoutUsingVisibilityConfig() throws Exception {
+        String json = MAPPER.writeValueAsString(new RecordWithInterfaceWithGetter("Bob"));
+
+        assertEquals("{\"id\":\"ID:Bob\",\"name\":\"Bob\",\"count\":999}", json);
+    }
+
+    public void testSerializeIgnoreInterfaceGetter_UsingVisibilityConfig() throws Exception {
+        MAPPER.setVisibility(PropertyAccessor.GETTER, Visibility.NONE);
+        MAPPER.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+
+        String json = MAPPER.writeValueAsString(new RecordWithInterfaceWithGetter("Bob"));
+
+        assertEquals("{\"name\":\"Bob\"}", json);
+    }
+}


### PR DESCRIPTION
The reason why the fields are needed is because this kind of config needs it:
```java
new ObjectMapper()
  .setVisibility(PropertyAccessor.GETTER, Visibility.NONE)
  .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
```

And currently, we have 3 use cases that uses that config:
| | Who | Why |
|--|--|--|
| 1 | #3628 | Easy way to ignore methods (that looks like a property) that comes from interface(s), and only serializing Record components. |
| 2 | https://github.com/FasterXML/jackson-databind/pull/3724#issuecomment-1520643404 | Easy way (albeit overkill) way to exclude a method (that looks like a property) from being serialized, to avoid making test assertion complicated.
| 3 | #3895, https://github.com/FasterXML/jackson-databind/issues/3906#issuecomment-1532842582 | A way to ignore non-accessor `getXXX` methods. |

For the 2nd use case, [there's an alternative solution](https://github.com/FasterXML/jackson-databind/pull/3724#issuecomment-1520643404).  Not so lucky for 1st & 3rd use cases.