### PR TITLE
Implement new `EnumResolver.constructUsingToString(DeserializationConfig, AnnotatedClass)` instead of `(DeserializationConfig, Class<?>)`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1713,7 +1713,9 @@ factory.toString()));
             if (deser == null) {
                 deser = new EnumDeserializer(constructEnumResolver(enumClass, config, beanDesc),
                         config.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS),
-                        constructEnumNamingStrategyResolver(config, enumClass, beanDesc.getClassInfo())
+                        constructEnumNamingStrategyResolver(config, enumClass, beanDesc.getClassInfo()),
+                        // since 2.16
+                        EnumResolver.constructUsingToString(config, beanDesc.getClassInfo())
                 );
             }
         }
@@ -1922,6 +1924,7 @@ factory.toString()));
         }
         EnumResolver enumRes = constructEnumResolver(enumClass, config, beanDesc);
         EnumResolver byEnumNamingResolver = constructEnumNamingStrategyResolver(config, enumClass, beanDesc.getClassInfo());
+        EnumResolver byToStringResolver = EnumResolver.constructUsingToString(config, beanDesc.getClassInfo());
 
         // May have @JsonCreator for static factory method
         for (AnnotatedMethod factory : beanDesc.getFactoryMethods()) {
@@ -1943,7 +1946,7 @@ factory.toString()));
                             ClassUtil.checkAndFixAccess(factory.getMember(),
                                     ctxt.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
                         }
-                        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, factory, byEnumNamingResolver);
+                        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, factory, byEnumNamingResolver, byToStringResolver);
                     }
                 }
                 throw new IllegalArgumentException("Unsuitable method ("+factory+") decorated with @JsonCreator (for Enum type "
@@ -1951,7 +1954,7 @@ factory.toString()));
             }
         }
         // Also, need to consider @JsonValue, if one found
-        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, byEnumNamingResolver);
+        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, byEnumNamingResolver, byToStringResolver);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -47,6 +47,8 @@ public class EnumDeserializer
     /**
      * Alternatively, we may need a different lookup object if "use toString"
      * is defined.
+     * <p>
+     * Note: this will be final in Jackson 3.x, by removing deprecated {@link #_getToStringLookup(DeserializationContext)}
      *
      * @since 2.7.3
      */
@@ -76,14 +78,16 @@ public class EnumDeserializer
 
     /**
      * @since 2.9
+     * @deprecated since 2.16
      */
     public EnumDeserializer(EnumResolver byNameResolver, Boolean caseInsensitive)
     {
-        this(byNameResolver, caseInsensitive, null);
+        this(byNameResolver, caseInsensitive, null, null);
     }
 
     /**
      * @since 2.15
+     * @deprecated since 2.16
      */
     public EnumDeserializer(EnumResolver byNameResolver, boolean caseInsensitive,
                             EnumResolver byEnumNamingResolver)
@@ -95,6 +99,23 @@ public class EnumDeserializer
         _caseInsensitive = caseInsensitive;
         _isFromIntValue = byNameResolver.isFromIntValue();
         _lookupByEnumNaming = byEnumNamingResolver == null ? null : byEnumNamingResolver.constructLookup();
+        _lookupByToString = null;
+    }
+
+    /**
+     * @since 2.16
+     */
+    public EnumDeserializer(EnumResolver byNameResolver, boolean caseInsensitive,
+                            EnumResolver byEnumNamingResolver, EnumResolver toStringResolver)
+    {
+        super(byNameResolver.getEnumClass());
+        _lookupByName = byNameResolver.constructLookup();
+        _enumsByIndex = byNameResolver.getRawEnums();
+        _enumDefaultValue = byNameResolver.getDefaultValue();
+        _caseInsensitive = caseInsensitive;
+        _isFromIntValue = byNameResolver.isFromIntValue();
+        _lookupByEnumNaming = byEnumNamingResolver == null ? null : byEnumNamingResolver.constructLookup();
+        _lookupByToString = toStringResolver == null ? null : toStringResolver.constructLookup();
     }
 
     /**
@@ -112,6 +133,7 @@ public class EnumDeserializer
         _useDefaultValueForUnknownEnum = useDefaultValueForUnknownEnum;
         _useNullForUnknownEnum = useNullForUnknownEnum;
         _lookupByEnumNaming = base._lookupByEnumNaming;
+        _lookupByToString = base._lookupByToString;
     }
 
     /**
@@ -430,6 +452,13 @@ public class EnumDeserializer
         return handledType();
     }
 
+    /**
+     * Since 2.16, {@link #_lookupByToString} it is passed via 
+     * {@link #EnumDeserializer(EnumResolver, boolean, EnumResolver, EnumResolver)}, so there is no need for lazy
+     * initialization. But kept for backward-compatilibility reasons. In case {@link #_lookupByToString} is null.
+     *
+     * @deprecated Since 2.16
+     */
     protected CompactStringObjectMap _getToStringLookup(DeserializationContext ctxt) {
         CompactStringObjectMap lookup = _lookupByToString;
         if (lookup == null) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -366,7 +366,9 @@ public class StdKeyDeserializer extends KeyDeserializer
         /**
          * Lazily constructed alternative in case there is need to
          * use 'toString()' method as the source.
-         *
+         * <p>
+         * Note: this will be final in Jackson 3.x, by removing deprecated {@link #_getToStringResolver(DeserializationContext)}
+         * 
          * @since 2.7.3
          */
         protected volatile EnumResolver _byToStringResolver;
@@ -396,10 +398,12 @@ public class StdKeyDeserializer extends KeyDeserializer
             _factory = factory;
             _enumDefaultValue = er.getDefaultValue();
             _byEnumNamingResolver = null;
+            _byToStringResolver = null;
         }
 
         /**
          * @since 2.15
+         * @deprecated Since 2.16
          */
         protected EnumKD(EnumResolver er, AnnotatedMethod factory, EnumResolver byEnumNamingResolver) {
             super(-1, er.getEnumClass());
@@ -407,7 +411,23 @@ public class StdKeyDeserializer extends KeyDeserializer
             _factory = factory;
             _enumDefaultValue = er.getDefaultValue();
             _byEnumNamingResolver = byEnumNamingResolver;
+            _byToStringResolver = null;
         }
