### PR TITLE
Fix test failure aroun JsonLocation "against 2.16"

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/exc/BasicExceptionTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/BasicExceptionTest.java
@@ -137,7 +137,7 @@ public class BasicExceptionTest extends BaseMapTest
             JsonLocation loc = e.getLocation();
 //          String expectedLocation = "line: 4, column: 4";
             assertEquals(4, loc.getLineNr());
-            assertEquals(3, loc.getColumnNr());
+            assertEquals(4, loc.getColumnNr());
         }
     }
 }


### PR DESCRIPTION
My other PR is failing. This commit https://github.com/FasterXML/jackson-core/commit/5c9909015023ca048888463fec29612dda7a4003 in Jackson-core made this to fail.