### PR TITLE
Improve handling of `@JsonEnumDefaultValue` via `AnnotatedClass`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -1182,9 +1182,10 @@ public abstract class AnnotationIntrospector
     }
 
     /**
-     * Finds the Enum value that should be considered the default value, if possible.
+     * Finds the first Enum value that should be considered as default value 
+     * for unknown Enum values, if present.
      * <p>
-     * This implementation relies on {@link JsonEnumDefaultValue} annotation to determine the default value if present.
+     * Note that this implementation directly relies on {@link JsonEnumDefaultValue} annotation.
      *
      * @param annotatedClass The Enum class to scan for the default value.
      * @param enumValues     The Enum values of the Enum class.

--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -1174,8 +1174,24 @@ public abstract class AnnotationIntrospector
      * @return null if none found or it's not possible to determine one
      *
      * @since 2.8
+     * @deprecated Since 2.16. Use {@link #findDefaultEnumValue(AnnotatedClass, Enum[])} instead.
      */
+    @Deprecated
     public Enum<?> findDefaultEnumValue(Class<Enum<?>> enumCls) {
+        return null;
+    }
+
+    /**
+     * Finds the Enum value that should be considered the default value, if possible.
+     * <p>
+     * This implementation relies on {@link JsonEnumDefaultValue} annotation to determine the default value if present.
+     *
+     * @param annotatedClass The Enum class to scan for the default value.
+     * @param enumValues     The Enum values of the Enum class.
+     * @return null if none found or it's not possible to determine one.
+     * @since 2.16
+     */
+    public Enum<?> findDefaultEnumValue(AnnotatedClass annotatedClass, Enum<?>[] enumValues) {
         return null;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotationIntrospectorPair.java
@@ -652,9 +652,16 @@ public class AnnotationIntrospectorPair
     }
 
     @Override
+    @Deprecated // since 2.16
     public Enum<?> findDefaultEnumValue(Class<Enum<?>> enumCls) {
         Enum<?> en = _primary.findDefaultEnumValue(enumCls);
         return (en == null) ? _secondary.findDefaultEnumValue(enumCls) : en;
+    }
+    
+    @Override // since 2.16
+    public Enum<?> findDefaultEnumValue(AnnotatedClass annotatedClass, Enum<?>[] enumValues) {
+        Enum<?> en = _primary.findDefaultEnumValue(annotatedClass, enumValues);
+        return (en == null) ? _secondary.findDefaultEnumValue(annotatedClass, enumValues) : en;
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -323,6 +323,27 @@ public class JacksonAnnotationIntrospector
     public Enum<?> findDefaultEnumValue(Class<Enum<?>> enumCls) {
         return ClassUtil.findFirstAnnotatedEnumValue(enumCls, JsonEnumDefaultValue.class);
     }
+    
+    @Override // since 2.16
+    public Enum<?> findDefaultEnumValue(AnnotatedClass annotatedClass, Enum<?>[] enumValues) {
+        // find first annotation
+        for (Annotated field : annotatedClass.fields()) {
+            if (!field.getType().isEnumType()) {
+                continue;
+            }
+            JsonEnumDefaultValue found = _findAnnotation(field, JsonEnumDefaultValue.class);
+            if (found == null) {
+                continue;
+            }
+            // Return the "first" enum with annotation
+            for (Enum<?> enumValue : enumValues) {
+                if (enumValue.name().equals(field.getName())) {
+                    return enumValue;
+                }
+            }
+        }
+        return null;
+    }
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -326,7 +326,6 @@ public class JacksonAnnotationIntrospector
     
     @Override // since 2.16
     public Enum<?> findDefaultEnumValue(AnnotatedClass annotatedClass, Enum<?>[] enumValues) {
-        // find first annotation
         for (Annotated field : annotatedClass.fields()) {
             if (!field.getType().isEnumType()) {
                 continue;

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -129,6 +129,7 @@ public class EnumResolver implements java.io.Serializable
         final Class<?> enumCls0 = annotatedClass.getRawType();
         final Class<Enum<?>> enumCls = _enumClass(enumCls0);
         final Enum<?>[] enumConstants = _enumConstants(enumCls0);
+        final Enum<?> defaultEnum = _enumDefault(ai, annotatedClass, enumConstants);
 
         // introspect
         String[] names = ai.findEnumValues(config, annotatedClass,
@@ -154,7 +155,7 @@ public class EnumResolver implements java.io.Serializable
             }
         }
         return new EnumResolver(enumCls, enumConstants, map,
-            _enumDefault(ai, enumCls), isIgnoreCase, false);
+                defaultEnum, isIgnoreCase, false);
     }
 
     /**
@@ -207,6 +208,7 @@ public class EnumResolver implements java.io.Serializable
         final Class<?> enumCls0 = annotatedClass.getRawType();
         final Class<Enum<?>> enumCls = _enumClass(enumCls0);
         final Enum<?>[] enumConstants = _enumConstants(enumCls0);
+        final Enum<?> defaultEnum = _enumDefault(ai, annotatedClass, enumConstants);
 
         // introspect
         final String[][] allAliases = new String[enumConstants.length][];
@@ -229,7 +231,7 @@ public class EnumResolver implements java.io.Serializable
             }
         }
         return new EnumResolver(enumCls, enumConstants, map,
-                _enumDefault(ai, enumCls), isIgnoreCase, false);
+                defaultEnum, isIgnoreCase, false);
     }
 
     /**
@@ -345,8 +347,22 @@ public class EnumResolver implements java.io.Serializable
         return enumValues;
     }
 
+    /**
+     * @deprecated Since 2.16. Use {@link #_enumDefault(AnnotationIntrospector, AnnotatedClass, Enum[])} instead.
+     */
+    @Deprecated
     protected static Enum<?> _enumDefault(AnnotationIntrospector intr, Class<?> enumCls) {
         return (intr != null) ? intr.findDefaultEnumValue(_enumClass(enumCls)) : null;
+    }
+
+    /**
+     * Internal helper method used to resolve {@link com.fasterxml.jackson.annotation.JsonEnumDefaultValue}
+     * 
+     * @since 2.16
+     * @see AnnotationIntrospector#findDefaultEnumValue(AnnotatedClass, Enum[]) 
+     */
+    protected static Enum<?> _enumDefault(AnnotationIntrospector intr, AnnotatedClass annotatedClass, Enum<?>[] enums) {
+        return (intr != null) ? intr.findDefaultEnumValue(annotatedClass, enums) : null;
     }
 
     protected static boolean _isIntType(Class<?> erasedType) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDefaultReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDefaultReadTest.java
@@ -54,12 +54,27 @@ public class EnumDefaultReadTest extends BaseMapTest
     }
     
     enum BaseEnumDefault {
-        A, B, C,
-        Z;
+        A, B, C, Z;
     }
 
     enum MixinEnumDefault {
         A, B, C,
+        @JsonEnumDefaultValue
+        Z;
+    }
+
+    enum BaseOverloaded {
+        A, B, C,
+        Z;
+    }
+
+    enum MixinOverloadedDefault {
+        @JsonEnumDefaultValue
+        A,
+        @JsonEnumDefaultValue
+        B,
+        @JsonEnumDefaultValue
+        C,
         @JsonEnumDefaultValue
         Z;
     }
