### PR TITLE
Fixed com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -70,7 +70,14 @@ public class AnnotatedFieldCollector
         // Let's add super-class' fields first, then ours.
         fields = _findFields(new TypeResolutionContext.Basic(_typeFactory, parent.getBindings()),
                 parent, fields);
-        for (Field f : cls.getDeclaredFields()) {
+        Field clsFields[] = cls.getDeclaredFields();
+        Arrays.sort(clsFields, new Comparator<Field>() {
+            @Override
+            public int compare(Field field1, Field field2) {
+                return field1.getName().compareTo(field2.getName());
+            }
+        });
+        for (Field f : clsFields) {
             // static fields not included (transients are at this point, filtered out later)
             if (!_isIncludableField(f)) {
                 continue;


### PR DESCRIPTION
This pull request addresses the flakiness in the `EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements returned by `cls.getDeclaredFields()` in `AnnotatedFieldCollector.java`. The test can be found [here](https://github.com/FasterXML/jackson-databind/blob/2.17/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDefaultReadTest.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
The order of elements returned by `cls.getDeclaredFields()` in `AnnotatedFieldCollector.java` is not deterministic. This non determinism cascades and results in failure of `EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin`.

- How I fixed the test?
I fixed the test by sorting the elements returned by `cls.getDeclaredFields()`. This sorting ensures a deterministic order of the elements in the list of `Fields` returned by `cls.getDeclaredFields()`.

- Output from NonDex:
```
[INFO] Running com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.101 s <<< FAILURE! -- in com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest
[ERROR] com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin -- Time elapsed: 0.081 s <<< FAILURE!
junit.framework.AssertionFailedError: expected:<A> but was:<Z>
	at junit.framework.Assert.fail(Assert.java:57)
	at junit.framework.Assert.failNotEquals(Assert.java:329)
	at junit.framework.Assert.assertEquals(Assert.java:78)
	at junit.framework.Assert.assertEquals(Assert.java:86)
	at junit.framework.TestCase.assertEquals(TestCase.java:246)
	at com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin(EnumDefaultReadTest.java:295)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin:295 expected:<A> but was:<Z>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for CO2p4yPOEppE0uKQSODa4JrQtbdBhwV2nLx4rb+FHnc=
INFO: Adding excluded groups to newly created one
INFO: Adding NonDex argLine to existing argLine specified by the project
CONFIG: nondexFilter=.*
nondexMode=FULL
nondexSeed=974622
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false
nondexDir=/home/shetty5/project/fixes/jackson-databind/.nondex
nondexJarDir=/home/shetty5/project/fixes/jackson-databind/.nondex
nondexExecid=MhISxy9aw774IiGFmnBcuh15ee+0u2IZ7E8mbUkUUlM=
nondexLogging=CONFIG
```

You can run the following command to run the test using the NonDex tool:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest#testFirstEnumDefaultValueViaMixin
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!