### PR TITLE
Fix failing test for `JsonReadFeature.ALLOW_JAVA_COMMENTS` error message 

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectReaderTest.java
@@ -139,7 +139,8 @@ public class ObjectReaderTest extends BaseMapTest
             fail("Should not have passed");
         } catch (DatabindException e) {
             // DatabindException since it gets wrapped
-            verifyException(e, "foo");
+            verifyException(e, "Unexpected character");
+            verifyException(e, "maybe a (non-standard) comment");
         }
     }
 


### PR DESCRIPTION
I have not succeeded in tracking down the specific commit for causing this, but should be around `jackson-core` module.

Exception message changed, 

```
Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)
 at [Source: UNKNOWN; line: 1, column: 4] (through reference chain: int[][0])
```

Attaching my IDE capture, just in case it helps.

![image](https://github.com/FasterXML/jackson-databind/assets/61615301/3f181a2c-8471-4323-b4a9-f54a3e335d5f)
