### PR TITLE
Ignore ConstructorDetector.SingleArgConstructor.PROPERTIES preference for Records.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -482,7 +482,9 @@ index, owner, defs[index], propDef);
         final AnnotationIntrospector intr = ccState.annotationIntrospector();
         final VisibilityChecker<?> vchecker = ccState.vchecker;
         List<AnnotatedWithParams> implicitCtors = null;
-        final boolean preferPropsBased = config.getConstructorDetector().singleArgCreatorDefaultsToProperties();
+        final boolean preferPropsBased = config.getConstructorDetector().singleArgCreatorDefaultsToProperties()
+                // [databind#3968]: Only Record's canonical constructor is allowed to be considered for properties-based creator
+                && !beanDesc.isRecordType();
 
         for (CreatorCandidate candidate : ctorCandidates) {
             final int argCount = candidate.paramCount();

--- a/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordImplicitSingleValueUsePropertiesBasedCreatorsTest.java
+++ b/src/test-jdk14/java/com/fasterxml/jackson/databind/records/RecordImplicitSingleValueUsePropertiesBasedCreatorsTest.java
@@ -1,0 +1,75 @@
+package com.fasterxml.jackson.databind.records;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
+public class RecordImplicitSingleValueUsePropertiesBasedCreatorsTest extends BaseMapTest
+{
+
+    record RecordWithMultiValueCanonAndSingleValueAltConstructor(int id, String name) {
+
+        public RecordWithMultiValueCanonAndSingleValueAltConstructor(int id) {
+            this(id, "AltConstructor");
+        }
+    }
+
+    record RecordWithSingleValueCanonAndMultiValueAltConstructor(String name) {
+
+        public RecordWithSingleValueCanonAndMultiValueAltConstructor(String name, String email) {
+            this("AltConstructor");
+        }
+    }
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+            .annotationIntrospector(new Jdk8ConstructorParameterNameAnnotationIntrospector())
+            .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
+            .build();
+
+    /*
+    /**********************************************************************
+    /* Test methods, multi-value canonical constructor + single-value alt constructor
+    /**********************************************************************
+     */
+
+    public void testDeserializeMultipleConstructors_UsingMultiValueCanonicalConstructor() throws Exception {
+        RecordWithMultiValueCanonAndSingleValueAltConstructor value = MAPPER.readValue(
+                a2q("{'id':123,'name':'Bob'}"),
+                RecordWithMultiValueCanonAndSingleValueAltConstructor.class);
+
+        assertEquals(new RecordWithMultiValueCanonAndSingleValueAltConstructor(123, "Bob"), value);
+    }
+
+    public void testDeserializeMultipleConstructors_WillIgnoreSingleValueAltConstructor() throws Exception {
+        RecordWithMultiValueCanonAndSingleValueAltConstructor value = MAPPER.readValue(
+                a2q("{'id':123}"),
+                RecordWithMultiValueCanonAndSingleValueAltConstructor.class);
+
+        assertEquals(new RecordWithMultiValueCanonAndSingleValueAltConstructor(123, null), value);
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, single-value canonical constructor + multi-value alt constructor
+    /**********************************************************************
+     */
+
+    public void testDeserializeMultipleConstructors_UsingSingleValueCanonicalConstructor() throws Exception {
+        RecordWithSingleValueCanonAndMultiValueAltConstructor value = MAPPER.readValue(
+                a2q("{'name':'Bob'}"),
+                RecordWithSingleValueCanonAndMultiValueAltConstructor.class);
+
+        assertEquals(new RecordWithSingleValueCanonAndMultiValueAltConstructor("Bob"), value);
+    }
+
+    public void testDeserializeMultipleConstructors_WillIgnoreMultiValueAltConstructor() throws Exception {
+        try {
+            MAPPER.readValue(a2q("{'name':'Bob','email':'bob@email.com'}"), RecordWithSingleValueCanonAndMultiValueAltConstructor.class);
+        } catch (UnrecognizedPropertyException e) {
+            verifyException(e, "Unrecognized");
+            verifyException(e, "\"email\"");
+            verifyException(e, "RecordWithSingleValueCanonAndMultiValueAltConstructor");
+        }
+    }
+}


### PR DESCRIPTION
To fix #3968.

**NOTE**: I also wanted to add test case to see what happens when the canonical constructor is `@JsonIgnore`-ed, but apparently that's (currently) not allowed because it will throw exception:
https://github.com/FasterXML/jackson-databind/blob/2cea7c9ce9cbdcb14e22838ea07937c376b7ab78/src/main/java/com/fasterxml/jackson/databind/jdk14/JDK14Util.java#L206-L209