### PR TITLE
Use `@JsonProperty` for Enum values also when `READ_ENUMS_USING_TO_STRING` enabled

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -222,15 +222,21 @@ public class EnumResolver implements java.io.Serializable
         final Class<Enum<?>> enumCls = _enumClass(enumCls0);
         final Enum<?>[] enumConstants = _enumConstants(enumCls0);
         HashMap<String, Enum<?>> map = new HashMap<String, Enum<?>>();
+        final String[] names = new String[enumConstants.length];
         final String[][] allAliases = new String[enumConstants.length][];
         if (ai != null) {
+            ai.findEnumValues(enumCls, enumConstants, names);
             ai.findEnumAliases(enumCls, enumConstants, allAliases);
         }
 
         // from last to first, so that in case of duplicate values, first wins
         for (int i = enumConstants.length; --i >= 0; ) {
             Enum<?> enumValue = enumConstants[i];
-            map.put(enumValue.toString(), enumValue);
+            String name = names[i];
+            if (name == null) {
+                name = enumValue.toString();
+            }
+            map.put(name, enumValue);
             String[] aliases = allAliases[i];
             if (aliases != null) {
                 for (String alias : aliases) {

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -176,8 +176,10 @@ public class EnumResolver implements java.io.Serializable
         final Enum<?>[] enumConstants = _enumConstants(enumCls0);
 
         // introspect
+        final String[] names = new String[enumConstants.length];
         final String[][] allAliases = new String[enumConstants.length][];
         if (ai != null) {
+            ai.findEnumValues(config, annotatedClass, enumConstants, names);
             ai.findEnumAliases(config, annotatedClass, enumConstants, allAliases);
         }
         
@@ -186,7 +188,11 @@ public class EnumResolver implements java.io.Serializable
         HashMap<String, Enum<?>> map = new HashMap<String, Enum<?>>();
         for (int i = enumConstants.length; --i >= 0; ) {
             Enum<?> enumValue = enumConstants[i];
-            map.put(enumValue.toString(), enumValue);
+            String name = names[i];
+            if (name == null) {
+                name = enumValue.toString();
+            }
+            map.put(name, enumValue);
             String[] aliases = allAliases[i];
             if (aliases != null) {
                 for (String alias : aliases) {

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -222,21 +222,15 @@ public class EnumResolver implements java.io.Serializable
         final Class<Enum<?>> enumCls = _enumClass(enumCls0);
         final Enum<?>[] enumConstants = _enumConstants(enumCls0);
         HashMap<String, Enum<?>> map = new HashMap<String, Enum<?>>();
-        final String[] names = new String[enumConstants.length];
         final String[][] allAliases = new String[enumConstants.length][];
         if (ai != null) {
-            ai.findEnumValues(enumCls, enumConstants, names);
             ai.findEnumAliases(enumCls, enumConstants, allAliases);
         }
 
         // from last to first, so that in case of duplicate values, first wins
         for (int i = enumConstants.length; --i >= 0; ) {
             Enum<?> enumValue = enumConstants[i];
-            String name = names[i];
-            if (name == null) {
-                name = enumValue.toString();
-            }
-            map.put(name, enumValue);
+            map.put(enumValue.toString(), enumValue);
             String[] aliases = allAliases[i];
             if (aliases != null) {
                 for (String alias : aliases) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
@@ -539,6 +539,13 @@ public class EnumDeserializationTest
         assertSame(EnumWithPropertyAnno.B, result[0]);
         assertSame(EnumWithPropertyAnno.A, result[1]);
     }
+    
+    public void testEnumWithJsonPropertyRenameWithToString() throws Exception {
+        EnumWithPropertyAnno result = MAPPER.readerFor(EnumWithPropertyAnno.class)
+                .with(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+                .readValue(q("a"));
+        assertSame(EnumWithPropertyAnno.A, result);
+    }
 
     /**
      * {@link #testEnumWithJsonPropertyRename()}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
@@ -541,10 +541,21 @@ public class EnumDeserializationTest
     }
     
     public void testEnumWithJsonPropertyRenameWithToString() throws Exception {
-        EnumWithPropertyAnno result = MAPPER.readerFor(EnumWithPropertyAnno.class)
+        EnumWithPropertyAnno a = MAPPER.readerFor(EnumWithPropertyAnno.class)
                 .with(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
                 .readValue(q("a"));
-        assertSame(EnumWithPropertyAnno.A, result);
+        assertSame(EnumWithPropertyAnno.A, a);
+
+        EnumWithPropertyAnno b = MAPPER.readerFor(EnumWithPropertyAnno.class)
+                .with(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+                .readValue(q("b"));
+        assertSame(EnumWithPropertyAnno.B, b);
+
+        EnumWithPropertyAnno c = MAPPER.readerFor(EnumWithPropertyAnno.class)
+                .with(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+                .readValue(q("bb"));
+        assertNull(c);
     }
 
     /**

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
@@ -89,7 +89,10 @@ public class EnumDeserializationTest
             public String toString() {
                 return "bb";
             }
-        }
+        },
+        
+        @JsonProperty("cc")
+        C
         ;
     }
 
@@ -551,11 +554,16 @@ public class EnumDeserializationTest
                 .readValue(q("b"));
         assertSame(EnumWithPropertyAnno.B, b);
 
-        EnumWithPropertyAnno c = MAPPER.readerFor(EnumWithPropertyAnno.class)
+        EnumWithPropertyAnno bb = MAPPER.readerFor(EnumWithPropertyAnno.class)
                 .with(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
                 .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
                 .readValue(q("bb"));
-        assertNull(c);
+        assertNull(bb);
+
+        EnumWithPropertyAnno c = MAPPER.readerFor(EnumWithPropertyAnno.class)
+                .with(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+                .readValue(q("cc"));
+        assertSame(EnumWithPropertyAnno.C, c);
     }
 
     /**


### PR DESCRIPTION
When `DeserializationFeature.READ_ENUMS_USING_TO_STRING` is enabled, the enum deserializer neglects inspecting `@JsonProperty`; see the test case, it succeeds if `READ_ENUMS_USING_TO_STRING` is disabled and would fail with `READ_ENUMS_USING_TO_STRING` enabled (without this patch).
