### PR TITLE
Make `NamedType` iteration predictable by using `LinkedHashSet` instead of `HashSet` in `StdSubtypeResolver.collectAndResolveSubtypesByTypeId()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdSubtypeResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/StdSubtypeResolver.java
@@ -167,7 +167,7 @@ public class StdSubtypeResolver
         Class<?> rawBase = baseType.getRawClass();
 
         // Need to keep track of classes that have been handled already
-        Set<Class<?>> typesHandled = new HashSet<Class<?>>();
+        Set<Class<?>> typesHandled = new LinkedHashSet<Class<?>>();
         Map<String,NamedType> byName = new LinkedHashMap<String,NamedType>();
 
         // start with lowest-precedence, which is from type hierarchy
@@ -205,7 +205,7 @@ public class StdSubtypeResolver
             AnnotatedClass baseType)
     {
         final Class<?> rawBase = baseType.getRawType();
-        Set<Class<?>> typesHandled = new HashSet<Class<?>>();
+        Set<Class<?>> typesHandled = new LinkedHashSet<Class<?>>();
         Map<String,NamedType> byName = new LinkedHashMap<String,NamedType>();
 
         NamedType rootType = new NamedType(rawBase, null);


### PR DESCRIPTION
(blocks #4065)

## Motivation

Since `HashSet` does not guarantee any particular order, `StdSubtypeResolver.collectAndResolveSubtypesByTypeId()` can be flakey, resulting in test failures such as [🔗this github action](https://github.com/FasterXML/jackson-databind/actions/runs/5909712329/job/16030566769?pr=4065).

## Modification

- Use LinkedHashSet to allow predictable iteration order