### PR TITLE
Add basic impl of IterationType

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,7 @@ Project: jackson-databind
 
 #3928: `@JsonProperty` on constructor parameter changes default field serialization order
  (contributed by @pjfanning)
+#3950: Create new `JavaType` subtype `IterationType` (extending `SimpleType`)
 
 2.15.2 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/JavaType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JavaType.java
@@ -359,6 +359,18 @@ public abstract class JavaType
         return ClassUtil.isRecordType(_class);
     }
 
+    /**
+     * Method that returns true if this instance is of type
+     * {@code IterationType}.
+     *
+     * @since 2.16
+     *
+     * @return True if this type is considered "iteration type"
+     */
+    public boolean isIterationType() {
+        return false;
+    }
+
     @Override
     public final boolean isInterface() { return _class.isInterface(); }
 

--- a/src/main/java/com/fasterxml/jackson/databind/type/IterationType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/IterationType.java
@@ -1,29 +1,176 @@
 package com.fasterxml.jackson.databind.type;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.databind.JavaType;
 
 /**
  * Specialized {@link SimpleType} for types that are allow iteration
  * over Collection(-like) types: this includes types like
  * {@link java.util.Iterator}.
- * Referenced type is accessible using {@link #getContentType()}.
+ * Iterated (content) type is accessible using {@link #getContentType()}.
  *
  * @since 2.16
  */
