### PR TITLE
Remove `final` on method BeanSerializer.serialize()

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1780,3 +1780,7 @@ Teodor Danciu (teodord@github)
  * Reported #4464: When `Include.NON_DEFAULT` setting is used, `isEmpty()` method is
    not called on the serializer
   (2.18.0)
+
+Matthew Luckam (mluckam@github)
+ * Contributed #4483: Remove `final` on method BeanSerializer.serialize()
+  (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,8 @@ Project: jackson-databind
  (fix by Joo-Hyuk K)
 #4472: Rework synchronized block in `TypeDeserializerBase`
  (contributed by @pjfanning)
+#4483: Remove `final` on method BeanSerializer.serialize()
+ (contributed by Matthew L)
 
 2.17.1 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java
@@ -168,7 +168,7 @@ public class BeanSerializer
      * {@link BeanPropertyWriter} instances.
      */
     @Override
-    public final void serialize(Object bean, JsonGenerator gen, SerializerProvider provider)
+    public void serialize(Object bean, JsonGenerator gen, SerializerProvider provider)
         throws IOException
     {
         if (_objectIdWriter != null) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java
@@ -168,6 +168,7 @@ public class BeanSerializer
      * {@link BeanPropertyWriter} instances.
      */
     @Override
+    // note: was final before 2.18
     public void serialize(Object bean, JsonGenerator gen, SerializerProvider provider)
         throws IOException
     {


### PR DESCRIPTION
The method [`BeanDeserializer.deserialize`](https://github.com/FasterXML/jackson-databind/blob/2.18/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java#L172) is not final.  This allows for modification to the deserialization process generally via proxy or subclass, ex [adding validation](https://www.baeldung.com/java-object-validation-deserialization).  The reverse is not allowed though as [`BeanSerializer.Serialize`](https://github.com/FasterXML/jackson-databind/blob/2.18/src/main/java/com/fasterxml/jackson/databind/ser/BeanSerializer.java#L171) is final.

I propose removing final from the method to allow for these two inverse functions to be exposed equally.  Idea originally discussed in #4482 