### PR TITLE
Prioritize constructor parameter over field if both are annotated with `@JsonAnySetter`, to fix #4634

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -666,12 +666,7 @@ ClassUtil.name(propName)));
               BeanDescription beanDesc, SettableBeanProperty[] creatorProps)
             throws JsonMappingException
     {
-        // Find the regular method/field level any-setter
-        AnnotatedMember anySetter = beanDesc.findAnySetterAccessor();
-        if (anySetter != null) {
-            return constructAnySetter(ctxt, beanDesc, anySetter);
-        }
-        // else look for any-setter via @JsonCreator
+        // Look for any-setter via @JsonCreator
         if (creatorProps != null) {
             for (SettableBeanProperty prop : creatorProps) {
                 AnnotatedMember member = prop.getMember();
@@ -679,6 +674,11 @@ ClassUtil.name(propName)));
                     return constructAnySetter(ctxt, beanDesc, member);
                 }
             }
+        }
+        // else find the regular method/field level any-setter
+        AnnotatedMember anySetter = beanDesc.findAnySetterAccessor();
+        if (anySetter != null) {
+            return constructAnySetter(ctxt, beanDesc, anySetter);
         }
         // not found, that's fine, too
         return null;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/AnySetterForCreator562Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/AnySetterForCreator562Test.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 // [databind#562] Allow @JsonAnySetter on Creator constructors
@@ -36,13 +37,29 @@ public class AnySetterForCreator562Test extends DatabindTestUtil
         }
     }
 
+    static class POJO562WithAnnotationOnBothCtorParamAndField
+    {
+        String a;
+        @JsonAnySetter
+        Map<String,Object> stuffFromField;
+        Map<String,Object> stuffFromConstructor;
+
+        @JsonCreator
+        public POJO562WithAnnotationOnBothCtorParamAndField(@JsonProperty("a") String a,
+                                                            @JsonAnySetter Map<String, Object> leftovers
+        ) {
+            this.a = a;
+            stuffFromConstructor = leftovers;
+        }
+    }
+
     static class POJO562WithField
     {
         String a;
         Map<String,Object> stuff;
 
         public String b;
-        
+
         @JsonCreator
         public POJO562WithField(@JsonProperty("a") String a,
             @JsonAnySetter Map<String, Object> leftovers
@@ -115,12 +132,32 @@ public class AnySetterForCreator562Test extends DatabindTestUtil
 
         assertEquals("value", pojo.a);
         assertEquals(expected, pojo.stuff);
-        
+
         // Should also initialize any-setter-Map even if no contents
         pojo = MAPPER.readValue(a2q("{'a':'value2'}"), POJO562.class);
         assertEquals("value2", pojo.a);
         assertEquals(new HashMap<>(), pojo.stuff);
+    }
 
+    // [databind#4634]
+    @Test
+    public void mapAnySetterViaCreatorWhenBothCreatorAndFieldAreAnnotated() throws Exception
+    {
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("b", Integer.valueOf(42));
+        expected.put("c", Integer.valueOf(111));
+
+        POJO562WithAnnotationOnBothCtorParamAndField pojo = MAPPER.readValue(a2q(
+                "{'a':'value', 'b':42, 'c': 111}"
+                ),
+                POJO562WithAnnotationOnBothCtorParamAndField.class);
+
+        assertEquals("value", pojo.a);
+        assertEquals(expected, pojo.stuffFromConstructor);
+        // In an ideal world, maybe exception should be thrown for annotating both field + constructor parameter,
+        // but that scenario is possible in this imperfect world e.g. annotating `@JsonAnySetter` on a Record component
+        // will cause that annotation to be (auto)propagated to both the field & constructor parameter (& accessor method)
+        assertNull(pojo.stuffFromField);
     }
 
     // Creator and non-Creator props AND any-setter ought to be fine too


### PR DESCRIPTION
Switching the priority not just because doing so happens to fix #4634, but also because it feels weird to prioritise field if both are annotated with `@JsonAnySetter`.