-public abstract class IterationType extends SimpleType
+public class IterationType extends SimpleType
 {
     private static final long serialVersionUID = 1L;
 
     protected final JavaType _iteratedType;
 
+    protected IterationType(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType iteratedType,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(cls, bindings, superClass, superInts, Objects.hashCode(iteratedType),
+                valueHandler, typeHandler, asStatic);
+        _iteratedType = iteratedType;
+    }
+
     /**
      * Constructor used when upgrading into this type (via {@link #upgradeFrom},
      * the usual way for {@link IterationType}s to come into existence.
-     * Sets up what is considered the "base" reference type
+     * Sets up what is considered the "base" iteration type
      */
     protected IterationType(TypeBase base, JavaType iteratedType)
     {
         super(base);
         _iteratedType = iteratedType;
+    }
+
+    /**
+     * Factory method that can be used to "upgrade" a basic type into iteration
+     * type; usually done via {@link TypeModifier}
+     *
+     * @param baseType Resolved non-iteration type (usually {@link SimpleType}) that is being upgraded
+     * @param iteratedType Iterated type; usually the first and only type parameter, but not necessarily
+     */
+    public static IterationType upgradeFrom(JavaType baseType, JavaType iteratedType) {
+        Objects.requireNonNull(iteratedType);
+        // 19-Oct-2015, tatu: Not sure if and how other types could be used as base;
+        //    will cross that bridge if and when need be
+        if (baseType instanceof TypeBase) {
+            return new IterationType((TypeBase) baseType, iteratedType);
+        }
+        throw new IllegalArgumentException("Cannot upgrade from an instance of "+baseType.getClass());
+    }
+
+    public static IterationType construct(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType iteratedType)
+    {
+        return new IterationType(cls, bindings, superClass, superInts,
+                iteratedType, null, null, false);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        if (_iteratedType == contentType) {
+            return this;
+        }
+        return new IterationType(_class, _bindings, _superClass, _superInterfaces,
+                contentType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public IterationType withTypeHandler(Object h)
+    {
+        if (h == _typeHandler) {
+            return this;
+        }
+        return new IterationType(_class, _bindings, _superClass, _superInterfaces,
+                _iteratedType, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public IterationType withContentTypeHandler(Object h)
+    {
+        if (h == _iteratedType.<Object>getTypeHandler()) {
+            return this;
+        }
+        return new IterationType(_class, _bindings, _superClass, _superInterfaces,
+                _iteratedType.withTypeHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public IterationType withValueHandler(Object h) {
+        if (h == _valueHandler) {
+            return this;
+        }
+        return new IterationType(_class, _bindings,
+                _superClass, _superInterfaces, _iteratedType,
+                h, _typeHandler,_asStatic);
+    }
+
+    @Override
+    public IterationType withContentValueHandler(Object h) {
+        if (h == _iteratedType.<Object>getValueHandler()) {
+            return this;
+        }
+        return new IterationType(_class, _bindings,
+                _superClass, _superInterfaces, _iteratedType.withValueHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public IterationType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new IterationType(_class, _bindings, _superClass, _superInterfaces,
+                _iteratedType.withStaticTyping(),
+                 _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return new IterationType(rawType, _bindings,
+                superClass, superInterfaces, _iteratedType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    protected String buildCanonicalName()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(_class.getName());
+        if ((_iteratedType != null) && _hasNTypeParameters(1)) {
+            sb.append('<');
+            sb.append(_iteratedType.toCanonical());
+            sb.append('>');
+        }
+        return sb.toString();
+    }
+
+    /*
+    /**********************************************************
+    /* Public API overrides
+    /**********************************************************
+     */
+
+    @Override
+    public JavaType getContentType() {
+        return _iteratedType;
+    }
+
+    @Override
+    public boolean hasContentType() {
+        return true;
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        return _classSignature(_class, sb, true);
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb)
+    {
+        _classSignature(_class, sb, false);
+        sb.append('<');
+        sb = _iteratedType.getGenericSignature(sb);
+        sb.append(">;");
+        return sb;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/type/IterationType.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/IterationType.java
@@ -160,6 +160,11 @@ public class IterationType extends SimpleType
     }
 
     @Override
+    public boolean isIterationType() {
+        return true;
+    }
+
+    @Override
     public StringBuilder getErasedSignature(StringBuilder sb) {
         return _classSignature(_class, sb, true);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestJavaType.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestJavaType.java
@@ -308,8 +308,11 @@ public class TestJavaType
                 Stream.class, Object.class);
 
         // Then generic but direct
-        _verifyIteratorType(tf.constructType(new TypeReference<Iterator<String>>() { }),
+        JavaType t = _verifyIteratorType(tf.constructType(new TypeReference<Iterator<String>>() { }),
                 Iterator.class, String.class);
+        assertEquals("java.util.Iterator<java.lang.String>", t.toCanonical());
+        assertEquals("Ljava/util/Iterator;", t.getErasedSignature());
+        assertEquals("Ljava/util/Iterator<Ljava/lang/String;>;", t.getGenericSignature());
         _verifyIteratorType(tf.constructType(new TypeReference<Stream<Long>>() { }),
                 Stream.class, Long.class);
 
@@ -336,11 +339,12 @@ public class TestJavaType
                 stringStream.getClass(), Object.class);
     }
 
-    private void _verifyIteratorType(JavaType type,
+    private JavaType _verifyIteratorType(JavaType type,
             Class<?> expType, Class<?> expContentType) {
         assertTrue(type.isIterationType());
         assertEquals(IterationType.class, type.getClass());
         assertEquals(expType, type.getRawClass());
         assertEquals(expContentType, type.getContentType().getRawClass());
+        return type;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestJavaType.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestJavaType.java
@@ -60,6 +60,9 @@ public class TestJavaType
     @SuppressWarnings("serial")
     static class AtomicStringReference extends AtomicReference<String> { }
 
+    static interface StringStream extends Stream<String> { }
+    static interface StringIterator extends Iterator<String> { }
+
     /*
     /**********************************************************
     /* Test methods
@@ -337,6 +340,16 @@ public class TestJavaType
         Stream<String> stringStream = strings.stream();
         _verifyIteratorType(tf.constructType(stringStream.getClass()),
                 stringStream.getClass(), Object.class);
+    }
+
+    // for [databind#3950]: resolve `Iterator`, `Stream`
+    public void testIterationSubTypes() throws Exception
+    {
+        TypeFactory tf = TypeFactory.defaultInstance();
+        _verifyIteratorType(tf.constructType(StringIterator.class),
+                StringIterator.class, String.class);
+        _verifyIteratorType(tf.constructType(StringStream.class),
+                StringStream.class, String.class);
     }
 
     private JavaType _verifyIteratorType(JavaType type,

--- a/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TestTypeFactory.java
@@ -142,11 +142,13 @@ public class TestTypeFactory
         assertSame(String.class, mt.getContentType().getRawClass());
     }
 
+    // note: changed for [databind#3950]
     public void testIterator()
     {
         TypeFactory tf = TypeFactory.defaultInstance();
         JavaType t = tf.constructType(new TypeReference<Iterator<String>>() { });
-        assertEquals(SimpleType.class, t.getClass());
+        assertEquals(IterationType.class, t.getClass());
+        assertTrue(t.isIterationType());
         assertSame(Iterator.class, t.getRawClass());
         assertEquals(1, t.containedTypeCount());
         assertEquals(tf.constructType(String.class), t.containedType(0));


### PR DESCRIPTION
Once complete, will provide new type to make it easier to detect and handle "Iteration" type; type for iterators capable of traversing content to serialize (but not necessarily to deserialize, nor allow any other access beyond forward-iteration).

Will support JDK types:

* `Iterator`
* `Stream`
* `IntStream`, `LongStream`, `DoubleStream`
