### PR TITLE
Correct JavaDoc @return description for JsonNode#booleanValue()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -517,8 +517,7 @@ public abstract class JsonNode
      * literals 'true' and 'false').
      * For other types, always returns false.
      *
-     * @return Textual value this node contains, iff it is a textual
-     *   json node (comes from JSON String value entry)
+     * @return Boolean value this node contains, if any; otherwise always <code>false</code>
      */
     public boolean booleanValue() { return false; }
 


### PR DESCRIPTION
While attempting another go at #4502 i stumbled upon this particular JavaDoc description, which looks like it was copied over by mistake from `textValue()`.

On purpose not re-using "iff" here – compare original JavaDoc for `numberValue()` and follows (which do fine without it). 