+
+        /**
+         * 
+         * @since 2.16
+         */
+        protected EnumKD(EnumResolver er, AnnotatedMethod factory, EnumResolver byEnumNamingResolver, 
+                         EnumResolver byToStringResolver) {
+            super(-1, er.getEnumClass());
+            _byNameResolver = er;
+            _factory = factory;
+            _enumDefaultValue = er.getDefaultValue();
+            _byEnumNamingResolver = byEnumNamingResolver;
+            _byToStringResolver = byToStringResolver;
+        }
+        
 
         @Override
         public Object _parse(String key, DeserializationContext ctxt) throws IOException
@@ -451,7 +471,14 @@ public class StdKeyDeserializer extends KeyDeserializer
                 ? _getToStringResolver(ctxt)
                 : _byNameResolver;
         }
-
+        
+        /**
+         * Since 2.16, {@link #_byToStringResolver} it is passed via 
+         * {@link #EnumKD(EnumResolver, AnnotatedMethod, EnumResolver, EnumResolver)}, so there is no need for lazy
+         * initialization. But kept for backward-compatilibility reasons.
+         * 
+         * @deprecated Since 2.16
+         */
         private EnumResolver _getToStringResolver(DeserializationContext ctxt)
         {
             EnumResolver res = _byToStringResolver;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -46,6 +46,7 @@ public class StdKeyDeserializers
 
     /**
      * @since 2.15
+     * @deprecated use {@link #constructEnumKeyDeserializer(EnumResolver, EnumResolver, EnumResolver)} instead.
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumResolver,
                                                                EnumResolver enumNamingResolver) {
@@ -53,11 +54,27 @@ public class StdKeyDeserializers
     }
 
     /**
+     * @since 2.16
+     */
+    public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, EnumResolver byToStringResolver) {
+        return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver);
+    }
+
+    /**
      * @since 2.15
+     * @deprecated use {@link #constructEnumKeyDeserializer(EnumResolver, AnnotatedMethod, EnumResolver, EnumResolver)} instead.
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumResolver,
                                             AnnotatedMethod factory, EnumResolver enumNamingResolver) {
         return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver);
+    }
+
+    /**
+     * @since 2.16
+     */
+    public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumResolver, AnnotatedMethod factory, 
+            EnumResolver enumNamingResolver, EnumResolver byToStringResolver) {
+        return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver, byToStringResolver);
     }
 
     public static KeyDeserializer constructDelegatingKeyDeserializer(DeserializationConfig config,

--- a/src/test/java/com/fasterxml/jackson/databind/util/EnumValuesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/EnumValuesTest.java
@@ -66,6 +66,21 @@ public class EnumValuesTest extends BaseMapTest
         assertEquals(ABC.C, enums.get(2));
     }
 
+    public void testEnumResolverNew()
+    {
+        AnnotatedClass annotatedClass = resolve(MAPPER, ABC.class);
+        EnumResolver enumRes = EnumResolver.constructUsingToString(MAPPER.getDeserializationConfig(), annotatedClass);
+        assertEquals(ABC.B, enumRes.getEnum(1));
+        assertNull(enumRes.getEnum(-1));
+        assertNull(enumRes.getEnum(3));
+        assertEquals(2, enumRes.lastValidIndex());
+        List<Enum<?>> enums = enumRes.getEnums();
+        assertEquals(3, enums.size());
+        assertEquals(ABC.A, enums.get(0));
+        assertEquals(ABC.B, enums.get(1));
+        assertEquals(ABC.C, enums.get(2));
+    }
+
     // [databind#3053]
     public void testConstructFromNameLowerCased() {
         SerializationConfig cfg = MAPPER.getSerializationConfig()


### PR DESCRIPTION
parent issue : #3990 

### Note

This PR might have been called as... "Deprecate lazy initialization of `EnumResolver _byToStringResolver` in EnumDeserializers" -- I was 50/50 on this.

### Motivation

This PR will...

1. Effectively remove the last usage of deprecated `AnnotationIntrospector.findEnumAliases(Class<?>, Enum<?>[], String[][])`
2. Deprecate unncessary locking in `_getToStringLookup`

### Modifications

- Initialize  `EnumResolver _byToStringResolver` during construction, not lazily.
- Deprecate old `EnumResolver.constructUsingToString(DeserializationConfig, Class<?>)`
- Implement new `EnumResolver.constructUsingToString(DeserializationConfig, AnnotatedClass)`