### PR TITLE
Instantiators for additional container classes

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1738,3 +1738,7 @@ Muhammad Khalikov (mukham12@github)
  * Contributed fix for #4209: Make `BeanDeserializerModifier`/`BeanSerializerModifier`
   implement `java.io.Serializable`
  (2.17.0)
+
+Eduard Dudar (edudar@github)
+ * Contributed #4299: Some `Collection` and `Map` fallbacks don't work in GraalVM native image
+ (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -31,6 +31,8 @@ Project: jackson-databind
 #4262: Improve handling of `null` insertion failure for `TreeSet`
 #4263: Change `ObjectArrayDeserializer` to use "generic" type parameter
   (`java.lang.Object`) to remove co-variant return type
+#4299: Some `Collection` and `Map` fallbacks don't work in GraalVM native image
+ (contributed by Eduard D)
 #4309: `@JsonSetter(nulls=...)` handling of `Collection` `null` values during
   deserialization with `READ_UNKNOWN_ENUM_VALUES_AS_NULL` and `FAIL_ON_INVALID_SUBTYPE` wrong
  (reported by @ivan-zaitsev)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -24,28 +24,28 @@ public abstract class JDKValueInstantiators
             Class<?> raw)
     {
         if (raw == JsonLocation.class) {
-            return JsonLocationInstantiator.instance();
+            return new JsonLocationInstantiator();
         }
         // [databind#1868]: empty List/Set/Map
         // [databind#2416]: optimize commonly needed default creators
         if (Collection.class.isAssignableFrom(raw)) {
-            if (raw == ArrayList.class) {
+            if (raw == ArrayList.class) { // default impl, pre-constructed instance
                 return ArrayListInstantiator.INSTANCE;
             }
             if (raw == LinkedList.class) {
-                return LinkedListInstantiator.instance();
+                return new LinkedListInstantiator();
             }
-            if (raw == HashSet.class) {
+            if (raw == HashSet.class) { // default impl, pre-constructed instance
                 return HashSetInstantiator.INSTANCE;
             }
             if (raw == TreeSet.class) {
-                return TreeSetInstantiator.instance();
+                return new TreeSetInstantiator();
             }
             if (raw == Collections.emptySet().getClass()) {
-                return EmptySetInstantiator.instance();
+                return new ConstantValueInstantiator(Collections.emptySet());
             }
             if (raw == Collections.emptyList().getClass()) {
-                return EmptyListInstantiator.instance();
+                return new ConstantValueInstantiator(Collections.emptyList());
             }
         } else if (Map.class.isAssignableFrom(raw)) {
             if (raw == LinkedHashMap.class) {
@@ -55,13 +55,13 @@ public abstract class JDKValueInstantiators
                 return HashMapInstantiator.INSTANCE;
             }
             if (raw == ConcurrentHashMap.class) {
-                return ConcurrentHashMapInstantiator.instance();
+                return new ConcurrentHashMapInstantiator();
             }
             if (raw == TreeMap.class) {
-                return TreeMapInstantiator.instance();
+                return new TreeMapInstantiator();
             }
             if (raw == Collections.emptyMap().getClass()) {
-                return EmptyMapInstantiator.instance();
+                return new ConstantValueInstantiator(Collections.emptyMap());
             }
         }
         return null;
@@ -93,7 +93,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static final ArrayListInstantiator INSTANCE = new ArrayListInstantiator();
+        static final ArrayListInstantiator INSTANCE = new ArrayListInstantiator();
 
         public ArrayListInstantiator() {
             super(ArrayList.class);
@@ -111,15 +111,6 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static LinkedListInstantiator _instance;
-
-        private static LinkedListInstantiator instance() {
-            if (_instance == null) {
-                _instance = new LinkedListInstantiator();
-            }
-            return _instance;
-        }
-
         public LinkedListInstantiator() {
             super(LinkedList.class);
         }
@@ -136,7 +127,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static final HashSetInstantiator INSTANCE = new HashSetInstantiator();
+        static final HashSetInstantiator INSTANCE = new HashSetInstantiator();
 
         public HashSetInstantiator() {
             super(HashSet.class);
@@ -154,15 +145,6 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static TreeSetInstantiator _instance;
-
-        private static TreeSetInstantiator instance() {
-            if (_instance == null) {
-                _instance = new TreeSetInstantiator();
-            }
-            return _instance;
-        }
-
         public TreeSetInstantiator() {
             super(TreeSet.class);
         }
@@ -179,15 +161,6 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static ConcurrentHashMapInstantiator _instance;
-
-        private static ConcurrentHashMapInstantiator instance() {
-            if (_instance == null) {
-                _instance = new ConcurrentHashMapInstantiator();
-            }
-            return _instance;
-        }
-
         public ConcurrentHashMapInstantiator() {
             super(ConcurrentHashMap.class);
         }
@@ -203,7 +176,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static final HashMapInstantiator INSTANCE = new HashMapInstantiator();
+        static final HashMapInstantiator INSTANCE = new HashMapInstantiator();
 
         public HashMapInstantiator() {
             super(HashMap.class);
@@ -220,7 +193,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        private static final LinkedHashMapInstantiator INSTANCE = new LinkedHashMapInstantiator();
+        static final LinkedHashMapInstantiator INSTANCE = new LinkedHashMapInstantiator();
 
         public LinkedHashMapInstantiator() {
             super(LinkedHashMap.class);
@@ -237,15 +210,6 @@ public abstract class JDKValueInstantiators
         extends JDKValueInstantiator
     {
         private static final long serialVersionUID = 2L;
-
-        private static TreeMapInstantiator _instance;
-
-        private static TreeMapInstantiator instance() {
-            if (_instance == null) {
-                _instance = new TreeMapInstantiator();
-            }
-            return _instance;
-        }
 
         public TreeMapInstantiator() {
             super(TreeMap.class);
@@ -270,68 +234,8 @@ public abstract class JDKValueInstantiators
         }
 
         @Override
-        public Object createUsingDefault(DeserializationContext ctxt) throws IOException {
+        public final Object createUsingDefault(DeserializationContext ctxt) throws IOException {
             return _value;
-        }
-    }
-
-    // @since 2.17 [databind#4299] Instantiators for additional container classes
-    private static class EmptySetInstantiator
-        extends ConstantValueInstantiator
-    {
-        private static final long serialVersionUID = 2L;
-
-        private static EmptySetInstantiator _instance;
-
-        private static EmptySetInstantiator instance() {
-            if (_instance == null) {
-                _instance = new EmptySetInstantiator();
-            }
-            return _instance;
-        }
-
-        public EmptySetInstantiator() {
-            super(Collections.emptySet());
-        }
-    }
-
-    // @since 2.17 [databind#4299] Instantiators for additional container classes
-    private static class EmptyListInstantiator
-        extends ConstantValueInstantiator
-    {
-        private static final long serialVersionUID = 2L;
-
-        private static EmptyListInstantiator _instance;
-
-        private static EmptyListInstantiator instance() {
-            if (_instance == null) {
-                _instance = new EmptyListInstantiator();
-            }
-            return _instance;
-        }
-
-        public EmptyListInstantiator() {
-            super(Collections.emptyList());
-        }
-    }
-
-    // @since 2.17 [databind#4299] Instantiators for additional container classes
-    private static class EmptyMapInstantiator
-        extends ConstantValueInstantiator
-    {
-        private static final long serialVersionUID = 2L;
-
-        private static EmptyMapInstantiator _instance;
-
-        private static EmptyMapInstantiator instance() {
-            if (_instance == null) {
-                _instance = new EmptyMapInstantiator();
-            }
-            return _instance;
-        }
-
-        public EmptyMapInstantiator() {
-            super(Collections.emptyMap());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -24,7 +24,7 @@ public abstract class JDKValueInstantiators
             Class<?> raw)
     {
         if (raw == JsonLocation.class) {
-            return JsonLocationInstantiator.INSTANCE;
+            return JsonLocationInstantiator.instance();
         }
         // [databind#1868]: empty List/Set/Map
         // [databind#2416]: optimize commonly needed default creators
@@ -33,19 +33,19 @@ public abstract class JDKValueInstantiators
                 return ArrayListInstantiator.INSTANCE;
             }
             if (raw == LinkedList.class) {
-                return LinkedListInstantiator.INSTANCE;
+                return LinkedListInstantiator.instance();
             }
             if (raw == HashSet.class) {
                 return HashSetInstantiator.INSTANCE;
             }
             if (raw == TreeSet.class) {
-                return TreeSetInstantiator.INSTANCE;
+                return TreeSetInstantiator.instance();
             }
-            if (Collections.EMPTY_SET.getClass() == raw) {
-                return ConstantValueInstantiator.EMPTY_SET_INSTANCE;
+            if (raw == Collections.emptySet().getClass()) {
+                return EmptySetInstantiator.instance();
             }
-            if (Collections.EMPTY_LIST.getClass() == raw) {
-                return ConstantValueInstantiator.EMPTY_LIST_INSTANCE;
+            if (raw == Collections.emptyList().getClass()) {
+                return EmptyListInstantiator.instance();
             }
         } else if (Map.class.isAssignableFrom(raw)) {
             if (raw == LinkedHashMap.class) {
@@ -55,13 +55,13 @@ public abstract class JDKValueInstantiators
                 return HashMapInstantiator.INSTANCE;
             }
             if (raw == ConcurrentHashMap.class) {
-                return ConcurrentHashMapInstantiator.INSTANCE;
+                return ConcurrentHashMapInstantiator.instance();
             }
             if (raw == TreeMap.class) {
-                return TreeMapInstantiator.INSTANCE;
+                return TreeMapInstantiator.instance();
             }
-            if (Collections.EMPTY_MAP.getClass() == raw) {
-                return ConstantValueInstantiator.EMPTY_MAP_INSTANCE;
+            if (raw == Collections.emptyMap().getClass()) {
+                return EmptyMapInstantiator.instance();
             }
         }
         return null;
@@ -89,7 +89,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final ArrayListInstantiator INSTANCE = new ArrayListInstantiator();
+        private static final ArrayListInstantiator INSTANCE = new ArrayListInstantiator();
 
         public ArrayListInstantiator() {
             super(ArrayList.class);
@@ -107,7 +107,14 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final LinkedListInstantiator INSTANCE = new LinkedListInstantiator();
+        private static LinkedListInstantiator _instance;
+
+        private static LinkedListInstantiator instance() {
+            if (_instance == null) {
+                _instance = new LinkedListInstantiator();
+            }
+            return _instance;
+        }
 
         public LinkedListInstantiator() {
             super(LinkedList.class);
@@ -125,7 +132,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final HashSetInstantiator INSTANCE = new HashSetInstantiator();
+        private static final HashSetInstantiator INSTANCE = new HashSetInstantiator();
 
         public HashSetInstantiator() {
             super(HashSet.class);
@@ -143,7 +150,14 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final TreeSetInstantiator INSTANCE = new TreeSetInstantiator();
+        private static TreeSetInstantiator _instance;
+
+        private static TreeSetInstantiator instance() {
+            if (_instance == null) {
+                _instance = new TreeSetInstantiator();
+            }
+            return _instance;
+        }
 
         public TreeSetInstantiator() {
             super(TreeSet.class);
@@ -161,7 +175,14 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final ConcurrentHashMapInstantiator INSTANCE = new ConcurrentHashMapInstantiator();
+        private static ConcurrentHashMapInstantiator _instance;
+
+        private static ConcurrentHashMapInstantiator instance() {
+            if (_instance == null) {
+                _instance = new ConcurrentHashMapInstantiator();
+            }
+            return _instance;
+        }
 
         public ConcurrentHashMapInstantiator() {
             super(ConcurrentHashMap.class);
@@ -178,7 +199,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final HashMapInstantiator INSTANCE = new HashMapInstantiator();
+        private static final HashMapInstantiator INSTANCE = new HashMapInstantiator();
 
         public HashMapInstantiator() {
             super(HashMap.class);
@@ -195,7 +216,7 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final LinkedHashMapInstantiator INSTANCE = new LinkedHashMapInstantiator();
+        private static final LinkedHashMapInstantiator INSTANCE = new LinkedHashMapInstantiator();
 
         public LinkedHashMapInstantiator() {
             super(LinkedHashMap.class);
@@ -213,7 +234,14 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final TreeMapInstantiator INSTANCE = new TreeMapInstantiator();
+        private static TreeMapInstantiator _instance;
+
+        private static TreeMapInstantiator instance() {
+            if (_instance == null) {
+                _instance = new TreeMapInstantiator();
+            }
+            return _instance;
+        }
 
         public TreeMapInstantiator() {
             super(TreeMap.class);
@@ -230,15 +258,6 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final ConstantValueInstantiator EMPTY_SET_INSTANCE
-                = new ConstantValueInstantiator(Collections.EMPTY_SET);
-
-        public static final ConstantValueInstantiator EMPTY_LIST_INSTANCE
-                = new ConstantValueInstantiator(Collections.EMPTY_LIST);
-
-        public static final ConstantValueInstantiator EMPTY_MAP_INSTANCE
-                = new ConstantValueInstantiator(Collections.EMPTY_MAP);
-
         protected final Object _value;
 
         public ConstantValueInstantiator(Object value) {
@@ -252,4 +271,63 @@ public abstract class JDKValueInstantiators
         }
     }
 
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
+    private static class EmptySetInstantiator
+            extends ConstantValueInstantiator
+    {
+        private static final long serialVersionUID = 2L;
+
+        private static EmptySetInstantiator _instance;
+
+        private static EmptySetInstantiator instance() {
+            if (_instance == null) {
+                _instance = new EmptySetInstantiator();
+            }
+            return _instance;
+        }
+
+        public EmptySetInstantiator() {
+            super(Collections.emptySet());
+        }
+    }
+
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
+    private static class EmptyListInstantiator
+            extends ConstantValueInstantiator
+    {
+        private static final long serialVersionUID = 2L;
+
+        private static EmptyListInstantiator _instance;
+
+        private static EmptyListInstantiator instance() {
+            if (_instance == null) {
+                _instance = new EmptyListInstantiator();
+            }
+            return _instance;
+        }
+
+        public EmptyListInstantiator() {
+            super(Collections.emptyList());
+        }
+    }
+
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
+    private static class EmptyMapInstantiator
+            extends ConstantValueInstantiator
+    {
+        private static final long serialVersionUID = 2L;
+
+        private static EmptyMapInstantiator _instance;
+
+        private static EmptyMapInstantiator instance() {
+            if (_instance == null) {
+                _instance = new EmptyMapInstantiator();
+            }
+            return _instance;
+        }
+
+        public EmptyMapInstantiator() {
+            super(Collections.emptyMap());
+        }
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -42,10 +42,10 @@ public abstract class JDKValueInstantiators
                 return TreeSetInstantiator.INSTANCE;
             }
             if (Collections.EMPTY_SET.getClass() == raw) {
-                return ConstantValueInstantiator.EMPTY_SET;
+                return ConstantValueInstantiator.EMPTY_SET_INSTANCE;
             }
             if (Collections.EMPTY_LIST.getClass() == raw) {
-                return ConstantValueInstantiator.EMPTY_LIST;
+                return ConstantValueInstantiator.EMPTY_LIST_INSTANCE;
             }
         } else if (Map.class.isAssignableFrom(raw)) {
             if (raw == LinkedHashMap.class) {
@@ -61,7 +61,7 @@ public abstract class JDKValueInstantiators
                 return TreeMapInstantiator.INSTANCE;
             }
             if (Collections.EMPTY_MAP.getClass() == raw) {
-                return ConstantValueInstantiator.EMPTY_MAP;
+                return ConstantValueInstantiator.EMPTY_MAP_INSTANCE;
             }
         }
         return null;
@@ -99,6 +99,7 @@ public abstract class JDKValueInstantiators
         }
     }
 
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class LinkedListInstantiator
         extends JDKValueInstantiator
     {
@@ -116,6 +117,7 @@ public abstract class JDKValueInstantiators
         }
     }
 
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class HashSetInstantiator
         extends JDKValueInstantiator
     {
@@ -133,6 +135,7 @@ public abstract class JDKValueInstantiators
         }
     }
 
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class TreeSetInstantiator
         extends JDKValueInstantiator
     {
@@ -150,6 +153,7 @@ public abstract class JDKValueInstantiators
         }
     }
 
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class ConcurrentHashMapInstantiator
         extends JDKValueInstantiator
     {
@@ -201,6 +205,7 @@ public abstract class JDKValueInstantiators
         }
     }
 
+    // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class TreeMapInstantiator
         extends JDKValueInstantiator
     {
@@ -223,11 +228,14 @@ public abstract class JDKValueInstantiators
     {
         private static final long serialVersionUID = 2L;
 
-        public static final ConstantValueInstantiator EMPTY_SET = new ConstantValueInstantiator(Collections.EMPTY_SET);
+        public static final ConstantValueInstantiator EMPTY_SET_INSTANCE
+                = new ConstantValueInstantiator(Collections.EMPTY_SET);
 
-        public static final ConstantValueInstantiator EMPTY_LIST = new ConstantValueInstantiator(Collections.EMPTY_LIST);
+        public static final ConstantValueInstantiator EMPTY_LIST_INSTANCE
+                = new ConstantValueInstantiator(Collections.EMPTY_LIST);
 
-        public static final ConstantValueInstantiator EMPTY_MAP = new ConstantValueInstantiator(Collections.EMPTY_MAP);
+        public static final ConstantValueInstantiator EMPTY_MAP_INSTANCE
+                = new ConstantValueInstantiator(Collections.EMPTY_MAP);
 
         protected final Object _value;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -273,7 +273,7 @@ public abstract class JDKValueInstantiators
 
     // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class EmptySetInstantiator
-            extends ConstantValueInstantiator
+        extends ConstantValueInstantiator
     {
         private static final long serialVersionUID = 2L;
 
@@ -293,7 +293,7 @@ public abstract class JDKValueInstantiators
 
     // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class EmptyListInstantiator
-            extends ConstantValueInstantiator
+        extends ConstantValueInstantiator
     {
         private static final long serialVersionUID = 2L;
 
@@ -313,7 +313,7 @@ public abstract class JDKValueInstantiators
 
     // @since 2.17 [databind#4299] Instantiators for additional container classes
     private static class EmptyMapInstantiator
-            extends ConstantValueInstantiator
+        extends ConstantValueInstantiator
     {
         private static final long serialVersionUID = 2L;
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -32,11 +32,11 @@ public abstract class JDKValueInstantiators
             if (raw == ArrayList.class) { // default impl, pre-constructed instance
                 return ArrayListInstantiator.INSTANCE;
             }
-            if (raw == LinkedList.class) {
-                return new LinkedListInstantiator();
-            }
             if (raw == HashSet.class) { // default impl, pre-constructed instance
                 return HashSetInstantiator.INSTANCE;
+            }
+            if (raw == LinkedList.class) {
+                return new LinkedListInstantiator();
             }
             if (raw == TreeSet.class) {
                 return new TreeSetInstantiator();
@@ -67,6 +67,7 @@ public abstract class JDKValueInstantiators
         return null;
     }
 
+    // @since 2.17
     private abstract static class JDKValueInstantiator
         extends ValueInstantiator.Base
         implements java.io.Serializable

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/JDKValueInstantiators.java
@@ -71,6 +71,8 @@ public abstract class JDKValueInstantiators
         extends ValueInstantiator.Base
         implements java.io.Serializable
     {
+        private static final long serialVersionUID = 2L;
+
         public JDKValueInstantiator(Class<?> type) {
             super(type);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
@@ -21,7 +21,14 @@ public class JsonLocationInstantiator
 {
     private static final long serialVersionUID = 1L;
 
-    public static final JsonLocationInstantiator INSTANCE = new JsonLocationInstantiator();
+    private static JsonLocationInstantiator _instance;
+
+    public static JsonLocationInstantiator instance() {
+        if (_instance == null) {
+            _instance = new JsonLocationInstantiator();
+        }
+        return _instance;
+    }
 
     public JsonLocationInstantiator() {
         super(JsonLocation.class);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.deser.CreatorProperty;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
-import com.fasterxml.jackson.databind.deser.impl.JDKValueInstantiators;
 
 /**
  * For {@link JsonLocation}, we should be able to just implement

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.deser.CreatorProperty;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
+import com.fasterxml.jackson.databind.deser.impl.JDKValueInstantiators;
 
 /**
  * For {@link JsonLocation}, we should be able to just implement
@@ -20,6 +21,8 @@ public class JsonLocationInstantiator
     extends ValueInstantiator.Base
 {
     private static final long serialVersionUID = 1L;
+
+    public static final JsonLocationInstantiator INSTANCE = new JsonLocationInstantiator();
 
     public JsonLocationInstantiator() {
         super(JsonLocation.class);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonLocationInstantiator.java
@@ -21,15 +21,6 @@ public class JsonLocationInstantiator
 {
     private static final long serialVersionUID = 1L;
 
-    private static JsonLocationInstantiator _instance;
-
-    public static JsonLocationInstantiator instance() {
-        if (_instance == null) {
-            _instance = new JsonLocationInstantiator();
-        }
-        return _instance;
-    }
-
     public JsonLocationInstantiator() {
         super(JsonLocation.class);
     }


### PR DESCRIPTION
Took a stab at #4299


Added support for `LinkedList`, `HashSet`, `TreeSet`, `ConcurrentHashMap`, and `TreeMap`. 

Also, replaced other new instantiator invocations with singletons.
