### PR TITLE
Migrate `/contextual` tests to `JUnit 5`

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
@@ -4,10 +4,8 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,11 +12,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestContextAttributeWithDeser {
     final static String KEY = "foobar";

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithDeser.java
@@ -16,31 +16,35 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
 
-public class TestContextAttributeWithDeser {
+public class TestContextAttributeWithDeser
+{
     final static String KEY = "foobar";
 
     @SuppressWarnings("serial")
-    static class PrefixStringDeserializer extends StdScalarDeserializer<String> {
+    static class PrefixStringDeserializer extends StdScalarDeserializer<String>
+    {
         protected PrefixStringDeserializer() {
             super(String.class);
         }
 
         @Override
         public String deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException {
+            throws IOException
+        {
             Integer I = (Integer) ctxt.getAttribute(KEY);
             if (I == null) {
                 I = Integer.valueOf(0);
             }
             int i = I.intValue();
             ctxt.setAttribute(KEY, Integer.valueOf(i + 1));
-            return jp.getText() + "/" + i;
+            return jp.getText()+"/"+i;
         }
 
     }
 
-    static class TestPOJO {
-        @JsonDeserialize(using = PrefixStringDeserializer.class)
+    static class TestPOJO
+    {
+        @JsonDeserialize(using=PrefixStringDeserializer.class)
         public String value;
     }
 
@@ -53,7 +57,8 @@ public class TestContextAttributeWithDeser {
     final ObjectMapper MAPPER = newJsonMapper();
 
     @Test
-    public void testSimplePerCall() throws Exception {
+    public void testSimplePerCall() throws Exception
+    {
         final String INPUT = a2q("[{'value':'a'},{'value':'b'}]");
         TestPOJO[] pojos = MAPPER.readerFor(TestPOJO[].class).readValue(INPUT);
         assertEquals(2, pojos.length);
@@ -68,22 +73,24 @@ public class TestContextAttributeWithDeser {
     }
 
     @Test
-    public void testSimpleDefaults() throws Exception {
+    public void testSimpleDefaults() throws Exception
+    {
         final String INPUT = a2q("{'value':'x'}");
         TestPOJO pojo = MAPPER.readerFor(TestPOJO.class)
-            .withAttribute(KEY, Integer.valueOf(3))
-            .readValue(INPUT);
+                .withAttribute(KEY, Integer.valueOf(3))
+                .readValue(INPUT);
         assertEquals("x/3", pojo.value);
 
         // as above, should not carry on state
         TestPOJO pojo2 = MAPPER.readerFor(TestPOJO.class)
-            .withAttribute(KEY, Integer.valueOf(5))
-            .readValue(INPUT);
+                .withAttribute(KEY, Integer.valueOf(5))
+                .readValue(INPUT);
         assertEquals("x/5", pojo2.value);
     }
 
     @Test
-    public void testHierarchic() throws Exception {
+    public void testHierarchic() throws Exception
+    {
         final String INPUT = a2q("[{'value':'x'},{'value':'y'}]");
         ObjectReader r = MAPPER.readerFor(TestPOJO[].class).withAttribute(KEY, Integer.valueOf(2));
         TestPOJO[] pojos = r.readValue(INPUT);
@@ -100,26 +107,27 @@ public class TestContextAttributeWithDeser {
 
     @Test
     // [databind#3001]
-    public void testDefaultsViaMapper() throws Exception {
+    public void testDefaultsViaMapper() throws Exception
+    {
         final String INPUT = a2q("{'value':'x'}");
         ContextAttributes attrs = ContextAttributes.getEmpty()
-            .withSharedAttribute(KEY, Integer.valueOf(72));
+                .withSharedAttribute(KEY, Integer.valueOf(72));
         ObjectMapper mapper = jsonMapperBuilder()
-            .defaultAttributes(attrs)
-            .build();
+                .defaultAttributes(attrs)
+                .build();
         TestPOJO pojo = mapper.readerFor(TestPOJO.class)
-            .readValue(INPUT);
+                .readValue(INPUT);
         assertEquals("x/72", pojo.value);
 
         // as above, should not carry on state
         TestPOJO pojo2 = mapper.readerFor(TestPOJO.class)
-            .readValue(INPUT);
+                .readValue(INPUT);
         assertEquals("x/72", pojo2.value);
 
         // And should be overridable too
         TestPOJO pojo3 = mapper.readerFor(TestPOJO.class)
-            .withAttribute(KEY, Integer.valueOf(19))
-            .readValue(INPUT);
+                .withAttribute(KEY, Integer.valueOf(19))
+                .readValue(INPUT);
         assertEquals("x/19", pojo3.value);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
@@ -2,17 +2,19 @@ package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestContextAttributeWithSer
 {

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
@@ -8,7 +8,13 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 
-public class TestContextAttributeWithSer extends BaseMapTest
+import org.junit.jupiter.api.Test;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestContextAttributeWithSer
 {
     final static String KEY = "foobar";
 
@@ -48,8 +54,9 @@ public class TestContextAttributeWithSer extends BaseMapTest
     /**********************************************************
      */
 
-    final ObjectMapper MAPPER = sharedMapper();
+    final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testSimplePerCall() throws Exception
     {
         final String EXP = a2q("[{'value':'0:a'},{'value':'1:b'}]");
@@ -62,6 +69,7 @@ public class TestContextAttributeWithSer extends BaseMapTest
         assertEquals(EXP, w.writeValueAsString(INPUT));
     }
 
+    @Test
     public void testSimpleDefaults() throws Exception
     {
         final String EXP = a2q("{'value':'3:xyz'}");
@@ -75,6 +83,7 @@ public class TestContextAttributeWithSer extends BaseMapTest
         assertEquals(EXP, json2);
     }
 
+    @Test
     public void testHierarchic() throws Exception
     {
         final TestPOJO[] INPUT = new TestPOJO[] { new TestPOJO("a"), new TestPOJO("b") };
@@ -87,6 +96,7 @@ public class TestContextAttributeWithSer extends BaseMapTest
     }
 
     // [databind#3001]
+    @Test
     public void testDefaultsViaMapper() throws Exception
     {
         final TestPOJO[] INPUT = new TestPOJO[] { new TestPOJO("a"), new TestPOJO("b") };

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextAttributeWithSer.java
@@ -5,8 +5,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
@@ -1,16 +1,15 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
-
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
@@ -6,9 +6,11 @@ import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
+
 import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
@@ -4,7 +4,11 @@ import java.io.IOException;
 import java.lang.annotation.*;
 import java.util.*;
 
-import com.fasterxml.jackson.annotation.*;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;
@@ -14,12 +18,10 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import org.junit.jupiter.api.Test;
-
-import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
 
 /**
  * Test cases to verify that it is possible to define deserializers

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualDeserialization.java
@@ -1,10 +1,7 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.*;
@@ -17,13 +14,20 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
+import org.junit.jupiter.api.Test;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * Test cases to verify that it is possible to define deserializers
  * that can use contextual information (like field/method
  * annotations) for configuration.
  */
 @SuppressWarnings("serial")
-public class TestContextualDeserialization extends BaseMapTest
+public class TestContextualDeserialization
 {
     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)
@@ -186,6 +190,7 @@ public class TestContextualDeserialization extends BaseMapTest
             ))
             .build();
 
+    @Test
     public void testSimple() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -202,6 +207,7 @@ public class TestContextualDeserialization extends BaseMapTest
         assertEquals("b=4", bean.b.value);
     }
 
+    @Test
     public void testSimpleWithAnnotations() throws Exception
     {
         ObjectMapper mapper = _mapperWithAnnotatedContextual();
@@ -215,6 +221,7 @@ public class TestContextualDeserialization extends BaseMapTest
         assertEquals("NameB=y", bean.b.value);
     }
 
+    @Test
     public void testSimpleWithClassAnnotations() throws Exception
     {
         ObjectMapper mapper = _mapperWithAnnotatedContextual();
@@ -227,6 +234,7 @@ public class TestContextualDeserialization extends BaseMapTest
         assertEquals("NameB=345", bean.b.value);
     }
 
+    @Test
     public void testAnnotatedCtor() throws Exception
     {
         ObjectMapper mapper = _mapperWithAnnotatedContextual();
@@ -239,6 +247,7 @@ public class TestContextualDeserialization extends BaseMapTest
         assertEquals("CtorB=0", bean.b);
     }
 
+    @Test
     public void testAnnotatedArray() throws Exception
     {
         ObjectMapper mapper = _mapperWithAnnotatedContextual();
@@ -252,6 +261,7 @@ public class TestContextualDeserialization extends BaseMapTest
         assertEquals("array=b", bean.beans[1].value);
     }
 
+    @Test
     public void testAnnotatedList() throws Exception
     {
         ObjectMapper mapper = _mapperWithAnnotatedContextual();
@@ -266,6 +276,7 @@ public class TestContextualDeserialization extends BaseMapTest
         assertEquals("list=z", bean.beans.get(2).value);
     }
 
+    @Test
     public void testAnnotatedMap() throws Exception
     {
         ObjectMapper mapper = _mapperWithAnnotatedContextual();
@@ -287,6 +298,7 @@ public class TestContextualDeserialization extends BaseMapTest
     }
 
     // for [databind#165]
+    @Test
     public void testContextualType() throws Exception {
         GenericBean bean = new ObjectMapper().readValue(a2q("{'stuff':{'1':'b'}}"),
                 GenericBean.class);

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualKeyTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualKeyTypes.java
@@ -1,7 +1,10 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.Version;
@@ -10,8 +13,6 @@ import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualKeyTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualKeyTypes.java
@@ -11,11 +11,16 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * Tests to ensure that we can do contextual key serializers and
  * deserializers as well as value ser/deser.
  */
-public class TestContextualKeyTypes extends BaseMapTest
+public class TestContextualKeyTypes
 {
     /*
     /**********************************************************
@@ -85,6 +90,7 @@ public class TestContextualKeyTypes extends BaseMapTest
     /**********************************************************
      */
 
+    @Test
     public void testSimpleKeySer() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -104,6 +110,7 @@ public class TestContextualKeyTypes extends BaseMapTest
     /**********************************************************
      */
 
+    @Test
     public void testSimpleKeyDeser() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualKeyTypes.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualKeyTypes.java
@@ -1,8 +1,7 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualSerialization.java
@@ -5,7 +5,6 @@ import java.lang.annotation.*;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.*;
-
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -13,12 +12,18 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
 
+import org.junit.jupiter.api.Test;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * Test cases to verify that it is possible to define serializers
  * that can use contextual information (like field/method
  * annotations) for configuration.
  */
-public class TestContextualSerialization extends BaseMapTest
+public class TestContextualSerialization
 {
     // NOTE: important; MUST be considered a 'Jackson' annotation to be seen
     // (or recognized otherwise via AnnotationIntrospect.isHandled())
@@ -219,6 +224,7 @@ public class TestContextualSerialization extends BaseMapTest
 
     // Test to verify that contextual serializer can make use of property
     // (method, field) annotations.
+    @Test
     public void testMethodAnnotations() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -230,6 +236,7 @@ public class TestContextualSerialization extends BaseMapTest
 
     // Test to verify that contextual serializer can also use annotations
     // for enclosing class.
+    @Test
     public void testClassAnnotations() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -239,6 +246,7 @@ public class TestContextualSerialization extends BaseMapTest
         assertEquals("{\"value\":\"Voila->xyz\"}", mapper.writeValueAsString(new BeanWithClassConfig("xyz")));
     }
 
+    @Test
     public void testWrappedBean() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -249,6 +257,7 @@ public class TestContextualSerialization extends BaseMapTest
     }
 
     // Serializer should get passed property context even if contained in an array.
+    @Test
     public void testMethodAnnotationInArray() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -260,6 +269,7 @@ public class TestContextualSerialization extends BaseMapTest
     }
 
     // Serializer should get passed property context even if contained in a Collection.
+    @Test
     public void testMethodAnnotationInList() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -271,6 +281,7 @@ public class TestContextualSerialization extends BaseMapTest
     }
 
     // Serializer should get passed property context even if contained in a Collection.
+    @Test
     public void testMethodAnnotationInMap() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -282,6 +293,7 @@ public class TestContextualSerialization extends BaseMapTest
         assertEquals("{\"beans\":{\"first\":\"map->In Map\"}}", mapper.writeValueAsString(map));
     }
 
+    @Test
     public void testContextualViaAnnotation() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -289,6 +301,7 @@ public class TestContextualSerialization extends BaseMapTest
         assertEquals("{\"value\":\"prefix->abc\"}", mapper.writeValueAsString(bean));
     }
 
+    @Test
     public void testResolveOnContextual() throws Exception
     {
         SimpleModule module = new SimpleModule("test", Version.unknownVersion());
@@ -302,6 +315,7 @@ public class TestContextualSerialization extends BaseMapTest
         assertEquals(q("contextual=1,resolved=1"), mapper.writeValueAsString("foo"));
     }
 
+    @Test
     public void testContextualArrayElement() throws Exception
     {
         ObjectMapper mapper = newJsonMapper();
@@ -310,6 +324,7 @@ public class TestContextualSerialization extends BaseMapTest
     }
 
     // Test to verify aspects of [databind#2429]
+    @Test
     public void testRootContextualization2429() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualSerialization.java
@@ -1,24 +1,14 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.lang.annotation.*;
+import java.util.*;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualSerialization.java
@@ -1,22 +1,32 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.lang.annotation.*;
-import java.util.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test cases to verify that it is possible to define serializers

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualWithAnnDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualWithAnnDeserializer.java
@@ -1,18 +1,15 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
+
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualWithAnnDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualWithAnnDeserializer.java
@@ -1,7 +1,10 @@
 package com.fasterxml.jackson.databind.contextual;
 
 import java.io.IOException;
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualWithAnnDeserializer.java
+++ b/src/test/java/com/fasterxml/jackson/databind/contextual/TestContextualWithAnnDeserializer.java
@@ -12,7 +12,12 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 
-public class TestContextualWithAnnDeserializer extends BaseMapTest
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestContextualWithAnnDeserializer
 {
     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)
@@ -65,6 +70,7 @@ public class TestContextualWithAnnDeserializer extends BaseMapTest
     }
 
     // ensure that direct associations also work
+    @Test
     public void testAnnotatedContextual() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
## Notes

- Jupiter's `assertEquals(exp, act)` follows same `exp -> act` order. So would be okay to use Jupiter's `org.Junitjupiter.Assertions.assertEquals`. cc. @pjfanning.
- imports ordered `java -> third party -> jackson` for both (non-)static