### PR TITLE
Fix "iff" typo in Javadoc, comments and release notes

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -2815,7 +2815,7 @@ Other changes:
 
 * New variant of AnnotationIntrospector.getFormat(), to support class
   annotations
-* It is now possible to serialize instances of plain old Object, iff
+* It is now possible to serialize instances of plain old Object, if
   'FAIL_ON_EMPTY_BEANS' is disabled.
 * Trying to remove reference to "JSON" in datatype conversion errors
  (since databinding is format-agnostic)

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -314,7 +314,7 @@ public abstract class JsonNode
 
     /**
      * Method that can be used to check if the node is a wrapper
-     * for a POJO ("Plain Old Java Object" aka "bean".
+     * for a POJO ("Plain Old Java Object" aka "bean").
      * Returns true only for
      * instances of <code>POJONode</code>.
      *

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -493,7 +493,7 @@ public abstract class JsonNode
      * false) null will be returned.
      * For String values, null is never returned (but empty Strings may be)
      *
-     * @return Textual value this node contains, iff it is a textual
+     * @return Textual value this node contains, if (and only if) it is a textual
      *   JSON node (comes from JSON String value entry)
      */
     public String textValue() { return null; }
@@ -505,7 +505,7 @@ public abstract class JsonNode
      * to read decoded base64 data.
      * For other types of nodes, returns null.
      *
-     * @return Binary data this node contains, iff it is a binary
+     * @return Binary data this node contains, if (and only if) it is a binary
      *   node; null otherwise
      */
     public byte[] binaryValue() throws IOException {
@@ -517,7 +517,7 @@ public abstract class JsonNode
      * literals 'true' and 'false').
      * For other types, always returns false.
      *
-     * @return Textual value this node contains, iff it is a textual
+     * @return Textual value this node contains, if (and only if) it is a textual
      *   json node (comes from JSON String value entry)
      */
     public boolean booleanValue() { return false; }
@@ -1009,7 +1009,7 @@ public abstract class JsonNode
     public final Iterator<JsonNode> iterator() { return elements(); }
 
     /**
-     * Method for accessing all value nodes of this Node, iff
+     * Method for accessing all value nodes of this Node, if
      * this node is a JSON Array or Object node. In case of Object node,
      * field names (keys) are not included, only values.
      * For other types of nodes, returns empty iterator.

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -139,7 +139,7 @@ public class ObjectMapper
      * is found, but this enumeration further limits subset of those types.
      *<p>
      * Since 2.4 there are special exceptions for JSON Tree model
-     * types (sub-types of {@link TreeNode}: default typing is never
+     * types (sub-types of {@link TreeNode}): default typing is never
      * applied to them.
      * Since 2.8(.4) additional checks are made to avoid attempts at default
      * typing primitive-valued properties.
@@ -211,7 +211,7 @@ public class ObjectMapper
          * as it tends to add Type Ids everywhere, even in cases
          * where type can not be anything other than declared (for example
          * if declared value type of a property is {@code final} -- for example,
-         * properties of type {@code long} (or wrapper {@code Long}).
+         * properties of type {@code long} or wrapper {@code Long}).
          *<p>
          * Note that this is rarely the option you should use as it results
          * in adding type information in many places where it should not be needed:
@@ -543,7 +543,7 @@ public class ObjectMapper
      */
 
     /**
-     * Set of module types (as per {@link Module#getTypeId()} that have been
+     * Set of module types (as per {@link Module#getTypeId()}) that have been
      * registered; kept track of if (and only if) {@link MapperFeature#IGNORE_DUPLICATE_MODULE_REGISTRATIONS}
      * is enabled, so that duplicate registration calls can be ignored
      * (to avoid adding same handlers multiple times, mostly).
@@ -3657,7 +3657,7 @@ public class ObjectMapper
      * it could deserialize an Object of given type.
      * Check is done by checking whether a registered deserializer can
      * be found or built for the type; if not (either by no mapping being
-     * found, or through an <code>Exception</code> being thrown, false
+     * found, or through an <code>Exception</code> being thrown) false
      * is returned.
      *<p>
      * <b>NOTE</b>: in case an exception is thrown during course of trying
@@ -4114,7 +4114,7 @@ public class ObjectMapper
     /**
      * Factory method for constructing {@link ObjectWriter} that will
      * serialize objects using specified {@link DateFormat}; or, if
-     * null passed, using timestamp (64-bit number.
+     * null passed, using timestamp (64-bit number).
      */
     public ObjectWriter writer(DateFormat df) {
         return _newWriter(getSerializationConfig().with(df));

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -544,7 +544,7 @@ public class ObjectMapper
 
     /**
      * Set of module types (as per {@link Module#getTypeId()} that have been
-     * registered; kept track of iff {@link MapperFeature#IGNORE_DUPLICATE_MODULE_REGISTRATIONS}
+     * registered; kept track of if (and only if) {@link MapperFeature#IGNORE_DUPLICATE_MODULE_REGISTRATIONS}
      * is enabled, so that duplicate registration calls can be ignored
      * (to avoid adding same handlers multiple times, mostly).
      *

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -1912,7 +1912,7 @@ public class ObjectReader
      * Sequence can be either wrapped or unwrapped root-level sequence:
      * wrapped means that the elements are enclosed in JSON Array;
      * and unwrapped that elements are directly accessed at main level.
-     * Assumption is that iff the first token of the document is
+     * Assumption is that if the first token of the document is
      * <code>START_ARRAY</code>, we have a wrapped sequence; otherwise
      * unwrapped. For wrapped sequences, leading <code>START_ARRAY</code>
      * is skipped, so that for both cases, underlying {@link JsonParser}

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/DatatypeFeatures.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/DatatypeFeatures.java
@@ -258,7 +258,7 @@ public class DatatypeFeatures
 
     /**
      * Accessor for getting explicit state of given feature in this set
-     * iff explicitly set, or {@code null} if not explicitly set (default value)
+     * if explicitly set, or {@code null} if not explicitly set (default value)
      *
      * @param f Feature to check
      *

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -567,7 +567,7 @@ public abstract class BasicDeserializerFactory
                     */
                     continue;
                 }
