### PR TITLE
Do not rewind `position` when serializing direct `ByteBuffer`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteBufferSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteBufferSerializer.java
@@ -27,9 +27,6 @@ public class ByteBufferSerializer extends StdScalarSerializer<ByteBuffer>
         // the other case is more complicated however. Best to handle with InputStream wrapper.
         // But should we rewind it; and/or make a copy?
         ByteBuffer copy = bbuf.asReadOnlyBuffer();
-        if (copy.position() > 0) {
-            copy.rewind();
-        }
         InputStream in = new ByteBufferBackedInputStream(copy);
         gen.writeBinary(in, copy.remaining());
         in.close();

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteBufferSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/ByteBufferSerializer.java
@@ -25,7 +25,7 @@ public class ByteBufferSerializer extends StdScalarSerializer<ByteBuffer>
             return;
         }
         // the other case is more complicated however. Best to handle with InputStream wrapper.
-        // But should we rewind it; and/or make a copy?
+        // Prior to jackson-databind#4164 we rewound here, but that didn't match heap buffer behavior.
         ByteBuffer copy = bbuf.asReadOnlyBuffer();
         InputStream in = new ByteBufferBackedInputStream(copy);
         gen.writeBinary(in, copy.remaining());

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
@@ -143,6 +143,7 @@ public class JDKTypeSerializationTest
         // so far so good, but must ensure Native buffers also work:
         ByteBuffer bbuf2 = ByteBuffer.allocateDirect(5);
         bbuf2.put(INPUT_BYTES);
+        bbuf2.flip();
         assertEquals(exp, MAPPER.writeValueAsString(bbuf2));
     }
 
@@ -180,6 +181,18 @@ public class JDKTypeSerializationTest
         exp = MAPPER.writeValueAsString(new byte[] { 2, 3, 4 });
         bbuf = ByteBuffer.wrap(INPUT_BYTES, 1, 3);
         assertEquals(exp, MAPPER.writeValueAsString(bbuf.duplicate()));
+    }
+
+    public void testDuplicatedByteBufferWithCustomPositionDirect() throws IOException
+    {
+        final byte[] INPUT_BYTES = new byte[] { 1, 2, 3, 4, 5 };
+
+        String exp = MAPPER.writeValueAsString(new byte[] { 3, 4, 5 });
+        ByteBuffer bbuf = ByteBuffer.allocateDirect(INPUT_BYTES.length);
+        bbuf.put(INPUT_BYTES);
+        bbuf.position(2);
+        ByteBuffer duplicated = bbuf.duplicate();
+        assertEquals(exp, MAPPER.writeValueAsString(duplicated));
     }
 
     // [databind#2197]


### PR DESCRIPTION
ByteBufferSerializer considers the position when serializing heap buffers, but ignores it (by rewinding) for direct buffers. I believe the former behavior is correct, so I've aligned the direct buffer code with that.

This might be better for 2.17, I don't know.

`testByteBuffer` was broken by this change because it didn't flip the buffer after writing.