### PR TITLE
Complete `LookupCache.emptyCopy()` JavaDoc

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/LookupCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/LookupCache.java
@@ -14,9 +14,11 @@ public interface LookupCache<K,V>
     /**
      * Method needed for creating clones but without contents.
      *<p>
-     * Default implementation th
-     *
+     * Default implementation throws {@link UnsupportedOperationException},
+     * so implementations should override this method.
+     * 
      * @since 2.16
+     * @throws UnsupportedOperationException if implementation does not override this method.
      */
     default LookupCache<K,V> emptyCopy() {
         throw new UnsupportedOperationException("LookupCache implementation "

--- a/src/main/java/com/fasterxml/jackson/databind/util/LookupCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/LookupCache.java
@@ -14,8 +14,8 @@ public interface LookupCache<K,V>
     /**
      * Method needed for creating clones but without contents.
      *<p>
-     * Default implementation throws {@link UnsupportedOperationException},
-     * so implementations should override this method.
+     * Default implementation throws {@link UnsupportedOperationException}.
+     * Implementations are required to override this method.
      * 
      * @since 2.16
      * @throws UnsupportedOperationException if implementation does not override this method.


### PR DESCRIPTION
Seems like the JavaDoc was left in WIP status in https://github.com/FasterXML/jackson-databind/commit/c0f01a5ceedcd57582c3555c03e9c92ed5e42b1c