-                // One more thing: implicit names are ok iff ctor has creator annotation
+                // One more thing: implicit names are ok if ctor has creator annotation
                 /*
                 if (isCreator && (name != null && !name.isEmpty())) {
                     ++implicitWithCreatorCount;
@@ -749,7 +749,7 @@ nonAnnotatedParamIndex, ctor);
                     */
                     continue;
                 }
-                // One more thing: implicit names are ok iff ctor has creator annotation
+                // One more thing: implicit names are ok if ctor has creator annotation
                 /*
                 if (isCreator) {
                     if (name != null && !name.isEmpty()) {
@@ -1136,7 +1136,7 @@ candidate.creator());
                 creators.addBigDecimalCreator(ctor, isCreator);
             }
         }
-        // Delegating Creator ok iff it has @JsonCreator (etc)
+        // Delegating Creator ok if it has @JsonCreator (etc)
         if (isCreator) {
             creators.addDelegatingCreator(ctor, isCreator, null, 0);
             return true;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -66,7 +66,7 @@ public abstract class BeanDeserializerBase
     protected final ValueInstantiator _valueInstantiator;
 
     /**
-     * Deserializer that is used iff delegate-based creator is
+     * Deserializer that is used if delegate-based creator is
      * to be used for deserializing from JSON Object.
      *<p>
      * NOTE: cannot be {@code final} because we need to get it during
@@ -75,7 +75,7 @@ public abstract class BeanDeserializerBase
     protected JsonDeserializer<Object> _delegateDeserializer;
 
     /**
-     * Deserializer that is used iff array-delegate-based creator
+     * Deserializer that is used if array-delegate-based creator
      * is to be used for deserializing from JSON Object.
      *<p>
      * NOTE: cannot be {@code final} because we need to get it during

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -52,7 +52,7 @@ public class CollectionDeserializer
     protected final ValueInstantiator _valueInstantiator;
 
     /**
-     * Deserializer that is used iff delegate-based creator is
+     * Deserializer that is used if delegate-based creator is
      * to be used for deserializing from JSON Object.
      */
     protected final JsonDeserializer<Object> _delegateDeserializer;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumMapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumMapDeserializer.java
