### PR TITLE
Add `LookUpCache.contents(BiConsumer<K,V>)`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/util/LRUMap.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/LRUMap.java
@@ -74,12 +74,7 @@ public class LRUMap<K,V>
     @Override
     public int size() { return _map.size(); }
 
-    /*
-    /**********************************************************************
-    /* Extended API (2.14)
-    /**********************************************************************
-     */
-
+    @Override
     public void contents(BiConsumer<K,V> consumer) {
         for (Map.Entry<K,V> entry : _map.entrySet()) {
             consumer.accept(entry.getKey(), entry.getValue());

--- a/src/main/java/com/fasterxml/jackson/databind/util/LookupCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/LookupCache.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.util;
 
+import java.util.function.BiConsumer;
+
 /**
  * An interface describing the required API for the Jackson-databind Type cache.
  *<p>
@@ -11,6 +13,20 @@ package com.fasterxml.jackson.databind.util;
  */
 public interface LookupCache<K,V>
 {
+    /**
+     * Method to apply operation on cache contents without exposing them.
+     *<p>
+     * Default implementation throws {@link UnsupportedOperationException}.
+     * Implementations are required to override this method.
+     *
+     * @since 2.16
+     * @throws UnsupportedOperationException if implementation does not override this method.
+     * @param consumer Operation to apply on cache contents.
+     */
+    default void contents(BiConsumer<K,V> consumer) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Method needed for creating clones but without contents.
      *<p>


### PR DESCRIPTION
(part of #2502)

As discussed in https://github.com/FasterXML/jackson-databind/pull/4111#discussion_r1322271058, add new `LookupCache.contents(BiConsumer<K,V>)` method 