### PR TITLE
Remove remaining `JUnit 4` usage

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/MapperFootprintTest.java
@@ -1,9 +1,10 @@
 package com.fasterxml.jackson.databind;
 
 import com.google.common.testing.GcFinalization;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jol.info.GraphLayout;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MapperFootprintTest {
     /*
@@ -28,10 +29,10 @@ public class MapperFootprintTest {
 
         // 29-Nov-2022, tatu: Should be under 10k, but... flakiness.
         final int maxByteSize = 20_000;
-        Assert.assertTrue(
+        assertTrue(
+                mapperLayout.totalSize() < maxByteSize,
                 "ObjectMapper memory footprint ("+mapperLayout.totalSize()
                 +") exceeded limit ("+maxByteSize
-                +"). Footprint details: " + mapperLayout.toFootprint(),
-                mapperLayout.totalSize() < maxByteSize);
+                +"). Footprint details: " + mapperLayout.toFootprint());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/big/BiggerDataTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/big/BiggerDataTest.java
@@ -105,6 +105,7 @@ public class BiggerDataTest
 		assertEquals(1, citm.venueNames.size());
 	}
 
+	@Test
 	public void testRoundTrip() throws Exception
 	{
 		Citm citm = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"),

--- a/src/test/java/com/fasterxml/jackson/databind/deser/AnySetterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/AnySetterTest.java
@@ -496,6 +496,7 @@ public class AnySetterTest extends DatabindTestUtil
     }
 
     // [databind#4316]
+    @Test
     public void testWithAnySetter() throws Exception
     {
         Problem4316 problem = new Problem4316();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/BeanDeserializerModifier4216Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/BeanDeserializerModifier4216Test.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind.deser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JsonDeserializer;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/DelegatingCreatorImplicitNames2543Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/DelegatingCreatorImplicitNames2543Test.java
@@ -2,8 +2,6 @@ package com.fasterxml.jackson.databind.deser.creators;
 
 import java.util.Objects;
 
-import org.junit.Test;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -11,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/LocaleDeser4009Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/LocaleDeser4009Test.java
@@ -15,6 +15,7 @@ public class LocaleDeser4009Test
 {
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @Test
     public void testLocaleWithFeatureDisabled() throws Exception 
     {
         assertEquals(Locale.ROOT,

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapKeyDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapKeyDeserializationTest.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -122,11 +121,11 @@ public class MapKeyDeserializationTest
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'true':'foobar'}}"), type);
 
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Boolean.TRUE, result.map.entrySet().iterator().next().getKey());
+        assertEquals(Boolean.TRUE, result.map.entrySet().iterator().next().getKey());
 
         result = MAPPER.readValue(a2q("{'map':{'false':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Boolean.FALSE, result.map.entrySet().iterator().next().getKey());
+        assertEquals(Boolean.FALSE, result.map.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -135,7 +134,7 @@ public class MapKeyDeserializationTest
         TypeReference<MapWrapper<Byte, String>> type = new TypeReference<MapWrapper<Byte, String>>() { };
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'13':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Byte.valueOf((byte) 13), result.map.entrySet().iterator().next().getKey());
+        assertEquals(Byte.valueOf((byte) 13), result.map.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -144,7 +143,7 @@ public class MapKeyDeserializationTest
         TypeReference<MapWrapper<Short, String>> type = new TypeReference<MapWrapper<Short, String>>() { };
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'13':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Short.valueOf((short) 13), result.map.entrySet().iterator().next().getKey());
+        assertEquals(Short.valueOf((short) 13), result.map.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -153,7 +152,7 @@ public class MapKeyDeserializationTest
         TypeReference<MapWrapper<Integer, String>> type = new TypeReference<MapWrapper<Integer, String>>() { };
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'-3':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Integer.valueOf(-3), result.map.entrySet().iterator().next().getKey());
+        assertEquals(Integer.valueOf(-3), result.map.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -162,7 +161,7 @@ public class MapKeyDeserializationTest
         TypeReference<MapWrapper<Long, String>> type = new TypeReference<MapWrapper<Long, String>>() { };
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'42':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Long.valueOf(42), result.map.entrySet().iterator().next().getKey());
+        assertEquals(Long.valueOf(42), result.map.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -171,7 +170,7 @@ public class MapKeyDeserializationTest
         TypeReference<MapWrapper<Float, String>> type = new TypeReference<MapWrapper<Float, String>>() { };
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'3.5':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Float.valueOf(3.5f), result.map.entrySet().iterator().next().getKey());
+        assertEquals(Float.valueOf(3.5f), result.map.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -180,7 +179,7 @@ public class MapKeyDeserializationTest
         TypeReference<MapWrapper<Double, String>> type = new TypeReference<MapWrapper<Double, String>>() { };
         MapWrapper<?,?> result = MAPPER.readValue(a2q("{'map':{'0.25':'foobar'}}"), type);
         assertEquals(1, result.map.size());
-        Assert.assertEquals(Double.valueOf(0.25), result.map.entrySet().iterator().next().getKey());
+        assertEquals(Double.valueOf(0.25), result.map.entrySet().iterator().next().getKey());
     }
 
     /*
@@ -215,7 +214,7 @@ public class MapKeyDeserializationTest
         Map.Entry<byte[],String> entry = result.map.entrySet().iterator().next();
         assertEquals("foobar", entry.getValue());
         byte[] key = entry.getKey();
-        Assert.assertArrayEquals(binary, key);
+        assertArrayEquals(binary, key);
     }
 
     // [databind#2725]

--- a/src/test/java/com/fasterxml/jackson/databind/deser/merge/ArrayNode3338MergeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/merge/ArrayNode3338MergeTest.java
@@ -71,6 +71,7 @@ public class ArrayNode3338MergeTest
        return mapper.readerForUpdating(mergeTarget).readValue(updateNode);
     }
 
+    @Test
     public void testEnabledObjectNodeMerge() throws Exception {
         final ObjectMapper mapperWithMerge = sharedMapper();
 
@@ -91,6 +92,7 @@ public class ArrayNode3338MergeTest
         assertEquals(expected, merged);
     }
 
+    @Test
     public void testDisabledObjectNodeMerge() throws Exception {
         ObjectMapper mapperNoObjectMerge = jsonMapperBuilder()
                 .withConfigOverride(ObjectNode.class,

--- a/src/test/java/com/fasterxml/jackson/databind/exc/CustomExceptionDeser4071Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/exc/CustomExceptionDeser4071Test.java
@@ -49,7 +49,6 @@ public class CustomExceptionDeser4071Test
         _testDeserAsThrowable(MAPPER.writeValueAsString(new CustomThrowable4071()));
     }
 
-    @Test
     private void _testDeserAsThrowable(String exStr) throws Exception
     {
         assertNotNull(MAPPER.readValue(exStr, Throwable.class));

--- a/src/test/java/com/fasterxml/jackson/databind/interop/ImmutablesTypeSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/interop/ImmutablesTypeSerializationTest.java
@@ -14,10 +14,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for serialization and deserialization of objects based on

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/deftyping/TestDefaultWithCreators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/deftyping/TestDefaultWithCreators.java
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.databind.jsontype.deftyping;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.*;
@@ -103,6 +102,6 @@ public class TestDefaultWithCreators
         assertNotNull(result.value);
         assertEquals(Bean1385.class, result.value.getClass());
         Bean1385 b = (Bean1385) result.value;
-        Assert.assertArrayEquals(BYTES, b.raw);
+        assertArrayEquals(BYTES, b.raw);
     }
  }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/TestPropertyCreatorSubtypesExternalPropertyMissingProperty.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/ext/TestPropertyCreatorSubtypesExternalPropertyMissingProperty.java
@@ -1,7 +1,5 @@
 package com.fasterxml.jackson.databind.jsontype.ext;
 
-import org.junit.Test;
-
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
@@ -10,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/jdk/TypedArrayDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/jdk/TypedArrayDeserTest.java
@@ -5,7 +5,7 @@ import java.util.LinkedList;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import com.fasterxml.jackson.annotation.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/jdk/TypedContainerSerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/jdk/TypedContainerSerTest.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.databind.jsontype.jdk;
 
 import java.util.*;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.*;
@@ -116,13 +115,13 @@ public class TypedContainerSerTest
 		Container1 c1 = new Container1();
 		c1.setAnimal(dog);
 		String s1 = mapper.writeValueAsString(c1);
-		Assert.assertTrue("polymorphic type info is kept (1)", s1
-				.indexOf("\"object-type\":\"doggy\"") >= 0);
+		assertTrue(s1.indexOf("\"object-type\":\"doggy\"") >= 0,
+				"polymorphic type info is kept (1)");
 		Container2<Animal> c2 = new Container2<Animal>();
 		c2.setAnimal(dog);
 		String s2 = mapper.writeValueAsString(c2);
-		Assert.assertTrue("polymorphic type info is kept (2)", s2
-				.indexOf("\"object-type\":\"doggy\"") >= 0);
+		assertTrue(s2.indexOf("\"object-type\":\"doggy\"") >= 0,
+				"polymorphic type info is kept (2)");
     }
 
 	@Test

--- a/src/test/java/com/fasterxml/jackson/databind/node/ArrayNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ArrayNodeTest.java
@@ -10,10 +10,12 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.util.RawValue;
+
 import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Additional tests for {@link ArrayNode} container class.

--- a/src/test/java/com/fasterxml/jackson/databind/node/EmptyContentAsTreeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/EmptyContentAsTreeTest.java
@@ -135,7 +135,7 @@ public class EmptyContentAsTreeTest extends DatabindTestUtil
     }
 
     private void _assertMissing(JsonNode n) {
-        assertNotNull("Should not get `null` but `MissingNode`", n);
+        assertNotNull(n, "Should not get `null` but `MissingNode`");
         if (!n.isMissingNode()) {
             fail("Should get `MissingNode` but got: "+n.getClass().getName());
         }

--- a/src/test/java/com/fasterxml/jackson/databind/node/EmptyContentAsTreeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/EmptyContentAsTreeTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**

--- a/src/test/java/com/fasterxml/jackson/databind/node/JsonNodeConversionsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/JsonNodeConversionsTest.java
@@ -6,11 +6,10 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
-import org.junit.Assert;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.*;
@@ -272,9 +271,9 @@ public class JsonNodeConversionsTest extends DatabindTestUtil
         Issue709Bean resultFromConvert = MAPPER.convertValue(node, Issue709Bean.class);
 
         // all methods should work equally well:
-        Assert.assertArrayEquals(inputData, resultFromString.data);
-        Assert.assertArrayEquals(inputData, resultFromConvert.data);
-        Assert.assertArrayEquals(inputData, result.data);
+        assertArrayEquals(inputData, resultFromString.data);
+        assertArrayEquals(inputData, resultFromConvert.data);
+        assertArrayEquals(inputData, result.data);
     }
 
     @Test
@@ -328,7 +327,7 @@ public class JsonNodeConversionsTest extends DatabindTestUtil
 
         // then via conversions: should become JSON Object
         JsonNode tree = MAPPER.valueToTree(input);
-        assertTrue("Expected Object, got "+tree.getNodeType(), tree.isObject());
+        assertTrue(tree.isObject(), "Expected Object, got "+tree.getNodeType());
         assertEquals(EXP, MAPPER.writeValueAsString(tree));
     }
 
@@ -345,7 +344,8 @@ public class JsonNodeConversionsTest extends DatabindTestUtil
 
         // then via conversions: should become JSON Object
         JsonNode tree = MAPPER.valueToTree(input);
-        assertTrue("Expected Object, got "+tree.getNodeType(), tree.isBoolean());
+        assertTrue(tree.isBoolean(),
+                "Expected Object, got "+tree.getNodeType());
         assertEquals(EXP, MAPPER.writeValueAsString(tree));
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/TextNodeTest.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.databind.node;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/seq/PolyMapWriter827Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/seq/PolyMapWriter827Test.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -52,6 +51,6 @@ public class PolyMapWriter827Test extends DatabindTestUtil
 
         final ObjectWriter writer = mapper.writerFor(new TypeReference<Map<CustomKey,String>>() { });
         String json = writer.writeValueAsString(map);
-        Assert.assertEquals("[\"java.util.HashMap\",{\"foo,1\":\"bar\"}]", json);
+        assertEquals("[\"java.util.HashMap\",{\"foo,1\":\"bar\"}]", json);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/seq/SequenceWriterTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/seq/SequenceWriterTest.java
@@ -145,6 +145,7 @@ public class SequenceWriterTest extends DatabindTestUtil
         //   will not work in 2.x.
     }
 
+    @Test
     public void testSimpleArray() throws Exception
     {
         StringWriter strw = new StringWriter();
@@ -176,6 +177,7 @@ public class SequenceWriterTest extends DatabindTestUtil
      */
 
     @SuppressWarnings("resource")
+    @Test
     public void testPolymorphicNonArrayWithoutType() throws Exception
     {
         StringWriter strw = new StringWriter();
@@ -189,6 +191,7 @@ public class SequenceWriterTest extends DatabindTestUtil
     }
 
     @SuppressWarnings("resource")
+    @Test
     public void testPolymorphicArrayWithoutType() throws Exception
     {
         StringWriter strw = new StringWriter();
@@ -201,6 +204,7 @@ public class SequenceWriterTest extends DatabindTestUtil
                 strw.toString());
     }
 
