### PR TITLE
Add `JsonNodeFeature.WRITE_PROPERTIES_SORTED` for sorting `ObjectNode` properties on serialization

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -23,6 +23,8 @@ Project: jackson-databind
 #3950: Create new `JavaType` subtype `IterationType` (extending `SimpleType`)
 #3953: Use `JsonTypeInfo.Value` for annotation handling
  (contributed by Joo-Hyuk K)
+#3965: Add `JsonNodeFeature.WRITE_PROPERTIES_SORTED` for sorting `ObjectNode` properties
+  on serialization
 
 2.15.3 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/JsonNodeFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/JsonNodeFeature.java
@@ -27,6 +27,19 @@ public enum JsonNodeFeature implements DatatypeFeature
      */
     WRITE_NULL_PROPERTIES(true),
 
+    /**
+     * When writing {@code com.fasterxml.jackson.databind.JsonNode}s are Object properties
+     * (for {@code ObjectNode}s) sorted alphabetically (using natural order of
+     * {@link java.lang.String}) or not?
+     * If not sorted, order is the insertion order; when reading this also means retaining
+     * order from the input document.
+     *<p>
+     * Default value: {@code false}
+     *
+     * @since 2.16
+     */
+    WRITE_PROPERTIES_SORTED(false),
+
     // // // Merge configuration settings
 
     // // // 03-Aug-2022, tatu: Possible other additions:

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -430,7 +430,7 @@ public class ObjectNode
             }
         }
         g.writeStartObject(this);
-        for (Map.Entry<String, JsonNode> en : _children.entrySet()) {
+        for (Map.Entry<String, JsonNode> en : _contentsToSerialize(provider).entrySet()) {
             JsonNode value = en.getValue();
             g.writeFieldName(en.getKey());
             value.serialize(g, provider);
@@ -457,7 +457,7 @@ public class ObjectNode
         if (trimEmptyArray || skipNulls) {
             serializeFilteredContents(g, provider, trimEmptyArray, skipNulls);
         } else {
-            for (Map.Entry<String, JsonNode> en : _children.entrySet()) {
+            for (Map.Entry<String, JsonNode> en : _contentsToSerialize(provider).entrySet()) {
                 JsonNode value = en.getValue();
                 g.writeFieldName(en.getKey());
                 value.serialize(g, provider);
@@ -476,7 +476,7 @@ public class ObjectNode
             final boolean trimEmptyArray, final boolean skipNulls)
         throws IOException
     {
-        for (Map.Entry<String, JsonNode> en : _children.entrySet()) {
+        for (Map.Entry<String, JsonNode> en : _contentsToSerialize(provider).entrySet()) {
             // 17-Feb-2009, tatu: Can we trust that all nodes will always
             //   extend BaseJsonNode? Or if not, at least implement
             //   JsonSerializable? Let's start with former, change if
@@ -495,6 +495,21 @@ public class ObjectNode
             g.writeFieldName(en.getKey());
             value.serialize(g, provider);
         }
+    }
+
+    /**
+     * Helper method for encapsulating details of accessing child node entries
+     * to serialize.
+     *
+     * @since 2.16
+     */
+    protected Map<String, JsonNode> _contentsToSerialize(SerializerProvider ctxt) {
+        if (ctxt.isEnabled(JsonNodeFeature.WRITE_PROPERTIES_SORTED)) {
+            if (!_children.isEmpty()) {
+                return new TreeMap<>(_children);
+            }
+        }
+        return _children;
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/databind/node/NodeFeaturesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NodeFeaturesTest.java
@@ -56,7 +56,7 @@ public class NodeFeaturesTest extends BaseMapTest
 
     /*
     /**********************************************************************
-    /* ObjectNode property handling
+    /* ObjectNode property handling: null-handling
     /**********************************************************************
      */
 
@@ -107,6 +107,31 @@ public class NodeFeaturesTest extends BaseMapTest
         doc.putNull("b");
         doc.put("c", true);
         assertEquals(a2q("{'a':1,'c':true}"), w.writeValueAsString(doc));
+    }
+
+    /*
+    /**********************************************************************
+    /* ObjectNode property handling: sorting on write
+    /**********************************************************************
+     */
+
+    // [databind#3476]
+    public void testWriteSortedProperties() throws Exception
+    {
+        assertFalse(WRITER.isEnabled(JsonNodeFeature.WRITE_PROPERTIES_SORTED));
+
+        ObjectNode doc = MAPPER.createObjectNode();
+        doc.put("b", 2);
+        doc.put("c", 3);
+        doc.put("a", 1);
+
+        // by default, retain insertion order:
+        assertEquals(a2q("{'b':2,'c':3,'a':1}"), WRITER.writeValueAsString(doc));
+
+        // but if forcing sorting, changes
+        ObjectWriter w2 = WRITER.with(JsonNodeFeature.WRITE_PROPERTIES_SORTED);
+        assertTrue(w2.isEnabled(JsonNodeFeature.WRITE_PROPERTIES_SORTED));
+        assertEquals(a2q("{'a':1,'b':2,'c':3}"), w2.writeValueAsString(doc));
     }
 
     /*


### PR DESCRIPTION
Fixes #3965 