### PR TITLE
Fix #3906 by forcing Record constructors to be visible regardless of visibility overrides

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfigBase.java
@@ -832,6 +832,11 @@ public abstract class MapperConfigBase<CFG extends ConfigFeature,
             vc = VisibilityChecker.Std.allPublicInstance();
         } else {
             vc = getDefaultVisibilityChecker();
+            // 20-May-2023, tatu: [databind#3906] Must reset visibility for Records
+            //    to avoid hiding Constructors
+            if (ClassUtil.isRecordType(baseType)) {
+                vc = vc.withCreatorVisibility(Visibility.NON_PRIVATE);
+            }
         }
         AnnotationIntrospector intr = getAnnotationIntrospector();
         if (intr != null) {

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordCreatorVisibility3906Test.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordCreatorVisibility3906Test.java
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.*;
+
+// [databind#3906]
+public class RecordCreatorVisibility3906Test extends BaseMapTest
+{
+    // [databind#3906]
+    record Record3906(String string, int integer) { }
+
+    // [databind#3906]
+    public void testRecordCreatorVisibility3906() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .visibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+                .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                .build();
+        Record3906 recordTest_deserialized = mapper.readValue("{}", Record3906.class);
+        assertEquals(new Record3906(null, 0), recordTest_deserialized);
+    }
+}


### PR DESCRIPTION
Fixes #3906 as per title.