### PR TITLE
perf: actually cache EnumValues#internalMap

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumValues.java
@@ -218,7 +218,7 @@ public final class EnumValues
             for (Enum<?> en : _values) {
                 map.put(en, _textual[en.ordinal()]);
             }
-            result = new EnumMap(map);
+            _asMap = result = new EnumMap(map);
         }
         return result;
     }


### PR DESCRIPTION
It appears `EnumValues#internalMap` is meant to be cached (upon first execution), but `_asMap` was never updated with the computed value.

Original commit: https://github.com/FasterXML/jackson-databind/commit/003e5b05d02b6d62c506776f1f2fa05606a63ffc
