### PR TITLE
Migrate tests in `view` test package to `JUnit 5` using `DatabindTestUtil`

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -292,18 +292,9 @@ public abstract class BaseMapTest
     /**********************************************************
      */
 
+    @SuppressWarnings("unchecked")
     protected Map<String,Object> writeAndMap(ObjectMapper m, Object value)
         throws IOException
-    {
-        return writeAndMap2(m, value);
-    }
-
-    /**
-     * To prepare for 3.0 that will move away from JUnit 4, we need to avoid using protected methods.
-     */
-    @SuppressWarnings("unchecked")
-    public static Map<String,Object> writeAndMap2(ObjectMapper m, Object value)
-            throws IOException
     {
         String str = m.writeValueAsString(value);
         return (Map<String,Object>) m.readValue(str, LinkedHashMap.class);

--- a/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/BaseMapTest.java
@@ -292,9 +292,18 @@ public abstract class BaseMapTest
     /**********************************************************
      */
 
-    @SuppressWarnings("unchecked")
     protected Map<String,Object> writeAndMap(ObjectMapper m, Object value)
         throws IOException
+    {
+        return writeAndMap2(m, value);
+    }
+
+    /**
+     * To prepare for 3.0 that will move away from JUnit 4, we need to avoid using protected methods.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String,Object> writeAndMap2(ObjectMapper m, Object value)
+            throws IOException
     {
         String str = m.writeValueAsString(value);
         return (Map<String,Object>) m.readValue(str, LinkedHashMap.class);

--- a/src/test/java/com/fasterxml/jackson/databind/DatabindTestUtil.java
+++ b/src/test/java/com/fasterxml/jackson/databind/DatabindTestUtil.java
@@ -1,0 +1,55 @@
+package com.fasterxml.jackson.databind;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Class containing test utility methods.
+ * The methods are migrated from {@link BaseMapTest} and {@link BaseTest},
+ * as part of JUnit 5 migration.
+ *
+ * @since 2.17
+ */
+public class DatabindTestUtil
+{
+
+    /*
+    /**********************************************************
+    /* Helper methods, serialization
+    /**********************************************************
+     */
+
+    @SuppressWarnings("unchecked")
+    public static Map<String,Object> writeAndMap(ObjectMapper m, Object value)
+            throws IOException
+    {
+        String str = m.writeValueAsString(value);
+        return (Map<String,Object>) m.readValue(str, LinkedHashMap.class);
+    }
+
+    /*
+    /**********************************************************
+    /* Construction
+    /**********************************************************
+     */
+
+    public static ObjectMapper newJsonMapper() {
+        return new JsonMapper();
+    }
+
+    public static JsonMapper.Builder jsonMapperBuilder() {
+        return JsonMapper.builder();
+    }
+
+    /*
+    /**********************************************************
+    /* Encoding or String representations
+    /**********************************************************
+     */
+
+    public static String a2q(String json) {
+        return json.replace("'", "\"");
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind.views;
 
-import static com.fasterxml.jackson.databind.BaseTest.a2q;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.a2q;
 import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 

--- a/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.databind.views;
 
 import static com.fasterxml.jackson.databind.BaseTest.a2q;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
@@ -1,13 +1,16 @@
 package com.fasterxml.jackson.databind.views;
 
+import static com.fasterxml.jackson.databind.BaseTest.a2q;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
+import org.junit.jupiter.api.Test;
 
 // for [databind#507], supporting default views
-public class DefaultViewTest extends BaseMapTest
+public class DefaultViewTest
 {
     // Classes that represent views
     static class ViewA { }
@@ -32,6 +35,7 @@ public class DefaultViewTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = new ObjectMapper();
 
+    @Test
     public void testDeserialization() throws IOException
     {
         final String JSON = a2q("{'a':1,'b':2}");
@@ -56,6 +60,7 @@ public class DefaultViewTest extends BaseMapTest
         assertEquals(result.b, 2);
     }
 
+    @Test
     public void testSerialization() throws IOException
     {
         assertEquals(a2q("{'a':3,'b':5}"),

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewDeserialization.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.databind.views;
 
-import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
-import static com.fasterxml.jackson.databind.BaseTest.a2q;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.a2q;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.jsonMapperBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewDeserialization.java
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.databind.views;
 
 import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
 import static com.fasterxml.jackson.databind.BaseTest.a2q;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewDeserialization.java
@@ -1,12 +1,17 @@
 package com.fasterxml.jackson.databind.views;
 
+import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.BaseTest.a2q;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import com.fasterxml.jackson.databind.*;
+import org.junit.jupiter.api.Test;
 
-public class TestViewDeserialization extends BaseMapTest
+public class TestViewDeserialization
 {
     // Classes that represent views
     static class ViewA { }
@@ -61,6 +66,7 @@ public class TestViewDeserialization extends BaseMapTest
 
     private final ObjectMapper mapper = new ObjectMapper();
 
+    @Test
     public void testSimple() throws Exception
     {
         // by default, should have it all...
@@ -95,6 +101,7 @@ public class TestViewDeserialization extends BaseMapTest
         assertEquals(2, bean.b);
     }
 
+    @Test
     public void testWithoutDefaultInclusion() throws Exception
     {
         // without active view, all included still:
@@ -116,6 +123,7 @@ public class TestViewDeserialization extends BaseMapTest
         assertEquals(2, bean.b);
     }
 
+    @Test
     public void testWithCreatorAndViews() throws Exception
     {
         ViewsAndCreatorBean result;

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewSerialization.java
@@ -1,18 +1,23 @@
 package com.fasterxml.jackson.databind.views;
 
+import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
+import static com.fasterxml.jackson.databind.BaseMapTest.writeAndMap2;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import java.io.*;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for verifying JSON view functionality: ability to declaratively
  * suppress subset of properties from being serialized.
  */
 public class TestViewSerialization
-    extends BaseMapTest
 {
     // Classes that represent views
     static class ViewA { }
@@ -75,15 +80,16 @@ public class TestViewSerialization
     /**********************************************************
      */
 
-    private final ObjectMapper MAPPER = objectMapper();
+    private final ObjectMapper MAPPER = newJsonMapper();
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testSimple() throws IOException
     {
         StringWriter sw = new StringWriter();
         // Ok, first, using no view whatsoever; all 3
         Bean bean = new Bean();
-        Map<String,Object> map = writeAndMap(MAPPER, bean);
+        Map<String,Object> map = writeAndMap2(MAPPER, bean);
         assertEquals(3, map.size());
 
         // Then with "ViewA", just one property
@@ -128,6 +134,7 @@ public class TestViewSerialization
      * a view.
      */
     @SuppressWarnings("unchecked")
+    @Test
     public void testDefaultExclusion() throws IOException
     {
         MixedBean bean = new MixedBean();
@@ -163,12 +170,14 @@ public class TestViewSerialization
      * As per [JACKSON-261], @JsonView annotation should imply that associated
      * method/field does indicate a property.
      */
+    @Test
     public void testImplicitAutoDetection() throws Exception
     {
         assertEquals("{\"a\":1}",
                 MAPPER.writeValueAsString(new ImplicitBean()));
     }
 
+    @Test
     public void testVisibility() throws Exception
     {
         VisibilityBean bean = new VisibilityBean();
@@ -179,6 +188,7 @@ public class TestViewSerialization
     }
 
     // [JACKSON-868]
+    @Test
     public void test868() throws IOException
     {
         ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewSerialization.java
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.databind.views;
 
-import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
-import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
-import static com.fasterxml.jackson.databind.BaseMapTest.writeAndMap2;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.newJsonMapper;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.writeAndMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import java.io.*;
@@ -89,7 +89,7 @@ public class TestViewSerialization
         StringWriter sw = new StringWriter();
         // Ok, first, using no view whatsoever; all 3
         Bean bean = new Bean();
-        Map<String,Object> map = writeAndMap2(MAPPER, bean);
+        Map<String,Object> map = writeAndMap(MAPPER, bean);
         assertEquals(3, map.size());
 
         // Then with "ViewA", just one property

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewSerialization.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.databind.views;
 import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
 import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
 import static com.fasterxml.jackson.databind.BaseMapTest.writeAndMap2;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import java.io.*;
 import java.util.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewsSerialization2.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewsSerialization2.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind.views;
 
-import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.jsonMapperBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import java.io.*;

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewsSerialization2.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewsSerialization2.java
@@ -1,12 +1,16 @@
 package com.fasterxml.jackson.databind.views;
 
+import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.*;
 
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
+import org.junit.jupiter.api.Test;
 
-public class TestViewsSerialization2 extends BaseMapTest
+public class TestViewsSerialization2
 {
     /*
     /************************************************************************
@@ -121,6 +125,7 @@ public class TestViewsSerialization2 extends BaseMapTest
     /************************************************************************
      */
 
+    @Test
     public void testDataBindingUsage( ) throws Exception
     {
         ObjectMapper mapper = createMapper();
@@ -128,6 +133,7 @@ public class TestViewsSerialization2 extends BaseMapTest
         assertEquals(-1, result.indexOf( "nameHidden" ));
     }
 
+    @Test
     public void testDataBindingUsageWithoutView( ) throws Exception
     {
         ObjectMapper mapper = createMapper();

--- a/src/test/java/com/fasterxml/jackson/databind/views/TestViewsSerialization2.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/TestViewsSerialization2.java
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.databind.views;
 
 import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.io.*;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind.views;
 
-import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
+import static com.fasterxml.jackson.databind.DatabindTestUtil.newJsonMapper;
 import static org.junit.Assert.assertEquals;
 import com.fasterxml.jackson.annotation.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
@@ -1,10 +1,9 @@
 package com.fasterxml.jackson.databind.views;
 
 import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import com.fasterxml.jackson.annotation.*;
 
-import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
@@ -1,13 +1,15 @@
 package com.fasterxml.jackson.databind.views;
 
+import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.jupiter.api.Test;
 
 public class ViewsWithCreatorTest
-    extends BaseMapTest
 {
     static class View { }
     static class View1 extends View { }
@@ -74,6 +76,7 @@ public class ViewsWithCreatorTest
     private final ObjectMapper MAPPER = newJsonMapper();
     
     // [databind#1172]
+    @Test
     public void testWithJsonCreator() throws Exception
     {
         ObjectReader reader = MAPPER.readerFor(ObjWithCreator.class).withView(View1.class);
@@ -85,6 +88,7 @@ public class ViewsWithCreatorTest
     }
 
     // [databind#1172]
+    @Test
     public void testWithoutJsonCreator() throws Exception
     {
         ObjectReader reader = MAPPER.readerFor(ObjWithoutCreator.class).withView(View1.class);

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithSchemaTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithSchemaTest.java
@@ -1,12 +1,14 @@
 package com.fasterxml.jackson.databind.views;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
+import org.junit.jupiter.api.Test;
 
-public class ViewsWithSchemaTest extends BaseMapTest
+public class ViewsWithSchemaTest
 {
     interface ViewBC { }
     interface ViewAB { }
@@ -52,6 +54,7 @@ public class ViewsWithSchemaTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = new ObjectMapper();
 
+    @Test
     public void testSchemaWithViews() throws Exception
     {
         ListingVisitor v = new ListingVisitor();
@@ -65,6 +68,7 @@ public class ViewsWithSchemaTest extends BaseMapTest
         assertEquals(Arrays.asList("a", "b"), v.names);
     }
 
+    @Test
     public void testSchemaWithoutViews() throws Exception
     {
         ListingVisitor v = new ListingVisitor();

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithSchemaTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithSchemaTest.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind.views;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.*;


### PR DESCRIPTION
As per title and https://github.com/FasterXML/jackson-databind/discussions/4190