### PR TITLE
Expose `NativeImageUtil.isRunningInNativeImage()` method

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -55,6 +55,7 @@ Project: jackson-databind
  (contributed by Joo-Hyuk K)
 #4056: Provide the "ObjectMapper.treeToValue(TreeNode, TypeReference)" method
  (contributed by @fantasy0v0)
+#4060: Expose `NativeImageUtil.isRunningInNativeImage()` method
 
 2.15.3 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -21,8 +21,10 @@ public class NativeImageUtil {
     /**
      * Check whether we're running in substratevm native image runtime mode. This check cannot be a constant, because
      * the static initializer may run early during build time
+     *<p>
+     * NOTE: {@code public} since 2.16 (before that, {@code private}).
      */
-    private static boolean isRunningInNativeImage() {
+    public static boolean isRunningInNativeImage() {
         return RUNNING_IN_SVM && "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 


### PR DESCRIPTION
Changes modifier for said method to `public` from `private`, to allow external usage by modules.