### PR TITLE
Support for sorted trees

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/JsonNodeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/JsonNodeFactory.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.util.RawValue;
@@ -58,14 +57,14 @@ public class JsonNodeFactory
      * 
      * @since 2.16
      */
-    public static final Supplier<Map<String, JsonNode>> DEFAULT_OBJECT_NODE_CHILDREN_FACTORY = LinkedHashMap::new;
+    public static final SerializableSupplier<Map<String, JsonNode>> DEFAULT_OBJECT_NODE_CHILDREN_FACTORY = LinkedHashMap::new;
 
     /**
      * Factory for the {@link Map} to use for children of {@link ObjectNode} which sorts the entries by name.
      * 
      * @since 2.16
      */
-    public static final Supplier<Map<String, JsonNode>> SORTED_OBJECT_NODE_CHILDREN_FACTORY = TreeMap::new;
+    public static final SerializableSupplier<Map<String, JsonNode>> SORTED_OBJECT_NODE_CHILDREN_FACTORY = TreeMap::new;
 
     @Deprecated // as of 2.15
     private final boolean _cfgBigDecimalExact;
@@ -77,7 +76,7 @@ public class JsonNodeFactory
      *
      * @since 2.16
      */
-    private final Supplier<Map<String, JsonNode>> _objectNodeChildrenFactory;
+    private final SerializableSupplier<Map<String, JsonNode>> _objectNodeChildrenFactory;
     
     /**
      * Default singleton instance that construct "standard" node instances:
@@ -109,14 +108,14 @@ public class JsonNodeFactory
     /**
      * @since 2.16
      */
-    public JsonNodeFactory(Supplier<Map<String, JsonNode>> objectNodeChildrenFactory) {
+    public JsonNodeFactory(SerializableSupplier<Map<String, JsonNode>> objectNodeChildrenFactory) {
         this(false, objectNodeChildrenFactory);
     }
     
     /**
      * @since 2.16
      */
-    public JsonNodeFactory(boolean bigDecimalExact, Supplier<Map<String, JsonNode>> objectNodeChildrenFactory) {
+    public JsonNodeFactory(boolean bigDecimalExact, SerializableSupplier<Map<String, JsonNode>> objectNodeChildrenFactory) {
         _cfgBigDecimalExact = bigDecimalExact;
         _objectNodeChildrenFactory = objectNodeChildrenFactory;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -29,7 +29,7 @@ public class ObjectNode
 
     public ObjectNode(JsonNodeFactory nc) {
         super(nc);
-        _children = new LinkedHashMap<String, JsonNode>();
+        _children = nc == null ? JsonNodeFactory.DEFAULT_OBJECT_NODE_CHILDREN_FACTORY.get() : nc.objectNodeChildren();
     }
 
     /**
@@ -53,7 +53,7 @@ public class ObjectNode
     @Override
     public ObjectNode deepCopy()
     {
-        ObjectNode ret = new ObjectNode(_nodeFactory);
+        ObjectNode ret = objectNode();
 
         for (Map.Entry<String, JsonNode> entry: _children.entrySet())
             ret._children.put(entry.getKey(), entry.getValue().deepCopy());

--- a/src/main/java/com/fasterxml/jackson/databind/node/SerializableSupplier.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/SerializableSupplier.java
@@ -1,0 +1,8 @@
+package com.fasterxml.jackson.databind.node;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+public interface SerializableSupplier<T> extends Supplier<T>, Serializable {
+    // empty
+}

--- a/src/test/java/com/fasterxml/jackson/databind/BaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseTest.java
@@ -444,6 +444,10 @@ public abstract class BaseTest
     protected static String a2q(String json) {
         return json.replace("'", "\"");
     }
+    
+    protected static String q2a(String json) {
+        return json.replace("\"", "'");
+    }
 
     @Deprecated // use a2q
     protected static String aposToQuotes(String json) {

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectWriterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectWriterTest.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -35,6 +37,10 @@ public class ObjectWriterTest
 
     final ObjectMapper MAPPER = new ObjectMapper();
 
+    private final ObjectMapper SORTED_MAPPER = JsonMapper.builder()
+            .nodeFactory(new JsonNodeFactory(JsonNodeFactory.SORTED_OBJECT_NODE_CHILDREN_FACTORY))
+            .build();
+    
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
     static class PolyBase {
     }
@@ -118,6 +124,21 @@ public class ObjectWriterTest
         assertEquals(a2q("{'type':'A','value':3}"), json);
         json = writer.writeValueAsString(new ImplB(-5));
         assertEquals(a2q("{'type':'B','b':-5}"), json);
+    }
+    
+    public void testJsonTypeInfoWithSorting() throws Exception
+    {
+        assertSerialization("{'type':'A','value':3}", new ImplA(3), SORTED_MAPPER);
+    }
+    
+    public void testJsonTypeInfoWithSorting2() throws Exception
+    {
+        assertSerialization("{'b':-5,'type':'B'}", new ImplB(-5), SORTED_MAPPER);
+    }
+
+    private void assertSerialization(String expected, Object value, ObjectMapper mapper) throws Exception {
+        JsonNode json = mapper.valueToTree(value);
+        assertEquals(a2q(expected), mapper.writeValueAsString(json));
     }
 
     public void testCanSerialize() throws Exception


### PR DESCRIPTION
This patch moves the factory for `ObjectNode`'s children to the `JsonNodeFactory`.

Along with a new `deepCopy()` method in `JsonNodeFactory`, this allows to create sorted trees from the mapper or sort existing trees by copying them with a `JsonNodeFactory` where sorting is enabled.

There was a problem with `TestJDKSerialization` but that could be fixed very easily with just adding an interface which merges `Serializable` and `Supplier<T>`; Java then knows what to do.