### PR TITLE
Remove hard-coded `StreamReadConstraints` test variables to isolate change in `jackson-core` itself

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepJsonNodeDeser3397Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepJsonNodeDeser3397Test.java
@@ -13,8 +13,7 @@ public class DeepJsonNodeDeser3397Test extends BaseMapTest
     // ... currently gets a bit slow at 1M but passes.
     // But test with 100k as practical limit, to guard against regression
 //    private final static int TOO_DEEP_NESTING = 1_000_000;
-    private final static int TOO_DEEP_NESTING = StreamReadConstraints.DEFAULT_MAX_DEPTH * 10 < 0
-                                                    ? Integer.MAX_VALUE : StreamReadConstraints.DEFAULT_MAX_DEPTH * 10;
+    private final static int TOO_DEEP_NESTING = StreamReadConstraints.DEFAULT_MAX_DEPTH * 10;
 
     private final JsonFactory jsonFactory = JsonFactory.builder()
             .streamReadConstraints(StreamReadConstraints.builder().maxNestingDepth(Integer.MAX_VALUE).build())

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepJsonNodeDeser3397Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepJsonNodeDeser3397Test.java
@@ -13,7 +13,8 @@ public class DeepJsonNodeDeser3397Test extends BaseMapTest
     // ... currently gets a bit slow at 1M but passes.
     // But test with 100k as practical limit, to guard against regression
 //    private final static int TOO_DEEP_NESTING = 1_000_000;
-    private final static int TOO_DEEP_NESTING = 10_000;
+    private final static int TOO_DEEP_NESTING = StreamReadConstraints.DEFAULT_MAX_DEPTH * 10 < 0
+                                                    ? Integer.MAX_VALUE : StreamReadConstraints.DEFAULT_MAX_DEPTH * 10;
 
     private final JsonFactory jsonFactory = JsonFactory.builder()
             .streamReadConstraints(StreamReadConstraints.builder().maxNestingDepth(Integer.MAX_VALUE).build())

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
@@ -18,8 +18,7 @@ public class DeepNestingUntypedDeserTest extends BaseMapTest
     // 31-May-2022, tatu: But no more! Can handle much much larger
     //   nesting levels, bounded by memory usage not stack. Tested with
     //   1 million (!) nesting levels, but to keep tests fast use 100k
-    private final static int TOO_DEEP_NESTING = StreamReadConstraints.DEFAULT_MAX_DEPTH * 100 < 0
-                                                ? Integer.MAX_VALUE : StreamReadConstraints.DEFAULT_MAX_DEPTH * 100;
+    private final static int TOO_DEEP_NESTING = StreamReadConstraints.DEFAULT_MAX_DEPTH * 100;
 
     private final JsonFactory jsonFactory = JsonFactory.builder()
             .streamReadConstraints(StreamReadConstraints.builder().maxNestingDepth(Integer.MAX_VALUE).build())

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.databind.deser.dos;
 
-import static com.fasterxml.jackson.core.StreamReadConstraints.DEFAULT_MAX_DEPTH;
 import java.util.List;
 import java.util.Map;
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
@@ -26,6 +26,7 @@ public class DeepNestingUntypedDeserTest extends BaseMapTest
             .build();
     private final ObjectMapper MAPPER = JsonMapper.builder(jsonFactory).build();
 
+
     public void testFormerlyTooDeepUntypedWithArray() throws Exception
     {
         final String doc = _nestedDoc(TOO_DEEP_NESTING, "[ ", "] ");

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/DeepNestingUntypedDeserTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.deser.dos;
 
+import static com.fasterxml.jackson.core.StreamReadConstraints.DEFAULT_MAX_DEPTH;
 import java.util.List;
 import java.util.Map;
 
@@ -18,13 +19,13 @@ public class DeepNestingUntypedDeserTest extends BaseMapTest
     // 31-May-2022, tatu: But no more! Can handle much much larger
     //   nesting levels, bounded by memory usage not stack. Tested with
     //   1 million (!) nesting levels, but to keep tests fast use 100k
-    private final static int TOO_DEEP_NESTING = 100_000;
+    private final static int TOO_DEEP_NESTING = StreamReadConstraints.DEFAULT_MAX_DEPTH * 100 < 0
+                                                ? Integer.MAX_VALUE : StreamReadConstraints.DEFAULT_MAX_DEPTH * 100;
 
     private final JsonFactory jsonFactory = JsonFactory.builder()
             .streamReadConstraints(StreamReadConstraints.builder().maxNestingDepth(Integer.MAX_VALUE).build())
             .build();
     private final ObjectMapper MAPPER = JsonMapper.builder(jsonFactory).build();
-
 
     public void testFormerlyTooDeepUntypedWithArray() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
@@ -32,7 +32,8 @@ public class StreamReadStringConstraintsTest extends BaseMapTest
     /**********************************************************************
      */
 
-    private final static int TOO_LONG_STRING_VALUE = StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 1;
+    private final static int TOO_LONG_STRING_VALUE = StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 100 < 0 
+                                            ? Integer.MAX_VALUE : StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 100;
     
     private final ObjectMapper MAPPER = newJsonMapper();
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
@@ -32,7 +32,7 @@ public class StreamReadStringConstraintsTest extends BaseMapTest
     /**********************************************************************
      */
 
-    private final static int TOO_LONG_STRING_VALUE = 20_100_000;
+    private final static int TOO_LONG_STRING_VALUE = StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 1;
     
     private final ObjectMapper MAPPER = newJsonMapper();
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/dos/StreamReadStringConstraintsTest.java
@@ -32,8 +32,7 @@ public class StreamReadStringConstraintsTest extends BaseMapTest
     /**********************************************************************
      */
 
-    private final static int TOO_LONG_STRING_VALUE = StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 100 < 0 
-                                            ? Integer.MAX_VALUE : StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 100;
+    private final static int TOO_LONG_STRING_VALUE = StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 100;
     
     private final ObjectMapper MAPPER = newJsonMapper();
 


### PR DESCRIPTION
### Motivation: 

This PR aims to improve maintenance by removing hard-coded test variables related to `StreamReadConstraints` default limits. With this change, we can expect to isolate the change within the `jackson-core` codebase itself and still get the same expected behavior.