### PR TITLE
Implement new `EnumResolver.constructUsingIndex()` via `AnnotatedClass` instead of `Class<?>`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1947,8 +1947,7 @@ factory.toString()));
                             ClassUtil.checkAndFixAccess(factory.getMember(),
                                     ctxt.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
                         }
-                        return StdKeyDeserializers.constructEnumKeyDeserializer(
-                                enumRes, factory, byEnumNamingResolver, byToStringResolver, byIndexResolver);
+                        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, factory, byEnumNamingResolver, byToStringResolver, byIndexResolver);
                     }
                 }
                 throw new IllegalArgumentException("Unsuitable method ("+factory+") decorated with @JsonCreator (for Enum type "
@@ -1956,8 +1955,7 @@ factory.toString()));
             }
         }
         // Also, need to consider @JsonValue, if one found
-        return StdKeyDeserializers.constructEnumKeyDeserializer(
-                enumRes, byEnumNamingResolver, byToStringResolver, byIndexResolver);
+        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, byEnumNamingResolver, byToStringResolver, byIndexResolver);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1925,6 +1925,7 @@ factory.toString()));
         EnumResolver enumRes = constructEnumResolver(enumClass, config, beanDesc);
         EnumResolver byEnumNamingResolver = constructEnumNamingStrategyResolver(config, enumClass, beanDesc.getClassInfo());
         EnumResolver byToStringResolver = EnumResolver.constructUsingToString(config, beanDesc.getClassInfo());
+        EnumResolver byIndexResolver = EnumResolver.constructUsingIndex(config, beanDesc.getClassInfo());
 
         // May have @JsonCreator for static factory method
         for (AnnotatedMethod factory : beanDesc.getFactoryMethods()) {
@@ -1946,7 +1947,8 @@ factory.toString()));
                             ClassUtil.checkAndFixAccess(factory.getMember(),
                                     ctxt.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
                         }
-                        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, factory, byEnumNamingResolver, byToStringResolver);
+                        return StdKeyDeserializers.constructEnumKeyDeserializer(
+                                enumRes, factory, byEnumNamingResolver, byToStringResolver, byIndexResolver);
                     }
                 }
                 throw new IllegalArgumentException("Unsuitable method ("+factory+") decorated with @JsonCreator (for Enum type "
@@ -1954,7 +1956,8 @@ factory.toString()));
             }
         }
         // Also, need to consider @JsonValue, if one found
-        return StdKeyDeserializers.constructEnumKeyDeserializer(enumRes, byEnumNamingResolver, byToStringResolver);
+        return StdKeyDeserializers.constructEnumKeyDeserializer(
+                enumRes, byEnumNamingResolver, byToStringResolver, byIndexResolver);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -406,13 +406,14 @@ public class StdKeyDeserializer extends KeyDeserializer
          * @since 2.16
          */
         protected EnumKD(EnumResolver er, AnnotatedMethod factory, EnumResolver byEnumNamingResolver, 
-                         EnumResolver byToStringResolver) {
+                         EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
             super(-1, er.getEnumClass());
             _byNameResolver = er;
             _factory = factory;
             _enumDefaultValue = er.getDefaultValue();
             _byEnumNamingResolver = byEnumNamingResolver;
             _byToStringResolver = byToStringResolver;
+            _byIndexResolver = byIndexResolver;
         }
         
 
@@ -461,7 +462,7 @@ public class StdKeyDeserializer extends KeyDeserializer
         
         /**
          * Since 2.16, {@link #_byToStringResolver} it is passed via 
-         * {@link #EnumKD(EnumResolver, AnnotatedMethod, EnumResolver, EnumResolver)}, so there is no need for lazy
+         * {@link #EnumKD(EnumResolver, AnnotatedMethod, EnumResolver, EnumResolver, EnumResolver)}, so there is no need for lazy
          * initialization. But kept for backward-compatilibility reasons.
          * 
          * @deprecated Since 2.16
@@ -483,6 +484,14 @@ public class StdKeyDeserializer extends KeyDeserializer
             return res;
         }
 
+        /**
+         * Since 2.16, {@link #_byIndexResolver} it is passed via 
+         * {@link #EnumKD(EnumResolver, AnnotatedMethod, EnumResolver, EnumResolver, EnumResolver)}, so there is no need for lazy
+         * initialization. But kept for backward-compatilibility reasons.
+         *
+         * @deprecated Since 2.16
+         */
+        @Deprecated
         private EnumResolver _getIndexResolver(DeserializationContext ctxt) {
             EnumResolver res = _byIndexResolver;
             if (res == null) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -48,7 +48,8 @@ public class StdKeyDeserializers
      * @since 2.16
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, 
-            EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
+            EnumResolver byToStringResolver, EnumResolver byIndexResolver) 
+    {
         return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver, byIndexResolver);
     }
 
