### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -1110,6 +1110,7 @@ public abstract class AnnotationIntrospector
      */
     @Deprecated
     public void findEnumAliases(Class<?> enumType, Enum<?>[] enumValues, String[][] aliases) {
+        ; // do nothing
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java
@@ -68,7 +68,6 @@ public abstract class AnnotationIntrospector
              * {@link com.fasterxml.jackson.annotation.JsonBackReference}
              */
             BACK_REFERENCE
-            ;
         }
 
         private final Type _type;
@@ -1111,7 +1110,6 @@ public abstract class AnnotationIntrospector
      */
     @Deprecated
     public void findEnumAliases(Class<?> enumType, Enum<?>[] enumValues, String[][] aliases) {
-        ;
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -79,7 +79,7 @@ public abstract class JsonNode
          * Mode in which all incompatible node types may be replaced, including
          * Array and Object nodes where necessary.
          */
-        ALL;
+        ALL
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -1543,7 +1543,6 @@ public class ObjectWriter
                     return new Prefetch(newType, ser, null);
                 } catch (DatabindException e) {
                     // need to swallow?
-                    ;
                 }
             }
             return new Prefetch(newType, null, typeSerializer);

--- a/src/main/java/com/fasterxml/jackson/databind/annotation/JsonSerialize.java
+++ b/src/main/java/com/fasterxml/jackson/databind/annotation/JsonSerialize.java
@@ -240,7 +240,6 @@ public @interface JsonSerialize
          * @since 2.3
          */
         DEFAULT_INCLUSION
-        ;
     }
 
     /**
@@ -269,6 +268,5 @@ public @interface JsonSerialize
          * @since 2.3
          */
         DEFAULT_TYPING
-        ;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/CoercionAction.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/CoercionAction.java
@@ -37,6 +37,5 @@ public enum CoercionAction
      * empty collection; for POJOs instance configured with default constructor
      * and so on.
      */
-    AsEmpty;
-    ;
+    AsEmpty
 }

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/CoercionInputShape.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/CoercionInputShape.java
@@ -92,5 +92,4 @@ public enum CoercionInputShape
      */
     EmptyString
 
-    ;
 }

--- a/src/main/java/com/fasterxml/jackson/databind/cfg/ConstructorDetector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/cfg/ConstructorDetector.java
@@ -55,7 +55,7 @@ public final class ConstructorDetector
          * {@link com.fasterxml.jackson.databind.exc.InvalidDefinitionException}
          * in ambiguous case.
          */
