### PR TITLE
Add failing test for #3439

### DIFF
--- a/src/test-jdk17/java/com/fasterxml/jackson/databind/failing/JsonAnySetterRecord3439Test.java
+++ b/src/test-jdk17/java/com/fasterxml/jackson/databind/failing/JsonAnySetterRecord3439Test.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.databind.failing;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.fasterxml.jackson.databind.BaseMapTest.newJsonMapper;
+
+// [databind#3439]: Java Record @JsonAnySetter value is null after deserialization
+public class JsonAnySetterRecord3439Test
+{
+    record TestRecord(
+        @JsonProperty String field,
+        @JsonAnySetter Map<String, Object> anySetter
+    ) {
+    }
+
+    @Test
+    void testJsonAnySetterOnRecord() throws JsonProcessingException
+    {
+        // Given
+        var json = """
+            {
+                "field": "value",
+                "unmapped1": "value1",
+                "unmapped2": "value2"
+            }
+            """;
+        var objectMapper = newJsonMapper();
+
+        // When
+        var deserialized = objectMapper.readValue(json, TestRecord.class);
+
+        // Then
+        assertEquals("value", deserialized.field());
+        assertEquals(Map.of("unmapped1", "value1", "unmapped2", "value2"), deserialized.anySetter());
+    }
+}


### PR DESCRIPTION
reproduces #3439 

Only the reproduction is intended to be against 2.15 for tracking purpose. E.g. ...

> "Did it work in 2.15? Okay it doesn't. let's try later version."

Fix will be made against later versions, probably 2.17

