### PR TITLE
Fix `NPE` when deserializing `Throwable` with ignored JDK fields (e.g. message)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -147,6 +147,10 @@ public class ThrowableDeserializer
                 continue;
             }
             if (_anySetter != null) {
+                // [databind#4316] Since 2.16.2 : at this point throwable should be non-null
+                if (throwable == null) {
+                    throwable = _instantiate(ctxt, hasStringCreator, null);
+                }
                 _anySetter.deserializeAndSet(p, ctxt, throwable, propName);
                 continue;
             }
@@ -194,7 +198,7 @@ public class ThrowableDeserializer
     /**
      * Helper method to initialize Throwable
      *
-     * @since 2.17
+     * @since 2.16.2
      */
     private Throwable _instantiate(DeserializationContext ctxt, boolean hasStringCreator, String valueAsString)
         throws IOException

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -147,10 +147,6 @@ public class ThrowableDeserializer
                 continue;
             }
             if (_anySetter != null) {
-                // [databind#4316] Since 2.16.2 : at this point throwable should be non-null
-                if (throwable == null) {
-                    throwable = _instantiate(ctxt, hasStringCreator, null);
-                }
                 _anySetter.deserializeAndSet(p, ctxt, throwable, propName);
                 continue;
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThrowableDeserializer.java
@@ -147,6 +147,10 @@ public class ThrowableDeserializer
                 continue;
             }
             if (_anySetter != null) {
+                // [databind#4316] Since 2.16.2 : at this point throwable should be non-null
+                if (throwable == null) {
+                    throwable = _instantiate(ctxt, hasStringCreator, null);
+                }
                 _anySetter.deserializeAndSet(p, ctxt, throwable, propName);
                 continue;
             }

--- a/src/test/java/com/fasterxml/jackson/databind/exc/ExceptionWithAnySetter4316Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/ExceptionWithAnySetter4316Test.java
@@ -39,13 +39,13 @@ public class ExceptionWithAnySetter4316Test extends BaseMapTest
                 result.additionalProperties);
     }
 
-    // With ignorals
-    public void testWithAnySetterAndIgnorals() throws Exception
+    // Map with ignored props keys specified in @JsonIgnoreProperties
+    public void testWithAnySetterAndIgnoralsPut() throws Exception
     {
         // Given
         ProblemWithIgnorals problem = new ProblemWithIgnorals();
         problem.additionalProperties.put("key", "value");
-        // Below key-value pairs also should be ignored from here....
+        // Below key-value pairs also ignored from here....
         problem.additionalProperties.put("cause", "ignored");
         problem.additionalProperties.put("stackTrace", "ignored");
         problem.additionalProperties.put("response", "ignored");
@@ -53,10 +53,29 @@ public class ExceptionWithAnySetter4316Test extends BaseMapTest
         problem.additionalProperties.put("localizedMessage", "ignored");
         problem.additionalProperties.put("suppressed", "ignored");
 
+        // When
         String json = MAPPER.writeValueAsString(problem);
         ProblemWithIgnorals result = MAPPER.readValue(json, ProblemWithIgnorals.class);
+
+        // Then
         assertEquals(Collections.singletonMap("key", "value"),
-                result.additionalProperties);
+            result.additionalProperties);
+    }
+
+    // With ignorals
+    public void testWithAnySetterAndIgnoralSimple() throws Exception
+    {
+        // Given
+        ProblemWithIgnorals problem = new ProblemWithIgnorals();
+        problem.additionalProperties.put("key", "value");
+
+        // When
+        String json = MAPPER.writeValueAsString(problem);
+        ProblemWithIgnorals result = MAPPER.readValue(json, ProblemWithIgnorals.class);
+
+        // Then
+        assertEquals(Collections.singletonMap("key", "value"),
+            result.additionalProperties);
     }
 
     // With Include.NON_NULL


### PR DESCRIPTION
Fixes another issue from #4316 described in https://github.com/FasterXML/jackson-databind/issues/4316#issuecomment-1895650318