### PR TITLE
Fix regression from #4008,  optimize `ObjectNode.findValue(s)` and `findParent(s)`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -382,18 +382,15 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     @Override
     public List<JsonNode> findValues(String propertyName, List<JsonNode> foundSoFar)
     {
-        JsonNode jsonNode = _children.get(propertyName);
-        if (jsonNode != null) {
-            if (foundSoFar == null) {
-                foundSoFar = new ArrayList<>();
+        for (Map.Entry<String, JsonNode> entry : _children.entrySet()) {
+            if (propertyName.equals(entry.getKey())) {
+                if (foundSoFar == null) {
+                    foundSoFar = new ArrayList<JsonNode>();
+                }
+                foundSoFar.add(entry.getValue());
+            } else { // only add children if parent not added
+                foundSoFar = entry.getValue().findValues(propertyName, foundSoFar);
             }
-            foundSoFar.add(jsonNode);
-            return foundSoFar;
-        }
-
-        // only add children if parent not added
-        for (JsonNode child : _children.values()) {
-            foundSoFar = child.findValues(propertyName, foundSoFar);
         }
         return foundSoFar;
     }
@@ -401,18 +398,16 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     @Override
     public List<String> findValuesAsText(String propertyName, List<String> foundSoFar)
     {
-        JsonNode jsonNode = _children.get(propertyName);
-        if (jsonNode != null) {
-            if (foundSoFar == null) {
-                foundSoFar = new ArrayList<>();
+        for (Map.Entry<String, JsonNode> entry : _children.entrySet()) {
+            if (propertyName.equals(entry.getKey())) {
+                if (foundSoFar == null) {
+                    foundSoFar = new ArrayList<String>();
+                }
+                foundSoFar.add(entry.getValue().asText());
+            } else { // only add children if parent not added
+                foundSoFar = entry.getValue().findValuesAsText(propertyName,
+                    foundSoFar);
             }
-            foundSoFar.add(jsonNode.asText());
-            return foundSoFar;
-        }
-
-        // only add children if parent not added
-        for (JsonNode child : _children.values()) {
-            foundSoFar = child.findValuesAsText(propertyName, foundSoFar);
         }
         return foundSoFar;
     }
@@ -436,18 +431,16 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     @Override
     public List<JsonNode> findParents(String propertyName, List<JsonNode> foundSoFar)
     {
-        JsonNode jsonNode = _children.get(propertyName);
-        if (jsonNode != null) {
-            if (foundSoFar == null) {
-                foundSoFar = new ArrayList<>();
+        for (Map.Entry<String, JsonNode> entry : _children.entrySet()) {
+            if (propertyName.equals(entry.getKey())) {
+                if (foundSoFar == null) {
+                    foundSoFar = new ArrayList<JsonNode>();
+                }
+                foundSoFar.add(this);
+            } else { // only add children if parent not added
+                foundSoFar = entry.getValue()
+                    .findParents(propertyName, foundSoFar);
             }
-            foundSoFar.add(this);
-            return foundSoFar;
-        }
-
-        // only add children if parent not added
-        for (JsonNode child : _children.values()) {
-            foundSoFar = child.findParents(propertyName, foundSoFar);
         }
         return foundSoFar;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/node/MissingValues4229Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/MissingValues4229Test.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.databind.node;
+
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MissingValues4229Test {
+    private static final String jsonString =
+            "{\n"
+                    + "                      \"target\": \"target1\"," // Found in <= 2.15.3 and 2.16.0\n
+                    + "                      \"object1\": {\n"
+                    + "                        \"target\": \"target2\"" // Found in <= 2.15.3, but not in 2.16.0\n
+                    + "                      },\n"
+                    + "                      \"object2\": {\n"
+                    + "                        \"target\": {" // Found in <= 2.15.3, but not in 2.16.0
+                    + "                          \"target\": \"ignoredAsParentIsTarget\""
+                    // Expect not to be found (as sub-tree search ends when parent is found)\n
+                    + "                        }\n"
+                    + "                      }\n"
+                    + "                    }";
+
+    private JsonNode rootNode;
+
+    @BeforeEach
+    public void init() throws JsonProcessingException {
+        ObjectMapper objectMapper =
+                new ObjectMapper().configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        rootNode = objectMapper.readTree(jsonString);
+    }
+
+    @Test
+    public void testFindValues() {
+        List<JsonNode> foundNodes = rootNode.findValues("target");
+
+        List<String> expectedNodePaths = new ArrayList<>();
+        expectedNodePaths.add("/target");
+        expectedNodePaths.add("/object1/target");
+        expectedNodePaths.add("/object2/target");
+
+        List<JsonNode> expectedNodes = expectedNodePaths.stream().map(rootNode::at).collect(Collectors.toList());
+
+        Assertions.assertEquals(expectedNodes, foundNodes);
+    }
+
+    @Test
+    public void testFindParents() {
+        List<JsonNode> foundNodes = rootNode.findParents("target");
+
+        List<JsonNode> expectedNodes = new ArrayList<>();
+        expectedNodes.add(rootNode.at(""));
+        expectedNodes.add(rootNode.at("/object1"));
+        expectedNodes.add(rootNode.at("/object2"));
+
+        Assertions.assertEquals(expectedNodes, foundNodes);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/node/MissingValues4229Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/MissingValues4229Test.java
@@ -1,63 +1,61 @@
 package com.fasterxml.jackson.databind.node;
 
-
+import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.BaseTest.a2q;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class MissingValues4229Test {
-    private static final String jsonString =
-            "{\n"
-                    + "                      \"target\": \"target1\"," // Found in <= 2.15.3 and 2.16.0\n
-                    + "                      \"object1\": {\n"
-                    + "                        \"target\": \"target2\"" // Found in <= 2.15.3, but not in 2.16.0\n
-                    + "                      },\n"
-                    + "                      \"object2\": {\n"
-                    + "                        \"target\": {" // Found in <= 2.15.3, but not in 2.16.0
-                    + "                          \"target\": \"ignoredAsParentIsTarget\""
-                    // Expect not to be found (as sub-tree search ends when parent is found)\n
-                    + "                        }\n"
-                    + "                      }\n"
-                    + "                    }";
+// [databind#4229] JsonNode findValues and findParents missing expected values
+public class MissingValues4229Test
+{
 
-    private JsonNode rootNode;
+    private final String JSON = a2q("{"
+            + "    'target': 'target1'," // Found in <= 2.15.3 and 2.16.0
+            + "    'object1': {"
+            + "        'target': 'target2' " // Found in <= 2.15.3, but not in 2.16.0
+            + "    },"
+            + "    'object2': {"
+            + "        'target': { " // Found in <= 2.15.3, but not in 2.16.0
+            + "            'target': 'ignoredAsParentIsTarget'" // Expect not to be found (as sub-tree search ends when parent is found)
+            + "        }"
+            + "    }"
+            + "}");
 
-    @BeforeEach
-    public void init() throws JsonProcessingException {
-        ObjectMapper objectMapper =
-                new ObjectMapper().configure(JsonParser.Feature.ALLOW_COMMENTS, true);
-        rootNode = objectMapper.readTree(jsonString);
+    private final ObjectMapper objectMapper = jsonMapperBuilder()
+            .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
+            .build();
+
+    @Test
+    public void testFindValues() throws Exception
+    {
+        JsonNode rootNode = objectMapper.readTree(JSON);
+
+        List<JsonNode> expectedNodes = new ArrayList<>();
+        expectedNodes.add(rootNode.at("/target"));
+        expectedNodes.add(rootNode.at("/object1/target"));
+        expectedNodes.add(rootNode.at("/object2/target"));
+
+        List<JsonNode> actualNodes = rootNode.findValues("target");
+
+        Assertions.assertEquals(expectedNodes, actualNodes);
     }
 
     @Test
-    public void testFindValues() {
-        List<JsonNode> foundNodes = rootNode.findValues("target");
-
-        List<String> expectedNodePaths = new ArrayList<>();
-        expectedNodePaths.add("/target");
-        expectedNodePaths.add("/object1/target");
-        expectedNodePaths.add("/object2/target");
-
-        List<JsonNode> expectedNodes = expectedNodePaths.stream().map(rootNode::at).collect(Collectors.toList());
-
-        Assertions.assertEquals(expectedNodes, foundNodes);
-    }
-
-    @Test
-    public void testFindParents() {
-        List<JsonNode> foundNodes = rootNode.findParents("target");
+    public void testFindParents() throws Exception
+    {
+        JsonNode rootNode = objectMapper.readTree(JSON);
 
         List<JsonNode> expectedNodes = new ArrayList<>();
         expectedNodes.add(rootNode.at(""));
         expectedNodes.add(rootNode.at("/object1"));
         expectedNodes.add(rootNode.at("/object2"));
+
+        List<JsonNode> foundNodes = rootNode.findParents("target");
 
         Assertions.assertEquals(expectedNodes, foundNodes);
     }


### PR DESCRIPTION
fixes #4229 