### PR TITLE
Make `PropertyNamingStrategy` skip renaming on `Enum`s

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1728,3 +1728,8 @@ Jan Pachol (janpacho@github)
  * Reported #4175: Exception when deserialization of `private` record with
    default constructor
   (2.16.0)
+
+Pieter Dirk Soels (Badbond@github)
+ * Reprted #4302: Problem deserializing some type of Enums when using
+  `PropertyNamingStrategy`
+  (2.16.2)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -11,6 +11,9 @@ Project: jackson-databind
 #4303: `ObjectReader` is not serializable if it's configured for polymorphism
  (reported by @asardaes)
  (fix contributed by Joo-Hyuk K)
+#4302: Problem deserializing some type of Enums when using `PropertyNamingStrategy`
+ (reported by Pieter D-S)
+ (fix contributed by Joo-Hyuk K)
 
 2.16.1 (24-Dec-2023)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,11 +8,11 @@ Project: jackson-databind
 
 2.16.2 (not yet released)
 
-#4303: `ObjectReader` is not serializable if it's configured for polymorphism
- (reported by @asardaes)
- (fix contributed by Joo-Hyuk K)
 #4302: Problem deserializing some type of Enums when using `PropertyNamingStrategy`
  (reported by Pieter D-S)
+ (fix contributed by Joo-Hyuk K)
+#4303: `ObjectReader` is not serializable if it's configured for polymorphism
+ (reported by @asardaes)
  (fix contributed by Joo-Hyuk K)
 
 2.16.1 (24-Dec-2023)

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1128,6 +1128,10 @@ public class POJOPropertiesCollector
         for (POJOPropertyBuilder prop : props) {
             PropertyName fullName = prop.getFullName();
             String rename = null;
+            // [databind#4302] since 2.17, Need to skip renaming for Enum properties
+            if (!prop.hasSetter() && prop.getPrimaryType().isEnumType()) {
+                continue;
+            }
             // As per [databind#428] need to skip renaming if property has
             // explicitly defined name, unless feature  is enabled
             if (!prop.isExplicitlyNamed() || _config.isEnabled(MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING)) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
@@ -1,0 +1,84 @@
+package com.fasterxml.jackson.databind.deser.enums;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.BaseTest.q;
+
+
+// [databind#4302]
+public class EnumSameName4302Test
+{
+
+    enum Field4302Enum {
+        FOO(0);
+
+        public final int foo;
+
+        Field4302Enum(int foo) {
+            this.foo = foo;
+        }
+    }
+
+    enum Getter4302Enum {
+        BAR("bar");
+
+        public String bar;
+
+        Getter4302Enum(String bar) {
+            this.bar = bar;
+        }
+
+        public String getBar() {
+            return "bar";
+        }
+    }
+
+    enum Setter4302Enum {
+        CAT("dog");
+
+        public String cat;
+
+        Setter4302Enum(String cat) {
+            this.cat = cat;
+        }
+
+        public void setCat(String cat) {
+            this.cat = cat;
+        }
+    }
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+        .propertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE)
+        .build();
+
+    @Test
+    void testShouldWork() throws IOException {
+        // First, try roundtrip with same-ignore-case name field
+        assertEquals(Field4302Enum.FOO,
+            MAPPER.readValue("\"FOO\"", Field4302Enum.class));
+        assertEquals(q("FOO"),
+            MAPPER.writeValueAsString(Field4302Enum.FOO));
+
+        // Now, try roundtrip with same-ignore-case name getter
+        assertEquals(Getter4302Enum.BAR,
+            MAPPER.readValue("\"BAR\"", Getter4302Enum.class));
+        assertEquals(q("BAR"),
+            MAPPER.writeValueAsString(Getter4302Enum.BAR));
+
+        // Now, try roundtrip with same-ignore-case name setter
+        Setter4302Enum.CAT.setCat("cat");
+        assertEquals(Setter4302Enum.CAT,
+            MAPPER.readValue("\"CAT\"", Setter4302Enum.class));
+        assertEquals(q("CAT"),
+            MAPPER.writeValueAsString(Setter4302Enum.CAT));
+    }
+}
+

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
@@ -1,7 +1,5 @@
 package com.fasterxml.jackson.databind.deser.enums;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
 import static com.fasterxml.jackson.databind.BaseTest.q;
-
 
 // [databind#4302]
 public class EnumSameName4302Test
@@ -60,7 +57,8 @@ public class EnumSameName4302Test
         .build();
 
     @Test
-    void testShouldWork() throws IOException {
+    void testShouldWork() throws Exception
+    {
         // First, try roundtrip with same-ignore-case name field
         assertEquals(Field4302Enum.FOO,
             MAPPER.readValue("\"FOO\"", Field4302Enum.class));


### PR DESCRIPTION
fixes #4302.
