### PR TITLE
enable working object id test

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/ObjectIdDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/ObjectIdDeserializationTest.java
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.databind.deser;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.objectid.TestObjectId.Employee;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Unit test to verify handling of Object Id deserialization.
+ */
+class ObjectIdDeserializationTest extends DatabindTestUtil {
+
+  static class ArrayBlockingQueueCompany {
+    public ArrayBlockingQueue<Employee> employees;
+  }
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  // Do a specific test for ArrayBlockingQueue since it has its own deser.
+  @Test
+  void forwardReferenceInQueue() throws Exception {
+    String json = "{\"employees\":["
+        + "{\"id\":1,\"name\":\"First\",\"manager\":null,\"reports\":[2]},"
+        + "2,"
+        + "{\"id\":2,\"name\":\"Second\",\"manager\":1,\"reports\":[]}"
+        + "]}";
+    ArrayBlockingQueueCompany company = mapper.readValue(json, ArrayBlockingQueueCompany.class);
+    assertEquals(3, company.employees.size());
+    Employee firstEmployee = company.employees.take();
+    Employee secondEmployee = company.employees.take();
+    assertEmployees(firstEmployee, secondEmployee);
+  }
+
+  private void assertEmployees(Employee firstEmployee, Employee secondEmployee) {
+    assertEquals(1, firstEmployee.id);
+    assertEquals(2, secondEmployee.id);
+    assertEquals(1, firstEmployee.reports.size());
+    assertSame(secondEmployee, firstEmployee.reports.get(0)); // Ensure that forward reference was properly resolved and in order.
+    assertSame(firstEmployee, secondEmployee.manager); // And that back reference is also properly resolved.
+  }
+}

--- a/src/test/java/com/fasterxml/jackson/failing/ObjectIdDeserializationFailTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/ObjectIdDeserializationFailTest.java
@@ -27,10 +27,6 @@ class ObjectIdDeserializationFailTest extends DatabindTestUtil {
         public Employee[] employees;
     }
 
-    static class ArrayBlockingQueueCompany {
-        public ArrayBlockingQueue<Employee> employees;
-    }
-
     static class EnumMapCompany {
         public EnumMap<FooEnum, Employee> employees;
 
@@ -63,21 +59,6 @@ class ObjectIdDeserializationFailTest extends DatabindTestUtil {
         assertEquals(3, company.employees.length);
         Employee firstEmployee = company.employees[0];
         Employee secondEmployee = company.employees[1];
-        assertEmployees(firstEmployee, secondEmployee);
-    }
-
-    // Do a specific test for ArrayBlockingQueue since it has its own deser.
-    @Test
-    void forwardReferenceInQueue() throws Exception {
-        String json = "{\"employees\":["
-                + "{\"id\":1,\"name\":\"First\",\"manager\":null,\"reports\":[2]},"
-                + "2,"
-                + "{\"id\":2,\"name\":\"Second\",\"manager\":1,\"reports\":[]}"
-                + "]}";
-        ArrayBlockingQueueCompany company = mapper.readValue(json, ArrayBlockingQueueCompany.class);
-        assertEquals(3, company.employees.size());
-        Employee firstEmployee = company.employees.take();
-        Employee secondEmployee = company.employees.take();
         assertEmployees(firstEmployee, secondEmployee);
     }
 

--- a/src/test/java/com/fasterxml/jackson/failing/ObjectIdDeserializationFailTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/ObjectIdDeserializationFailTest.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.failing;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
see #4642

I couldn't find any issue relating to the broken tests - there are still 3 broken tests in ObjectIdDeserializationFailTest