### PR TITLE
Use static PropertyNamingStrategy instances in POJOPropertiesCollector._findNamingStrategy()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -88,6 +88,59 @@ public abstract class PropertyNamingStrategies
      */
     public static final PropertyNamingStrategy LOWER_DOT_CASE = LowerDotCaseStrategy.INSTANCE;
 
+    /**
+     * Returns a default instance of standard {@link PropertyNamingStrategy} which is statically defined in
+     * {@link PropertyNamingStrategies}. Otherwise, returns null.
+     *
+     * @param type type of {@link PropertyNamingStrategy}
+     * @return a default instance of standard {@link PropertyNamingStrategy}, or null
+     */
+    public static PropertyNamingStrategy getDefaultInstanceOf(Class<? extends PropertyNamingStrategy> type) {
+        // PropertyNamingStrategy
+        if (type == PropertyNamingStrategy.SnakeCaseStrategy.class) {
+            return PropertyNamingStrategies.SNAKE_CASE;
+        }
+        if (type == PropertyNamingStrategy.UpperCamelCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
+        }
+        if (type == PropertyNamingStrategy.KebabCaseStrategy.class) {
+            return PropertyNamingStrategies.KEBAB_CASE;
+        }
+        if (type == PropertyNamingStrategy.LowerDotCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_DOT_CASE;
+        }
+        if (type == PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy.class) {
+            return PropertyNamingStrategies.SNAKE_CASE;
+        }
+        if (type == PropertyNamingStrategy.PascalCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
+        }
+
+        // PropertyNamingStrategies
+        if (type == PropertyNamingStrategies.SnakeCaseStrategy.class) {
+            return PropertyNamingStrategies.SNAKE_CASE;
+        }
+        if (type == PropertyNamingStrategies.UpperSnakeCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_SNAKE_CASE;
+        }
+        if (type == PropertyNamingStrategies.LowerCamelCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_CAMEL_CASE;
+        }
+        if (type == PropertyNamingStrategies.UpperCamelCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
+        }
+        if (type == PropertyNamingStrategies.LowerCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_CASE;
+        }
+        if (type == PropertyNamingStrategies.KebabCaseStrategy.class) {
+            return PropertyNamingStrategies.KEBAB_CASE;
+        }
+        if (type == PropertyNamingStrategies.LowerDotCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_DOT_CASE;
+        }
+        return null;
+    }
+
     /*
     /**********************************************************************
     /* Public base class for simple implementations

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1451,47 +1451,10 @@ public class POJOPropertiesCollector
             }
         }
 
-        // PropertyNamingStrategy
-        if (namingClass == PropertyNamingStrategy.SnakeCaseStrategy.class) {
-            return PropertyNamingStrategies.SNAKE_CASE;
-        }
-        if (namingClass == PropertyNamingStrategy.UpperCamelCaseStrategy.class) {
-            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
-        }
-        if (namingClass == PropertyNamingStrategy.KebabCaseStrategy.class) {
-            return PropertyNamingStrategies.KEBAB_CASE;
-        }
-        if (namingClass == PropertyNamingStrategy.LowerDotCaseStrategy.class) {
-            return PropertyNamingStrategies.LOWER_DOT_CASE;
-        }
-        if (namingClass == PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy.class) {
-            return PropertyNamingStrategies.SNAKE_CASE;
-        }
-        if (namingClass == PropertyNamingStrategy.PascalCaseStrategy.class) {
-            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
-        }
-
-        // PropertyNamingStrategies
-        if (namingClass == PropertyNamingStrategies.SnakeCaseStrategy.class) {
-            return PropertyNamingStrategies.SNAKE_CASE;
-        }
-        if (namingClass == PropertyNamingStrategies.UpperSnakeCaseStrategy.class) {
-            return PropertyNamingStrategies.UPPER_SNAKE_CASE;
-        }
-        if (namingClass == PropertyNamingStrategies.LowerCamelCaseStrategy.class) {
-            return PropertyNamingStrategies.LOWER_CAMEL_CASE;
-        }
-        if (namingClass == PropertyNamingStrategies.UpperCamelCaseStrategy.class) {
-            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
-        }
-        if (namingClass == PropertyNamingStrategies.LowerCaseStrategy.class) {
-            return PropertyNamingStrategies.LOWER_CASE;
-        }
-        if (namingClass == PropertyNamingStrategies.KebabCaseStrategy.class) {
-            return PropertyNamingStrategies.KEBAB_CASE;
-        }
-        if (namingClass == PropertyNamingStrategies.LowerDotCaseStrategy.class) {
-            return PropertyNamingStrategies.LOWER_DOT_CASE;
+        PropertyNamingStrategy defaultInstance = PropertyNamingStrategies
+                .getDefaultInstanceOf((Class<? extends PropertyNamingStrategy>) namingClass);
+        if (defaultInstance != null) {
+            return defaultInstance;
         }
 
         return (PropertyNamingStrategy) ClassUtil.createInstance(namingClass,

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1450,6 +1450,50 @@ public class POJOPropertiesCollector
                 return pns;
             }
         }
+
+        // PropertyNamingStrategy
+        if (namingClass == PropertyNamingStrategy.SnakeCaseStrategy.class) {
+            return PropertyNamingStrategies.SNAKE_CASE;
+        }
+        if (namingClass == PropertyNamingStrategy.UpperCamelCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
+        }
+        if (namingClass == PropertyNamingStrategy.KebabCaseStrategy.class) {
+            return PropertyNamingStrategies.KEBAB_CASE;
+        }
+        if (namingClass == PropertyNamingStrategy.LowerDotCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_DOT_CASE;
+        }
+        if (namingClass == PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy.class) {
+            return PropertyNamingStrategies.SNAKE_CASE;
+        }
+        if (namingClass == PropertyNamingStrategy.PascalCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
+        }
+
+        // PropertyNamingStrategies
+        if (namingClass == PropertyNamingStrategies.SnakeCaseStrategy.class) {
+            return PropertyNamingStrategies.SNAKE_CASE;
+        }
+        if (namingClass == PropertyNamingStrategies.UpperSnakeCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_SNAKE_CASE;
+        }
+        if (namingClass == PropertyNamingStrategies.LowerCamelCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_CAMEL_CASE;
+        }
+        if (namingClass == PropertyNamingStrategies.UpperCamelCaseStrategy.class) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE;
+        }
+        if (namingClass == PropertyNamingStrategies.LowerCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_CASE;
+        }
+        if (namingClass == PropertyNamingStrategies.KebabCaseStrategy.class) {
+            return PropertyNamingStrategies.KEBAB_CASE;
+        }
+        if (namingClass == PropertyNamingStrategies.LowerDotCaseStrategy.class) {
+            return PropertyNamingStrategies.LOWER_DOT_CASE;
+        }
+
         return (PropertyNamingStrategy) ClassUtil.createInstance(namingClass,
                     _config.canOverrideAccessModifiers());
     }

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/TestNamingStrategyStd.java
@@ -627,4 +627,53 @@ public class TestNamingStrategyStd extends BaseMapTest
             assertEquals(" ", namingStrategy.translate(" "));
         }
     }
+
+    public void testGetDefaultInstance() {
+        // PropertyNamingStrategy
+        assertSame(
+            PropertyNamingStrategies.SNAKE_CASE,
+            PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.SnakeCaseStrategy.class));
+        assertSame(
+            PropertyNamingStrategies.UPPER_CAMEL_CASE,
+            PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.UpperCamelCaseStrategy.class));
+        assertSame(
+            PropertyNamingStrategies.KEBAB_CASE,
+            PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.KebabCaseStrategy.class));
+        assertSame(
+            PropertyNamingStrategies.LOWER_DOT_CASE,
+            PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.LowerDotCaseStrategy.class));
+        assertSame(
+            PropertyNamingStrategies.SNAKE_CASE,
+            PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy.class));
+        assertSame(
+            PropertyNamingStrategies.UPPER_CAMEL_CASE,
+            PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.PascalCaseStrategy.class));
+
+        // PropertyNamingStrategies
+        assertSame(
+                PropertyNamingStrategies.SNAKE_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.SnakeCaseStrategy.class));
+        assertSame(
+                PropertyNamingStrategies.UPPER_SNAKE_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.UpperSnakeCaseStrategy.class));
+        assertSame(
+                PropertyNamingStrategies.LOWER_CAMEL_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.LowerCamelCaseStrategy.class));
+        assertSame(
+                PropertyNamingStrategies.UPPER_CAMEL_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.UpperCamelCaseStrategy.class));
+        assertSame(
+                PropertyNamingStrategies.LOWER_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.LowerCaseStrategy.class));
+        assertSame(
+                PropertyNamingStrategies.KEBAB_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.KebabCaseStrategy.class));
+        assertSame(
+                PropertyNamingStrategies.LOWER_DOT_CASE,
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategies.LowerDotCaseStrategy.class));
+
+        // others
+        assertNull(
+                PropertyNamingStrategies.getDefaultInstanceOf(PropertyNamingStrategy.class));
+    }
 }


### PR DESCRIPTION
Returns static `PropertyNamingStrategy` instances defined in `PropertyNamingStrategies` from `POJOPropertiesCollector._findNamingStrategy()` instead of creating new instance every time.

This also eliminates risk of dead-lock mentioned in #2715 when subclasses of `PropertyNamingStrategy` are used with `@JsonNaiming` though they have been already deprecated.