+    @Test
     public void testPolymorphicArrayWithType() throws Exception
     {
         StringWriter strw = new StringWriter();
@@ -217,6 +221,7 @@ public class SequenceWriterTest extends DatabindTestUtil
     }
 
     @SuppressWarnings("resource")
+    @Test
     public void testSimpleCloseable() throws Exception
     {
         JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/DateSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/DateSerializationTest.java
@@ -5,7 +5,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -15,7 +14,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -392,11 +391,11 @@ public class DateSerializationTest
     }
 
     private void serialize(ObjectMapper mapper, Object date, String expected) throws IOException {
-        Assert.assertEquals(q(expected), mapper.writeValueAsString(date));
+        assertEquals(q(expected), mapper.writeValueAsString(date));
     }
 
     private void serialize(ObjectWriter w, Object date, String expected) throws IOException {
-        Assert.assertEquals(q(expected), w.writeValueAsString(date));
+        assertEquals(q(expected), w.writeValueAsString(date));
     }
 
     private String zoneOffset(String raw) {

--- a/src/test/java/com/fasterxml/jackson/databind/type/TypeBindingsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TypeBindingsTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.verifyException;

--- a/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.*;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newTypeFactory;

--- a/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryTest.java
@@ -505,9 +505,9 @@ public class TypeFactoryTest
         JavaType mapIntString = tf.constructType(new TypeReference<Map<Integer,String>>() {});
         assertNotEquals(mapStringInt, mapIntString);
         assertNotEquals(
-                "hashCode should depend on parameter order",
                 mapStringInt.hashCode(),
-                mapIntString.hashCode());
+                mapIntString.hashCode(),
+                "hashCode should depend on parameter order");
 
         JavaType mapStringString = tf.constructType(new TypeReference<Map<String,String>>() {});
         JavaType mapIntInt = tf.constructType(new TypeReference<Map<Integer,Integer>>() {});
