### PR TITLE
Improve `Enum` serialization via `AnnotatedClass`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -212,6 +212,7 @@ public class EnumDeserializer
           JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)).orElse(_useDefaultValueForUnknownEnum);
         Boolean useNullForUnknownEnum = Optional.ofNullable(findFormatFeature(ctxt, property, handledType(),
           JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)).orElse(_useNullForUnknownEnum);
+        
         return withResolved(caseInsensitive, useDefaultValueForUnknownEnum, useNullForUnknownEnum);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
@@ -99,7 +99,6 @@ public class EnumSerializer
          *   handle toString() case dynamically (for example)
          */
         EnumValues v = EnumValues.constructFromName(config, beanDesc.getClassInfo());
-//        EnumValues v = EnumValues.constructFromName(config, (Class<Enum<?>>) enumClass);
         EnumValues valuesByEnumNaming = constructEnumNamingStrategyValues(config, (Class<Enum<?>>) enumClass, beanDesc.getClassInfo());
         Boolean serializeAsIndex = _isShapeWrittenUsingIndex(enumClass, format, true, null);
         return new EnumSerializer(v, serializeAsIndex, valuesByEnumNaming);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/EnumSerializer.java
@@ -98,7 +98,8 @@ public class EnumSerializer
          *   between name() and toString(), need to construct `EnumValues` with names,
          *   handle toString() case dynamically (for example)
          */
