### PR TITLE
support null data in nodes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
@@ -119,6 +119,7 @@ public class BigIntegerNode
 
     @Override
     public int hashCode() {
-        return _value.hashCode();
+        // we need a stable hash code for _value == null
+        return _value == null ? -1 : _value.hashCode();
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
@@ -113,7 +113,8 @@ public class BigIntegerNode
         if (!(o instanceof BigIntegerNode)) {
             return false;
         }
-        return ((BigIntegerNode) o)._value.equals(_value);
+        BigIntegerNode otherNode = (BigIntegerNode) o;
+        return java.util.Objects.equals(otherNode._value, _value);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/BigIntegerNode.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.node;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -114,12 +115,11 @@ public class BigIntegerNode
             return false;
         }
         BigIntegerNode otherNode = (BigIntegerNode) o;
-        return java.util.Objects.equals(otherNode._value, _value);
+        return Objects.equals(otherNode._value, _value);
     }
 
     @Override
     public int hashCode() {
-        // we need a stable hash code for _value == null
-        return _value == null ? -1 : _value.hashCode();
+        return Objects.hashCode(_value);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -141,7 +141,7 @@ public class DecimalNode
     public int hashCode() {
         if (_value == null) {
             // we need a stable hash code for _value == null
-            return -1;
+            return 0;
         }
         return Double.valueOf(doubleValue()).hashCode();
     }

--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -138,5 +138,11 @@ public class DecimalNode
     }
 
     @Override
-    public int hashCode() { return Double.valueOf(doubleValue()).hashCode(); }
+    public int hashCode() {
+        if (_value == null) {
+            // we need a stable hash code for _value == null
+            return -1;
+        }
+        return Double.valueOf(doubleValue()).hashCode();
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/DecimalNode.java
@@ -126,7 +126,13 @@ public class DecimalNode
         if (o == this) return true;
         if (o == null) return false;
         if (o instanceof DecimalNode) {
-            return ((DecimalNode) o)._value.compareTo(_value) == 0;
+            DecimalNode otherNode = (DecimalNode) o;
+            if (otherNode._value == null) {
+                return _value == null;
+            } else if (_value == null) {
+                return false;
+            }
+            return otherNode._value.compareTo(_value) == 0;
         }
         return false;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
@@ -22,7 +22,7 @@ public class NullDataEqualsTest {
         assertEquals(new BigIntegerNode(null), new BigIntegerNode(null));
         assertNotEquals(new BigIntegerNode(BigInteger.ZERO), new BigIntegerNode(null));
         assertNotEquals(new BigIntegerNode(null), new BigIntegerNode(BigInteger.ZERO));
-        assertEquals(-1, new BigIntegerNode(null).hashCode());
+        assertEquals(0, new BigIntegerNode(null).hashCode());
     }
 
     @Test
@@ -30,6 +30,6 @@ public class NullDataEqualsTest {
         assertEquals(new DecimalNode(null), new DecimalNode(null));
         assertNotEquals(new DecimalNode(BigDecimal.ZERO), new DecimalNode(null));
         assertNotEquals( new DecimalNode(null), new DecimalNode(BigDecimal.ZERO));
-        assertEquals(-1, new DecimalNode(null).hashCode());
+        assertEquals(0, new DecimalNode(null).hashCode());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
@@ -1,0 +1,32 @@
+package com.fasterxml.jackson.databind.node;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class NullDataEqualsTest {
+    @Test
+    void testNullBinaryNode() {
+        assertEquals(new BinaryNode(null), new BinaryNode(null));
+        assertNotEquals(new BinaryNode(new byte[8]), new BinaryNode(null));
+        assertNotEquals(new BinaryNode(null), new BinaryNode(new byte[8]));
+    }
+
+    @Test
+    void testNullBigIntegerNode() {
+        assertEquals(new BigIntegerNode(null), new BigIntegerNode(null));
+        assertNotEquals(new BigIntegerNode(BigInteger.ZERO), new BigIntegerNode(null));
+        assertNotEquals(new BigIntegerNode(null), new BigIntegerNode(BigInteger.ZERO));
+    }
+
+    @Test
+    void testNullDecimalNode() {
+        assertEquals(new DecimalNode(null), new DecimalNode(null));
+        assertNotEquals(new DecimalNode(BigDecimal.ZERO), new DecimalNode(null));
+        assertNotEquals( new DecimalNode(null), new DecimalNode(BigDecimal.ZERO));
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
@@ -14,6 +14,7 @@ public class NullDataEqualsTest {
         assertEquals(new BinaryNode(null), new BinaryNode(null));
         assertNotEquals(new BinaryNode(new byte[8]), new BinaryNode(null));
         assertNotEquals(new BinaryNode(null), new BinaryNode(new byte[8]));
+        assertEquals(-1, new BinaryNode(null).hashCode());
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NullDataEqualsTest.java
@@ -22,6 +22,7 @@ public class NullDataEqualsTest {
         assertEquals(new BigIntegerNode(null), new BigIntegerNode(null));
         assertNotEquals(new BigIntegerNode(BigInteger.ZERO), new BigIntegerNode(null));
         assertNotEquals(new BigIntegerNode(null), new BigIntegerNode(BigInteger.ZERO));
+        assertEquals(-1, new BigIntegerNode(null).hashCode());
     }
 
     @Test
@@ -29,5 +30,6 @@ public class NullDataEqualsTest {
         assertEquals(new DecimalNode(null), new DecimalNode(null));
         assertNotEquals(new DecimalNode(BigDecimal.ZERO), new DecimalNode(null));
         assertNotEquals( new DecimalNode(null), new DecimalNode(BigDecimal.ZERO));
+        assertEquals(-1, new DecimalNode(null).hashCode());
     }
 }


### PR DESCRIPTION
relates to #4379 

It may not be expected that these node types wrap nulls but our constructors let you create instances that wrap nulls. So unfortunately, we need to code for them.

There is an argument that we should fix the constructors to not allow null inputs.