### PR TITLE
Improve and fix JavaDocs for Jackson 2.15

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -59,7 +59,7 @@ public abstract class AnnotationIntrospector
              * Usually this can be defined by using
              * {@link com.fasterxml.jackson.annotation.JsonManagedReference}
              */
-            MANAGED_REFERENCE
+            MANAGED_REFERENCE,
 
             /**
              * Reference property that Jackson manages by suppressing it during serialization,
@@ -67,7 +67,7 @@ public abstract class AnnotationIntrospector
              * Usually this can be defined by using
              * {@link com.fasterxml.jackson.annotation.JsonBackReference}
              */
-            ,BACK_REFERENCE
+            BACK_REFERENCE
             ;
         }
 

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -322,7 +322,7 @@ public enum MapperFeature implements ConfigFeature
      * Feature is enabled by default which means that deserialization does
      * support deserializing types via builders with type parameters (generic types).
      *<p>
-     * See: https://github.com/FasterXML/jackson-databind/issues/921
+     * See: <a href="https://github.com/FasterXML/jackson-databind/issues/921">databind#921</a>
      *
      * @since 2.12
      */

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -401,6 +401,11 @@ public enum MapperFeature implements ConfigFeature
      *<p>
      * Note: does <b>not</b> apply to {@link java.util.Map} serialization (since
      * entries are not considered Bean/POJO properties.
+     * <p>
+     * WARNING: Disabling it may have a negative impact on deserialization performance.
+     * When disabled, all properties before the last creator property in the input need to be buffered,
+     * since all creator properties are required to create the instance.
+     * Enabling this feature ensures that there is as little buffering as possible. 
      *<p>
      * Feature is enabled by default.
      *

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -4623,7 +4623,7 @@ public class ObjectMapper
      * @param t The class to generate schema for
      * @return Constructed JSON schema.
      *
-     * @deprecated Since 2.6 use external JSON Schema generator (https://github.com/FasterXML/jackson-module-jsonSchema)
+     * @deprecated Since 2.6 use external JSON Schema generator (<a href="https://github.com/FasterXML/jackson-module-jsonSchema">jackson-module-jsonSchema</a>)
      *    (which under the hood calls {@link #acceptJsonFormatVisitor(JavaType, JsonFormatVisitorWrapper)})
      */
     @Deprecated

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -947,14 +947,13 @@ public abstract class SerializerProvider
     }
 
     /**
-     * Method called to find a serializer to use for null values for given
-     * declared type. Note that type is completely based on declared type,
+     * Method called to find a serializer to serializes Map keys that are nulls, 
+     * as JSON does not allow any non-String value as a key, including null.
+     * Note that type is completely based on declared type,
      * since nulls in Java have no type and thus runtime type cannot be
      * determined.
-     * <p>
-     * This method serializes Map keys that are nulls.
-     * JSON does not allow any non-String value as a key, including null.
-     * The returned serializer handles the serialization of null keys,
+     * 
+     * @return JsonSerializer that handles the serialization of null keys, 
      * usually by throwing an exception or using an empty String,
      * but other behaviors are also possible.
      *

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -947,19 +947,16 @@ public abstract class SerializerProvider
     }
 
     /**
-     * Method called to get the serializer to use for serializing
-     * Map keys that are nulls: this is needed since JSON does not allow
-     * any non-String value as key, including null.
-     *<p>
-     * Typically, returned serializer
-     * will either throw an exception, or use an empty String; but
-     * other behaviors are possible.
-     */
-    /**
      * Method called to find a serializer to use for null values for given
      * declared type. Note that type is completely based on declared type,
      * since nulls in Java have no type and thus runtime type cannot be
      * determined.
+     * <p>
+     * This method serializes Map keys that are nulls.
+     * JSON does not allow any non-String value as a key, including null.
+     * The returned serializer handles the serialization of null keys,
+     * usually by throwing an exception or using an empty String,
+     * but other behaviors are also possible.
      *
      * @since 2.0
      */

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -529,8 +529,8 @@ _containerType,
 
     /**
      * Helper class to maintain processing order of value. The resolved
-     * object associated with {@link #_id} comes before the values in
-     * {@link #next}.
+     * object associated with {@code #id} parameter from {@link #handleResolvedForwardReference(Object, Object)} 
+     * comes before the values in {@link #next}.
      */
     private final static class CollectionReferring extends Referring {
         private final CollectionReferringAccumulator _parent;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedClass.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedClass.java
@@ -202,8 +202,7 @@ public final class AnnotatedClass
      * Method similar to {@link #construct}, but that will NOT include
      * information from supertypes; only class itself and any direct
      * mix-ins it may have.
-     */
-    /**
+     * 
      * @deprecated Since 2.9, use methods in {@link AnnotatedClassResolver} instead.
      */
     @Deprecated

--- a/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMap.java
@@ -136,7 +136,7 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
 
     /**
      * The number of read buffers to use.
-     * The max of 4 was introduced due to https://github.com/FasterXML/jackson-databind/issues/3665.
+     * The max of 4 was introduced due to <a href="https://github.com/FasterXML/jackson-databind/issues/3665">databind#3665</a>.
      */
     static final int NUMBER_OF_READ_BUFFERS = Math.min(4, ceilingNextPowerOfTwo(NCPU));
 
@@ -145,7 +145,7 @@ public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
 
     /**
      * The number of pending read operations before attempting to drain.
-     * The threshold of 4 was introduced due to https://github.com/FasterXML/jackson-databind/issues/3665.
+     * The threshold of 4 was introduced due to <a href="https://github.com/FasterXML/jackson-databind/issues/3665">databind#3665</a>.
      */
     static final int READ_BUFFER_THRESHOLD = 4;
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
- * Tests for {@a href="https://github.com/FasterXML/jackson-core/issues/863"}.
+ * Tests for <a href="https://github.com/FasterXML/jackson-core/issues/863">databind#863</a>"
  */
 public class StreamReadStringConstraintsTest extends BaseMapTest
 {

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicDeserialization676.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/TestPolymorphicDeserialization676.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * Reproduction of [https://github.com/FasterXML/jackson-databind/issues/676]
+ * Reproduction of <a href="https://github.com/FasterXML/jackson-databind/issues/676">databind#676</a>
  * <p/>
  * Deserialization of class with generic collection inside
  * depends on how is was deserialized first time.


### PR DESCRIPTION
### Changes Made

- Fix unresolved `{@link }` tag.
- Changes links in plain text into a link tag.
- Merge dangling JavaDocs so that they can be included in [JavaDocs](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/index.html))
- Improves JavaDoc on `MapperFeature.SORT_CREATOR_PROPERTIES_FIRST` as mentioned by https://github.com/FasterXML/jackson-databind/issues/3900#issuecomment-1535852049