-        REQUIRE_MODE;
+        REQUIRE_MODE
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -282,7 +282,6 @@ public abstract class BasicDeserializerFactory
             final boolean isNonStaticInnerClass = beanDesc.isNonStaticInnerClass();
             if (isNonStaticInnerClass) {
                 // TODO: look for `@JsonCreator` annotated ones, throw explicit exception?
-                ;
             } else {
                 // 18-Sep-2020, tatu: Although by default implicit introspection is allowed, 2.12
                 //   has settings to prevent that either generally, or at least for JDK types
@@ -964,7 +963,6 @@ candidate.creator());
                 if (!useProps) {
                     // Otherwise, `@JsonValue` suggests delegation
                     if (beanDesc.findJsonValueAccessor() != null) {
-                        ;
                     } else if (injectId != null) {
                         // But Injection suggests property-based (for legacy reasons?)
                         useProps = true;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -1044,8 +1044,7 @@ public class BeanDeserializer
                 // first: let's check to see if this might be part of value with external type id:
                 // 11-Sep-2015, tatu: Important; do NOT pass buffer as last arg, but null,
                 //   since it is not the bean
-                if (ext.handlePropertyValue(p, ctxt, propName, null)) {
-                } else {
+                if (!ext.handlePropertyValue(p, ctxt, propName, null)) {
                     // Last creator property to set?
                     if (buffer.assignParameter(creatorProp,
                             _deserializeWithErrorWrapping(p, ctxt, creatorProp))) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -1045,7 +1045,6 @@ public class BeanDeserializer
                 // 11-Sep-2015, tatu: Important; do NOT pass buffer as last arg, but null,
                 //   since it is not the bean
                 if (ext.handlePropertyValue(p, ctxt, propName, null)) {
-                    ;
                 } else {
                     // Last creator property to set?
                     if (buffer.assignParameter(creatorProp,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -594,6 +594,7 @@ ClassUtil.name(propName)));
                         // 23-Jan-2018, tatu: As per [databind#1805], need to ensure we don't
                         //   accidentally sneak in getter-as-setter for `READ_ONLY` properties
                         if (builder.hasIgnorable(propDef.getName())) {
+                            ; // skip
                         } else {
                             prop = constructSetterlessProperty(ctxt, beanDesc, propDef);
                         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -594,7 +594,6 @@ ClassUtil.name(propName)));
                         // 23-Jan-2018, tatu: As per [databind#1805], need to ensure we don't
                         //   accidentally sneak in getter-as-setter for `READ_ONLY` properties
                         if (builder.hasIgnorable(propDef.getName())) {
-                            ;
                         } else {
                             prop = constructSetterlessProperty(ctxt, beanDesc, propDef);
                         }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -330,9 +330,7 @@ public abstract class SettableBeanProperty
      *
      * @since 2.8.3
      */
-    public void fixAccess(DeserializationConfig config) {
-        ;
-    }
+    public void fixAccess(DeserializationConfig config) { }
 
     /**
      * @since 2.9.4

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableBeanProperty.java
@@ -330,12 +330,12 @@ public abstract class SettableBeanProperty
      *
      * @since 2.8.3
      */
-    public void fixAccess(DeserializationConfig config) { }
+    public void fixAccess(DeserializationConfig config) { /* nop */ }
 
     /**
      * @since 2.9.4
      */
-    public void markAsIgnorable() { }
+    public void markAsIgnorable() { /* nop */ }
 
     /**
      * @since 2.9.4

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
@@ -320,8 +320,7 @@ public class CreatorCollector
                     if (_isEnumValueOf(newOne)) {
                         return false; // ignore
                     }
-                    if (_isEnumValueOf(oldOne)) {
-                    } else {
+                    if (!_isEnumValueOf(oldOne)) {
                         _reportDuplicateCreator(typeIndex, explicit, oldOne, newOne);
                     }
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/CreatorCollector.java
@@ -321,7 +321,6 @@ public class CreatorCollector
                         return false; // ignore
                     }
                     if (_isEnumValueOf(oldOne)) {
-                        ;
                     } else {
                         _reportDuplicateCreator(typeIndex, explicit, oldOne, newOne);
                     }
@@ -332,7 +331,6 @@ public class CreatorCollector
                     return false;
                 } else if (oldType.isAssignableFrom(newType)) {
                     // new type more specific, use it
-                    ;
                     // 23-Feb-2021, tatu: due to [databind#3062], backwards-compatibility,
                     //   let's allow "primitive/Wrapper" case and tie-break in favor
                     //   of PRIMITIVE argument (null would never map to scalar creators,

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -419,7 +419,6 @@ public class EnumDeserializer
                     // index yet (might need combination of "Does format have Numbers"
                     // (XML does not f.ex) and new `EnumFeature`. But can disallow "001" etc.
                     if (c == '0' && name.length() > 1) {
-                        ;
                     } else {
                         try {
                             int index = Integer.parseInt(name);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -419,6 +419,7 @@ public class EnumDeserializer
                     // index yet (might need combination of "Does format have Numbers"
                     // (XML does not f.ex) and new `EnumFeature`. But can disallow "001" etc.
                     if (c == '0' && name.length() > 1) {
+                        ; // skip
                     } else {
                         try {
                             int index = Integer.parseInt(name);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java
@@ -823,7 +823,6 @@ abstract class BaseNodeDeserializer<T extends JsonNode>
                 bigDec = bigDec.stripTrailingZeros();
             } catch (ArithmeticException e) {
                 // If we can't, we can't...
-                ;
             }
         }
         return nodeFactory.numberNode(bigDec);

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/PolymorphicTypeValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/PolymorphicTypeValidator.java
@@ -74,7 +74,6 @@ public abstract class PolymorphicTypeValidator
          * determination will be {@code DENIED}, for safety reasons.
          */
         INDETERMINATE
-        ;
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
@@ -274,7 +274,6 @@ public class SubTypeValidator
             //    for some Spring framework types
             // 05-Jan-2017, tatu: ... also, only applies to classes, not interfaces
             if (raw.isInterface()) {
-                ;
             } else if (full.startsWith(PREFIX_SPRING)) {
                 for (Class<?> cls = raw; (cls != null) && (cls != Object.class); cls = cls.getSuperclass()){
                     String name = cls.getSimpleName();

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
@@ -274,6 +274,7 @@ public class SubTypeValidator
             //    for some Spring framework types
             // 05-Jan-2017, tatu: ... also, only applies to classes, not interfaces
             if (raw.isInterface()) {
+                ; // skip
             } else if (full.startsWith(PREFIX_SPRING)) {
                 for (Class<?> cls = raw; (cls != null) && (cls != Object.class); cls = cls.getSuperclass()){
                     String name = cls.getSimpleName();

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -284,7 +284,7 @@ public class PropertyBuilder
             // Must be a super type to be usable
             Class<?> rawDeclared = declaredType.getRawClass();
             if (serClass.isAssignableFrom(rawDeclared)) {
-                ; // fine as is
+                // fine as is
             } else {
                 /* 18-Nov-2010, tatu: Related to fixing [JACKSON-416], an issue with such
                  *   check is that for deserialization more specific type makes sense;

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -471,6 +471,7 @@ public abstract class BeanSerializerBase
                 // 16-Oct-2016, tatu: Ditto for `Map`, `Map.Entry` subtypes
                 } else if (shape == JsonFormat.Shape.NATURAL) {
                     if (_beanType.isMapLikeType() && Map.class.isAssignableFrom(_handledType)) {
+                        ;
                     } else if (Map.Entry.class.isAssignableFrom(_handledType)) {
                         JavaType mapEntryType = _beanType.findSuperType(Map.Entry.class);
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java
@@ -471,7 +471,6 @@ public abstract class BeanSerializerBase
                 // 16-Oct-2016, tatu: Ditto for `Map`, `Map.Entry` subtypes
                 } else if (shape == JsonFormat.Shape.NATURAL) {
                     if (_beanType.isMapLikeType() && Map.class.isAssignableFrom(_handledType)) {
-                        ;
                     } else if (Map.Entry.class.isAssignableFrom(_handledType)) {
                         JavaType mapEntryType = _beanType.findSuperType(Map.Entry.class);
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/AccessPattern.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/AccessPattern.java
@@ -27,5 +27,4 @@ public enum AccessPattern {
      * needed.
      */
     DYNAMIC
-    ;
 }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -583,6 +583,7 @@ public final class ClassUtil
             }
             return ctor;
         } catch (NoSuchMethodException e) {
+            return null;
         } catch (Exception e) {
             ClassUtil.unwrapAndThrowAsIAE(e, "Failed to find default constructor of class "+cls.getName()+", problem: "+e.getMessage());
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -583,7 +583,6 @@ public final class ClassUtil
             }
             return ctor;
         } catch (NoSuchMethodException e) {
-            ;
         } catch (Exception e) {
             ClassUtil.unwrapAndThrowAsIAE(e, "Failed to find default constructor of class "+cls.getName()+", problem: "+e.getMessage());
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ISO8601DateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ISO8601DateFormat.java
@@ -20,8 +20,8 @@ public class ISO8601DateFormat extends DateFormat
     private static final long serialVersionUID = 1L;
 
     public ISO8601DateFormat() {
-        this.numberFormat = new DecimalFormat();;
-        this.calendar = new GregorianCalendar();;
+        this.numberFormat = new DecimalFormat();
+        this.calendar = new GregorianCalendar();
     }
 
     @Override


### PR DESCRIPTION
In the spirit of conciseness, this PR skims redundant semicolons from the code base (analogous to https://github.com/FasterXML/jackson-core/pull/1280).

Regarding 01f700234b14ec00555ad268ae00f701dfe6c203, i made the return path more explicit as otherwise most IDEs will flag this empty catch block (using `catch (NoSuchMethodException ignored)` would be another workaround, but that would still mean the return value being implicit, increasing cognitive complexity).