### PR TITLE
only run cifuzz on 2.18 branch

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,8 +2,7 @@ name: CIFuzz
 on:
   pull_request:
     branches:
-    - master
-    - "2.17"
+    - "2.18"
 
 permissions: {}
 


### PR DESCRIPTION
this job is broken on master due to the package rename