### PR TITLE
Ignore `"message"` property for deserialization of custom `Throwable`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -156,7 +156,11 @@ public class ThrowableDeserializer
 
             // 23-Jan-2018, tatu: One concern would be `message`, but without any-setter or single-String-ctor
             //   (or explicit constructor). We could just ignore it but for now, let it fail
-
+            // [databind#4071]: In case of "message", skip for default constructor
+            if (PROP_NAME_MESSAGE.equalsIgnoreCase(propName)) {
+                p.skipChildren();
+                continue;
+            }
             // Unknown: let's call handler method
             handleUnknownProperty(p, ctxt, throwable, propName);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/exc/CustomExceptionDeser4071Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/CustomExceptionDeser4071Test.java
@@ -1,0 +1,46 @@
+package com.fasterxml.jackson.databind.exc;
+
+import com.fasterxml.jackson.databind.BaseMapTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// [databind#4071]: Ignore "message" for custom exceptions with only default constructor
+public class CustomExceptionDeser4071Test extends BaseMapTest
+{
+    static class CustomThrowable4071 extends Throwable { }
+    
+    static class CustomRuntimeException4071 extends RuntimeException { }
+    
+    static class CustomCheckedException4071 extends Exception { }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+    
+    public void testCustomException() throws Exception
+    {
+        String exStr = MAPPER.writeValueAsString(new CustomThrowable4071());
+        assertNotNull(MAPPER.readValue(exStr, CustomThrowable4071.class));
+    }
+    
+    public void testCustomRuntimeException() throws Exception
+    {
+        String exStr = MAPPER.writeValueAsString(new CustomRuntimeException4071());
+        assertNotNull(MAPPER.readValue(exStr, CustomRuntimeException4071.class));
+    }
+    
+    public void testCustomCheckedException() throws Exception
+    {
+        String exStr = MAPPER.writeValueAsString(new CustomCheckedException4071());
+        assertNotNull(MAPPER.readValue(exStr, CustomCheckedException4071.class));
+    }
+    
+    public void testDeserAsThrowable() throws Exception
+    {
+        _testDeserAsThrowable(MAPPER.writeValueAsString(new CustomRuntimeException4071()));
+        _testDeserAsThrowable(MAPPER.writeValueAsString(new CustomCheckedException4071()));
+        _testDeserAsThrowable(MAPPER.writeValueAsString(new CustomThrowable4071()));
+    }
+
+    private void _testDeserAsThrowable(String exStr) throws Exception
+    {
+        assertNotNull(MAPPER.readValue(exStr, Throwable.class));
+    }
+}


### PR DESCRIPTION
resolves #4071 