### PR TITLE
support nulls in TextNode equals

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -164,7 +164,8 @@ e.getMessage()),
         if (o == this) return true;
         if (o == null) return false;
         if (o instanceof TextNode) {
-            return ((TextNode) o)._value.equals(_value);
+            TextNode otherNode = (TextNode) o;
+            return java.util.Objects.equals(otherNode._value, _value);
         }
         return false;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -171,7 +171,10 @@ e.getMessage()),
     }
 
     @Override
-    public int hashCode() { return _value.hashCode(); }
+    public int hashCode() {
+        // we need a hardcoded value for null _value to ensure that hash codes are stable
+        return _value == null ? 0 : _value.hashCode();
+    }
 
     @Deprecated // since 2.10
     protected static void appendQuoted(StringBuilder sb, String content)

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.node;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharTypes;
@@ -165,15 +166,14 @@ e.getMessage()),
         if (o == null) return false;
         if (o instanceof TextNode) {
             TextNode otherNode = (TextNode) o;
-            return java.util.Objects.equals(otherNode._value, _value);
+            return Objects.equals(otherNode._value, _value);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        // we need a hardcoded value for null _value to ensure that hash codes are stable
-        return _value == null ? -1 : _value.hashCode();
+        return Objects.hashCode(_value);
     }
 
     @Deprecated // since 2.10

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -173,7 +173,7 @@ e.getMessage()),
     @Override
     public int hashCode() {
         // we need a hardcoded value for null _value to ensure that hash codes are stable
-        return _value == null ? 0 : _value.hashCode();
+        return _value == null ? -1 : _value.hashCode();
     }
 
     @Deprecated // since 2.10

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -50,7 +50,7 @@ public class TextNodeTest extends NodeTestBase
 
     public void testHashCode()
     {
-        assertEquals(-1, new TextNode(null).hashCode());
+        assertEquals(0, new TextNode(null).hashCode());
         assertEquals("abc".hashCode(), new TextNode("abc").hashCode());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -50,7 +50,7 @@ public class TextNodeTest extends NodeTestBase
 
     public void testHashCode()
     {
-        assertEquals(0, new TextNode(null).hashCode());
+        assertEquals(-1, new TextNode(null).hashCode());
         assertEquals("abc".hashCode(), new TextNode("abc").hashCode());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -47,4 +47,10 @@ public class TextNodeTest extends NodeTestBase
         assertNotEquals(new TextNode("abc"), new TextNode("def"));
         assertNotEquals(new TextNode("abc"), new TextNode(null));
     }
+
+    public void testHashCode()
+    {
+        assertEquals(0, new TextNode(null).hashCode());
+        assertEquals("abc".hashCode(), new TextNode("abc").hashCode());
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.node;
 
+import static org.junit.Assert.assertNotEquals;
+
 public class TextNodeTest extends NodeTestBase
 {
     public void testText()
@@ -35,5 +37,12 @@ public class TextNodeTest extends NodeTestBase
         assertTrue(TextNode.valueOf("true").asBoolean(false));
         assertFalse(TextNode.valueOf("false").asBoolean(true));
         assertFalse(TextNode.valueOf("false").asBoolean(false));
+    }
+
+    public void testEquals()
+    {
+        assertEquals(new TextNode(null), new TextNode(null));
+        assertEquals(new TextNode("abc"), new TextNode("abc"));
+        assertNotEquals(new TextNode("abc"), new TextNode("def"));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -43,6 +43,8 @@ public class TextNodeTest extends NodeTestBase
     {
         assertEquals(new TextNode(null), new TextNode(null));
         assertEquals(new TextNode("abc"), new TextNode("abc"));
+        assertNotEquals(new TextNode(null), new TextNode("def"));
         assertNotEquals(new TextNode("abc"), new TextNode("def"));
+        assertNotEquals(new TextNode("abc"), new TextNode(null));
     }
 }


### PR DESCRIPTION
relates to #4378 

@cowtowncoder since this is a bug - could we consider backporting this?