### PR TITLE
Deserialize `java.util.UUID` encoded as Base64 and base64Url with or without padding

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1742,3 +1742,8 @@ Muhammad Khalikov (mukham12@github)
 Eduard Dudar (edudar@github)
  * Contributed #4299: Some `Collection` and `Map` fallbacks don't work in GraalVM native image
  (2.17.0)
+
+Jesper Blomquist (jebl01@github)
+ * Contributed #4394: Deserialize `java.util.UUID` encoded as Base64 and base64Url with or
+   without padding
+ (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -42,6 +42,9 @@ Project: jackson-databind
  (fix contributed by Joo-Hyuk K)
 #4337: `AtomicReference` serializer does not support `@JsonSerialize(contentConverter=...)`
 #4364: `@JsonProperty` and equivalents should merge with `AnnotationIntrospectorPair`
+#4394: Deserialize `java.util.UUID` encoded as Base64 and base64Url with or
+  without padding
+ (fix contributed by Jesper B)
 - JUnit5 upgraded to 5.10.1
 
 2.16.2 (not yet released)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
@@ -41,19 +41,13 @@ public class UUIDDeserializer extends FromStringDeserializer<UUID>
              *   length it must have...
              */
             if (id.length() == 24) {
-                byte[] stuff = Base64Variants.getDefaultVariant().decode(id
-                    //cater for url safe chars
-                    .replace("-", "+")
-                    .replace("_", "/"));
+                byte[] stuff = Base64Variants.getDefaultVariant().decode(convertFromUrlSafe(id));
                 return _fromBytes(stuff, ctxt);
             }
 
             // support for Base64Url encoding (without padding)
             if (id.length() == 22) {
-                byte[] stuff = Base64Variants.MODIFIED_FOR_URL.decode(id
-                    //cater for non url safe chars
-                    .replace("+", "-")
-                    .replace("/", "_"));
+                byte[] stuff = Base64Variants.MODIFIED_FOR_URL.decode(convertToUrlSafe(id));
                 return _fromBytes(stuff, ctxt);
             }
             return _badFormat(id, ctxt);
@@ -140,6 +134,18 @@ public class UUIDDeserializer extends FromStringDeserializer<UUID>
                     bytes, handledType());
         }
         return new UUID(_long(bytes, 0), _long(bytes, 8));
+    }
+
+    private String convertToUrlSafe(String base64) {
+        return base64
+            .replace('+', '-')
+            .replace('/', '_');
+    }
+
+    private String convertFromUrlSafe(String base64) {
+        return base64
+            .replace('-', '+')
+            .replace('_', '/');
     }
 
     private static long _long(byte[] b, int offset) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
@@ -37,17 +37,20 @@ public class UUIDDeserializer extends FromStringDeserializer<UUID>
         // Adapted from java-uuid-generator (https://github.com/cowtowncoder/java-uuid-generator)
         // which is 5x faster than UUID.fromString(value), as oper "ManualReadPerfWithUUID"
         if (id.length() != 36) {
-            /* 14-Sep-2013, tatu: One trick we do allow, Base64-encoding, since we know
-             *   length it must have...
-             */
+            // 14-Sep-2013, tatu: One trick we do allow, Base64-encoding, since we know
+            //   length it must have...
             if (id.length() == 24) {
-                byte[] stuff = Base64Variants.getDefaultVariant().decode(convertFromUrlSafe(id));
+                // 20-Feb-2024, tatu: As per [databind#4394] need to massage a bit first:
+                id = convertFromUrlSafe(id);
+                byte[] stuff = Base64Variants.getDefaultVariant().decode(id);
                 return _fromBytes(stuff, ctxt);
             }
 
             // support for Base64Url encoding (without padding)
             if (id.length() == 22) {
-                byte[] stuff = Base64Variants.MODIFIED_FOR_URL.decode(convertToUrlSafe(id));
+                // 20-Feb-2024, tatu: As per [databind#4394] need to massage a bit first:
+                id = convertToUrlSafe(id);
+                byte[] stuff = Base64Variants.MODIFIED_FOR_URL.decode(id);
                 return _fromBytes(stuff, ctxt);
             }
             return _badFormat(id, ctxt);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializer.java
@@ -41,7 +41,19 @@ public class UUIDDeserializer extends FromStringDeserializer<UUID>
              *   length it must have...
              */
             if (id.length() == 24) {
-                byte[] stuff = Base64Variants.getDefaultVariant().decode(id);
+                byte[] stuff = Base64Variants.getDefaultVariant().decode(id
+                    //cater for url safe chars
+                    .replace("-", "+")
+                    .replace("_", "/"));
+                return _fromBytes(stuff, ctxt);
+            }
+
+            // support for Base64Url encoding (without padding)
+            if (id.length() == 22) {
+                byte[] stuff = Base64Variants.MODIFIED_FOR_URL.decode(id
+                    //cater for non url safe chars
+                    .replace("+", "-")
+                    .replace("/", "_"));
                 return _fromBytes(stuff, ctxt);
             }
             return _badFormat(id, ctxt);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UUIDDeserializer4394Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UUIDDeserializer4394Test.java
@@ -1,11 +1,13 @@
 package com.fasterxml.jackson.databind.deser.jdk;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.UUIDDeserializer;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,39 +15,50 @@ import static org.junit.jupiter.api.Assertions.*;
 // Tests for [databind#4394]
 public class UUIDDeserializer4394Test
 {
-  private static final UUID TEST_UUID = UUID.fromString("a7161c6c-be14-4ae3-a3c4-f27c2b2c6ef4");
+    private static final UUID TEST_UUID = UUID.fromString("a7161c6c-be14-4ae3-a3c4-f27c2b2c6ef4");
 
-  private final UUIDDeserializer UUID_DESERIALIZER = new UUIDDeserializer();
+    private final TestableUUIDDeserializer UUID_DESERIALIZER = new TestableUUIDDeserializer();
 
-  @Test
-  void testCanDeserializeUUIDFromString() throws Exception {
-    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(TEST_UUID.toString(), null));
-  }
+    static class TestableUUIDDeserializer extends UUIDDeserializer
+    {
+        private static final long serialVersionUID = 1L;
 
-  @Test
-  void testCanDeserializeUUIDFromBase64() throws Exception {
-    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
-  }
+        @Override
+        public UUID _deserialize(String id, DeserializationContext ctxt) throws IOException
+        {
+            return super._deserialize(id, ctxt);
+        }
+    }
+  
+    @Test
+    void testCanDeserializeUUIDFromString() throws Exception {
+        assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(TEST_UUID.toString(), null));
+    }
 