@@ -49,7 +49,7 @@ public class EnumMapDeserializer
     protected final ValueInstantiator _valueInstantiator;
 
     /**
-     * Deserializer that is used iff delegate-based creator is
+     * Deserializer that is used if delegate-based creator is
      * to be used for deserializing from JSON Object.
      */
     protected JsonDeserializer<Object> _delegateDeserializer;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -70,7 +70,7 @@ public class MapDeserializer
     protected final ValueInstantiator _valueInstantiator;
 
     /**
-     * Deserializer that is used iff delegate-based creator is
+     * Deserializer that is used if delegate-based creator is
      * to be used for deserializing from JSON Object.
      */
     protected JsonDeserializer<Object> _delegateDeserializer;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/NumberDeserializers.java
@@ -450,7 +450,7 @@ public class NumberDeserializers
                 //   coercion -- as long as it has length of 1.
                 text = p.getText();
                 break;
-            case JsonTokenId.ID_NUMBER_INT: // ok iff Unicode value
+            case JsonTokenId.ID_NUMBER_INT: // ok if Unicode value
                 CoercionAction act = ctxt.findCoercionAction(logicalType(), _valueClass, CoercionInputShape.Integer);
                 switch (act) {
                 case Fail:

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -47,7 +47,7 @@ public final class StringCollectionDeserializer
     protected final ValueInstantiator _valueInstantiator;
 
     /**
-     * Deserializer that is used iff delegate-based creator is
+     * Deserializer that is used if delegate-based creator is
      * to be used for deserializing from JSON Object.
      */
     protected final JsonDeserializer<Object> _delegateDeserializer;

--- a/src/main/java/com/fasterxml/jackson/databind/ext/Java7SupportImpl.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/Java7SupportImpl.java
@@ -37,7 +37,7 @@ public class Java7SupportImpl extends Java7Support
     public Boolean hasCreatorAnnotation(Annotated a) {
         ConstructorProperties props = a.getAnnotation(ConstructorProperties.class);
         // 08-Nov-2015, tatu: One possible check would be to ensure there is at least
-        //    one name iff constructor has arguments. But seems unnecessary for now.
+        //    one name if constructor has arguments. But seems unnecessary for now.
         if (props != null) {
             return Boolean.TRUE;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -62,7 +62,7 @@ public class POJOPropertyBuilder
     protected transient PropertyMetadata _metadata;
 
     /**
-     * Lazily accessed information about this property iff it is a forward or
+     * Lazily accessed information about this property if it is a forward or
      * back reference.
      *
      * @since 2.9

--- a/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
@@ -42,7 +42,7 @@ public abstract class DefaultSerializerProvider
      */
 
     /**
-     * Per-serialization map Object Ids that have seen so far, iff
+     * Per-serialization map Object Ids that have seen so far, if
      * Object Id handling is enabled.
      */
     protected transient Map<Object, WritableObjectId> _seenObjectIds;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/TestCreators.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/TestCreators.java
@@ -454,7 +454,7 @@ public class TestCreators
     }
 
     /**
-     * Test to verify that multiple creators may co-exist, iff
+     * Test to verify that multiple creators may co-exist, if
      * they use different JSON type as input
      */
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -265,7 +265,7 @@ public class JDKStringLikeTypeDeserTest
         assertNotNull(bean.location);
         assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
 
-        // and then directly, iff registered
+        // and then directly, if registered
         ObjectMapper mapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
         module.addDeserializer(StackTraceElement.class, new MyStackTraceElementDeserializer());


### PR DESCRIPTION
While working with Jackson, i noticed this typo while exploring the API via JavaDoc.

If this gets merged, i can happily also assemble PRs for all other branches. Kindly advise if 2.13 and 2.14 will still see patch releases (latest Spring Boot 2.x branch [still relies on 2.13](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom)).