### PR TITLE
Allow override `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` with `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` 

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -28,6 +28,10 @@ Project: jackson-databind
 #4481: Unable to override `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL`
   with `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_AS_NULL`
  (reported by @luozhenyu)
+#4489: Unable to override `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`
+  with `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`
+  (reported by Joo-Hyuk K)
+  (fix by Joo-Hyuk K)
 
 2.17.0 (12-Mar-2024)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -494,8 +494,16 @@ public class EnumDeserializer
 
     // @since 2.15
     protected boolean useDefaultValueForUnknownEnum(DeserializationContext ctxt) {
-        return (_enumDefaultValue != null)
-          && (Boolean.TRUE.equals(_useDefaultValueForUnknownEnum)
-          || ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE));
+        // If we have a default value...
+        if (_enumDefaultValue != null) {
+            // Check if FormatFeature overrides exist first
+            if (_useDefaultValueForUnknownEnum != null) {
+                return _useDefaultValueForUnknownEnum;
+            }
+            // Otherwise, check the global setting
+            return ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+        }
+        // No default value? then false
+        return false;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAltIdTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAltIdTest.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.databind.deser.enums;
 import java.io.IOException;
 import java.util.EnumSet;
 
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
@@ -11,10 +10,8 @@ import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -333,7 +330,8 @@ public class EnumAltIdTest
     }
 
     /**
-     * Test to verify that configuration via {@link JsonFormat.Feature#READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE}
+     * Test to verify that configuration via
+     * {@link com.fasterxml.jackson.annotation.JsonFormat.Feature#READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE}
      * takes precedence over global configuration.
      */
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAltIdTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAltIdTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.databind.deser.enums;
 import java.io.IOException;
 import java.util.EnumSet;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
@@ -101,6 +102,22 @@ public class EnumAltIdTest
     static class Book4481 {
         @JsonFormat(without = JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
         public Color color;
+    }
+
+    enum Types {
+        @JsonEnumDefaultValue
+        DEFAULT_TYPE,
+        FAST, SLOW
+    }
+
+    static class SpeedWithoutDefaultOverride {
+        @JsonFormat(without = JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        public Types type;
+    }
+
+    static class SpeedWithDefaultOverride {
+        @JsonFormat(with = JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        public Types type;
     }
 
     /*
@@ -313,6 +330,37 @@ public class EnumAltIdTest
           .readValue(JSON);
         assertEquals(1, pojo.value.size());
         assertTrue(pojo.value.contains(MyEnum2352_3.B));
+    }
+
+    /**
+     * Test to verify that configuration via {@link JsonFormat.Feature#READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE}
+     * takes precedence over global configuration.
+     */
+    @Test
+    public void testJsonEnumDefaultValueOverrideOverGlobalConfig() throws Exception {
+        final String UNKNOWN_JSON = a2q("{'type':'OOPS!'}");
+
+        // First, global configuration is ENABLED and JsonFeature configuration is DISABLED
+        // So the test should fail
+        try {
+            JsonMapper.builder()
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .build()
+                .readValue(UNKNOWN_JSON, SpeedWithoutDefaultOverride.class);
+            fail();
+        } catch (InvalidFormatException e) {
+            verifyException(e, "Cannot deserialize value of type");
+            verifyException(e, "not one of the values accepted for Enum class");
+        }
+
+        // Second, global configuration is DISABLED and JsonFeature configuration is ENABLED
+        // So the test should pass
+        SpeedWithDefaultOverride pojo = JsonMapper.builder()
+            .disable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+            .build()
+            .readValue(UNKNOWN_JSON, SpeedWithDefaultOverride.class);
+
+        assertEquals(Types.DEFAULT_TYPE, pojo.type);
     }
 
     /*


### PR DESCRIPTION
Fixes #4489