### PR TITLE
Fix broken test in by jackso-core#1173 in Jackson 2.16 

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/exc/BasicExceptionTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/BasicExceptionTest.java
@@ -137,7 +137,7 @@ public class BasicExceptionTest extends BaseMapTest
             JsonLocation loc = e.getLocation();
 //          String expectedLocation = "line: 4, column: 4";
             assertEquals(4, loc.getLineNr());
-            assertEquals(4, loc.getColumnNr());
+            assertEquals(3, loc.getColumnNr());
         }
     }
 }


### PR DESCRIPTION
I was mistaken...  🙉
#4297 should've been against 2.16, not 2.17. 