### PR TITLE
Migrate `/deser/filter` tests to `JUnit 5`

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreCreatorProp1317Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreCreatorProp1317Test.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.beans.ConstructorProperties;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.*;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreCreatorProp1317Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreCreatorProp1317Test.java
@@ -3,10 +3,15 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.*;
 
-public class IgnoreCreatorProp1317Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class IgnoreCreatorProp1317Test
 {
     static class Testing {
         @JsonIgnore
@@ -40,8 +45,9 @@ public class IgnoreCreatorProp1317Test extends BaseMapTest
         }
     }
 
+    @Test
     public void testThatJsonIgnoreWorksWithConstructorProperties() throws Exception {
-        ObjectMapper om = objectMapper();
+        ObjectMapper om = newJsonMapper();
         Testing testing = new Testing("shouldBeIgnored", "notIgnore");
         String json = om.writeValueAsString(testing);
 //        System.out.println(json);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertyOnDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertyOnDeserTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.json.JsonMapper;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertyOnDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertyOnDeserTest.java
@@ -2,15 +2,20 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
-public class IgnorePropertyOnDeserTest extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
+public class IgnorePropertyOnDeserTest
 {
     // [databind#426]
     @JsonIgnoreProperties({ "userId" })
@@ -92,6 +97,7 @@ public class IgnorePropertyOnDeserTest extends BaseMapTest
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // [databind#426]
+    @Test
     public void testIssue426() throws Exception
     {
         final String JSON = a2q("{'userId': 9, 'firstName': 'Mike' }");
@@ -102,6 +108,7 @@ public class IgnorePropertyOnDeserTest extends BaseMapTest
     }
 
     // [databind#1217]
+    @Test
     public void testIgnoreOnProperty1217() throws Exception
     {
         TestIgnoreObject result = MAPPER.readValue(
@@ -124,6 +131,7 @@ public class IgnorePropertyOnDeserTest extends BaseMapTest
     }
 
     // [databind#1217]
+    @Test
     public void testIgnoreViaConfigOverride1217() throws Exception
     {
         ObjectMapper mapper = JsonMapper.builder()
@@ -137,6 +145,7 @@ public class IgnorePropertyOnDeserTest extends BaseMapTest
     }
 
     // [databind#3721]
+    @Test
     public void testIgnoreUnknownViaConfigOverride() throws Exception
     {
         final String DOC = a2q("{'x':2,'foobar':3}");
@@ -161,6 +170,7 @@ public class IgnorePropertyOnDeserTest extends BaseMapTest
     }
 
     // [databind#1595]
+    @Test
     public void testIgnoreGetterNotSetter1595() throws Exception
     {
         Simple1595 config = new Simple1595();
@@ -173,6 +183,7 @@ public class IgnorePropertyOnDeserTest extends BaseMapTest
     }
 
     // [databind#2627]
+    @Test
     public void testIgnoreUnknownOnField() throws IOException
     {
         String json = "{\"value\": {\"name\": \"my_name\", \"extra\": \"val\"}, \"type\":\"Json\"}";

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreUnknownPropertyUsingPropertyBasedTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnoreUnknownPropertyUsingPropertyBasedTest.java
@@ -1,18 +1,20 @@
 package com.fasterxml.jackson.databind.deser.filter;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import com.fasterxml.jackson.databind.BaseMapTest;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.HashMap;
 import java.util.Map;
 
-public class IgnoreUnknownPropertyUsingPropertyBasedTest extends BaseMapTest {
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class IgnoreUnknownPropertyUsingPropertyBasedTest
+{
 
   private final ObjectMapper MAPPER = newJsonMapper();
 
@@ -59,6 +61,7 @@ public class IgnoreUnknownPropertyUsingPropertyBasedTest extends BaseMapTest {
     }
   }
 
+  @Test
   public void testAnySetterWithFailOnUnknownDisabled() throws Exception {
     IgnoreUnknownAnySetter value = MAPPER.readValue("{\"a\":1, \"b\":2, \"x\":3, \"y\": 4}", IgnoreUnknownAnySetter.class);
     assertNotNull(value);
@@ -69,6 +72,7 @@ public class IgnoreUnknownPropertyUsingPropertyBasedTest extends BaseMapTest {
     assertEquals(2, value.props.size());
   }
 
+  @Test
   public void testUnwrappedWithFailOnUnknownDisabled() throws Exception {
     IgnoreUnknownUnwrapped value = MAPPER.readValue("{\"a\":1, \"b\": 2, \"x\":3, \"y\":4}", IgnoreUnknownUnwrapped.class);
     assertNotNull(value);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForContent4200Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForContent4200Test.java
@@ -2,13 +2,18 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.*;
+import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
 // [databind#4200]: Nulls.FAIL not taken into account with DELEGATING creator
-public class NullConversionsForContent4200Test extends BaseMapTest
+public class NullConversionsForContent4200Test
 {
     static class DelegatingWrapper4200 {
         private final Map<String, String> value;
@@ -40,6 +45,7 @@ public class NullConversionsForContent4200Test extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testDelegatingCreatorNulls4200() throws Exception
     {
         try {
@@ -50,6 +56,7 @@ public class NullConversionsForContent4200Test extends BaseMapTest
         }
     }
 
+    @Test
     public void testSetterNulls4200() throws Exception
     {
         try {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForContentTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForContentTest.java
@@ -2,15 +2,21 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
 // For [databind#1402]; configurable null handling, for contents of
 // Collections, Maps, arrays
-public class NullConversionsForContentTest extends BaseMapTest
+public class NullConversionsForContentTest
 {
     static class NullContentFail<T> {
         public T nullsOk;
@@ -43,6 +49,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // Tests to verify that we can set default settings for failure
+    @Test
     public void testFailOnNullFromDefaults() throws Exception
     {
         final String JSON = a2q("{'values':[null]}");
@@ -78,6 +85,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testFailOnNullWithCollections() throws Exception
     {
         TypeReference<NullContentFail<List<Integer>>> typeRef = new TypeReference<NullContentFail<List<Integer>>>() { };
@@ -111,6 +119,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testFailOnNullWithArrays() throws Exception
     {
         final String JSON = a2q("{'noNulls':[null]}");
@@ -133,6 +142,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testFailOnNullWithPrimitiveArrays() throws Exception
     {
         final String JSON = a2q("{'noNulls':[null]}");
@@ -163,6 +173,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testFailOnNullWithMaps() throws Exception
     {
         // Then: Map<String,String>
@@ -191,7 +202,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     /* Test methods, null-as-empty
     /**********************************************************
      */
-
+    @Test
     public void testNullsAsEmptyWithCollections() throws Exception
     {
         final String JSON = a2q("{'values':[null]}");
@@ -213,6 +224,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testNullsAsEmptyUsingDefaults() throws Exception
     {
         final String JSON = a2q("{'values':[null]}");
@@ -234,6 +246,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         assertEquals(Integer.valueOf(0), result.values.get(0));
     }
 
+    @Test
     public void testNullsAsEmptyWithArrays() throws Exception
     {
         // Note: skip `Object[]`, no default empty value at this point
@@ -248,6 +261,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testNullsAsEmptyWithPrimitiveArrays() throws Exception
     {
         final String JSON = a2q("{'values':[null]}");
@@ -277,6 +291,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
 }
 
+    @Test
     public void testNullsAsEmptyWithMaps() throws Exception
     {
         // Then: Map<String,String>
@@ -305,6 +320,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     /**********************************************************
      */
 
+    @Test
     public void testNullsSkipUsingDefaults() throws Exception
     {
         final String JSON = a2q("{'values':[null]}");
@@ -325,6 +341,7 @@ public class NullConversionsForContentTest extends BaseMapTest
     }
 
     // Test to verify that per-property setting overrides defaults:
+    @Test
     public void testNullsSkipWithOverrides() throws Exception
     {
         final String JSON = a2q("{'values':[null]}");
@@ -344,6 +361,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         assertEquals(0, result.values.size());
     }
 
+    @Test
     public void testNullsSkipWithCollections() throws Exception
     {
         // List<Integer>
@@ -367,6 +385,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testNullsSkipWithArrays() throws Exception
     {
         final String JSON = a2q("{'values':['a',null,'xy']}");
@@ -388,6 +407,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testNullsSkipWithPrimitiveArrays() throws Exception
     {
         // int[]
@@ -421,6 +441,7 @@ public class NullConversionsForContentTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testNullsSkipWithMaps() throws Exception
     {
         // Then: Map<String,String>

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForEnumsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsForEnumsTest.java
@@ -3,13 +3,21 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.util.EnumMap;
 import java.util.EnumSet;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class NullConversionsForEnumsTest extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.ABC;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class NullConversionsForEnumsTest
 {
     static class NullValueAsEmpty<T> {
         @JsonSetter(nulls=Nulls.AS_EMPTY)
@@ -34,6 +42,7 @@ public class NullConversionsForEnumsTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testEnumSetAsEmpty() throws Exception
     {
         NullValueAsEmpty<EnumSet<ABC>> result = MAPPER.readValue(a2q("{'value': null }"),
@@ -42,6 +51,7 @@ public class NullConversionsForEnumsTest extends BaseMapTest
         assertEquals(0, result.value.size());
     }
 
+    @Test
     public void testEnumMapAsEmpty() throws Exception
     {
         NullValueAsEmpty<EnumMap<ABC, String>> result = MAPPER.readValue(a2q("{'value': null }"),
@@ -57,7 +67,7 @@ public class NullConversionsForEnumsTest extends BaseMapTest
      */
 
     // // NOTE: no "empty" value for Enums, so can't use with EnumSet, only EnumMap
-
+    @Test
     public void testEnumMapNullsAsEmpty() throws Exception
     {
         NullContentAsEmpty<EnumMap<ABC, String>> result = MAPPER.readValue(a2q("{'values': {'B':null} }"),
@@ -73,7 +83,7 @@ public class NullConversionsForEnumsTest extends BaseMapTest
     /**********************************************************
      */
 
-
+    @Test
     public void testEnumSetSkipNulls() throws Exception
     {
         NullContentSkip<EnumSet<ABC>> result = MAPPER.readValue(a2q("{'values': [ null ]}"),
@@ -82,6 +92,7 @@ public class NullConversionsForEnumsTest extends BaseMapTest
         assertEquals(0, result.values.size());
     }
 
+    @Test
     public void testEnumMapSkipNulls() throws Exception
     {
         NullContentSkip<EnumMap<ABC, String>> result = MAPPER.readValue(a2q("{'values': {'B':null} }"),

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsGenericTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsGenericTest.java
@@ -3,16 +3,22 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.type.TypeReference;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil.Point;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
 
 // for [databind#1402]; configurable null handling, for values themselves,
 // using generic types
-public class NullConversionsGenericTest extends BaseMapTest
+public class NullConversionsGenericTest
 {
     static class GeneralEmpty<T> {
         // 09-Feb-2017, tatu: Should only need annotation either for field OR setter, not both:
@@ -42,6 +48,7 @@ public class NullConversionsGenericTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testNullsToEmptyPojo() throws Exception
     {
         GeneralEmpty<Point> result = MAPPER.readValue(a2q("{'value':null}"),
@@ -62,6 +69,7 @@ public class NullConversionsGenericTest extends BaseMapTest
     }
 
     // [databind#2023] two-part coercion from "" to `null` to skip/empty/exception should work
+    @Test
     public void testEmptyStringToNullToEmptyPojo() throws Exception
     {
         GeneralEmpty<Point> result = MAPPER.readerFor(new TypeReference<GeneralEmpty<Point>>() { })
@@ -73,6 +81,7 @@ public class NullConversionsGenericTest extends BaseMapTest
         assertEquals(0, p.y);
     }
 
+    @Test
     public void testNullsToEmptyCollection() throws Exception
     {
         GeneralEmpty<List<String>> result = MAPPER.readValue(a2q("{'value':null}"),
@@ -87,6 +96,7 @@ public class NullConversionsGenericTest extends BaseMapTest
         assertEquals(0, result2.value.size());
     }
 
+    @Test
     public void testNullsToEmptyMap() throws Exception
     {
         GeneralEmpty<Map<String,String>> result = MAPPER.readValue(a2q("{'value':null}"),
@@ -95,6 +105,7 @@ public class NullConversionsGenericTest extends BaseMapTest
         assertEquals(0, result.value.size());
     }
 
+    @Test
     public void testNullsToEmptyArrays() throws Exception
     {
         final String json = a2q("{'value':null}");

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsPojoTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsPojoTest.java
@@ -1,17 +1,22 @@
 package com.fasterxml.jackson.databind.deser.filter;
 
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
 
-import java.util.Collection;
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
 
 // for [databind#1402]; configurable null handling, for values themselves
-public class NullConversionsPojoTest extends BaseMapTest
+public class NullConversionsPojoTest
 {
     static class NullFail {
         public String nullsOk = "a";
@@ -84,6 +89,7 @@ public class NullConversionsPojoTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testFailOnNull() throws Exception
     {
         // first, ok if assigning non-null to not-nullable, null for nullable
@@ -119,6 +125,7 @@ public class NullConversionsPojoTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testFailOnNullWithDefaults() throws Exception
     {
         // also: config overrides by type should work
@@ -137,6 +144,7 @@ public class NullConversionsPojoTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testNullsToEmptyScalar() throws Exception
     {
         NullAsEmpty result = MAPPER.readValue(a2q("{'nullAsEmpty':'foo', 'nullsOk':null}"),
@@ -161,6 +169,7 @@ public class NullConversionsPojoTest extends BaseMapTest
         assertEquals("", named.getName());
     }
 
+    @Test
     public void testNullsToEmptyViaCtor() throws Exception
     {
         NullAsEmptyCtor result = MAPPER.readValue(a2q("{'nullAsEmpty':'foo', 'nullsOk':null}"),
@@ -179,6 +188,7 @@ public class NullConversionsPojoTest extends BaseMapTest
     }
 
     // [databind#3645]
+    @Test
     public void testDeserializeMissingCollectionFieldAsEmpty() throws Exception {
         String json = "{\"name\": \"Computer\"}";
 
@@ -189,6 +199,7 @@ public class NullConversionsPojoTest extends BaseMapTest
     }
 
     // [databind#3645]
+    @Test
     public void testDeserializeNullAsEmpty() throws Exception {
         String json = "{\"name\": \"Computer\", \"prices\" : null}";
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsSkipTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsSkipTest.java
@@ -17,7 +17,7 @@ public class NullConversionsSkipTest {
     static class NullSkipField {
         public String nullsOk = "a";
 
-        @JsonSetter(nulls = Nulls.SKIP)
+        @JsonSetter(nulls=Nulls.SKIP)
         public String noNulls = "b";
     }
 
@@ -29,7 +29,7 @@ public class NullConversionsSkipTest {
             _nullsOk = v;
         }
 
-        @JsonSetter(nulls = Nulls.SKIP)
+        @JsonSetter(nulls=Nulls.SKIP)
         public void setNoNulls(String v) {
             _noNulls = v;
         }
@@ -62,39 +62,42 @@ public class NullConversionsSkipTest {
     private final ObjectMapper MAPPER = newJsonMapper();
 
     @Test
-    public void testSkipNullField() throws Exception {
+    public void testSkipNullField() throws Exception
+    {
         // first, ok if assigning non-null to not-nullable, null for nullable
         NullSkipField result = MAPPER.readValue(a2q("{'noNulls':'foo', 'nullsOk':null}"),
-            NullSkipField.class);
+                NullSkipField.class);
         assertEquals("foo", result.noNulls);
         assertNull(result.nullsOk);
 
         // and then see that nulls are not ok for non-nullable
         result = MAPPER.readValue(a2q("{'noNulls':null}"),
-            NullSkipField.class);
+                NullSkipField.class);
         assertEquals("b", result.noNulls);
         assertEquals("a", result.nullsOk);
     }
 
     @Test
-    public void testSkipNullMethod() throws Exception {
+    public void testSkipNullMethod() throws Exception
+    {
         NullSkipMethod result = MAPPER.readValue(a2q("{'noNulls':'foo', 'nullsOk':null}"),
-            NullSkipMethod.class);
+                NullSkipMethod.class);
         assertEquals("foo", result._noNulls);
         assertNull(result._nullsOk);
 
         result = MAPPER.readValue(a2q("{'noNulls':null}"),
-            NullSkipMethod.class);
+                NullSkipMethod.class);
         assertEquals("b", result._noNulls);
         assertEquals("a", result._nullsOk);
     }
 
     // for [databind#2015]
     @Test
-    public void testEnumAsNullThenSkip() throws Exception {
+    public void testEnumAsNullThenSkip() throws Exception
+    {
         Pojo2015 p = MAPPER.readerFor(Pojo2015.class)
-            .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
-            .readValue("{\"number\":\"THREE\"}");
+                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+                .readValue("{\"number\":\"THREE\"}");
         assertEquals(NUMS2015.TWO, p.number);
     }
 
@@ -105,7 +108,8 @@ public class NullConversionsSkipTest {
      */
 
     @Test
-    public void testSkipNullWithDefaults() throws Exception {
+    public void testSkipNullWithDefaults() throws Exception
+    {
         String json = a2q("{'value':null}");
         StringValue result = MAPPER.readValue(json, StringValue.class);
         assertNull(result.value);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsSkipTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsSkipTest.java
@@ -1,16 +1,23 @@
 package com.fasterxml.jackson.databind.deser.filter;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
 // for [databind#1402]; configurable null handling, specifically with SKIP
-public class NullConversionsSkipTest extends BaseMapTest
-{
+public class NullConversionsSkipTest {
     static class NullSkipField {
         public String nullsOk = "a";
 
-        @JsonSetter(nulls=Nulls.SKIP)
+        @JsonSetter(nulls = Nulls.SKIP)
         public String noNulls = "b";
     }
 
@@ -22,7 +29,7 @@ public class NullConversionsSkipTest extends BaseMapTest
             _nullsOk = v;
         }
 
-        @JsonSetter(nulls=Nulls.SKIP)
+        @JsonSetter(nulls = Nulls.SKIP)
         public void setNoNulls(String v) {
             _noNulls = v;
         }
@@ -54,40 +61,40 @@ public class NullConversionsSkipTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    public void testSkipNullField() throws Exception
-    {
+    @Test
+    public void testSkipNullField() throws Exception {
         // first, ok if assigning non-null to not-nullable, null for nullable
         NullSkipField result = MAPPER.readValue(a2q("{'noNulls':'foo', 'nullsOk':null}"),
-                NullSkipField.class);
+            NullSkipField.class);
         assertEquals("foo", result.noNulls);
         assertNull(result.nullsOk);
 
         // and then see that nulls are not ok for non-nullable
         result = MAPPER.readValue(a2q("{'noNulls':null}"),
-                NullSkipField.class);
+            NullSkipField.class);
         assertEquals("b", result.noNulls);
         assertEquals("a", result.nullsOk);
     }
 
-    public void testSkipNullMethod() throws Exception
-    {
+    @Test
+    public void testSkipNullMethod() throws Exception {
         NullSkipMethod result = MAPPER.readValue(a2q("{'noNulls':'foo', 'nullsOk':null}"),
-                NullSkipMethod.class);
+            NullSkipMethod.class);
         assertEquals("foo", result._noNulls);
         assertNull(result._nullsOk);
 
         result = MAPPER.readValue(a2q("{'noNulls':null}"),
-                NullSkipMethod.class);
+            NullSkipMethod.class);
         assertEquals("b", result._noNulls);
         assertEquals("a", result._nullsOk);
     }
 
     // for [databind#2015]
-    public void testEnumAsNullThenSkip() throws Exception
-    {
+    @Test
+    public void testEnumAsNullThenSkip() throws Exception {
         Pojo2015 p = MAPPER.readerFor(Pojo2015.class)
-                .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
-                .readValue("{\"number\":\"THREE\"}");
+            .with(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+            .readValue("{\"number\":\"THREE\"}");
         assertEquals(NUMS2015.TWO, p.number);
     }
 
@@ -97,8 +104,8 @@ public class NullConversionsSkipTest extends BaseMapTest
     /**********************************************************
      */
 
-    public void testSkipNullWithDefaults() throws Exception
-    {
+    @Test
+    public void testSkipNullWithDefaults() throws Exception {
         String json = a2q("{'value':null}");
         StringValue result = MAPPER.readValue(json, StringValue.class);
         assertNull(result.value);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsViaCreator2458Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsViaCreator2458Test.java
@@ -3,12 +3,12 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.util.List;
 import java.util.Objects;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsViaCreator2458Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/NullConversionsViaCreator2458Test.java
@@ -7,10 +7,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.*;
 
-public class NullConversionsViaCreator2458Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.jsonMapperBuilder;
+
+public class NullConversionsViaCreator2458Test
 {
     // [databind#2458]
     static class Pojo {
@@ -36,6 +42,7 @@ public class NullConversionsViaCreator2458Test extends BaseMapTest
             .build();
 
     // [databind#2458]
+    @Test
     public void testMissingToEmptyViaCreator() throws Exception {
         Pojo pojo = MAPPER_WITH_AS_EMPTY.readValue("{}", Pojo.class);
         assertNotNull(pojo);
@@ -44,6 +51,7 @@ public class NullConversionsViaCreator2458Test extends BaseMapTest
     }
 
     // [databind#2458]
+    @Test
     public void testNullToEmptyViaCreator() throws Exception {
         Pojo pojo = MAPPER_WITH_AS_EMPTY.readValue("{\"value\":null}", Pojo.class);
         assertNotNull(pojo);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ParserFilterViaMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ParserFilterViaMapTest.java
@@ -3,12 +3,18 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.util.Collections;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.databind.*;
 
-public class ParserFilterViaMapTest extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class ParserFilterViaMapTest
 {
     private final ObjectMapper MAPPER = newJsonMapper();
 
@@ -24,6 +30,7 @@ public class ParserFilterViaMapTest extends BaseMapTest
 
     // From [core#700], to verify at databind level
     // (and actually found a bug in doing so -- fixed for 2.13.0)
+    @Test
     public void testSimplePropertyExcludeFilter() throws Exception
     {
         final String json = "{\"@type\":\"xxx\",\"a\":{\"@type\":\"yyy\",\"b\":11}}";

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandler1767Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandler1767Test.java
@@ -1,9 +1,16 @@
 package com.fasterxml.jackson.databind.deser.filter;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 
-public class ProblemHandler1767Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+
+public class ProblemHandler1767Test
 {
     static class IntHandler
             extends DeserializationProblemHandler
@@ -34,6 +41,7 @@ public class ProblemHandler1767Test extends BaseMapTest
 
     }
 
+    @Test
     public void testPrimitivePropertyWithHandler() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.addHandler(new IntHandler());

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandler2973Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandler2973Test.java
@@ -2,14 +2,20 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
-public class ProblemHandler2973Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
+public class ProblemHandler2973Test
 {
     // [databind#2973]
     static class WeirdTokenHandler
@@ -34,6 +40,7 @@ public class ProblemHandler2973Test extends BaseMapTest
      */
 
     // [databind#2973]
+    @Test
     public void testUnexpectedToken2973() throws Exception
     {
         // First: without handler, should get certain failure
@@ -49,7 +56,7 @@ public class ProblemHandler2973Test extends BaseMapTest
         mapper = jsonMapperBuilder()
             .addHandler(new WeirdTokenHandler())
             .build();
-        ;
+
         String str = mapper.readValue("{ }", String.class);
         assertEquals("START_OBJECT", str);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandler3450Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandler3450Test.java
@@ -1,10 +1,14 @@
 package com.fasterxml.jackson.databind.deser.filter;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
-public class ProblemHandler3450Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ProblemHandler3450Test
 {
     // [databind#3450]
     static class LenientDeserializationProblemHandler extends DeserializationProblemHandler {
@@ -30,6 +34,7 @@ public class ProblemHandler3450Test extends BaseMapTest
             JsonMapper.builder().addHandler(new LenientDeserializationProblemHandler()).build();
 
     // [databind#3450]
+    @Test
     public void testIntegerCoercion3450() throws Exception
     {
         TestPojo3450Int pojo;
@@ -43,6 +48,7 @@ public class ProblemHandler3450Test extends BaseMapTest
         assertNull(pojo.myInteger);
     }
 
+    @Test
     public void testLongCoercion3450() throws Exception
     {
         TestPojo3450Long pojo;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerLocation1440Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerLocation1440Test.java
@@ -3,15 +3,20 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.io.IOException;
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
-
 import com.fasterxml.jackson.core.*;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
 // Test(s) to verify [databind#1440]
-public class ProblemHandlerLocation1440Test extends BaseMapTest
+public class ProblemHandlerLocation1440Test
 {
     static class DeserializationProblem {
         public List<String> unknownProperties = new ArrayList<>();
@@ -113,6 +118,7 @@ public class ProblemHandlerLocation1440Test extends BaseMapTest
     /**********************************************************
      */
 
+    @Test
     public void testIncorrectContext() throws Exception
     {
         // need invalid to trigger problem:

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerTest.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -15,12 +17,16 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
 /**
  * Tests to exercise handler methods of {@link DeserializationProblemHandler}.
  *
  * @since 2.8
  */
-public class ProblemHandlerTest extends BaseMapTest
+public class ProblemHandlerTest
 {
     /*
     /**********************************************************
@@ -235,6 +241,7 @@ public class ProblemHandlerTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testWeirdKeyHandling() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -248,6 +255,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertEquals(Integer.valueOf(7), map.keySet().iterator().next());
     }
 
+    @Test
     public void testWeirdNumberHandling() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -257,6 +265,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertEquals(SingleValuedEnum.A, result);
     }
 
+    @Test
     public void testWeirdStringHandling() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -273,6 +282,7 @@ public class ProblemHandlerTest extends BaseMapTest
     }
 
     // [databind#3784]: Base64 decoding
+    @Test
     public void testWeirdStringForBase64() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -288,6 +298,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertEquals(0, binary.length);
     }
 
+    @Test
     public void testInvalidTypeId() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -299,6 +310,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertEquals(BaseImpl.class, w.value.getClass());
     }
 
+    @Test
     public void testInvalidClassAsId() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -312,6 +324,7 @@ public class ProblemHandlerTest extends BaseMapTest
 
     // 2.9: missing type id, distinct from unknown
 
+    @Test
     public void testMissingTypeId() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -323,6 +336,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertEquals(BaseImpl.class, w.value.getClass());
     }
 
+    @Test
     public void testMissingClassAsId() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -335,6 +349,7 @@ public class ProblemHandlerTest extends BaseMapTest
     }
 
     // verify that by default we get special exception type
+    @Test
     public void testInvalidTypeIdFail() throws Exception
     {
         try {
@@ -348,6 +363,7 @@ public class ProblemHandlerTest extends BaseMapTest
         }
     }
 
+    @Test
     public void testInstantiationExceptionHandling() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -358,6 +374,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertNotNull(w);
     }
 
+    @Test
     public void testMissingInstantiatorHandling() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()
@@ -368,6 +385,7 @@ public class ProblemHandlerTest extends BaseMapTest
         assertEquals(13, w.value);
     }
 
+    @Test
     public void testUnexpectedTokenHandling() throws Exception
     {
         ObjectMapper mapper = jsonMapperBuilder()

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerUnknownTypeId2221Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ProblemHandlerUnknownTypeId2221Test.java
@@ -3,17 +3,23 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.io.*;
 import java.util.Collection;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.testutil.NoCheckSubTypeValidator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+
 // for [databind#2221]
-public class ProblemHandlerUnknownTypeId2221Test extends BaseMapTest
+public class ProblemHandlerUnknownTypeId2221Test
 {
     @SuppressWarnings("rawtypes")
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "_class")
@@ -83,6 +89,7 @@ public class ProblemHandlerUnknownTypeId2221Test extends BaseMapTest
 "     }"
 );
 
+    @Test
     public void testWithDeserializationProblemHandler() throws Exception {
         final ObjectMapper mapper = new ObjectMapper()
                 .activateDefaultTyping(NoCheckSubTypeValidator.instance);
@@ -98,6 +105,7 @@ public class ProblemHandlerUnknownTypeId2221Test extends BaseMapTest
         assertEquals(2, processableContent.getInnerObjects().size());
     }
 
+    @Test
     public void testWithDisabledFAIL_ON_INVALID_SUBTYPE() throws Exception {
         final ObjectMapper mapper = new ObjectMapper()
                 .disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyDeser1890Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyDeser1890Test.java
@@ -2,13 +2,17 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.beans.ConstructorProperties;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.BaseMapTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
 public class ReadOnlyDeser1890Test
-    extends BaseMapTest
 {
     // [databind#95]
     @JsonIgnoreProperties(value={ "computed" }, allowGetters=true)
@@ -76,6 +80,7 @@ public class ReadOnlyDeser1890Test
    private final ObjectMapper MAPPER = newJsonMapper();
 
    // [databind#95]
+   @Test
    public void testReadOnlyProps95() throws Exception
    {
        ObjectMapper m = new ObjectMapper();
@@ -88,6 +93,7 @@ public class ReadOnlyDeser1890Test
    }
 
    // [databind#1890]
+   @Test
    public void testDeserializeAnnotationsOneField() throws Exception {
        PersonAnnotations person = MAPPER.readValue("{\"testEnum\":\"\"}", PersonAnnotations.class);
        // can not remain as is, so becomes `null`
@@ -95,6 +101,7 @@ public class ReadOnlyDeser1890Test
        assertNull(person.name);
    }
 
+    @Test
    public void testDeserializeAnnotationsTwoFields() throws Exception {
        PersonAnnotations person = MAPPER.readValue("{\"testEnum\":\"\",\"name\":\"changyong\"}",
                PersonAnnotations.class);
@@ -103,12 +110,14 @@ public class ReadOnlyDeser1890Test
        assertEquals("changyong", person.name);
    }
 
+    @Test
    public void testDeserializeOneField() throws Exception {
        Person person = MAPPER.readValue("{\"testEnum\":\"\"}", Person.class);
        assertEquals(TestEnum.DEFAULT, person.getTestEnum());
        assertNull(person.name);
    }
 
+    @Test
    public void testDeserializeTwoFields() throws Exception {
        Person person = MAPPER.readValue("{\"testEnum\":\"\",\"name\":\"changyong\"}",
                Person.class);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyDeserFailOnUnknown2719Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyDeserFailOnUnknown2719Test.java
@@ -1,11 +1,17 @@
 package com.fasterxml.jackson.databind.deser.filter;
 
-import com.fasterxml.jackson.annotation.*;
+import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
-public class ReadOnlyDeserFailOnUnknown2719Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.*;
+
+public class ReadOnlyDeserFailOnUnknown2719Test
 {
     // [databind#2719]
     static class UserWithReadOnly {
@@ -24,6 +30,7 @@ public class ReadOnlyDeserFailOnUnknown2719Test extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testFailOnIgnore() throws Exception
     {
         ObjectReader r = MAPPER.readerFor(UserWithReadOnly.class);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyListDeser2118Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyListDeser2118Test.java
@@ -2,11 +2,16 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.util.*;
 
-import com.fasterxml.jackson.annotation.*;
+import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 
-public class ReadOnlyListDeser2118Test extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class ReadOnlyListDeser2118Test
 {
     // [databind#2118]
     static class SecurityGroup {
@@ -49,6 +54,7 @@ public class ReadOnlyListDeser2118Test extends BaseMapTest
     private final ObjectMapper mapper = newJsonMapper();
 
     // [databind#2118]
+    @Test
     public void testAccessReadOnly() throws Exception {
         String data ="{\"security_group_rules\": [{\"id\": \"id1\"}]}";
 // This would work around the issue:

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyListDeser2283Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOnlyListDeser2283Test.java
@@ -2,13 +2,19 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.jsonMapperBuilder;
+
 // [databind#2283]: ignore read-only Lists even if "getter-as-setter" enabled
 public class ReadOnlyListDeser2283Test
-    extends BaseMapTest
 {
     static class RenamedToSameOnGetter {
         @JsonProperty(value = "list", access = JsonProperty.Access.READ_ONLY)
@@ -41,30 +47,33 @@ public class ReadOnlyListDeser2283Test
     private final ObjectMapper MAPPER = jsonMapperBuilder()
             .configure(MapperFeature.USE_GETTERS_AS_SETTERS, true).build();
 
+    @Test
     public void testRenamedToSameOnGetter() throws Exception
     {
         assertEquals("{\"list\":[]}",
                 MAPPER.writeValueAsString(new RenamedToSameOnGetter()));
         String payload = "{\"list\":[1,2,3,4]}";
         RenamedToSameOnGetter foo = MAPPER.readValue(payload, RenamedToSameOnGetter.class);
-        assertTrue("List should be empty", foo.getList().isEmpty());
+        assertTrue(foo.getList().isEmpty(), "List should be empty");
     }
 
+    @Test
     public void testRenamedToDifferentOnGetter() throws Exception
     {
         assertEquals("{\"renamedList\":[]}",
                 MAPPER.writeValueAsString(new RenamedToDifferentOnGetter()));
         String payload = "{\"renamedList\":[1,2,3,4]}";
         RenamedToDifferentOnGetter foo = MAPPER.readValue(payload, RenamedToDifferentOnGetter.class);
-        assertTrue("List should be empty", foo.getList().isEmpty());
+        assertTrue(foo.getList().isEmpty(), "List should be empty");
     }
 
+    @Test
     public void testRenamedOnClass() throws Exception
     {
         assertEquals("{\"renamedList\":[]}",
                 MAPPER.writeValueAsString(new RenamedOnClass()));
         String payload = "{\"renamedList\":[1,2,3,4]}";
         RenamedOnClass foo = MAPPER.readValue(payload, RenamedOnClass.class);
-        assertTrue("List should be empty", foo.getList().isEmpty());
+        assertTrue(foo.getList().isEmpty(), "List should be empty");
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOrWriteOnlyTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/ReadOrWriteOnlyTest.java
@@ -5,12 +5,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.fasterxml.jackson.databind.*;
 
-public class ReadOrWriteOnlyTest extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class ReadOrWriteOnlyTest
 {
     // for [databind#935], verify read/write-only cases
     static class ReadXWriteY {
@@ -130,9 +135,10 @@ public class ReadOrWriteOnlyTest extends BaseMapTest
     /**********************************************************
      */
 
-    private final ObjectMapper MAPPER = new ObjectMapper();
+    private final ObjectMapper MAPPER = newJsonMapper();
 
     // [databind#935]
+    @Test
     public void testReadOnlyAndWriteOnly() throws Exception
     {
         String json = MAPPER.writeValueAsString(new ReadXWriteY());
@@ -144,6 +150,7 @@ public class ReadOrWriteOnlyTest extends BaseMapTest
         assertEquals(6, result.y);
     }
 
+    @Test
     public void testReadOnly935() throws Exception
     {
         String json = MAPPER.writeValueAsString(new Pojo935());
@@ -152,6 +159,7 @@ public class ReadOrWriteOnlyTest extends BaseMapTest
     }
 
     // [databind#1345]
+    @Test
     public void testReadOnly1345() throws Exception
     {
         Foo1345 result = MAPPER.readValue("{\"name\":\"test\"}", Foo1345.class);
@@ -161,14 +169,16 @@ public class ReadOrWriteOnlyTest extends BaseMapTest
     }
 
     // [databind#1382]
+    @Test
     public void testReadOnly1382() throws Exception
     {
         String payload = "{\"list\":[1,2,3,4]}";
         Foo1382 foo = MAPPER.readValue(payload, Foo1382.class);
-        assertTrue("List should be empty", foo.getList().isEmpty());
+        assertTrue(foo.getList().isEmpty(), "List should be empty");
     }
 
     // [databind#1805]
+    @Test
     public void testViaReadOnly() throws Exception {
         UserWithReadOnly1805 user = new UserWithReadOnly1805();
         user.name = "foo";
@@ -178,6 +188,7 @@ public class ReadOrWriteOnlyTest extends BaseMapTest
     }
 
     // [databind#1805]
+    @Test
     public void testUsingAllowGetters() throws Exception {
         UserAllowGetters1805 user = new UserAllowGetters1805();
         user.name = "foo";
@@ -188,6 +199,7 @@ public class ReadOrWriteOnlyTest extends BaseMapTest
     }
 
     // [databind#2779]: ignorable property renaming
+    @Test
     public void testIssue2779() throws Exception
     {
         Bean2779 bean = new Bean2779();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/RecursiveIgnorePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/RecursiveIgnorePropertiesTest.java
@@ -2,12 +2,19 @@ package com.fasterxml.jackson.databind.deser.filter;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.fasterxml.jackson.databind.*;
 
-public class RecursiveIgnorePropertiesTest extends BaseMapTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+public class RecursiveIgnorePropertiesTest
 {
     static class Person {
         public String name;
@@ -33,6 +40,7 @@ public class RecursiveIgnorePropertiesTest extends BaseMapTest
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testRecursiveForDeser() throws Exception
     {
         String st = a2q("{ 'name': 'admin',\n"
@@ -44,6 +52,7 @@ public class RecursiveIgnorePropertiesTest extends BaseMapTest
         assertEquals("wyatt", result.personZ.name);
     }
 
+    @Test
     public void testRecursiveWithCollectionDeser() throws Exception
     {
         String st = a2q("{ 'name': 'admin',\n"
@@ -55,6 +64,7 @@ public class RecursiveIgnorePropertiesTest extends BaseMapTest
         assertEquals(2, result.personZ.size());
     }
 
+    @Test
     public void testRecursiveForSer() throws Exception
     {
         Person input = new Person();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/TestUnknownPropertyDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/TestUnknownPropertyDeserialization.java
@@ -3,6 +3,8 @@ package com.fasterxml.jackson.databind.deser.filter;
 import java.io.*;
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -10,11 +12,15 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.verifyException;
+
 /**
  * Unit tests for checking handling of unknown properties
  */
 public class TestUnknownPropertyDeserialization
-    extends BaseMapTest
 {
     final static class TestBean
     {
@@ -153,6 +159,7 @@ public class TestUnknownPropertyDeserialization
      * By default we should just get an exception if an unknown property
      * is encountered
      */
+    @Test
     public void testUnknownHandlingDefault() throws Exception
     {
         try {
@@ -167,6 +174,7 @@ public class TestUnknownPropertyDeserialization
      * Test that verifies that it is possible to ignore unknown properties using
      * {@link DeserializationProblemHandler}.
      */
+    @Test
     public void testUnknownHandlingIgnoreWithHandler() throws Exception
     {
         ObjectMapper mapper = newJsonMapper();
@@ -183,6 +191,7 @@ public class TestUnknownPropertyDeserialization
      * Test that verifies that it is possible to ignore unknown properties using
      * {@link DeserializationProblemHandler} and an ObjectReader.
      */
+    @Test
     public void testUnknownHandlingIgnoreWithHandlerAndObjectReader() throws Exception
     {
         ObjectMapper mapper = newJsonMapper();
@@ -198,6 +207,7 @@ public class TestUnknownPropertyDeserialization
      * Test for checking that it is also possible to simply suppress
      * error reporting for unknown properties.
      */
+    @Test
     public void testUnknownHandlingIgnoreWithFeature() throws Exception
     {
         ObjectMapper mapper = newJsonMapper();
@@ -214,6 +224,7 @@ public class TestUnknownPropertyDeserialization
         assertEquals(-1, result._b);
     }
 
+    @Test
     public void testWithClassIgnore() throws Exception
     {
         IgnoreSome result = MAPPER.readValue("{ \"a\":1,\"b\":2,\"c\":\"x\",\"d\":\"y\"}",
@@ -227,6 +238,7 @@ public class TestUnknownPropertyDeserialization
     }
 
     /// @since 1.4
+    @Test
     public void testClassIgnoreWithMap() throws Exception
     {
         // Let's actually use incompatible types for "a" and "d"; should not matter when ignored
@@ -244,6 +256,7 @@ public class TestUnknownPropertyDeserialization
         assertFalse(result.containsKey("d"));
     }
 
+    @Test
     public void testClassWithIgnoreUnknown() throws Exception
     {
         IgnoreUnknown result = MAPPER.readValue
@@ -251,6 +264,7 @@ public class TestUnknownPropertyDeserialization
         assertEquals(-3, result.a);
     }
 
+    @Test
     public void testAnySetterWithFailOnUnknownDisabled() throws Exception
     {
         IgnoreUnknownAnySetter value = MAPPER.readValue("{\"x\":\"y\", \"a\":\"b\"}",  IgnoreUnknownAnySetter.class);
@@ -258,6 +272,7 @@ public class TestUnknownPropertyDeserialization
         assertEquals(2, value.props.size());
     }
 
+    @Test
     public void testUnwrappedWithFailOnUnknownDisabled() throws Exception
     {
       IgnoreUnknownUnwrapped value = MAPPER.readValue("{\"a\":1, \"b\":2}",  IgnoreUnknownUnwrapped.class);
@@ -270,6 +285,7 @@ public class TestUnknownPropertyDeserialization
      * Test that verifies that use of {@link JsonIgnore} will add implicit
      * skipping of matching properties.
      */
+    @Test
     public void testClassWithUnknownAndIgnore() throws Exception
     {
         // should be ok: "a" and "b" ignored, "c" mapped:
@@ -286,6 +302,7 @@ public class TestUnknownPropertyDeserialization
         }
     }
 
+    @Test
     public void testPropertyIgnoral() throws Exception
     {
         XYZWrapper1 result = MAPPER.readValue("{\"value\":{\"y\":2,\"x\":1,\"z\":3}}", XYZWrapper1.class);
@@ -293,6 +310,7 @@ public class TestUnknownPropertyDeserialization
         assertEquals(3, result.value.z);
     }
 
+    @Test
     public void testPropertyIgnoralWithClass() throws Exception
     {
         XYZWrapper2 result = MAPPER.readValue("{\"value\":{\"y\":2,\"x\":1,\"z\":3}}",
@@ -300,6 +318,7 @@ public class TestUnknownPropertyDeserialization
         assertEquals(1, result.value.x);
     }
 
+    @Test
     public void testPropertyIgnoralForMap() throws Exception
     {
         MapWithoutX result = MAPPER.readValue("{\"values\":{\"x\":1,\"y\":2}}", MapWithoutX.class);
@@ -308,6 +327,7 @@ public class TestUnknownPropertyDeserialization
         assertEquals(Integer.valueOf(2), result.values.get("y"));
     }
 
+    @Test
     public void testIssue987() throws Exception
     {
         ObjectMapper jsonMapper = newJsonMapper();

--- a/src/test/java/com/fasterxml/jackson/databind/testutil/DatabindTestUtil.java
+++ b/src/test/java/com/fasterxml/jackson/databind/testutil/DatabindTestUtil.java
@@ -2,10 +2,11 @@ package com.fasterxml.jackson.databind.testutil;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import com.fasterxml.jackson.core.FormatSchema;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -21,11 +22,52 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class DatabindTestUtil
 {
+   /*
+    /**********************************************************
+    /* Shared helper classes
+    /**********************************************************
+     */
+
+    public static enum ABC { A, B, C; }
+
+    public static class Point {
+        public int x, y;
+
+        protected Point() { } // for deser
+        public Point(int x0, int y0) {
+            x = x0;
+            y = y0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof BaseMapTest.Point)) {
+                return false;
+            }
+            BaseMapTest.Point other = (BaseMapTest.Point) o;
+            return (other.x == x) && (other.y == y);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[x=%d, y=%d]", x, y);
+        }
+    }
+
     /*
     /**********************************************************
     /* Factory methods
     /**********************************************************
      */
+
+    private static ObjectMapper SHARED_MAPPER;
+
+    public static ObjectMapper sharedMapper() {
+        if (SHARED_MAPPER == null) {
+            SHARED_MAPPER = newJsonMapper();
+        }
+        return SHARED_MAPPER;
+    }
 
     public static TypeFactory newTypeFactory() {
         // this is a work-around; no null modifier added


### PR DESCRIPTION
Blocked by https://github.com/FasterXML/jackson-databind/pull/4297 (Fixes broken CI)