### PR TITLE
Preserve the original component type in merging to the array

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.deser.std;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -258,8 +259,7 @@ public class ObjectArrayDeserializer
                 return intoValue;
             }
             final int offset = intoValue.length;
-            Object[] result = new Object[offset + arr.length];
-            System.arraycopy(intoValue, 0, result, 0, offset);
+            Object[] result = Arrays.copyOf(intoValue, offset + arr.length);
             System.arraycopy(arr, 0, result, offset, arr.length);
             return result;
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/merge/ArrayMergeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/merge/ArrayMergeTest.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.*;
 
+import java.util.Date;
+
 public class ArrayMergeTest extends BaseMapTest
 {
     static class MergedX<T>
@@ -18,6 +20,12 @@ public class ArrayMergeTest extends BaseMapTest
 
         public MergedX(T v) { value = v; }
         protected MergedX() { }
+    }
+
+    static class Merged
+    {
+        @JsonMerge(OptBoolean.TRUE)
+        public Date[] value;
     }
 
     /*
@@ -55,6 +63,31 @@ public class ArrayMergeTest extends BaseMapTest
         assertEquals("foo", result.value[0]);
         assertEquals("bar", result.value[1]);
         assertEquals("zap", result.value[2]);
+    }
+
+    public void testComponentTypeArrayMerging() throws Exception
+    {
+        Merged input = new Merged();
+        input.value = new Date[] {new Date(1000L)};
+        final JavaType type = MAPPER.getTypeFactory().constructType(new TypeReference<Merged>() {});
+        Merged result = MAPPER.readerFor(type)
+                .withValueToUpdate(input)
+                .readValue(a2q("{'value':[2000]}"));
+        assertSame(input, result);
+        assertEquals(2, result.value.length);
+        assertEquals(1000L, result.value[0].getTime());
+        assertEquals(2000L, result.value[1].getTime());
+
+        // and with one trick
+        result = MAPPER.readerFor(type)
+                .with(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                .withValueToUpdate(input)
+                .readValue(a2q("{'value':3000}"));
+        assertSame(input, result);
+        assertEquals(3, result.value.length);
+        assertEquals(1000L, result.value[0].getTime());
+        assertEquals(2000L, result.value[1].getTime());
+        assertEquals(3000L, result.value[2].getTime());
     }
 
     public void testStringArrayMerging() throws Exception


### PR DESCRIPTION
It fixes an exception:

```
Exception in thread "main" com.fasterxml.jackson.databind.JsonMappingException: 
Problem deserializing property 'date1' (
expected type: [array type, component type: [simple type, class java.util.Date]];
actual type: `java.lang.Object[]`),
problem: Can not set [Ljava.util.Date; field com.example.Data.dates to [Ljava.lang.Object; 
(through reference chain: com.example.Data["date2"])
```
