### PR TITLE
issue-1770 - big number not returned as DecimalNode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -755,7 +755,11 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
             return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
         }
         if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-            return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
+            try {
+                return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
+            } catch (NumberFormatException nfe) {
+                // fall through - BigDecimal does not support values like NaN
+            }
         }
         if (nt == JsonParser.NumberType.FLOAT) {
             return nodeFactory.numberNode(p.getFloatValue());

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -755,11 +755,6 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
             return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
         }
         if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-            // 20-May-2016, tatu: As per [databind#1028], need to be careful
-            //   (note: JDK 1.8 would have `Double.isFinite()`)
-            if (p.isNaN()) {
-                return nodeFactory.numberNode(p.getDoubleValue());
-            }
             return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
         }
         if (nt == JsonParser.NumberType.FLOAT) {

--- a/src/test/java/com/fasterxml/jackson/databind/NumberNodes1770Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/NumberNodes1770Test.java
@@ -1,6 +1,4 @@
-package com.fasterxml.jackson.failing;
-
-import com.fasterxml.jackson.databind.*;
+package com.fasterxml.jackson.databind;
 
 import java.math.BigDecimal;
 

--- a/src/test/java/com/fasterxml/jackson/databind/NumberNodes1770Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/NumberNodes1770Test.java
@@ -1,5 +1,9 @@
 package com.fasterxml.jackson.databind;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
 import java.math.BigDecimal;
 
 /**
@@ -22,5 +26,18 @@ public class NumberNodes1770Test extends BaseMapTest
             .readTree(value);
         assertTrue("Expected DecimalNode, got: "+jsonNode.getClass().getName()+": "+jsonNode, jsonNode.isBigDecimal());
         assertEquals(new BigDecimal(value), jsonNode.decimalValue());
+    }
+
+    public void testBigDecimalCoercionInf() throws Exception
+    {
+        final String value = "+INF";
+        JsonFactory factory = JsonFactory.builder()
+                .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+                .build();
+        final JsonNode jsonNode = new JsonMapper(factory).reader()
+                .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .readTree(value);
+        assertTrue("Expected DoubleNode, got: "+jsonNode.getClass().getName()+": "+jsonNode, jsonNode.isDouble());
+        assertEquals(Double.POSITIVE_INFINITY, jsonNode.doubleValue());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/failing/NumberNodes1770Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/NumberNodes1770Test.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.failing;
 
 import com.fasterxml.jackson.databind.*;
 
+import java.math.BigDecimal;
+
 /**
  * Basic tests for {@link JsonNode} implementations that
  * contain numeric values.
@@ -16,11 +18,11 @@ public class NumberNodes1770Test extends BaseMapTest
     // `DoubleNode` being used even tho `BigDecimal` could fit the number.
     public void testBigDecimalCoercion() throws Exception
     {
+        final String value = "7976931348623157e309";
         final JsonNode jsonNode = MAPPER.reader()
             .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-            .readTree("7976931348623157e309");
+            .readTree(value);
         assertTrue("Expected DecimalNode, got: "+jsonNode.getClass().getName()+": "+jsonNode, jsonNode.isBigDecimal());
-        // the following fails with NumberFormatException, because jsonNode is a DoubleNode with a value of POSITIVE_INFINITY
-//        Assert.assertTrue(jsonNode.decimalValue().compareTo(new BigDecimal("7976931348623157e309")) == 0);
+        assertEquals(new BigDecimal(value), jsonNode.decimalValue());
     }
 }


### PR DESCRIPTION
see #1770 
also see https://github.com/FasterXML/jackson-core/pull/1135

Makes the failing test `NumberNodes1770Test` pass

Breaks another test - `NotANumberConversionTest.testBigDecimalWithNaN` - I have added a hack to this PR to fix that test. BigDecimal does not support NaN value.