### PR TITLE
Un-deprecate `JsonNode.asText(defaultValue)`

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -25,15 +25,15 @@ Project: jackson-databind
  (fix by Joo-Hyuk K)
 #4450: Empty QName deserialized as `null`
  (reported by @winfriedgerlach)
+#4471: Reconsider deprecation of `JsonNode.asText(defaultValue)`
+  (requested by @aerisnju)
+  (fix by Joo-Hyuk K)
 #4481: Unable to override `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL`
   with `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_AS_NULL`
  (reported by @luozhenyu)
 #4489: Unable to override `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`
   with `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`
   (reported by Joo-Hyuk K)
-  (fix by Joo-Hyuk K)
-#4471: Reconsider deprecation of `JsonNode.asText(defaultValue)`
-  (requested by @aerisnju)
   (fix by Joo-Hyuk K)
 
 2.17.0 (12-Mar-2024)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -33,7 +33,7 @@ Project: jackson-databind
   (reported by Joo-Hyuk K)
   (fix by Joo-Hyuk K)
 #4471: Reconsider deprecation of `JsonNode.asText(defaultValue)`
-  (reported by @aerisnju)
+  (requested by @aerisnju)
   (fix by Joo-Hyuk K)
 
 2.17.0 (12-Mar-2024)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -32,6 +32,9 @@ Project: jackson-databind
   with `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`
   (reported by Joo-Hyuk K)
   (fix by Joo-Hyuk K)
+#4471: Reconsider deprecation of `JsonNode.asText(defaultValue)`
+  (reported by @aerisnju)
+  (fix by Joo-Hyuk K)
 
 2.17.0 (12-Mar-2024)
 

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -636,16 +636,12 @@ public abstract class JsonNode
      * {@link com.fasterxml.jackson.databind.node.NullNode}, ensuring a default value is returned instead of null or missing indicators.
      *
      *<p>
-     * NOTE: deprecated since 2.17 because {@link #asText()} very rarely returns
-     * {@code null} for any node types -- in fact, neither {@link MissingNode}
-     * nor {@code NullNode} return {@code null} from {@link #asText()}.
+     * NOTE: This was deprecated in 2.17.0, but as discussed through [databind#4471], was un-deprecated in 2.17.1.
      *
      * @param defaultValue The default value to return if this node's text value is absent.
      * @return The text value of this node, or defaultValue if the text value is absent.
      * @since 2.4
-     * @deprecated Since 2.17, to be removed from 3.0
      */
-    @Deprecated // @since 2.17
     public String asText(String defaultValue) {
         String str = asText();
         return (str == null) ? defaultValue : str;

--- a/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/MissingNode.java
@@ -60,7 +60,6 @@ public final class MissingNode
 
     @Override public String asText() { return ""; }
 
-    @Deprecated // since 2.17
     @Override public String asText(String defaultValue) { return defaultValue; }
 
     // // Note: not a numeric node, hence default 'asXxx()' are fine:

--- a/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
@@ -41,7 +41,6 @@ public class NullNode
     @Override public JsonToken asToken() { return JsonToken.VALUE_NULL; }
 
     @Override
-    @Deprecated
     public String asText(String defaultValue) { return defaultValue; }
 
     @Override public String asText() { return "null"; }

--- a/src/main/java/com/fasterxml/jackson/databind/node/POJONode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/POJONode.java
@@ -58,7 +58,6 @@ public class POJONode
     public String asText() { return (_value == null) ? "null" : _value.toString(); }
 
     @Override
-    @Deprecated
     public String asText(String defaultValue) {
         return (_value == null) ? defaultValue : _value.toString();
     }

--- a/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TextNode.java
@@ -102,7 +102,6 @@ e.getMessage()),
     }
 
     @Override
-    @Deprecated // since 2.17
     public String asText(String defaultValue) {
         return (_value == null) ? defaultValue : _value;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/CustomDeserializersTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/CustomDeserializersTest.java
@@ -355,7 +355,7 @@ public class CustomDeserializersTest
                 throws IOException
         {
             JsonNode tree = ctxt.readTree(p);
-            String name = tree.path("name").asText();
+            String name = tree.path("name").asText(null);
             Point point = ctxt.readTreeAsValue(tree.get("point"), Point.class);
             return new NamedPoint(name, point);
         }

--- a/src/test/java/com/fasterxml/jackson/databind/node/MissingNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/MissingNodeTest.java
@@ -14,6 +14,7 @@ public class MissingNodeTest extends NodeTestBase
         assertTrue(n.isMissingNode());
         assertEquals(JsonToken.NOT_AVAILABLE, n.asToken());
         assertEquals("", n.asText());
+        assertEquals("default", n.asText("default"));
         assertStandardEquals(n);
         // 10-Dec-2018, tatu: With 2.10, should serialize same as via ObjectMapper/ObjectWriter
         // 10-Dec-2019, tatu: Surprise! No, this is not how it worked in 2.9, nor does it make

--- a/src/test/java/com/fasterxml/jackson/databind/node/NullNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NullNodeTest.java
@@ -48,6 +48,9 @@ public class NullNodeTest extends NodeTestBase
         assertEquals(0L, n.longValue());
         assertEquals(BigDecimal.ZERO, n.decimalValue());
         assertEquals(BigInteger.ZERO, n.bigIntegerValue());
+        // may be odd but...
+        assertEquals("null", n.asText());
+        assertEquals("fallback", n.asText("fallback"));
 
         assertEquals(0, n.size());
         assertTrue(n.isEmpty());

--- a/src/test/java/com/fasterxml/jackson/databind/node/NumberNodesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NumberNodesTest.java
@@ -82,7 +82,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals(BigInteger.ONE, n.bigIntegerValue());
         assertEquals("1", n.asText());
         // 2.4
-        assertEquals("1", n.asText());
+        assertEquals("1", n.asText("foo"));
 
         assertNodeNumbers(n, 1, 1.0);
 


### PR DESCRIPTION
To address https://github.com/FasterXML/jackson-databind/issues/4471