### PR TITLE
Add behavioral test regarding `transient` field with annotation

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
@@ -1,0 +1,92 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Transient3948Test extends BaseMapTest {
+
+    public static class Obj implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = -1L;
+
+        private String a;
+
+        @JsonIgnore
+        private transient String b;
+
+        @JsonProperty("cat")
+        private String c;
+
+        @JsonProperty("dog")
+        private transient String d;
+
+        public String getA() {
+            return a;
+        }
+
+        public void setA(String a) {
+            this.a = a;
+        }
+
+        public String getB() {
+            return b;
+        }
+
+        public void setB(String b) {
+            this.b = b;
+        }
+
+        public String getC() {
+            return c;
+        }
+
+        public void setC(String c) {
+            this.c = c;
+        }
+
+        public String getD() {
+            return d;
+        }
+
+        public void setD(String d) {
+            this.d = d;
+        }
+    }
+
+    final ObjectMapper DEFAULT_MAPPER = newJsonMapper();
+
+    final ObjectMapper MAPPER_TRANSIENT = jsonMapperBuilder()
+            .configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true)
+            .build();
+
+    public void testJsonIgnoreSerialization() throws Exception {
+        var obj1 = new Obj();
+        obj1.setA("hello");
+        obj1.setB("world");
+        obj1.setC("jackson");
+        obj1.setD("databind");
+
+        String json = DEFAULT_MAPPER.writeValueAsString(obj1);
+
+        assertEquals(a2q("{'a':'hello','b':'world','cat':'jackson','dog':'databind'}"), json);
+    }
+
+    public void testJsonIgnoreSerializationTransient() throws Exception {
+        var obj1 = new Obj();
+        obj1.setA("hello");
+        obj1.setB("world");
+        obj1.setC("jackson");
+        obj1.setD("databind");
+
+
+        String json = MAPPER_TRANSIENT.writeValueAsString(obj1);
+
+        assertEquals(a2q("{'a':'hello','cat':'jackson','dog':'databind'}"), json);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
@@ -50,7 +50,7 @@ public class Transient3948Test extends BaseMapTest {
             .build();
 
     public void testJsonIgnoreSerialization() throws Exception {
-        var obj1 = new Obj();
+        Obj obj1 = new Obj();
 
         String json = DEFAULT_MAPPER.writeValueAsString(obj1);
 
@@ -58,7 +58,7 @@ public class Transient3948Test extends BaseMapTest {
     }
 
     public void testJsonIgnoreSerializationTransient() throws Exception {
-        var obj1 = new Obj();
+        Obj obj1 = new Obj();
 
         String json = MAPPER_TRANSIENT.writeValueAsString(obj1);
 

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.introspect;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,6 +10,7 @@ import java.io.Serializable;
 
 public class Transient3948Test extends BaseMapTest {
 
+    @JsonPropertyOrder(alphabetic = true)
     static class Obj implements Serializable {
 
         private static final long serialVersionUID = -1L;

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
@@ -9,51 +9,35 @@ import java.io.Serializable;
 
 public class Transient3948Test extends BaseMapTest {
 
-    public static class Obj implements Serializable {
+    static class Obj implements Serializable {
 
         private static final long serialVersionUID = -1L;
 
-        private String a;
+        private String a = "hello";
 
         @JsonIgnore
-        private transient String b;
+        private transient String b = "world";
 
         @JsonProperty("cat")
-        private String c;
+        private String c = "jackson";
 
         @JsonProperty("dog")
-        private transient String d;
+        private transient String d = "databind";
 
         public String getA() {
             return a;
-        }
-
-        public void setA(String a) {
-            this.a = a;
         }
 
         public String getB() {
             return b;
         }
 
-        public void setB(String b) {
-            this.b = b;
-        }
-
         public String getC() {
             return c;
         }
 
-        public void setC(String c) {
-            this.c = c;
-        }
-
         public String getD() {
             return d;
-        }
-
-        public void setD(String d) {
-            this.d = d;
         }
     }
 
@@ -65,10 +49,6 @@ public class Transient3948Test extends BaseMapTest {
 
     public void testJsonIgnoreSerialization() throws Exception {
         var obj1 = new Obj();
-        obj1.setA("hello");
-        obj1.setB("world");
-        obj1.setC("jackson");
-        obj1.setD("databind");
 
         String json = DEFAULT_MAPPER.writeValueAsString(obj1);
 
@@ -77,11 +57,6 @@ public class Transient3948Test extends BaseMapTest {
 
     public void testJsonIgnoreSerializationTransient() throws Exception {
         var obj1 = new Obj();
-        obj1.setA("hello");
-        obj1.setB("world");
-        obj1.setC("jackson");
-        obj1.setD("databind");
-
 
         String json = MAPPER_TRANSIENT.writeValueAsString(obj1);
 

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/Transient3948Test.java
@@ -5,14 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Transient3948Test extends BaseMapTest {
 
     public static class Obj implements Serializable {
 
-        @Serial
         private static final long serialVersionUID = -1L;
 
         private String a;


### PR DESCRIPTION
Relates to #3948. We could add this test under [TransientTest.java](https://github.com/FasterXML/jackson-databind/blob/2.16/src/test/java/com/fasterxml/jackson/databind/introspect/TransientTest.java) if suggested.
