### PR TITLE
Add new `TypeResolverBuilder.withSettings()` method to simplify `JsonTypeInfo` configuration

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -1995,7 +1995,7 @@ public class ObjectMapper
         // we'll always use full class name, when using defaulting
         JsonTypeInfo.Value typeInfo = JsonTypeInfo.Value.construct(JsonTypeInfo.Id.CLASS, includeAs,
                 null, null, false, null);
-        typer = typer.init(typeInfo, null);
+        typer = typer.withSettings(typeInfo);
         return setDefaultTyping(typer);
     }
 
@@ -2026,7 +2026,7 @@ public class ObjectMapper
         // we'll always use full class name, when using defaulting
         JsonTypeInfo.Value typeInfo = JsonTypeInfo.Value.construct(JsonTypeInfo.Id.CLASS, JsonTypeInfo.As.PROPERTY,
                 propertyName, null, false, null);
-        typer = typer.init(typeInfo, null);
+        typer = typer.withSettings(typeInfo);
         return setDefaultTyping(typer);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/TypeResolverBuilder.java
@@ -191,4 +191,11 @@ public interface TypeResolverBuilder<T extends TypeResolverBuilder<T>>
         //    possibly unsafe variant
         return defaultImpl(defaultImpl);
     }
+
+    /**
+     * Method for overriding type information.
+     * 
+     * @since 2.16
+     */
+    public T withSettings(JsonTypeInfo.Value typeInfo);
 }

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -96,15 +96,7 @@ public class StdTypeResolverBuilder
      */
     public StdTypeResolverBuilder(JsonTypeInfo.Value settings) {
         if (settings != null) {
-            _idType = settings.getIdType();
-            if (_idType == null) {
-                throw new IllegalArgumentException("idType cannot be null");
-            }
-            _includeAs = settings.getInclusionType();
-            _typeProperty = _propName(settings.getPropertyName(), _idType);
-            _defaultImpl = settings.getDefaultImpl();
-            _typeIdVisible = settings.getIdVisible();
-            _requireTypeIdForSubtypes = settings.getRequireTypeIdForSubtypes();
+            withSettings(settings);
         }
     }
 
@@ -121,7 +113,7 @@ public class StdTypeResolverBuilder
     public static StdTypeResolverBuilder noTypeInfoBuilder() {
         JsonTypeInfo.Value typeInfo = JsonTypeInfo.Value.construct(JsonTypeInfo.Id.NONE, null,
                 null, null, false, null);
-        return new StdTypeResolverBuilder().init(typeInfo, null);
+        return new StdTypeResolverBuilder().withSettings(typeInfo);
     }
 
     @Override
@@ -145,20 +137,7 @@ public class StdTypeResolverBuilder
         _customIdResolver = idRes;
 
         if (settings != null) {
-            _idType = settings.getIdType();
-            if (_idType == null) {
-                throw new IllegalArgumentException("idType cannot be null");
-            }
-            _includeAs = settings.getInclusionType();
-
-            // Let's also initialize property name as per idType default
-            _typeProperty = settings.getPropertyName();
-            if (_typeProperty == null) {
-                _typeProperty = _idType.getDefaultPropertyName();
-            }
-            _typeIdVisible = settings.getIdVisible();
-            _defaultImpl = settings.getDefaultImpl();
-            _requireTypeIdForSubtypes = settings.getRequireTypeIdForSubtypes();
+            withSettings(settings);
         }
         return this;
     }
@@ -350,6 +329,20 @@ public class StdTypeResolverBuilder
 
     public String getTypeProperty() { return _typeProperty; }
     public boolean isTypeIdVisible() { return _typeIdVisible; }
+    
+    @Override
+    public StdTypeResolverBuilder withSettings(JsonTypeInfo.Value settings) {
+        _idType = settings.getIdType();
+        if (_idType == null) {
+            throw new IllegalArgumentException("idType cannot be null");
+        }
+        _includeAs = settings.getInclusionType();
+        _typeProperty = _propName(settings.getPropertyName(), _idType);
+        _defaultImpl = settings.getDefaultImpl();
+        _typeIdVisible = settings.getIdVisible();
+        _requireTypeIdForSubtypes = settings.getRequireTypeIdForSubtypes();
+        return this;
+    }
 
     /*
     /**********************************************************


### PR DESCRIPTION
as suggested by https://github.com/FasterXML/jackson-databind/pull/3959#discussion_r1233416629