### PR TITLE
Improve `JsonNodeDeserializer` handling of NaN wrt `USE_BIG_DECIMAL_FOR_FLOATS`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -757,15 +757,14 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
         if (ctxt.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
             // [databind#4194] Add an option to fail coercing NaN to BigDecimal
             // Currently, Jackson 2.x allows such coercion, but Jackson 3.x will not
-            if (p.isNaN() && ctxt.isEnabled(JsonNodeFeature.FAIL_ON_NAN_TO_BIG_DECIMAL_COERCION)) {
-                ctxt.handleWeirdNumberValue(handledType(), p.getDoubleValue(),
-                        "Cannot convert NaN into BigDecimal");
+            if (p.isNaN()) {
+                if (ctxt.isEnabled(JsonNodeFeature.FAIL_ON_NAN_TO_BIG_DECIMAL_COERCION)) {
+                    return (JsonNode) ctxt.handleWeirdNumberValue(handledType(), p.getDoubleValue(),
+                            "Cannot convert NaN into BigDecimal");
+                }
+                return nodeFactory.numberNode(p.getDoubleValue());
             }
-            try {
-                return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
-            } catch (NumberFormatException nfe) {
-                // fall through - BigDecimal does not support values like NaN
-            }
+            return _fromBigDecimal(ctxt, nodeFactory, p.getDecimalValue());
         }
         if (nt == JsonParser.NumberType.FLOAT) {
             return nodeFactory.numberNode(p.getFloatValue());

--- a/src/test/java/com/fasterxml/jackson/databind/node/NumberNodes1770Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NumberNodes1770Test.java
@@ -43,17 +43,22 @@ public class NumberNodes1770Test extends BaseMapTest
     // [databind#4194]: should be able to, by configuration, fail coercing NaN to BigDecimal
     public void testBigDecimalCoercionNaN() throws Exception
     {
-        _tryBigDecimalCoercionNaNWithOption(false);
+        JsonNode n = _tryBigDecimalCoercionNaNWithOption(false);
+        if (!n.isDouble()) {
+            fail("Expected DoubleNode, got: "+n.getClass().getName());
+        }
+        assertEquals(Double.NaN, n.doubleValue());
 
         try {
-            _tryBigDecimalCoercionNaNWithOption(true);
-            fail("Should not pass");
+            n = _tryBigDecimalCoercionNaNWithOption(true);
+            fail("Should not pass without allowing coercion: produced JsonNode of type "
+                    +n.getClass().getName());
         } catch (InvalidFormatException e) {
             verifyException(e, "Cannot convert NaN");
         }
     }
 
-    private void _tryBigDecimalCoercionNaNWithOption(boolean isEnabled) throws Exception
+    private JsonNode _tryBigDecimalCoercionNaNWithOption(boolean isEnabled) throws Exception
     {
         JsonFactory factory = JsonFactory.builder()
                 .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
@@ -64,11 +69,8 @@ public class NumberNodes1770Test extends BaseMapTest
 
         final String value = "NaN";
         // depending on option
-        final JsonNode jsonNode = isEnabled
+        return isEnabled
                 ? reader.with(JsonNodeFeature.FAIL_ON_NAN_TO_BIG_DECIMAL_COERCION).readTree(value)
                 : reader.without(JsonNodeFeature.FAIL_ON_NAN_TO_BIG_DECIMAL_COERCION).readTree(value);
-
-        assertTrue("Expected DoubleNode, got: "+jsonNode.getClass().getName()+": "+jsonNode, jsonNode.isDouble());
-        assertEquals(Double.NaN, jsonNode.doubleValue());
     }
 }


### PR DESCRIPTION
Based on improved `JsonParser.isNaN()` which now only reports explicit NaN and not possible value over-/underflow (for `double` and `float`)