### PR TITLE
Try fixing #4302 different way

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/Annotated.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/Annotated.java
@@ -36,6 +36,13 @@ public abstract class Annotated
         return Modifier.isPublic(getModifiers());
     }
 
+    /**
+     * @since 2.17
+     */
+    public boolean isStatic() {
+        return Modifier.isStatic(getModifiers());
+    }
+
     public abstract String getName();
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1123,15 +1123,16 @@ public class POJOPropertiesCollector
     protected void _renameUsing(Map<String, POJOPropertyBuilder> propMap,
             PropertyNamingStrategy naming)
     {
+        // [databind#4302] since 2.17, Need to skip renaming for Enum properties
+        if (_type.isEnumType()) {
+            return;
+        }
+
         POJOPropertyBuilder[] props = propMap.values().toArray(new POJOPropertyBuilder[propMap.size()]);
         propMap.clear();
         for (POJOPropertyBuilder prop : props) {
             PropertyName fullName = prop.getFullName();
             String rename = null;
-            // [databind#4302] since 2.17, Need to skip renaming for Enum properties
-            if (!prop.hasSetter() && prop.getPrimaryType().isEnumType()) {
-                continue;
-            }
             // As per [databind#428] need to skip renaming if property has
             // explicitly defined name, unless feature  is enabled
             if (!prop.isExplicitlyNamed() || _config.isEnabled(MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING)) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1123,11 +1123,6 @@ public class POJOPropertiesCollector
     protected void _renameUsing(Map<String, POJOPropertyBuilder> propMap,
             PropertyNamingStrategy naming)
     {
-        // [databind#4302] since 2.17, Need to skip renaming for Enum properties
-        if (_type.isEnumType()) {
-            return;
-        }
-
         POJOPropertyBuilder[] props = propMap.values().toArray(new POJOPropertyBuilder[propMap.size()]);
         propMap.clear();
         for (POJOPropertyBuilder prop : props) {

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -623,6 +623,21 @@ public class POJOPropertyBuilder
                     continue;
                 }
             }
+            // 11-Jan-2024, tatu: Wrt [databind#4302] problem here is that we have
+            //   Enum constant fields (static!) added due to change in 2.16.0 (see
+            //  {@code AnnotatedFieldCollector#_isIncludableField}) and they can
+            //  conflict with actual fields.
+            /// Let's resolve conflict in favor of non-static Field.
+            final boolean currStatic = field.isStatic();
+            final boolean nextStatic = nextField.isStatic();
+
+            if (currStatic != nextStatic) {
+                if (currStatic) {
+                    field = nextField;
+                }
+                continue;
+            }
+
             throw new IllegalArgumentException("Multiple fields representing property \""+getName()+"\": "
                     +field.getFullName()+" vs "+nextField.getFullName());
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumSameName4302Test.java
@@ -7,13 +7,13 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static com.fasterxml.jackson.databind.BaseMapTest.a2q;
 import static com.fasterxml.jackson.databind.BaseMapTest.jsonMapperBuilder;
-import static com.fasterxml.jackson.databind.BaseTest.q;
+import static com.fasterxml.jackson.databind.BaseMapTest.q;
 
 // [databind#4302]
 public class EnumSameName4302Test
 {
-
     enum Field4302Enum {
         FOO(0);
 
@@ -52,12 +52,21 @@ public class EnumSameName4302Test
         }
     }
 
+    static class Field4302Wrapper {
+        public Field4302Enum wrapped;
+
+        Field4302Wrapper() { }
+        public Field4302Wrapper(Field4302Enum w) {
+            wrapped = w;
+        }
+    }
+
     private final ObjectMapper MAPPER = jsonMapperBuilder()
         .propertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE)
         .build();
 
     @Test
-    void testShouldWork() throws Exception
+    void testStandaloneShouldWork() throws Exception
     {
         // First, try roundtrip with same-ignore-case name field
         assertEquals(Field4302Enum.FOO,
@@ -77,6 +86,18 @@ public class EnumSameName4302Test
             MAPPER.readValue("\"CAT\"", Setter4302Enum.class));
         assertEquals(q("CAT"),
             MAPPER.writeValueAsString(Setter4302Enum.CAT));
+    }
+
+    @Test
+    void testWrappedShouldWork() throws Exception
+    {
+        // First, try roundtrip with same-ignore-case name field
+        Field4302Wrapper input = new Field4302Wrapper(Field4302Enum.FOO);
+        String json = MAPPER.writeValueAsString(input);
+        assertEquals(a2q("{'wrapped':'FOO'}"), json);
+
+        Field4302Wrapper result = MAPPER.readValue(json, Field4302Wrapper.class);
+        assertEquals(Field4302Enum.FOO, result.wrapped);
     }
 }
 


### PR DESCRIPTION
Ok, the initial #4302 fix is incorrect in that it tries to change how Enum-valued properties are (not to be) renamed: what is needed is fields of Enum values themselves. This PR adds test to catch the issue with original approach and tries different fix.

I'm also getting bit nervous on merging this in 2.16, however, the original issue is nasty enough that this is probably required.
