### PR TITLE
Revert "Fix #4443: detect `Iterable` as `IterationType`"

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,8 +6,6 @@ Project: jackson-databind
 
 2.18.0 (not yet released)
 
-#4443: Add `Iterable<T>` as recognized `IterationType` instance (along with
-  `Iterable`, `Stream`)
 #4453: Allow JSON Integer to deserialize into a single-arg constructor of
   parameter type `double`
  (contributed by David M)

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1637,7 +1637,13 @@ ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
         //    detected, related to difficulties in propagating type upwards (Iterable, for
         //    example, is a weak, tag-on type). They may be detectable in future.
         // 23-May-2023, tatu: As of 2.16 we do, however, recognized certain `IterationType`s.
-        if (rawType == Iterator.class || rawType == Stream.class) {
+        if (rawType == Iterator.class || rawType == Stream.class
+                // 27-Apr-2024, tatu: Tried to do [databind#4443] for 2.18 but that caused
+                //    regression so cannot add "Iterable.class" without figuring out issue
+                //    with HPPC `ObjectArrayList`s type hierarchy first
+                //
+                // || rawType == Iterable.class
+                ) {
             return _iterationType(rawType, bindings, superClass, superInterfaces);
         }
         if (BaseStream.class.isAssignableFrom(rawType)) {

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -1637,9 +1637,7 @@ ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
         //    detected, related to difficulties in propagating type upwards (Iterable, for
         //    example, is a weak, tag-on type). They may be detectable in future.
         // 23-May-2023, tatu: As of 2.16 we do, however, recognized certain `IterationType`s.
-        if (rawType == Iterator.class || rawType == Stream.class
-                // 18-Apr-2024, tatu: [databind#4443] allow exact `Iterable`
-                || rawType == Iterable.class) {
+        if (rawType == Iterator.class || rawType == Stream.class) {
             return _iterationType(rawType, bindings, superClass, superInterfaces);
         }
         if (BaseStream.class.isAssignableFrom(rawType)) {

--- a/src/test/java/com/fasterxml/jackson/databind/type/JavaTypeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/JavaTypeTest.java
@@ -324,8 +324,6 @@ public class JavaTypeTest
                 Iterator.class, Object.class);
         _verifyIteratorType(tf.constructType(Stream.class),
                 Stream.class, Object.class);
-        _verifyIteratorType(tf.constructType(Iterable.class),
-                Iterable.class, Object.class);
 
         // Then generic but direct
         JavaType t = _verifyIteratorType(tf.constructType(new TypeReference<Iterator<String>>() { }),

--- a/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/type/TypeFactoryTest.java
@@ -165,19 +165,6 @@ public class TypeFactoryTest
         assertNull(t.containedType(1));
     }
 
-    // [databind#4443]
-    @Test
-    public void testIterable()
-    {
-        TypeFactory tf = TypeFactory.defaultInstance();
-        JavaType t = tf.constructType(new TypeReference<Iterable<String>>() { });
-        assertEquals(IterationType.class, t.getClass());
-        assertTrue(t.isIterationType());
-        assertSame(Iterable.class, t.getRawClass());
-        assertEquals(1, t.containedTypeCount());
-        assertEquals(tf.constructType(String.class), t.containedType(0));
-        assertNull(t.containedType(1));
-    }
     /**
      * Test for verifying that parametric types can be constructed
      * programmatically


### PR DESCRIPTION
Reverts FasterXML/jackson-databind#4487 due to regression in `jackson-datatypes-collections` (for HPPC).