### PR TITLE
[Jackson 3.0] Enable by default `DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES`

### DIFF
--- a/src/main/java/tools/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/tools/jackson/databind/DeserializationFeature.java
@@ -289,12 +289,9 @@ public enum DeserializationFeature implements ConfigFeature
      * by ensuring that only the properties relevant to the active view are considered during
      * deserialization, thereby preventing unintended data from being processed.
      *<p>
-     * In Jackson 2.x, this feature is disabled by default to maintain backward compatibility.
-     * In Jackson 3.x, this feature may be enabled by default.
-     *
-     * @since 2.17
+     * Feature is enabled by default.
      */
-    FAIL_ON_UNEXPECTED_VIEW_PROPERTIES(false),
+    FAIL_ON_UNEXPECTED_VIEW_PROPERTIES(true),
 
     /*
     /**********************************************************************

--- a/src/test/java/tools/jackson/databind/convert/TestUpdateViaObjectReader.java
+++ b/src/test/java/tools/jackson/databind/convert/TestUpdateViaObjectReader.java
@@ -277,8 +277,10 @@ public class TestUpdateViaObjectReader extends BaseMapTest
         Updateable bean = new Updateable();
         bean.num = 100;
         bean.str = "test";
-        Updateable result = MAPPER.readerForUpdating(bean)
+        Updateable result = MAPPER
+                .readerForUpdating(bean)
                 .withView(TextView.class)
+                .without(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
                 .readValue("{\"num\": 10, \"str\":\"foobar\"}");
         assertSame(bean, result);
 

--- a/src/test/java/tools/jackson/databind/deser/builder/BuilderWithViewTest.java
+++ b/src/test/java/tools/jackson/databind/deser/builder/BuilderWithViewTest.java
@@ -3,6 +3,7 @@ package tools.jackson.databind.deser.builder;
 import com.fasterxml.jackson.annotation.*;
 
 import tools.jackson.databind.BaseMapTest;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.annotation.JsonDeserialize;
 
@@ -78,7 +79,9 @@ public class BuilderWithViewTest extends BaseMapTest
     /**********************************************************
      */
 
-    private final ObjectMapper MAPPER = new ObjectMapper();
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+        .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+        .build();
 
     public void testSimpleViews() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/views/DefaultViewTest.java
+++ b/src/test/java/tools/jackson/databind/views/DefaultViewTest.java
@@ -2,6 +2,7 @@ package tools.jackson.databind.views;
 
 import static org.junit.Assert.assertEquals;
 import static tools.jackson.databind.testutil.DatabindTestUtil.a2q;
+import static tools.jackson.databind.testutil.DatabindTestUtil.jsonMapperBuilder;
 
 import java.io.IOException;
 
@@ -35,7 +36,9 @@ public class DefaultViewTest
     /**********************************************************
      */
 
-    private final ObjectMapper MAPPER = new ObjectMapper();
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+        .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+        .build();
 
     @Test
     public void testDeserialization() throws IOException

--- a/src/test/java/tools/jackson/databind/views/TestViewDeserialization.java
+++ b/src/test/java/tools/jackson/databind/views/TestViewDeserialization.java
@@ -66,7 +66,9 @@ public class TestViewDeserialization
     /************************************************************************
      */
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = jsonMapperBuilder()
+        .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+        .build();
 
     @Test
     public void testSimple() throws Exception
@@ -113,7 +115,8 @@ public class TestViewDeserialization
         assertEquals(9, bean.b);
 
         ObjectMapper myMapper = jsonMapperBuilder()
-                .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
                 .build();
 
         // but with, say, AA, will not get 'b'

--- a/src/test/java/tools/jackson/databind/views/ViewsWithCreatorTest.java
+++ b/src/test/java/tools/jackson/databind/views/ViewsWithCreatorTest.java
@@ -91,7 +91,9 @@ public class ViewsWithCreatorTest
     @Test
     public void testWithoutJsonCreator() throws Exception
     {
-        ObjectReader reader = MAPPER.readerFor(ObjWithoutCreator.class).withView(View1.class);
+        ObjectReader reader = MAPPER.readerFor(ObjWithoutCreator.class)
+            .without(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+            .withView(View1.class);
 
         // serialize first,
         String json = MAPPER.writeValueAsString(new ObjWithoutCreator("a", "b", "c"));


### PR DESCRIPTION
https://github.com/FasterXML/jackson-databind/pull/4275