### PR TITLE
Fixed potential test failure due to nondeterminism in the order of elements in wrapRootMapper.writeValueAsString(value) and wrapRootMapper.valueToTree(value).toString() in TestConversions.testValueToTree

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/node/TestConversions.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TestConversions.java
@@ -398,7 +398,7 @@ public class TestConversions extends BaseMapTest
 
         // Act & Assert
         String expected = "{\"event\":{\"id\":1,\"name\":\"foo\"}}";
-        assertEquals(expected, wrapRootMapper.writeValueAsString(value));
-        assertEquals(expected, wrapRootMapper.valueToTree(value).toString());
+        assertEquals(wrapRootMapper.readValue(expected, Map.class), wrapRootMapper.readValue(wrapRootMapper.writeValueAsString(value), Map.class));
+        assertEquals(wrapRootMapper.readValue(expected, Map.class), wrapRootMapper.readValue(wrapRootMapper.valueToTree(value).toString(), Map.class));
     }
 }


### PR DESCRIPTION
This pull request addresses the flakiness in the `TestConversions.testValueToTree` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements in the string returned by `wrapRootMapper.writeValueAsString(value)` and `wrapRootMapper.valueToTree(value).toString()`. The test can be found [here](https://github.com/FasterXML/jackson-databind/blob/2.17/src/test/java/com/fasterxml/jackson/databind/node/TestConversions.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
The test assumes that the `wrapRootMapper.writeValueAsString(value)` and `wrapRootMapper.valueToTree(value).toString()` will return strings with the expected value `{"event":{"[id":1,"name":"foo"]}}`. However, the order of elements in the returned strings is shuffled sometimes, due to which the returned strings are sometimes `{"event":{"[name":"foo","id":1]}` instead of `{"event":{"[id":1,"name":"foo"]}}`. Due to this, the test fails some times.

- How I fixed the test?
I fixed the test by creating map objects from the returned json strings and the expected string. Then, I compared the map objects in the assertion. This ensures that the two jsons are equivalent, irrespective of the order of elements within them.

- Output from NonDex:
```
[INFO] Running com.fasterxml.jackson.databind.node.TestConversions
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.095 s <<< FAILURE! -- in com.fasterxml.jackson.databind.node.TestConversions
[ERROR] com.fasterxml.jackson.databind.node.TestConversions.testValueToTree -- Time elapsed: 0.073 s <<< FAILURE!
junit.framework.ComparisonFailure: expected:<{"event":{"[id":1,"name":"foo"]}}> but was:<{"event":{"[name":"foo","id":1]}}>
	at junit.framework.Assert.assertEquals(Assert.java:100)
	at junit.framework.Assert.assertEquals(Assert.java:107)
	at junit.framework.TestCase.assertEquals(TestCase.java:260)
	at com.fasterxml.jackson.databind.node.TestConversions.testValueToTree(TestConversions.java:401)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestConversions.testValueToTree:401 expected:<{"event":{"[id":1,"name":"foo"]}}> but was:<{"event":{"[name":"foo","id":1]}}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for KNetBtA4QVRzDzoBkusC03HLi5OUUCbVI6BMYE0hws=
[INFO] NonDex SUMMARY:
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=933178 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/shetty5/project/fixes/jackson-databind-testconversions/jackson-databind/.nondex" -DnondexJarDir="/home/shetty5/project/fixes/jackson-databind-testconversions/jackson-databind/.nondex" -DnondexExecid=mc7IsJzpD1SMSDp8t4Rq9E68kks8ZefWAR70K4uGC20= -DnondexLogging=CONFIG
```

You can run the following command to run the test using the NonDex tool:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.fasterxml.jackson.databind.node.TestConversions#testValueToTree
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!