### PR TITLE
Put back enum field without renaming

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1130,6 +1130,8 @@ public class POJOPropertiesCollector
             String rename = null;
             // [databind#4302] since 2.17, Need to skip renaming for Enum properties
             if (!prop.hasSetter() && prop.getPrimaryType().isEnumType()) {
+                // Just put back
+                propMap.put(fullName.getSimpleName(), prop);
                 continue;
             }
             // As per [databind#428] need to skip renaming if property has

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1128,8 +1128,11 @@ public class POJOPropertiesCollector
         for (POJOPropertyBuilder prop : props) {
             PropertyName fullName = prop.getFullName();
             String rename = null;
-            // [databind#4302] since 2.17, Need to skip renaming for Enum properties
-            if (!prop.hasSetter() && prop.getPrimaryType().isEnumType()) {
+            // [databind#4302] since 2.16, Need to skip renaming for Enum instances, but rename fields
+            if (!prop.hasSetter()
+                    && Objects.nonNull(prop.getField())
+                    && (Objects.equals(_type, prop.getField().getType()) && prop.getPrimaryType().isEnumType())
+            ) {
                 // Just put back
                 propMap.put(fullName.getSimpleName(), prop);
                 continue;

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1128,7 +1128,7 @@ public class POJOPropertiesCollector
         for (POJOPropertyBuilder prop : props) {
             PropertyName fullName = prop.getFullName();
             String rename = null;
-            // [databind#4302] since 2.16, Need to skip renaming for Enum instances, but rename fields
+            // [databind#4302] since 2.16, Need to skip renaming for Enum instances (but not for Enum fields)
             if (!prop.hasSetter()
                     && Objects.nonNull(prop.getField())
                     && (Objects.equals(_type, prop.getField().getType()) && prop.getPrimaryType().isEnumType())

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
@@ -53,11 +53,12 @@ public class EnumSameName4302Test
     }
 
     enum AsField4302Enum {
+        APPLE_SUGAR,
         SOME_PERSON;
     }
 
     static class AsField4302Bean {
-        public AsField4302Enum somePerson = AsField4302Enum.SOME_PERSON;
+        public AsField4302Enum somePerson = AsField4302Enum.APPLE_SUGAR;
         public String someOtherField = "someOtherField";
     }
 
@@ -97,11 +98,15 @@ public class EnumSameName4302Test
     {
         AsField4302Bean bean = new AsField4302Bean();
 
-        assertEquals("{\"some_person\":\"SOME_PERSON\",\"some_other_field\":\"someOtherField\"}",
+        // ser
+        assertEquals("{\"somePerson\":\"APPLE_SUGAR\",\"some_other_field\":\"someOtherField\"}",
             SNAKE_MAPPER.writeValueAsString(bean));
 
-        AsField4302Bean result = SNAKE_MAPPER.readValue("{\"somePerson\":\"SOME_PERSON\"}",
+        // deser
+        AsField4302Bean result = SNAKE_MAPPER.readValue("{\"somePerson\":\"SOME_PERSON\", \"some_other_field\":\"thisField\"}",
             AsField4302Bean.class);
+        assertEquals(AsField4302Enum.SOME_PERSON, result.somePerson);
+        assertEquals("thisField", result.someOtherField);
     }
 }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
@@ -52,8 +52,21 @@ public class EnumSameName4302Test
         }
     }
 
+    enum AsField4302Enum {
+        SOME_PERSON;
+    }
+
+    static class AsField4302Bean {
+        public AsField4302Enum somePerson = AsField4302Enum.SOME_PERSON;
+        public String someOtherField = "someOtherField";
+    }
+
     private final ObjectMapper MAPPER = jsonMapperBuilder()
         .propertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE)
+        .build();
+
+    private final ObjectMapper SNAKE_MAPPER = jsonMapperBuilder()
+        .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         .build();
 
     @Test
@@ -77,6 +90,18 @@ public class EnumSameName4302Test
             MAPPER.readValue("\"CAT\"", Setter4302Enum.class));
         assertEquals(q("CAT"),
             MAPPER.writeValueAsString(Setter4302Enum.CAT));
+    }
+
+    @Test
+    void testDeserializeSuccessfulUnaffectedField() throws Exception
+    {
+        AsField4302Bean bean = new AsField4302Bean();
+
+        assertEquals("{\"some_person\":\"SOME_PERSON\",\"some_other_field\":\"someOtherField\"}",
+            SNAKE_MAPPER.writeValueAsString(bean));
+
+        AsField4302Bean result = SNAKE_MAPPER.readValue("{\"somePerson\":\"SOME_PERSON\"}",
+            AsField4302Bean.class);
     }
 }
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
+import static com.fasterxml.jackson.databind.BaseTest.a2q;
 import static com.fasterxml.jackson.databind.BaseTest.q;
 
 // [databind#4302]
@@ -58,8 +59,8 @@ public class EnumSameName4302Test
     }
 
     static class AsField4302Bean {
-        public AsField4302Enum somePerson = AsField4302Enum.APPLE_SUGAR;
-        public String someOtherField = "someOtherField";
+        public AsField4302Enum someEnum = AsField4302Enum.APPLE_SUGAR;
+        public String otherProp = "someOtherField";
     }
 
     private final ObjectMapper MAPPER = jsonMapperBuilder()
@@ -98,15 +99,16 @@ public class EnumSameName4302Test
     {
         AsField4302Bean bean = new AsField4302Bean();
 
-        // ser
-        assertEquals("{\"somePerson\":\"APPLE_SUGAR\",\"some_other_field\":\"someOtherField\"}",
+        // test serialization
+        assertEquals(
+            a2q("{'some_enum':'APPLE_SUGAR','other_prop':'someOtherField'}"),
             SNAKE_MAPPER.writeValueAsString(bean));
 
-        // deser
-        AsField4302Bean result = SNAKE_MAPPER.readValue("{\"somePerson\":\"SOME_PERSON\", \"some_other_field\":\"thisField\"}",
-            AsField4302Bean.class);
-        assertEquals(AsField4302Enum.SOME_PERSON, result.somePerson);
-        assertEquals("thisField", result.someOtherField);
+        // test deserialization
+        AsField4302Bean result = SNAKE_MAPPER.readValue(
+            a2q("{'some_enum':'SOME_PERSON', 'other_prop':'thisField'}"), AsField4302Bean.class);
+        assertEquals(AsField4302Enum.SOME_PERSON, result.someEnum);
+        assertEquals("thisField", result.otherProp);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR completes #4311 fix. 
This PR fixes behavior introduced by #4311, when Enum is used as field of other class and `POJOPropertiesCollector` tries to rename it via `_renameUsing()`, we just drop the field.

## Notes

- Cleaner solution suggestion is welcome.
- Fixes https://github.com/FasterXML/jackson-dataformats-binary/pull/454