@@ -56,7 +57,8 @@ public class StdKeyDeserializers
      * @since 2.16
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumResolver, AnnotatedMethod factory, 
-            EnumResolver enumNamingResolver, EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
+            EnumResolver enumNamingResolver, EnumResolver byToStringResolver, EnumResolver byIndexResolver) 
+    {
         return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver, byToStringResolver, byIndexResolver);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -47,16 +47,19 @@ public class StdKeyDeserializers
     /**
      * @since 2.16
      */
-    public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, EnumResolver byToStringResolver) {
-        return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver);
+    public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, 
+            EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
+        return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver, 
+                                            byIndexResolver);
     }
 
     /**
      * @since 2.16
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumResolver, AnnotatedMethod factory, 
-            EnumResolver enumNamingResolver, EnumResolver byToStringResolver) {
-        return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver, byToStringResolver);
+            EnumResolver enumNamingResolver, EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
+        return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver, byToStringResolver,
+                                            byIndexResolver);
     }
 
     public static KeyDeserializer constructDelegatingKeyDeserializer(DeserializationConfig config,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -49,8 +49,7 @@ public class StdKeyDeserializers
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, 
             EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
-        return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver, 
-                                            byIndexResolver);
+        return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver, byIndexResolver);
     }
 
     /**
@@ -58,8 +57,7 @@ public class StdKeyDeserializers
      */
     public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumResolver, AnnotatedMethod factory, 
             EnumResolver enumNamingResolver, EnumResolver byToStringResolver, EnumResolver byIndexResolver) {
-        return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver, byToStringResolver,
-                                            byIndexResolver);
+        return new StdKeyDeserializer.EnumKD(enumResolver, factory, enumNamingResolver, byToStringResolver, byIndexResolver);
     }
 
     public static KeyDeserializer constructDelegatingKeyDeserializer(DeserializationConfig config,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializers.java
@@ -47,8 +47,8 @@ public class StdKeyDeserializers
     /**
      * @since 2.16
      */
-    public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, 
-            EnumResolver byToStringResolver, EnumResolver byIndexResolver) 
+    public static KeyDeserializer constructEnumKeyDeserializer(EnumResolver enumRes, EnumResolver byEnumNamingResolver, EnumResolver byToStringResolver, 
+        EnumResolver byIndexResolver) 
     {
         return new StdKeyDeserializer.EnumKD(enumRes, null, byEnumNamingResolver, byToStringResolver, byIndexResolver);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -239,7 +239,9 @@ public class EnumResolver implements java.io.Serializable
      * Enum value
      *
      * @since 2.15
+     * @deprecated Since 2.16. Use {@link #constructUsingIndex(DeserializationConfig, AnnotatedClass)} instead.
      */
+    @Deprecated
     public static EnumResolver constructUsingIndex(DeserializationConfig config,
             Class<Enum<?>> enumCls0)
     {
@@ -256,6 +258,33 @@ public class EnumResolver implements java.io.Serializable
         }
         return new EnumResolver(enumCls, enumConstants, map,
             _enumDefault(ai, enumCls), isIgnoreCase, false);
+    }
+
+    /**
+     * Factory method for constructing resolver that maps from index of Enum.values() into
+     * Enum value.
+     *
+     * @since 2.16
+     */
+    public static EnumResolver constructUsingIndex(DeserializationConfig config, AnnotatedClass annotatedClass) 
+    {
+        // prepare data
+        final AnnotationIntrospector ai = config.getAnnotationIntrospector();
+        final boolean isIgnoreCase = config.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        final Class<?> enumCls0 = annotatedClass.getRawType();
+        final Class<Enum<?>> enumCls = _enumClass(enumCls0);
+        final Enum<?>[] enumConstants = _enumConstants(enumCls0);
+        final Enum<?> defaultEnum = _enumDefault(ai, annotatedClass, enumConstants);
+
+        // finally, build
+        // from last to first, so that in case of duplicate values, first wins
+        HashMap<String, Enum<?>> map = new HashMap<>();
+        for (int i = enumConstants.length; --i >= 0; ) {
+            Enum<?> enumValue = enumConstants[i];
+            map.put(String.valueOf(i), enumValue);
+        }
+        return new EnumResolver(enumCls, enumConstants, map,
+                defaultEnum, isIgnoreCase, false);
     }
 
     /**


### PR DESCRIPTION
parent issue : #3990

## Motivation
- Follow up of #4025
- This PR will effectively make implementions inside `EnumResolver` look more the same
- Retrofit the new `AnnotationIntrospector.findDefaultEnumValue(AnnotatedClass, Enum<?>[])`.

## Modification
- Same as motivation