### PR TITLE
Backport `TypeResolverBuilder` initialization mechanisms from Jackson 3.0

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeResolverBuilder.java
@@ -98,6 +98,24 @@ public interface TypeResolverBuilder<T extends TypeResolverBuilder<T>>
      */
     public T init(JsonTypeInfo.Id idType, TypeIdResolver res);
 
+    /**
+     * Initialization method that is called right after constructing
+     * the builder instance, in cases where information could not be
+     * passed directly (for example when instantiated for an annotation)
+     * <p>
+     * NOTE: This method is abstract in Jackson 3.0, at the moment of writing.
+     *
+     * @param settings Configuration settings to apply.
+     *
+     * @return Resulting builder instance (usually this builder,
+     *   but not necessarily)
+     *
+     * @since 2.16 (backported from Jackson 3.0)
+     */
+    default T init(JsonTypeInfo.Value settings, TypeIdResolver res) {
+        return init(settings.getIdType(), res);
+    }
+
     /*
     /**********************************************************
     /* Methods for configuring resolver to build

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -80,6 +80,32 @@ public class StdTypeResolverBuilder
         _defaultImpl = defaultImpl;
     }
 
+
+    /**
+     * @since 2.16 (backported from Jackson 3.0)
+     */
+    public StdTypeResolverBuilder(JsonTypeInfo.Value settings) {
+        if (settings != null) {
+            _idType = settings.getIdType();
+            if (_idType == null) {
+                throw new IllegalArgumentException("idType cannot be null");
+            }
+            _includeAs = settings.getInclusionType();
+            _typeProperty = _propName(settings.getPropertyName(), _idType);
+            _defaultImpl = settings.getDefaultImpl();
+        }
+    }
+
+    /**
+     * @since 2.16 (backported from Jackson 3.0)
+     */
+    protected static String _propName(String propName, JsonTypeInfo.Id idType) {
+        if (propName == null) {
+            propName = idType.getDefaultPropertyName();
+        }
+        return propName;
+    }
+
     public static StdTypeResolverBuilder noTypeInfoBuilder() {
         return new StdTypeResolverBuilder().init(JsonTypeInfo.Id.NONE, null);
     }
@@ -95,6 +121,33 @@ public class StdTypeResolverBuilder
         _customIdResolver = idRes;
         // Let's also initialize property name as per idType default
         _typeProperty = idType.getDefaultPropertyName();
+        return this;
+    }
+
+    /**
+     * @since 2.16 (backported from Jackson 3.0)
+     */
+    @Override
+    public StdTypeResolverBuilder init(JsonTypeInfo.Value settings,
+            TypeIdResolver idRes)
+    {
+        _customIdResolver = idRes;
+
+        if (settings != null) {
+            _idType = settings.getIdType();
+            if (_idType == null) {
+                throw new IllegalArgumentException("idType cannot be null");
+            }
+            _includeAs = settings.getInclusionType();
+
+            // Let's also initialize property name as per idType default
+            _typeProperty = settings.getPropertyName();
+            if (_typeProperty == null) {
+                _typeProperty = _idType.getDefaultPropertyName();
+            }
+            _typeIdVisible = settings.getIdVisible();
+            _defaultImpl = settings.getDefaultImpl();
+        }
         return this;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -80,7 +80,6 @@ public class StdTypeResolverBuilder
         _defaultImpl = defaultImpl;
     }
 
-
     /**
      * @since 2.16 (backported from Jackson 3.0)
      */


### PR DESCRIPTION
Done in accordance with, and as a sub-task of #3943 