### PR TITLE
Try to fix issue wrt parameter names, master

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -869,11 +869,11 @@ ctor.creator()));
         }
         if (ctor.paramCount() == 1) {
             // One more possibility: implicit name that maps to implied
-            // property based on Getter/Setter (but not field!)
+            // property with at least one visible accessor
             String implName = ctor.implicitNameSimple(0);
             if (implName != null) {
                 POJOPropertyBuilder prop = props.get(implName);
-                if ((prop != null) && (prop.hasGetter() || prop.hasSetter())) {
+                if ((prop != null) && prop.anyVisible() && !prop.anyIgnorals()) {
                     return true;
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -869,10 +869,13 @@ ctor.creator()));
         }
         if (ctor.paramCount() == 1) {
             // One more possibility: implicit name that maps to implied
-            // property based on Field/Getter/Setter
+            // property based on Getter/Setter (but not field!)
             String implName = ctor.implicitNameSimple(0);
-            if ((implName != null) && props.containsKey(implName)) {
-                return true;
+            if (implName != null) {
+                POJOPropertyBuilder prop = props.get(implName);
+                if ((prop != null) && (prop.hasGetter() || prop.hasSetter())) {
+                    return true;
+                }
             }
             // Second: injectable also suffices
             if ((_annotationIntrospector != null)


### PR DESCRIPTION
Trying to resolve a problem found with merge to `master` (3.0), wrt parameter names, 1-param constructor detection as Delegating. Basically behavior in 2.18 should match with 2.17 as closely as possible, at least wrt unit test suite.
