### PR TITLE
rework synchronized block in TypeDeserializerBase

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/TypeDeserializerBase.java
@@ -223,13 +223,15 @@ public abstract class TypeDeserializerBase
             return NullifyingDeserializer.instance;
         }
 
-        synchronized (_defaultImpl) {
-            if (_defaultImplDeserializer == null) {
-                _defaultImplDeserializer = ctxt.findContextualValueDeserializer(
+        if (_defaultImplDeserializer == null) {
+            synchronized (_defaultImpl) {
+                if (_defaultImplDeserializer == null) {
+                    _defaultImplDeserializer = ctxt.findContextualValueDeserializer(
                         _defaultImpl, _property);
+                }
             }
-            return _defaultImplDeserializer;
         }
+        return _defaultImplDeserializer;
     }
 
     /**


### PR DESCRIPTION
check condition before synchronizing - it's quite possible we can avoid locking in many cases