### PR TITLE
Revert "Fix #4561 (revert #4430)" -- i.e. go back to modified #4430.

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,11 +8,6 @@ Project: jackson-databind
 
 -
 
-2.17.2 (not yet released)
-
-#4561: Issues using jackson-databind 2.17.1 with Reactor
- (reported by @wdallastella)
-
 2.17.1 (04-May-2024)
 
 #4428: `ByteBuddy` scope went beyond `test` in version 2.17.0

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,11 @@ Project: jackson-databind
 
 -
 
+2.17.2 (not yet released)
+
+#4561: Issues using jackson-databind 2.17.1 with Reactor
+ (reported by @wdallastella)
+
 2.17.1 (04-May-2024)
 
 #4428: `ByteBuddy` scope went beyond `test` in version 2.17.0

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.databind.deser;
 
 import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.*;
@@ -51,6 +52,12 @@ public final class DeserializerCache
      */
     protected final HashMap<JavaType, JsonDeserializer<Object>> _incompleteDeserializers
         = new HashMap<JavaType, JsonDeserializer<Object>>(8);
+
+
+    /**
+     * We hold an explicit lock while creating deserializers to avoid creating duplicates.
+     */
+    private final ReentrantLock _incompleteDeserializersLock = new ReentrantLock();
 
     /*
     /**********************************************************
@@ -242,10 +249,12 @@ public final class DeserializerCache
             DeserializerFactory factory, JavaType type)
         throws JsonMappingException
     {
-        // Only one thread to construct deserializers at any given point in time;
-        // limitations necessary to ensure that only completely initialized ones
-        // are visible and used.
-        synchronized (_incompleteDeserializers) {
+        /* Only one thread to construct deserializers at any given point in time;
+         * limitations necessary to ensure that only completely initialized ones
+         * are visible and used.
+         */
+        _incompleteDeserializersLock.lock();
+        try {
             // Ok, then: could it be that due to a race condition, deserializer can now be found?
             JsonDeserializer<Object> deser = _findCachedDeserializer(type);
             if (deser != null) {
@@ -268,6 +277,8 @@ public final class DeserializerCache
                     _incompleteDeserializers.clear();
                 }
             }
+        } finally {
+            _incompleteDeserializersLock.unlock();
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java
@@ -56,6 +56,9 @@ public final class DeserializerCache
 
     /**
      * We hold an explicit lock while creating deserializers to avoid creating duplicates.
+     * Guards {@link #_incompleteDeserializers}.
+     *
+     * @since 2.17
      */
     private final ReentrantLock _incompleteDeserializersLock = new ReentrantLock();
 
@@ -169,10 +172,9 @@ public final class DeserializerCache
             // If not, need to request factory to construct (or recycle)
             deser = _createAndCacheValueDeserializer(ctxt, factory, propertyType);
             if (deser == null) {
-                /* Should we let caller handle it? Let's have a helper method
-                 * decide it; can throw an exception, or return a valid
-                 * deserializer
-                 */
+                // Should we let caller handle it? Let's have a helper method
+                // decide it; can throw an exception, or return a valid
+                // deserializer
                 deser = _handleUnknownValueDeserializer(ctxt, propertyType);
             }
         }
@@ -211,9 +213,8 @@ public final class DeserializerCache
             DeserializerFactory factory, JavaType type)
         throws JsonMappingException
     {
-        /* Note: mostly copied from findValueDeserializer, except for
-         * handling of unknown types
-         */
+        // Note: mostly copied from findValueDeserializer, except for
+        // handling of unknown types
         JsonDeserializer<Object> deser = _findCachedDeserializer(type);
         if (deser == null) {
             deser = _createAndCacheValueDeserializer(ctxt, factory, type);
@@ -249,10 +250,9 @@ public final class DeserializerCache
             DeserializerFactory factory, JavaType type)
         throws JsonMappingException
     {
-        /* Only one thread to construct deserializers at any given point in time;
-         * limitations necessary to ensure that only completely initialized ones
-         * are visible and used.
-         */
+        // Only one thread to construct deserializers at any given point in time;
+        // limitations necessary to ensure that only completely initialized ones
+        // are visible and used.
         _incompleteDeserializersLock.lock();
         try {
             // Ok, then: could it be that due to a race condition, deserializer can now be found?


### PR DESCRIPTION
Reverts #4562, as per discussion #4430 the fix we have (minor change to lock scoping) that confirms fix seems safe. So we should be good to go in patch (2.17.2), not waiting for next minor release (2.18.0).

Apologies for the whiplash to anyone following discussions. :)
