### PR TITLE
Modify `net.bytebuddy` maven dependency scope to `"test"` only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
       <version>1.14.9</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
addresses #4428.

Because `net.bytebuddy` dependency is quite common library used by many (at least from personal experience), thus we would be quite prone to conflict on runtime.