### PR TITLE
Implement new `EnumResolver.constructUsingMethod()` via `AnnotatedClass` instead of `Class<?>`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -2429,7 +2429,7 @@ factory.toString()));
                 ClassUtil.checkAndFixAccess(jvAcc.getMember(),
                         config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
             }
-            return EnumResolver.constructUsingMethod(config, enumClass, jvAcc);
+            return EnumResolver.constructUsingMethod(config, beanDesc.getClassInfo(), jvAcc);
         }
         return EnumResolver.constructFor(config, beanDesc.getClassInfo());
     }


### PR DESCRIPTION
parent issue : #3990

## Motivation
- Follow up of #4025
- This PR will effectively make implementions inside `EnumResolver` look more the same
- Retrofit the new `AnnotationIntrospector.findDefaultEnumValue(AnnotatedClass, Enum<?>[])`.

## Modification
- Same as motivation