-        EnumValues v = EnumValues.constructFromName(config, (Class<Enum<?>>) enumClass);
+        EnumValues v = EnumValues.constructFromName(config, beanDesc.getClassInfo());
+//        EnumValues v = EnumValues.constructFromName(config, (Class<Enum<?>>) enumClass);
         EnumValues valuesByEnumNaming = constructEnumNamingStrategyValues(config, (Class<Enum<?>>) enumClass, beanDesc.getClassInfo());
         Boolean serializeAsIndex = _isShapeWrittenUsingIndex(enumClass, format, true, null);
         return new EnumSerializer(v, serializeAsIndex, valuesByEnumNaming);

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdKeySerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdKeySerializers.java
@@ -103,7 +103,7 @@ public abstract class StdKeySerializers
             //    for subtypes.
             if (ClassUtil.isEnumType(rawKeyType)) {
                 return EnumKeySerializer.construct(rawKeyType,
-                    EnumValues.constructFromName(config, (Class<Enum<?>>) rawKeyType),
+                    EnumValues.constructFromName(config, annotatedClass),
                     EnumSerializer.constructEnumNamingStrategyValues(config, (Class<Enum<?>>) rawKeyType, annotatedClass));
             }
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -77,27 +77,30 @@ public final class EnumValues
     {
         // prepare data
         final AnnotationIntrospector ai = config.getAnnotationIntrospector();
+        final boolean useLowerCase = config.isEnabled(EnumFeature.WRITE_ENUMS_TO_LOWERCASE);
         final Class<?> enumCls0 = annotatedClass.getRawType();
         final Class<Enum<?>> enumCls = _enumClass(enumCls0);
-        final Enum<?>[] enumValues = _enumConstants(enumCls0);
+        final Enum<?>[] enumConstants = _enumConstants(enumCls0);
 
         // introspect
-        String[] names = ai.findEnumValues(config, annotatedClass, enumValues, new String[enumValues.length]);
+        String[] names = ai.findEnumValues(config, annotatedClass, 
+                enumConstants, new String[enumConstants.length]);
+
 
         // finally build
-        SerializableString[] textual = new SerializableString[enumValues.length];
-        for (int i = 0, len = enumValues.length; i < len; ++i) {
-            Enum<?> en = enumValues[i];
+        SerializableString[] textual = new SerializableString[enumConstants.length];
+        for (int i = 0, len = enumConstants.length; i < len; ++i) {
+            Enum<?> enumValue = enumConstants[i];
             String name = names[i];
             if (name == null) {
-                name = en.name();
+                name = enumValue.name();
             }
-            if (config.isEnabled(EnumFeature.WRITE_ENUMS_TO_LOWERCASE)) {
+            if (useLowerCase) {
                 name = name.toLowerCase();
             }
-            textual[en.ordinal()] = config.compileString(name);
+            textual[enumValue.ordinal()] = config.compileString(name);
         }
-        return construct(enumCls, textual);    
+        return construct(enumCls, textual);
     }
 
     public static EnumValues constructFromToString(MapperConfig<?> config, Class<Enum<?>> enumClass)
@@ -166,8 +169,11 @@ public final class EnumValues
         return (Class<Enum<?>>) enumCls0;
     }
 
+    /**
+     * @see EnumResolver#_enumConstants(Class) 
+     */
     protected static Enum<?>[] _enumConstants(Class<?> enumCls) {
-        final Enum<?>[] enumValues = _enumClass(enumCls).getEnumConstants();
+        final Enum<?>[] enumValues = ClassUtil.findEnumType(enumCls).getEnumConstants();
         if (enumValues == null) {
             throw new IllegalArgumentException("No enum constants for class "+enumCls.getName());
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -86,8 +86,7 @@ public final class EnumValues
         String[] names = ai.findEnumValues(config, annotatedClass, 
                 enumConstants, new String[enumConstants.length]);
 
-
-        // finally build
+        // build
         SerializableString[] textual = new SerializableString[enumConstants.length];
         for (int i = 0, len = enumConstants.length; i < len; ++i) {
             Enum<?> enumValue = enumConstants[i];

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -169,7 +169,8 @@ public final class EnumValues
     }
 
     /**
-     * @see EnumResolver#_enumConstants(Class) 
+     * Helper method <b>slightly</b> different from {@link EnumResolver#_enumConstants(Class)},
+     * with same method name to keep calling methods more consistent.
      */
     protected static Enum<?>[] _enumConstants(Class<?> enumCls) {
         final Enum<?>[] enumValues = ClassUtil.findEnumType(enumCls).getEnumConstants();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserMixin2787Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserMixin2787Test.java
@@ -68,6 +68,30 @@ public class EnumDeserMixin2787Test extends BaseMapTest {
         Enum2787 result = mapper.readValue(q("B_MIXIN_PROP"), Enum2787.class);
 
         assertEquals(Enum2787.ITEM_B, result);
+        
+        String value = mapper.writeValueAsString(EnumMixin2787.ITEM_B);
+    }
+
+    public void testEnumMixinRoundTripSerDeser() throws Exception {
+        // ser -> deser
+        ObjectMapper mapper = MAPPER.addMixIn(Enum2787.class, EnumMixin2787.class);
+        // from
+        String result = mapper.writeValueAsString(Enum2787.ITEM_B);
+        assertEquals(q("B_MIXIN_PROP"), result);
+        // to
+        Enum2787 result2 = mapper.readValue(result, Enum2787.class);
+        assertEquals(Enum2787.ITEM_B, result2);
+    }
+
+    public void testEnumMixinRoundTripDeserSer() throws Exception {
+        // deser -> ser
+        ObjectMapper mapper = MAPPER.addMixIn(Enum2787.class, EnumMixin2787.class);
+        // from
+        Enum2787 result = mapper.readValue(q("B_MIXIN_PROP"), Enum2787.class);
+        assertEquals(Enum2787.ITEM_B, result);
+        // to
+        String value = mapper.writeValueAsString(result);
+        assertEquals(q("B_MIXIN_PROP"), value);
     }
 
     public void testBeanMixin() throws Exception {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.deser.enums;
 
+import com.fasterxml.jackson.databind.module.TestTypeModifierNameResolution;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -91,6 +92,34 @@ public class EnumDeserializationTest
             }
         }
         ;
+    }
+
+    // [databind#677]
+    static enum EnumWithPropertyAnnoBase {
+        @JsonProperty("a") 
+        A,
+        // For this value, force use of anonymous sub-class, to ensure things still work
+        @JsonProperty("b")
+        B {
+            @Override
+            public String toString() {
+                return "bb";
+            }
+        }
+    }
+
+    // [databind#677]
+    static enum EnumWithPropertyAnnoMixin {
+        @JsonProperty("a_mixin")
+        A,
+        // For this value, force use of anonymous sub-class, to ensure things still work
+        @JsonProperty("b_mixin")
+        B {
+            @Override
+            public String toString() {
+                return "bb";
+            }
+        }
     }
 
     // [databind#1161]
@@ -510,6 +539,27 @@ public class EnumDeserializationTest
         assertEquals(2, result.length);
         assertSame(EnumWithPropertyAnno.B, result[0]);
         assertSame(EnumWithPropertyAnno.A, result[1]);
+    }
+
+    /**
+     * {@link #testEnumWithJsonPropertyRename()}
+     */
+    public void testEnumWithJsonPropertyRenameMixin() throws Exception
+    {
+        ObjectMapper mixinMapper = jsonMapperBuilder()
+                .addMixIn(EnumWithPropertyAnnoBase.class, EnumWithPropertyAnnoMixin.class)
+                .build();
+        String json = mixinMapper.writeValueAsString(new EnumWithPropertyAnnoBase[] {
+                EnumWithPropertyAnnoBase.B, EnumWithPropertyAnnoBase.A
+        });
+        assertEquals("[\"b_mixin\",\"a_mixin\"]", json);
+
+        // and while not really proper place, let's also verify deser while we're at it
+        EnumWithPropertyAnnoBase[] result = mixinMapper.readValue(json, EnumWithPropertyAnnoBase[].class);
+        assertNotNull(result);
+        assertEquals(2, result.length);
+        assertSame(EnumWithPropertyAnnoBase.B, result[0]);
+        assertSame(EnumWithPropertyAnnoBase.A, result[1]);
     }
 
     // [databind#1161], unable to switch READ_ENUMS_USING_TO_STRING

--- a/src/test/java/com/fasterxml/jackson/databind/ser/enums/EnumSerializationMixinTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/enums/EnumSerializationMixinTest.java
@@ -1,0 +1,76 @@
+package com.fasterxml.jackson.databind.ser.enums;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EnumSerializationMixinTest extends BaseMapTest 
+{
+
+    static enum EnumBaseA {
+        ITEM_A {
+            @Override
+            public String toString() {
+                return "A_base";
+            }
+        },
+
+        @JsonAlias({"B_ORIGIN_ALIAS_1", "B_ORIGIN_ALIAS_2"})
+        @JsonProperty("B_ORIGIN_PROP")
+        ITEM_B,
+
+        @JsonAlias({"C_ORIGIN_ALIAS"})
+        @JsonProperty("C_COMMON")
+        ITEM_C_BASE,
+        
+        ITEM_ORIGIN
+    }
+
+    static enum EnumMixinA {
+        ITEM_A {
+            @Override
+            public String toString() {
+                return "A_mixin";
+            }
+        },
+
+        @JsonProperty("B_MIXIN_PROP")
+        ITEM_B,
+
+        @JsonAlias({"C_MIXIN_ALIAS_1", "C_MIXIN_ALIAS_2"})
+        @JsonProperty("C_COMMON")
+        ITEM_C_MIXIN,
+
+        ITEM_MIXIN;
+
+        @Override
+        public String toString() {
+            return "SHOULD NOT USE WITH TO STRING";
+        }
+    }
+
+    public void testSerialization() throws Exception {
+        ObjectMapper mixinMapper = jsonMapperBuilder()
+                .addMixIn(EnumBaseA.class, EnumMixinA.class).build();
+
+        // equal name(), different toString() value
+        assertEquals(q("ITEM_A"), _w(EnumBaseA.ITEM_A, mixinMapper));
+        
+        // equal name(), differnt @JsonProperty
+        assertEquals(q("B_MIXIN_PROP"), _w(EnumBaseA.ITEM_B, mixinMapper));
+        
+        // different name(), equal @JsonProperty
+        assertEquals(q("C_COMMON"), _w(EnumBaseA.ITEM_C_BASE, mixinMapper));
+        
+        // different name(), equal ordinal()
+        assertEquals(q("ITEM_ORIGIN"), _w(EnumBaseA.ITEM_ORIGIN, mixinMapper));
+    }
+
+    /**
+     * Helper method to {@link ObjectMapper#writeValueAsString(Object)}
+     */
+    private <T> String _w(T value, ObjectMapper mapper) throws Exception {
+        return mapper.writeValueAsString(value);
+    }
+}


### PR DESCRIPTION
parent issue : #3990 

### Motivation

since #3832, `Enum` can be handled via `AnnotatedClass`, but the improvement was not included on the serialization part. This PR exactly does that.

### Modifications

- Deprecate `constructFromName(MapperConfig<?>, Class<Enum<?>>)` method.
- Implement `constructFromName(MapperConfig<?>, AnnotatedClass)` method.