### PR TITLE
Add reproduction (unit test) for #4118

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeBindings.java
@@ -217,6 +217,8 @@ public class TypeBindings
      * Create a new instance with the same bindings as this object, except with
      * the given variable removed. This is used to create generic types that are
      * "partially raw", i.e. only have some variables bound.
+     *
+     * @since 2.16
      */
     public TypeBindings withoutVariable(String name)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1706,8 +1706,8 @@ ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
             }
             newBindings = TypeBindings.create(rawType, pt);
 
-            // jackson-databind#4118: Unbind any wildcards with a less specific upper bound than
-            // declared on the type variable
+            // [databind#4118] Unbind any wildcards with a less specific upper bound than
+            // declared on the type variable (since 2.16)
             for (int i = 0; i < paramCount; ++i) {
                 if (args[i] instanceof WildcardType && !pt[i].hasGenericTypes()) {
                     TypeVariable<? extends Class<?>> typeVariable = rawType.getTypeParameters()[i];

--- a/src/test/java/com/fasterxml/jackson/databind/type/RecursiveWildcardTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/RecursiveWildcardTest.java
@@ -9,8 +9,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.checkerframework.common.value.qual.ArrayLenRange;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 
 public class RecursiveWildcardTest extends BaseMapTest
 {
@@ -28,24 +26,24 @@ public class RecursiveWildcardTest extends BaseMapTest
         }
     }
 
-    static class TestAttribute<T extends TestAttribute<?>> {
+    static class TestAttribute4118<T extends TestAttribute4118<?>> {
 
         public List<T> attributes;
 
-        public TestAttribute() { }
+        public TestAttribute4118() { }
 
-        public TestAttribute(List<T> attributes) {
+        public TestAttribute4118(List<T> attributes) {
             this.attributes = attributes;
         }
     }
 
-    static class TestObject {
+    static class TestObject4118 {
 
-        public List<TestAttribute<?>> attributes = new ArrayList<>();
+        public List<TestAttribute4118<?>> attributes = new ArrayList<>();
 
-        public TestObject() { }
+        public TestObject4118() { }
 
-        public TestObject(List<TestAttribute<?>> attributes) {
+        public TestObject4118(List<TestAttribute4118<?>> attributes) {
             this.attributes = attributes;
         }
     }
@@ -62,18 +60,22 @@ public class RecursiveWildcardTest extends BaseMapTest
         assertEquals(0, tree.children.get(0).children.get(0).children.size());
     }
 
-    public void testWildcard() throws Exception
+    // for [databind#4118]
+    public void testDeserWildcard4118() throws Exception
     {
-        TestAttribute a = new TestAttribute(null);
-        TestAttribute b = new TestAttribute(_listOf(a));
-        TestAttribute c = new TestAttribute(_listOf(b));
-        TestObject test = new TestObject(_listOf(c));
+        // Given
+        TestAttribute4118 a = new TestAttribute4118(null);
+        TestAttribute4118 b = new TestAttribute4118(_listOf(a));
+        TestAttribute4118 c = new TestAttribute4118(_listOf(b));
+        TestObject4118 test = new TestObject4118(_listOf(c));
 
         String serialized = MAPPER.writeValueAsString(test);
-        System.out.println(serialized);
 
-        TestObject deserialized = MAPPER.readValue(serialized, TestObject.class);
-        System.out.println(deserialized.attributes.get(0).attributes.get(0).getClass().getName());
+        // When
+        TestObject4118 deserialized = MAPPER.readValue(serialized, TestObject4118.class);
+
+        // Then
+        assertType(deserialized.attributes.get(0).attributes.get(0), TestAttribute4118.class);
     }
 
     private <T> List<T> _listOf(T elem) {

--- a/src/test/java/com/fasterxml/jackson/databind/type/RecursiveWildcardTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/RecursiveWildcardTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.type;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -8,22 +9,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.checkerframework.common.value.qual.ArrayLenRange;
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 
 public class RecursiveWildcardTest extends BaseMapTest
 {
-    public void test() throws Exception
-    {
-        ObjectMapper mapper = newJsonMapper();
-
-        Tree<?> tree = mapper.readValue("[[[]]]", new TypeReference<Tree<?>>() {
-        });
-
-        assertEquals(1, tree.children.size());
-        assertEquals(1, tree.children.get(0).children.size());
-        assertEquals(0, tree.children.get(0).children.get(0).children.size());
-    }
-
-    public static class Tree<T extends Tree<?>> {
+    static class Tree<T extends Tree<?>> {
 
         final List<T> children;
 
@@ -35,6 +26,59 @@ public class RecursiveWildcardTest extends BaseMapTest
             }
             this.children = children;
         }
+    }
 
+    static class TestAttribute<T extends TestAttribute<?>> {
+
+        public List<T> attributes;
+
+        public TestAttribute() { }
+
+        public TestAttribute(List<T> attributes) {
+            this.attributes = attributes;
+        }
+    }
+
+    static class TestObject {
+
+        public List<TestAttribute<?>> attributes = new ArrayList<>();
+
+        public TestObject() { }
+
+        public TestObject(List<TestAttribute<?>> attributes) {
+            this.attributes = attributes;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    public void testRecursiveWildcard() throws Exception
+    {
+        Tree<?> tree = MAPPER.readValue("[[[]]]", new TypeReference<Tree<?>>() {
+        });
+
+        assertEquals(1, tree.children.size());
+        assertEquals(1, tree.children.get(0).children.size());
+        assertEquals(0, tree.children.get(0).children.get(0).children.size());
+    }
+
+    public void testWildcard() throws Exception
+    {
+        TestAttribute a = new TestAttribute(null);
+        TestAttribute b = new TestAttribute(_listOf(a));
+        TestAttribute c = new TestAttribute(_listOf(b));
+        TestObject test = new TestObject(_listOf(c));
+
+        String serialized = MAPPER.writeValueAsString(test);
+        System.out.println(serialized);
+
+        TestObject deserialized = MAPPER.readValue(serialized, TestObject.class);
+        System.out.println(deserialized.attributes.get(0).attributes.get(0).getClass().getName());
+    }
+
+    private <T> List<T> _listOf(T elem) {
+        ArrayList<T> list = new ArrayList<>();
+        list.add(elem);
+        return list;
     }
 }


### PR DESCRIPTION
## Modifications

- Adds direct reproduction as per [comment](https://github.com/FasterXML/jackson-databind/issues/4118#issuecomment-1736335807)
- Organize things in `RecursiveWildcardTest` (from #4122)
- Modified comments to follow convention