### PR TITLE
Allow some jdk modules (such as `java.desktop`) to be optional in `Java7Support` again

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7Support.java
@@ -22,6 +22,9 @@ public abstract class Java7Support
         try {
             Class<?> cls = Class.forName("com.fasterxml.jackson.databind.ext.Java7SupportImpl");
             impl = (Java7Support) ClassUtil.createInstance(cls, false);
+        } catch (IllegalAccessError e) {
+            // [databind#4078]: make some jdk modules (such as java.desktop) optional, again.
+            // no-op
         } catch (Throwable t) {
             // 09-Sep-2019, tatu: Used to log earlier, but with 2.10.0 let's not log
 //            java.util.logging.Logger.getLogger(Java7Support.class.getName())


### PR DESCRIPTION
fixes #4078.