### PR TITLE
Update `NativeImageUtil` method name and expose new getter

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -34,7 +34,7 @@ public class NativeImageUtil {
      * @since 2.16
      */
     public static boolean isInNativeImage() {
-        return System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+        return RUNNING_IN_SVM;
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -9,31 +9,41 @@ import java.lang.reflect.InvocationTargetException;
  * @since 2.14
  */
 public class NativeImageUtil {
-    private static final boolean RUNNING_IN_SVM;
-
-    static {
-        RUNNING_IN_SVM = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
-    }
+    
+    private static final boolean RUNNING_IN_SVM = isInSVM();
 
     private NativeImageUtil() {
     }
 
     /**
-     * Check whether we're running in substratevm native image runtime mode.
-     * This check cannot be a constant, because
+     * Check whether we're running in SubstrateVM native image and also in "runtime" mode.
+     * The "runtime" check cannot be a constant, because
      * the static initializer may run early during build time
+     *<p>
+     * As optimization, {@link #RUNNING_IN_SVM} is used to short-circuit on normal JVMs.
      *<p>
      * NOTE: {@code public} since 2.16 (before that, {@code private}).
      */
-    public static boolean isRunningInNativeImage() {
+    public static boolean isInNativeImageAndIsAtRuntime() {
         return RUNNING_IN_SVM && "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+
+    /**
+     * Checks whether we're running in SubstrateVM native image <b>only by the presence</b> of 
+     * {@code "org.graalvm.nativeimage.imagecode"} system property, regardless of its value (buildtime or runtime).
+     * We are irrespective of the build or runtime phase, because native-image can initialize static initializers at build time.
+     *<p>
+     * @since 2.16
+     */
+    public static boolean isInSVM() {
+        return System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     }
 
     /**
      * Check whether the given error is a substratevm UnsupportedFeatureError
      */
     public static boolean isUnsupportedFeatureError(Throwable e) {
-        if (!isRunningInNativeImage()) {
+        if (!isInNativeImageAndIsAtRuntime()) {
             return false;
         }
         if (e instanceof InvocationTargetException) {
@@ -47,7 +57,7 @@ public class NativeImageUtil {
      * members visible in reflection).
      */
     public static boolean needsReflectionConfiguration(Class<?> cl) {
-        if (!isRunningInNativeImage()) {
+        if (!isInNativeImageAndIsAtRuntime()) {
             return false;
         }
         // records list their fields but not other members

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -10,7 +10,7 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class NativeImageUtil {
     
-    private static final boolean RUNNING_IN_SVM = isInNativeImage();
+    private static final boolean RUNNING_IN_SVM = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     private NativeImageUtil() {
     }

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -10,7 +10,7 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class NativeImageUtil {
     
-    private static final boolean RUNNING_IN_SVM = isInSVM();
+    private static final boolean RUNNING_IN_SVM = isInNativeImage();
 
     private NativeImageUtil() {
     }
@@ -33,7 +33,7 @@ public class NativeImageUtil {
      *<p>
      * @since 2.16
      */
-    public static boolean isInSVM() {
+    public static boolean isInNativeImage() {
         return System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NativeImageUtil.java
@@ -21,10 +21,8 @@ public class NativeImageUtil {
      * the static initializer may run early during build time
      *<p>
      * As optimization, {@link #RUNNING_IN_SVM} is used to short-circuit on normal JVMs.
-     *<p>
-     * NOTE: {@code public} since 2.16 (before that, {@code private}).
      */
-    public static boolean isInNativeImageAndIsAtRuntime() {
+    private static boolean isInNativeImageAndIsAtRuntime() {
         return RUNNING_IN_SVM && "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 


### PR DESCRIPTION
(As discussed in https://github.com/FasterXML/jackson-modules-base/pull/217#discussion_r1280263189)

### Motivation

Checks around native image needs update 

### Modifications

1. Renamed`isRunningInNativeImage()` to `isInNativeImageAndIsAtRuntime()`
2. Updated JavaDoc for method above (1)
3. Reverted modifier back to `private` for method above (1)
4. Introduced new method `isInNativeImage()` for only checking if we are in Native Image --will be used in https://github.com/FasterXML/jackson-modules-base/pull/217