-  @Test
-  void testCanDeserializeUUIDFromBase64WithoutPadding() throws Exception {
-    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
-  }
+    @Test
+    void testCanDeserializeUUIDFromBase64() throws Exception {
+        assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+    }
 
-  @Test
-  void testCanDeserializeUUIDFromBase64Url() throws Exception {
-    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
-  }
+    @Test
+    void testCanDeserializeUUIDFromBase64WithoutPadding() throws Exception {
+        assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+    }
 
-  @Test
-  void testCanDeserializeUUIDFromBase64UrlWithoutPadding() throws Exception {
-    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
-  }
+    @Test
+    void testCanDeserializeUUIDFromBase64Url() throws Exception {
+        assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+    }
 
-  private static byte[] getBytesFromUUID(UUID uuid) {
-    final ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-    bb.putLong(uuid.getMostSignificantBits());
-    bb.putLong(uuid.getLeastSignificantBits());
-    return bb.array();
-  }
+    @Test
+    void testCanDeserializeUUIDFromBase64UrlWithoutPadding() throws Exception {
+        assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+    }
+
+    private static byte[] getBytesFromUUID(UUID uuid) {
+        final ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return bb.array();
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UUIDDeserializer4394Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/UUIDDeserializer4394Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.deser.std;
+package com.fasterxml.jackson.databind.deser.jdk;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -6,9 +6,12 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.deser.std.UUIDDeserializer;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class UUIDDeserializerTest
+// Tests for [databind#4394]
+public class UUIDDeserializer4394Test
 {
   private static final UUID TEST_UUID = UUID.fromString("a7161c6c-be14-4ae3-a3c4-f27c2b2c6ef4");
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializerTest.java
@@ -1,0 +1,58 @@
+package com.fasterxml.jackson.databind.deser.std;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UUIDDeserializerTest {
+  @Test
+  void testCanDeserializeUUIDFromString() throws IOException {
+    final UUID uuid = UUID.randomUUID();
+    final UUIDDeserializer deserializer = new UUIDDeserializer();
+
+    assertEquals(uuid, deserializer._deserialize(uuid.toString(), null));
+  }
+
+  @Test
+  void testCanDeserializeUUIDFromBase64() throws IOException {
+    final UUID uuid = UUID.randomUUID();
+    final UUIDDeserializer deserializer = new UUIDDeserializer();
+
+    assertEquals(uuid, deserializer._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(uuid)), null));
+  }
+
+  @Test
+  void testCanDeserializeUUIDFromBase64WithoutPadding() throws IOException {
+    final UUID uuid = UUID.randomUUID();
+    final UUIDDeserializer deserializer = new UUIDDeserializer();
+
+    assertEquals(uuid, deserializer._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(uuid)), null));
+  }
+
+  @Test
+  void testCanDeserializeUUIDFromBase64Url() throws IOException {
+    final UUID uuid = UUID.randomUUID();
+    final UUIDDeserializer deserializer = new UUIDDeserializer();
+
+    assertEquals(uuid, deserializer._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(uuid)), null));
+  }
+
+  @Test
+  void testCanDeserializeUUIDFromBase64UrlWithoutPadding() throws IOException {
+    final UUID uuid = UUID.randomUUID();
+    final UUIDDeserializer deserializer = new UUIDDeserializer();
+
+    assertEquals(uuid, deserializer._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(uuid)), null));
+  }
+
+  private static byte[] getBytesFromUUID(UUID uuid) {
+    final ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+    bb.putLong(uuid.getMostSignificantBits());
+    bb.putLong(uuid.getLeastSignificantBits());
+    return bb.array();
+  }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializerTest.java
@@ -9,44 +9,40 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class UUIDDeserializerTest {
+  private static final UUID TEST_UUID = UUID.fromString("a7161c6c-be14-4ae3-a3c4-f27c2b2c6ef4");
+
   @Test
   void testCanDeserializeUUIDFromString() throws IOException {
-    final UUID uuid = UUID.randomUUID();
     final UUIDDeserializer deserializer = new UUIDDeserializer();
-
-    assertEquals(uuid, deserializer._deserialize(uuid.toString(), null));
+    assertEquals(TEST_UUID, deserializer._deserialize(TEST_UUID.toString(), null));
   }
 
   @Test
   void testCanDeserializeUUIDFromBase64() throws IOException {
-    final UUID uuid = UUID.randomUUID();
     final UUIDDeserializer deserializer = new UUIDDeserializer();
 
-    assertEquals(uuid, deserializer._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(uuid)), null));
+    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   @Test
   void testCanDeserializeUUIDFromBase64WithoutPadding() throws IOException {
-    final UUID uuid = UUID.randomUUID();
     final UUIDDeserializer deserializer = new UUIDDeserializer();
 
-    assertEquals(uuid, deserializer._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(uuid)), null));
+    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   @Test
   void testCanDeserializeUUIDFromBase64Url() throws IOException {
-    final UUID uuid = UUID.randomUUID();
     final UUIDDeserializer deserializer = new UUIDDeserializer();
 
-    assertEquals(uuid, deserializer._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(uuid)), null));
+    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   @Test
   void testCanDeserializeUUIDFromBase64UrlWithoutPadding() throws IOException {
-    final UUID uuid = UUID.randomUUID();
     final UUIDDeserializer deserializer = new UUIDDeserializer();
 
-    assertEquals(uuid, deserializer._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(uuid)), null));
+    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   private static byte[] getBytesFromUUID(UUID uuid) {

--- a/src/test/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/std/UUIDDeserializerTest.java
@@ -1,48 +1,42 @@
 package com.fasterxml.jackson.databind.deser.std;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
-class UUIDDeserializerTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UUIDDeserializerTest
+{
   private static final UUID TEST_UUID = UUID.fromString("a7161c6c-be14-4ae3-a3c4-f27c2b2c6ef4");
 
+  private final UUIDDeserializer UUID_DESERIALIZER = new UUIDDeserializer();
+
   @Test
-  void testCanDeserializeUUIDFromString() throws IOException {
-    final UUIDDeserializer deserializer = new UUIDDeserializer();
-    assertEquals(TEST_UUID, deserializer._deserialize(TEST_UUID.toString(), null));
+  void testCanDeserializeUUIDFromString() throws Exception {
+    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(TEST_UUID.toString(), null));
   }
 
   @Test
-  void testCanDeserializeUUIDFromBase64() throws IOException {
-    final UUIDDeserializer deserializer = new UUIDDeserializer();
-
-    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+  void testCanDeserializeUUIDFromBase64() throws Exception {
+    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   @Test
-  void testCanDeserializeUUIDFromBase64WithoutPadding() throws IOException {
-    final UUIDDeserializer deserializer = new UUIDDeserializer();
-
-    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+  void testCanDeserializeUUIDFromBase64WithoutPadding() throws Exception {
+    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   @Test
-  void testCanDeserializeUUIDFromBase64Url() throws IOException {
-    final UUIDDeserializer deserializer = new UUIDDeserializer();
-
-    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+  void testCanDeserializeUUIDFromBase64Url() throws Exception {
+    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getUrlEncoder().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   @Test
-  void testCanDeserializeUUIDFromBase64UrlWithoutPadding() throws IOException {
-    final UUIDDeserializer deserializer = new UUIDDeserializer();
-
-    assertEquals(TEST_UUID, deserializer._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
+  void testCanDeserializeUUIDFromBase64UrlWithoutPadding() throws Exception {
+    assertEquals(TEST_UUID, UUID_DESERIALIZER._deserialize(Base64.getUrlEncoder().withoutPadding().encodeToString(getBytesFromUUID(TEST_UUID)), null));
   }
 
   private static byte[] getBytesFromUUID(UUID uuid) {


### PR DESCRIPTION
*Vert.x 4* changed to `Base64UrlEncoder` as the default for binary columns in database responses (*Vert.x* serializes database responses into JSON arrays). This becomes a problem when Jackson tries to deserialize into a field of type `UUID`. The workaround is to provide a custom serializer for UUID or to have `byte[]` fields in your database entities.

This PR ensures all variants of Base64 is supported for UUIDs "out of the box".