### PR TITLE
Minor clean up example Tree Model in `README.md` wrt #4135

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Map<String, ResultValue> results = mapper.readValue(jsonSource,
 
 But wait! There is more!
 
+(enters Tree Model...)
+
+## Tree Model
+
 While dealing with `Map`s, `List`s and other "simple" Object types (Strings, Numbers, Booleans) can be simple, Object traversal can be cumbersome.
 This is where Jackson's [Tree model](https://github.com/FasterXML/jackson-databind/wiki/JacksonTreeModel) can come in handy:
 
@@ -186,11 +190,11 @@ with above, we end up with something like as 'json' String:
 Tree Model can be more convenient than data-binding, especially in cases where structure is highly dynamic, or does not map nicely to Java classes.
 
 Finally, feel free to mix and match, and even in the same json document (useful when only part of the document is known and modeled in your code)
+
 ```java
 // Some parts of this json are modeled in our code, some are not
 JsonNode root = mapper.readTree(complexJson);
 Person p = mapper.treeToValue(root.get("person"), Person.class); // known single pojo
-List<Person> friends = mapper.treeToValue(root.get("friends"), new TypeReference<List<Person>>() { }); // generics
 Map<String, Object> dynamicmetadata = mapper.treeToValue(root.get("dynamicmetadata"), Map.class); // unknown smallish subfield, convert all to collections
 int singledeep = root.get("deep").get("large").get("hiearchy").get("important").intValue(); // single value in very deep optional subfield, ignoring the rest
 int singledeeppath = root.at("/deep/large/hiearchy/important").intValue(); // json path
@@ -205,9 +209,17 @@ root.putPOJO("dynamicmetadata", dynamicmetadata);  // collections
 root.putPOJO("dynamicmetadata", mapper.valueToTree(dynamicmetadata)); // same thing
 root.set("dynamicmetadata", mapper.valueToTree(dynamicmetadata)); // same thing
 root.withObject("deep").withObject("large").withObject("hiearchy").put("important", 42); // create as you go
-root.withObjectProperty("deep").withObjectProperty("large").withObjectProperty("hiearchy").put("important", 42); // same but without trying json path
 root.withObject("/deep/large/hiearchy").put("important", 42); // json path
 mapper.writeValueAsString(root);
+```
+
+**Supported for Jackson 2.16+ versions**
+
+```java
+List<Person> friends = mapper.treeToValue(root.get("friends"), new TypeReference<List<Person>>() { }); // generics
+
+ObjectNode root = mapper.createObjectNode();
+root.withObjectProperty("deep").withObjectProperty("large").withObjectProperty("hiearchy").put("important", 42); // create as you go but without trying json path
 ```
 
 ## 5 minute tutorial: Streaming parser, generator

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ But wait! There is more!
 
 (enters Tree Model...)
 
-## Tree Model
+### Tree Model
 
 While dealing with `Map`s, `List`s and other "simple" Object types (Strings, Numbers, Booleans) can be simple, Object traversal can be cumbersome.
 This is where Jackson's [Tree model](https://github.com/FasterXML/jackson-databind/wiki/JacksonTreeModel) can come in handy:

--- a/README.md
+++ b/README.md
@@ -167,20 +167,20 @@ This is where Jackson's [Tree model](https://github.com/FasterXML/jackson-databi
 ```java
 // can be read as generic JsonNode, if it can be Object or Array; or,
 // if known to be Object, as ObjectNode, if array, ArrayNode etc:
-ObjectNode root = mapper.readTree("stuff.json");
+JsonNode root = mapper.readTree("{ \"name\": \"Joe\", \"age\": 13 }");
 String name = root.get("name").asText();
 int age = root.get("age").asInt();
 
 // can modify as well: this adds child Object as property 'other', set property 'type'
-root.with("other").put("type", "student");
-String json = mapper.writeValueAsString(root);
+root.withObject("/other").put("type", "student");
+String json = mapper.writeValueAsString(root); // prints below
 
 /*
 with above, we end up with something like as 'json' String:
 {
   "name" : "Bob",
   "age" : 13,
-    "other" : {
+  "other" : {
     "type" : "student"
   }
 } 
@@ -216,10 +216,10 @@ mapper.writeValueAsString(root);
 **Supported for Jackson 2.16+ versions**
 
 ```java
-List<Person> friends = mapper.treeToValue(root.get("friends"), new TypeReference<List<Person>>() { }); // generics
-
-ObjectNode root = mapper.createObjectNode();
-root.withObjectProperty("deep").withObjectProperty("large").withObjectProperty("hiearchy").put("important", 42); // create as you go but without trying json path
+// generics
+List<Person> friends = mapper.treeToValue(root.get("friends"), new TypeReference<List<Person>>() { });
+// create as you go but without trying json path
+root.withObjectProperty("deep").withObjectProperty("large").withObjectProperty("hiearchy").put("important", 42);
 ```
 
 ## 5 minute tutorial: Streaming parser, generator

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -1318,7 +1318,7 @@ public abstract class JsonNode
      * NOTE: before Jackson 2.14 behavior was always that of non-expression usage;
      * that is, {@code exprOrProperty} was always considered as a simple property name.
      *
-     * @deprecated Since 2.14 use {@code withObject(String)} instead
+     * @deprecated Since 2.14 use {@link #withObject(String)} instead
      */
     @Deprecated // since 2.14
     public <T extends JsonNode> T with(String exprOrProperty) {


### PR DESCRIPTION
Somehow I thought this one has been worked on already 😅. 

### Motivation

As per https://github.com/FasterXML/jackson-databind/pull/4135#issuecomment-1742500659,  this PR clean up `README.md` sample around **Tree Model**