### PR TITLE
Rework synchronized block from `BeanDeserializerBase`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -1891,13 +1891,13 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
         throws IOException
     {
         // First: maybe we have already created sub-type deserializer?
-        ClassKey classKey = new ClassKey(bean.getClass());
+        final ClassKey classKey = new ClassKey(bean.getClass());
         JsonDeserializer<Object> subDeser = (_subDeserializers == null) ? null : _subDeserializers.get(classKey);
         if (subDeser != null) {
             return subDeser;
         }
         // If not, maybe we can locate one. First, need provider
-        JavaType type = ctxt.constructType(bean.getClass());
+        final JavaType type = ctxt.constructType(bean.getClass());
         /* 30-Jan-2012, tatu: Ideally we would be passing referring
          *   property; which in theory we could keep track of via
          *   ResolvableDeserializer (if we absolutely must...).


### PR DESCRIPTION
Changed to use a ConcurrentHashMap internally so we don't have to lock at all - with one remaining exception.

The map is transient so we need to ensure that when we create it - that only one thread can do this. We have retained the synchronized block just for this part.