@@ -821,8 +821,8 @@ public class TypeFactoryTest
 
         assertNotEquals(charSequenceClass, numberClass);
         assertNotEquals(
-                "hash values should be distributed",
-                charSequenceClass.hashCode(), numberClass.hashCode());
+                charSequenceClass.hashCode(), numberClass.hashCode(),
+                "hash values should be distributed");
     }
 
     private void assertEqualsAndHash(JavaType t1, JavaType t2) {

--- a/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryWithClassLoaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryWithClassLoaderTest.java
@@ -59,7 +59,7 @@ public void testUsesCorrectClassLoaderWhenThreadClassLoaderIsNotNull() throws Cl
 	verify(spySut).classForName(any(String.class), any(Boolean.class), eq(classLoader));
 	assertNotNull(clazz);
 	assertEquals(classLoader, spySut.getClassLoader());
-//	Assert.assertEquals(typeModifier,spySut._modifiers[0]);
+//	assertEquals(typeModifier,spySut._modifiers[0]);
 }
 
 @Test

--- a/src/test/java/com/fasterxml/jackson/databind/util/ArrayBuildersTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ArrayBuildersTest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.util.ArrayBuilders.IntBuilder;
 import com.fasterxml.jackson.databind.util.ArrayBuilders.LongBuilder;
 import com.fasterxml.jackson.databind.util.ArrayBuilders.ShortBuilder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ArrayBuildersTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/BeanUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/BeanUtilTest.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class BeanUtilTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/BufferRecyclersDatabindTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/BufferRecyclersDatabindTest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // For [databind#4321]: basic test
 public class BufferRecyclersDatabindTest extends DatabindTestUtil

