### PR TITLE
SerializerCache: remove synchronization when only _sharedMap is access with a read call

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/SerializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/SerializerCache.java
@@ -97,7 +97,7 @@ public final class SerializerCache
     /**********************************************************
      */
 
-    public synchronized int size() {
+    public int size() {
         return _sharedMap.size();
     }
 
@@ -107,30 +107,22 @@ public final class SerializerCache
      */
     public JsonSerializer<Object> untypedValueSerializer(Class<?> type)
     {
-        synchronized (this) {
-            return _sharedMap.get(new TypeKey(type, false));
-        }
+        return _sharedMap.get(new TypeKey(type, false));
     }
 
     public JsonSerializer<Object> untypedValueSerializer(JavaType type)
     {
-        synchronized (this) {
-            return _sharedMap.get(new TypeKey(type, false));
-        }
+        return _sharedMap.get(new TypeKey(type, false));
     }
 
     public JsonSerializer<Object> typedValueSerializer(JavaType type)
     {
-        synchronized (this) {
-            return _sharedMap.get(new TypeKey(type, true));
-        }
+        return _sharedMap.get(new TypeKey(type, true));
     }
 
     public JsonSerializer<Object> typedValueSerializer(Class<?> cls)
     {
-        synchronized (this) {
-            return _sharedMap.get(new TypeKey(cls, true));
-        }
+        return _sharedMap.get(new TypeKey(cls, true));
     }
 
     /*


### PR DESCRIPTION
* there is a lot of synchronization in SerializerCache
* most of it may be necessary on the update side but on the read side, we can remove some
* we can follow up and replace the remaining synchronization later