### PR TITLE
Add missing `_requireTypeIdForSubtypes` in `StdTypeResolverBuilder` in Jackson 3

### DIFF
--- a/src/main/java/tools/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -100,6 +100,7 @@ public class StdTypeResolverBuilder
         _customIdResolver = base._customIdResolver;
 
         _defaultImpl = defaultImpl;
+        _requireTypeIdForSubtypes = base._requireTypeIdForSubtypes;
     }
 
     public static StdTypeResolverBuilder noTypeInfoBuilder() {

--- a/src/main/java/tools/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -65,6 +65,7 @@ public class StdTypeResolverBuilder
             _includeAs = settings.getInclusionType();
             _typeProperty = _propName(settings.getPropertyName(), _idType);
             _defaultImpl = settings.getDefaultImpl();
+            _requireTypeIdForSubtypes = settings.getRequireTypeIdForSubtypes();
         }
     }
 
@@ -125,6 +126,7 @@ public class StdTypeResolverBuilder
             }
             _typeIdVisible = settings.getIdVisible();
             _defaultImpl = settings.getDefaultImpl();
+            _requireTypeIdForSubtypes = settings.getRequireTypeIdForSubtypes();
         }
         return this;
     }


### PR DESCRIPTION
Fixes test failures in commit https://github.com/FasterXML/jackson-databind/commit/2fea0d26abf640a6384ae73500613e233c213687

## Root cause

There was missing part after couple of backport and forward-merges between branches `2.16` and `master`

## History

First, we backported to **2.16** from **master** the `JsonTypeInfo.Value` usage in `TypeResolverBuilder` with PR https://github.com/FasterXML/jackson-databind/pull/3949. 

At this point, none of **2.16** and **master** branch handled `_requireTypeIdForSubtypes` in `StdTypeResolverBuilder`

👉🏼 Then, we introduced in **2.16 only** `_requireTypeIdForSubtypes` in `StdTypeResolverBuilder` with PR https://github.com/FasterXML/jackson-databind/pull/3953. So there definitely was confusion regards to   whether #3953 was a feature or a backport

Hope it all makes sense 🙏🏼🙏🏼