--- a/src/test/java/com/fasterxml/jackson/databind/util/ByteBufferUtilsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ByteBufferUtilsTest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.testutil.FiveMinuteUser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufferUtilsTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/ClassUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ClassUtilTest.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ClassUtilTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/CompactStringObjectMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/CompactStringObjectMapTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CompactStringObjectMapTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/EnumValuesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/EnumValuesTest.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class EnumValuesTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/ExceptionUtilTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ExceptionUtilTest.java
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExceptionUtilTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/ISO8601DateFormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ISO8601DateFormatTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
 public class ISO8601DateFormatTest extends DatabindTestUtil

--- a/src/test/java/com/fasterxml/jackson/databind/util/ISO8601UtilsTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ISO8601UtilsTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("deprecation")
 public class ISO8601UtilsTest extends DatabindTestUtil

--- a/src/test/java/com/fasterxml/jackson/databind/util/JSONPObjectTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/JSONPObjectTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JSONPObjectTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/LRUMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/LRUMapTest.java
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LRUMapTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/NameTransformerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/NameTransformerTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NameTransformerTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/ObjectBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/ObjectBufferTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ObjectBufferTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/RawValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/RawValueTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonSerializable;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RawValueTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/util/StdDateFormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/StdDateFormatTest.java
@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StdDateFormatTest extends DatabindTestUtil
 {
     @SuppressWarnings("deprecation")
+    @Test
     public void testFactories() {
         TimeZone tz = TimeZone.getTimeZone("GMT");
         Locale loc = Locale.US;

--- a/src/test/java/com/fasterxml/jackson/databind/util/TokenBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/TokenBufferTest.java
@@ -90,7 +90,7 @@ public class TokenBufferTest extends DatabindTestUtil
         TokenBuffer buf = new TokenBuffer(MAPPER, false);
         try (JsonParser p = buf.asParser()) {
             for (JsonParser.Feature feat : JsonParser.Feature.values()) {
-                assertEquals("Feature "+feat, feat.enabledByDefault(), p.isEnabled(feat));
+                assertEquals(feat.enabledByDefault(), p.isEnabled(feat), "Feature "+feat);
             }
         }
     }

--- a/src/test/java/com/fasterxml/jackson/databind/util/TokenBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/TokenBufferTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("resource")
 public class TokenBufferTest extends DatabindTestUtil

--- a/src/test/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMapStressTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMapStressTest.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind.util.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PrivateMaxEntriesMapStressTest {
 

--- a/src/test/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/internal/PrivateMaxEntriesMapTest.java
@@ -18,10 +18,10 @@
  ****************************************************************/
 package com.fasterxml.jackson.databind.util.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 //copied from https://github.com/apache/cayenne/blob/b156addac1c8e4079fa88e977fee609210c5da69/cayenne-server/src/test/java/org/apache/cayenne/util/concurrentlinkedhashmap/ConcurrentLinkedHashMapTest.java
 public class PrivateMaxEntriesMapTest {

--- a/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/DefaultViewTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // for [databind#507], supporting default views
 public class DefaultViewTest extends DatabindTestUtil

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewDeserializationTest.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ViewDeserializationTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewSerialization2Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewSerialization2Test.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ViewSerialization2Test extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewSerializationTest.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Unit tests for verifying JSON view functionality: ability to declaratively

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithCreatorTest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ViewsWithCreatorTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithSchemaTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/ViewsWithSchemaTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ViewsWithSchemaTest extends DatabindTestUtil
 {

--- a/src/test/java/com/fasterxml/jackson/failing/DeserializerUpdateProperties4358Test.java
+++ b/src/test/java/com/fasterxml/jackson/failing/DeserializerUpdateProperties4358Test.java
@@ -109,7 +109,7 @@ class DeserializerUpdateProperties4358Test extends DatabindTestUtil {
     final ObjectMapper modifiedObjectMapper = jsonMapperBuilder().addModules(getSimpleModuleWithDeserializerModifier()).build();
 
     @BeforeAll
-    void setUp() {
+    static void setUp() {
         actualOrder.clear();
     }
 


### PR DESCRIPTION
This PR cleans up remaining `JUnit 4` usages.

We have JUnit 4 dependency in jackson-base left to remove.