### PR TITLE
Expose widely used `Base(Map)Test` util methods as `public static`

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -238,16 +238,18 @@ public abstract class BaseMapTest
         return sharedMapper().readerFor(cls);
     }
 
+    // `public` since 2.16, was only `protected` before then.
     // @since 2.10
-    protected static ObjectMapper newJsonMapper() {
+    public static ObjectMapper newJsonMapper() {
         return new JsonMapper();
     }
 
     // @since 2.10
-    protected static JsonMapper.Builder jsonMapperBuilder() {
+    public static JsonMapper.Builder jsonMapperBuilder() {
         return JsonMapper.builder();
     }
 
+    // `public` since 2.16, was only `protected` before then.
     // @since 2.7
     protected TypeFactory newTypeFactory() {
         // this is a work-around; no null modifier added

--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -244,12 +244,12 @@ public abstract class BaseMapTest
         return new JsonMapper();
     }
 
+    // `public` since 2.16, was only `protected` before then.
     // @since 2.10
     public static JsonMapper.Builder jsonMapperBuilder() {
         return JsonMapper.builder();
     }
 
-    // `public` since 2.16, was only `protected` before then.
     // @since 2.7
     protected TypeFactory newTypeFactory() {
         // this is a work-around; no null modifier added

--- a/src/test/java/com/fasterxml/jackson/databind/BaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseTest.java
@@ -437,7 +437,8 @@ public abstract class BaseTest
         return result;
     }
 
-    public String q(String str) {
+    // `static` since 2.16, was only `public` before then.
+    public static String q(String str) {
         return '"'+str+'"';
     }
 
@@ -446,7 +447,8 @@ public abstract class BaseTest
         return q(str);
     }
 
-    protected static String a2q(String json) {
+    // `public` since 2.16, was only `protected` before then.
+    public static String a2q(String json) {
         return json.replace("'", "\"");
     }
 


### PR DESCRIPTION
### Motivation

Address the inability to use `BaseMapTest` utility methods in `JUnit5` tests by exposing commonly-used methods in this PR.