### PR TITLE
move lock in DeserializerCache to before the try block

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
@@ -253,9 +253,8 @@ public final class DeserializerCache
          * limitations necessary to ensure that only completely initialized ones
          * are visible and used.
          */
+        _incompleteDeserializersLock.lock();
         try {
-            _incompleteDeserializersLock.lock();
-
             // Ok, then: could it be that due to a race condition, deserializer can now be found?
             JsonDeserializer<Object> deser = _findCachedDeserializer(type);
             if (deser != null) {


### PR DESCRIPTION
* see latest comments in #4430 - eg https://github.com/FasterXML/jackson-databind/pull/4430#issuecomment-2147625639
* this change is more correct - if the lock call fails, we don't want the finally to try to release the lock
* it could also allow the underlying issue to bubble up, the failure to release the lock may be reported but we need to see the stack trace from the failure to acquire the lock (if that is what is happening - but it appears likely that it is.