@@ -259,19 +274,25 @@ public class EnumDefaultReadTest extends BaseMapTest
         }
     }
     
-    public void testEnumDefaultValueViaMixin() throws Exception {
-        try {
-            MAPPER.readValue(q("UNKNOWN"),  BaseEnumDefault.class);
-            fail("Should not pass");
-        } catch (InvalidFormatException e) {
-            verifyException(e, "Cannot deserialize value of type");
-            verifyException(e, "\"UNKNOWN\": not one of the values accepted for Enum class: [A, B, C, Z]");
-        }
-        
+    public void testEnumDefaultValueViaMixin() throws Exception 
+    {
         ObjectMapper mixinMapper = jsonMapperBuilder()
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
                 .addMixIn(BaseEnumDefault.class, MixinEnumDefault.class)
                 .build();
-        BaseEnumDefault defaultEnum = mixinMapper.readValue(q("UNKNOWN"), BaseEnumDefault.class);
-        assertEquals(BaseEnumDefault.Z, defaultEnum);
+        
+        assertEquals(BaseEnumDefault.Z, 
+                mixinMapper.readValue(q("UNKNOWN"), BaseEnumDefault.class));
+    }
+    
+    public void testFirstEnumDefaultValueViaMixin() throws Exception 
+    {
+        ObjectMapper mixinMapper = jsonMapperBuilder()
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .addMixIn(BaseOverloaded.class, MixinOverloadedDefault.class)
+                .build();
+        
+        assertEquals(BaseOverloaded.A, 
+                mixinMapper.readValue(q("UNKNOWN"), BaseOverloaded.class));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDefaultReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDefaultReadTest.java
@@ -52,6 +52,17 @@ public class EnumDefaultReadTest extends BaseMapTest
             return this.number;
         }
     }
+    
+    enum BaseEnumDefault {
+        A, B, C,
+        Z;
+    }
+
+    enum MixinEnumDefault {
+        A, B, C,
+        @JsonEnumDefaultValue
+        Z;
+    }
 
     /*
     /**********************************************************
@@ -246,5 +257,21 @@ public class EnumDefaultReadTest extends BaseMapTest
             verifyException(e, "Cannot deserialize value of type");
             /* Expected. */
         }
+    }
+    
+    public void testEnumDefaultValueViaMixin() throws Exception {
+        try {
+            MAPPER.readValue(q("UNKNOWN"),  BaseEnumDefault.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "Cannot deserialize value of type");
+            verifyException(e, "\"UNKNOWN\": not one of the values accepted for Enum class: [A, B, C, Z]");
+        }
+        
+        ObjectMapper mixinMapper = jsonMapperBuilder()
+                .addMixIn(BaseEnumDefault.class, MixinEnumDefault.class)
+                .build();
+        BaseEnumDefault defaultEnum = mixinMapper.readValue(q("UNKNOWN"), BaseEnumDefault.class);
+        assertEquals(BaseEnumDefault.Z, defaultEnum);
     }
 }


### PR DESCRIPTION
parent issue : #3990

## Motivation

Currently, `@JsonEnumDefaultValue` is internally introspected via

```java
ClassUtil.findFirstAnnotatedEnumValue(Class<Enum<?>>, JsonEnumDefaultValue.class);
```
... which does not allow mixins.

## Note

Some non-deprecated `EnumResolver` construction methods still use the old

```java
_enumDefault(AnnotationIntrospector intr, Class<?> enumCls)
```
... method namely

- `EnumResolver.constructUsingIndex()`
- `EnumResolver.constructUsingMethod()`
- `EnumResolver.constructUsingEnumNamingStrategy()`

If this PR is accepted (=merged), can we discuss how we should approach the rest of them?