### PR TITLE
Add `UpperCamelCase` `EnumNamingStrategy`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1823,3 +1823,7 @@ Eduard Gomoliako (Gems@github)
  * Reported #4602: Possible wrong use of _arrayDelegateDeserializer in
    BeanDeserializerBase::deserializeFromObjectUsingNonDefault()
   (2.18.0)
+
+Lars Benedetto (lbenedetto@github)
+ * Contributed #4660: Add `UpperCamelCase` `EnumNamingStrategy`
+  (2.18.0)

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1825,5 +1825,5 @@ Eduard Gomoliako (Gems@github)
   (2.18.0)
 
 Lars Benedetto (lbenedetto@github)
- * Contributed #4660: Add `UpperCamelCase` `EnumNamingStrategy`
+ * Contributed #4663: Add `UpperCamelCase` naming strategy to `EnumNamingStrategies`
   (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -68,7 +68,7 @@ Project: jackson-databind
 #4634: `@JsonAnySetter` not working when annotated on both constructor
   parameter & field
  (contributed by Sim Y-T)
-#4660: Add `UpperCamelCase` `EnumNamingStrategy`
+#4663: Add `UpperCamelCase` naming strategy to `EnumNamingStrategies`
  (contributed by Lars B)
 
 2.17.2 (05-Jul-2024)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -68,6 +68,8 @@ Project: jackson-databind
 #4634: `@JsonAnySetter` not working when annotated on both constructor
   parameter & field
  (contributed by Sim Y-T)
+#4660: Add `UpperCamelCase` `EnumNamingStrategy`
+ (contributed by Lars B)
 
 2.17.2 (05-Jul-2024)
 

--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -1,14 +1,15 @@
 package com.fasterxml.jackson.databind;
 
+import java.util.Locale;
+
 /**
  * A container class for implementations of the {@link EnumNamingStrategy} interface.
  *
  * @since 2.15
  */
-public class EnumNamingStrategies {
-
-    private EnumNamingStrategies() {
-    }
+public class EnumNamingStrategies
+{
+    private EnumNamingStrategies() { }
 
     /**
      * Words other than first are capitalized and no separator is used between words.
@@ -16,7 +17,7 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "enumName".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy LOWER_CAMEL_CASE = LowerCamelCaseStrategy.INSTANCE;
 
@@ -27,7 +28,7 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "EnumName".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy UPPER_CAMEL_CASE = UpperCamelCaseStrategy.INSTANCE;
 
@@ -37,7 +38,7 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "enum_name".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy SNAKE_CASE = SnakeCaseStrategy.INSTANCE;
 
@@ -47,7 +48,7 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "ENUM_NAME", but "__ENUM_NAME_" would also be converted to "ENUM_NAME".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy UPPER_SNAKE_CASE = UpperSnakeCaseStrategy.INSTANCE;
 
@@ -57,7 +58,7 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "enumname".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy LOWER_CASE = LowerCaseStrategy.INSTANCE;
 
@@ -67,7 +68,7 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "enum-name".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy KEBAB_CASE = KebabCaseStrategy.INSTANCE;
 
@@ -78,13 +79,13 @@ public class EnumNamingStrategies {
      * <p>
      * Example "ENUM_NAME" would be converted to "enum.name".
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static final EnumNamingStrategy LOWER_DOT_CASE = LowerDotCaseStrategy.INSTANCE;
 
     /**
      * @since 2.15
-     * @deprecated Since 2.19 use {@link LowerCamelCaseStrategy} instead.
+     * @deprecated Since 2.18 use {@link LowerCamelCaseStrategy} instead.
      */
     @Deprecated
     public static class CamelCaseStrategy implements EnumNamingStrategy {
@@ -134,19 +135,19 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "username"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class LowerCamelCaseStrategy implements EnumNamingStrategy {
 
         /**
          * An instance of {@link LowerCamelCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final LowerCamelCaseStrategy INSTANCE = new LowerCamelCaseStrategy();
 
         /**
-         * @since 2.19
+         * @since 2.18
          */
         @Override
         public String convertEnumToExternalName(String enumName) {
@@ -180,14 +181,14 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "Username"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class UpperCamelCaseStrategy implements EnumNamingStrategy {
 
         /**
          * An instance of {@link LowerCamelCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final UpperCamelCaseStrategy INSTANCE = new UpperCamelCaseStrategy();
 
@@ -223,14 +224,14 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "username"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class SnakeCaseStrategy implements EnumNamingStrategy {
 
         /**
          * An instance of {@link SnakeCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final SnakeCaseStrategy INSTANCE = new SnakeCaseStrategy();
 
@@ -266,14 +267,14 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "USERNAME"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class UpperSnakeCaseStrategy extends SnakeCaseStrategy {
 
         /**
          * An instance of {@link UpperSnakeCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final UpperSnakeCaseStrategy INSTANCE = new UpperSnakeCaseStrategy();
 
@@ -309,14 +310,14 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "username"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class LowerCaseStrategy implements EnumNamingStrategy {
 
         /**
          * An instance of {@link LowerCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final LowerCaseStrategy INSTANCE = new LowerCaseStrategy();
 
@@ -352,14 +353,14 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "username"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class KebabCaseStrategy implements EnumNamingStrategy {
 
         /**
          * An instance of {@link KebabCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final KebabCaseStrategy INSTANCE = new KebabCaseStrategy();
 
@@ -395,14 +396,14 @@ public class EnumNamingStrategies {
      * <li>"Username" is converted into "username"</li>
      * </ul>
      *
-     * @since 2.19
+     * @since 2.18
      */
     public static class LowerDotCaseStrategy implements EnumNamingStrategy {
 
         /**
          * An instance of {@link LowerDotCaseStrategy} for reuse.
          *
-         * @since 2.19
+         * @since 2.18
          */
         public static final LowerDotCaseStrategy INSTANCE = new LowerDotCaseStrategy();
 
@@ -418,7 +419,7 @@ public class EnumNamingStrategies {
      * @param enumName the enum name to be normalized
      * @return the normalized enum name
      */
-    private static String toBeanName(String enumName) {
+    static String toBeanName(String enumName) {
         if (enumName == null) {
             return null;
         }
@@ -433,7 +434,7 @@ public class EnumNamingStrategies {
             if (lastSeparatorIdx != -1) {
                 if (iterationCnt == 0) {
                     out = new StringBuilder(enumName.length() + 4 * UNDERSCORE.length());
-                    out.append(enumName.substring(iterationCnt, lastSeparatorIdx).toLowerCase());
+                    out.append(enumName.substring(iterationCnt, lastSeparatorIdx).toLowerCase(Locale.ROOT));
                 } else {
                     out.append(normalizeWord(enumName.substring(iterationCnt, lastSeparatorIdx)));
                 }
@@ -442,7 +443,7 @@ public class EnumNamingStrategies {
         } while (lastSeparatorIdx != -1);
 
         if (iterationCnt == 0) {
-            return enumName.toLowerCase();
+            return enumName.toLowerCase(Locale.ROOT);
         }
         out.append(normalizeWord(enumName.substring(iterationCnt)));
         return out.toString();

--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -7,27 +7,80 @@ package com.fasterxml.jackson.databind;
  */
 public class EnumNamingStrategies {
 
-    private EnumNamingStrategies() {}
+    private EnumNamingStrategies() {
+    }
 
     /**
      * Words other than first are capitalized and no separator is used between words.
      * See {@link EnumNamingStrategies.LowerCamelCaseStrategy} for details.
-     *<p>
-     * Example external property names would be "numberValue", "namingStrategy", "theDefiniteProof".
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enumName".
      *
      * @since 2.19
      */
     public static final EnumNamingStrategy LOWER_CAMEL_CASE = LowerCamelCaseStrategy.INSTANCE;
 
     /**
-     * Words are capitalized and no separator is used between words.
+     * Naming convention used in languages like Pascal, where all words are capitalized and no separator is used between
+     * words.
      * See {@link EnumNamingStrategies.UpperCamelCaseStrategy} for details.
-     *<p>
-     * Example external property names would be "NumberValue", "NamingStrategy", "TheDefiniteProof".
+     * <p>
+     * Example "ENUM_NAME" would be converted to "EnumName".
      *
      * @since 2.19
      */
     public static final EnumNamingStrategy UPPER_CAMEL_CASE = UpperCamelCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention used in languages like C, where words are in lower-case letters, separated by underscores.
+     * See {@link EnumNamingStrategies.SnakeCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enum_name".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy SNAKE_CASE = SnakeCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention in which the words are in upper-case letters, separated by underscores.
+     * See {@link EnumNamingStrategies.UpperSnakeCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "ENUM_NAME", but "__ENUM_NAME_" would also be converted to "ENUM_NAME".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy UPPER_SNAKE_CASE = UpperSnakeCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention in which all words of the logical name are in lower case, and no separator is used between words.
+     * See {@link EnumNamingStrategies.LowerCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enumname".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy LOWER_CASE = LowerCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention used in languages like Lisp, where words are in lower-case letters, separated by hyphens.
+     * See {@link EnumNamingStrategies.KebabCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enum-name".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy KEBAB_CASE = KebabCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention widely used as configuration properties name, where words are in lower-case letters,
+     * separated by dots.
+     * See {@link EnumNamingStrategies.LowerDotCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enum.name".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy LOWER_DOT_CASE = LowerDotCaseStrategy.INSTANCE;
 
     /**
      * @since 2.15
@@ -61,14 +114,13 @@ public class EnumNamingStrategies {
      * regardless of its original case (upper or lower).</li>
      * <li>removes all underscores.</li>
      * </ol>
-     *
+     * <p>
      * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
      * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanutButter".
      * And "peanutButter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
      *
      * <p>
-     * These rules result in the following example conversions from upper snakecase names
-     * to lower camelcase names.
+     * This results in the following example conversions:
      * <ul>
      * <li>"USER_NAME" is converted into "userName"</li>
      * <li>"USER______NAME" is converted into "userName"</li>
@@ -98,88 +150,23 @@ public class EnumNamingStrategies {
          */
         @Override
         public String convertEnumToExternalName(String enumName) {
-            if (enumName == null) {
-                return null;
-            }
-
-            final String UNDERSCORE = "_";
-            StringBuilder out = null;
-            int iterationCnt = 0;
-            int lastSeparatorIdx = -1;
-
-            do {
-                lastSeparatorIdx = indexIn(enumName, lastSeparatorIdx + 1);
-                if (lastSeparatorIdx != -1) {
-                    if (iterationCnt == 0) {
-                        out = new StringBuilder(enumName.length() + 4 * UNDERSCORE.length());
-                        out.append(toLowerCase(enumName.substring(iterationCnt, lastSeparatorIdx)));
-                    } else {
-                        out.append(normalizeWord(enumName.substring(iterationCnt, lastSeparatorIdx)));
-                    }
-                    iterationCnt = lastSeparatorIdx + UNDERSCORE.length();
-                }
-            } while (lastSeparatorIdx != -1);
-
-            if (iterationCnt == 0) {
-                return toLowerCase(enumName);
-            }
-            out.append(normalizeWord(enumName.substring(iterationCnt)));
-            return out.toString();
-        }
-
-        private static int indexIn(CharSequence sequence, int start) {
-            int length = sequence.length();
-            for (int i = start; i < length; i++) {
-                if ('_' == sequence.charAt(i)) {
-                    return i;
-                }
-            }
-            return -1;
-        }
-
-        private static String normalizeWord(String word) {
-            int length = word.length();
-            if (length == 0) {
-                return word;
-            }
-            return new StringBuilder(length)
-                    .append(Character.toUpperCase(word.charAt(0)))
-                    .append(toLowerCase(word.substring(1)))
-                    .toString();
-        }
-
-        private static String toLowerCase(String string) {
-            int length = string.length();
-            StringBuilder builder = new StringBuilder(length);
-            for (int i = 0; i < length; i++) {
-                builder.append(Character.toLowerCase(string.charAt(i)));
-            }
-            return builder.toString();
+            return toBeanName(enumName);
         }
     }
 
     /**
      * <p>
      * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
-     * snake case format to upper camel case format. This implementation follows three rules
-     * described below.
-     *
-     * <ol>
-     * <li>converts any character preceded by an underscore into upper case character,
-     * regardless of its original case (upper or lower).</li>
-     * <li>converts any character NOT preceded by an underscore into a lower case character,
-     * regardless of its original case (upper or lower).</li>
-     * <li>converts the first char in the string, regardless of any underscores, to uppercase</li>
-     * <li>removes all underscores.</li>
-     * </ol>
-     *
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.UpperCamelCaseStrategy} to finish converting the name.
+     * <p>
      * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
      * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "PeanutButter".
      * And "PeanutButter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
      *
      * <p>
-     * These rules result in the following example conversions from upper snakecase names
-     * to upper camelcase names.
+     * This results in the following example conversions:
      * <ul>
      * <li>"USER_NAME" is converted into "UserName"</li>
      * <li>"USER______NAME" is converted into "UserName"</li>
@@ -206,8 +193,279 @@ public class EnumNamingStrategies {
 
         @Override
         public String convertEnumToExternalName(String enumName) {
-            String lowerCamelCase = LOWER_CAMEL_CASE.convertEnumToExternalName(enumName);
-            return PropertyNamingStrategies.UpperCamelCaseStrategy.INSTANCE.translate(lowerCamelCase);
+            return PropertyNamingStrategies.UpperCamelCaseStrategy.INSTANCE.translate(toBeanName(enumName));
         }
+    }
+
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.SnakeCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanut_butter".
+     * And "peanut_butter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "user_name"</li>
+     * <li>"USER______NAME" is converted into "user_name"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "user_name"</li>
+     * <li>"_user_name" is converted into "user_name"</li>
+     * <li>"_user_name_s" is converted into "user_name_s"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class SnakeCaseStrategy implements EnumNamingStrategy {
+
+        /**
+         * An instance of {@link SnakeCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final SnakeCaseStrategy INSTANCE = new SnakeCaseStrategy();
+
+        @Override
+        public String convertEnumToExternalName(String enumName) {
+            return PropertyNamingStrategies.SnakeCaseStrategy.INSTANCE.translate(toBeanName(enumName));
+        }
+    }
+
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.UpperSnakeCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "PEANUT_BUTTER".
+     * And "PEANUT_BUTTER" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "USER_NAME"</li>
+     * <li>"USER______NAME" is converted into "USER_NAME"</li>
+     * <li>"USERNAME" is converted into "USERNAME"</li>
+     * <li>"User__Name" is converted into "USER_NAME"</li>
+     * <li>"_user_name" is converted into "USER_NAME"</li>
+     * <li>"_user_name_s" is converted into "USER_NAME_S"</li>
+     * <li>"__Username" is converted into "USERNAME"</li>
+     * <li>"__username" is converted into "USERNAME"</li>
+     * <li>"username" is converted into "USERNAME"</li>
+     * <li>"Username" is converted into "USERNAME"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class UpperSnakeCaseStrategy extends SnakeCaseStrategy {
+
+        /**
+         * An instance of {@link UpperSnakeCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final UpperSnakeCaseStrategy INSTANCE = new UpperSnakeCaseStrategy();
+
+        @Override
+        public String convertEnumToExternalName(String enumName) {
+            return PropertyNamingStrategies.UpperSnakeCaseStrategy.INSTANCE.translate(toBeanName(enumName));
+        }
+    }
+
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.LowerCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanutbutter".
+     * And "peanutbutter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "username"</li>
+     * <li>"USER______NAME" is converted into "username"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "username"</li>
+     * <li>"_user_name" is converted into "username"</li>
+     * <li>"_user_name_s" is converted into "usernames"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class LowerCaseStrategy implements EnumNamingStrategy {
+
+        /**
+         * An instance of {@link LowerCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final LowerCaseStrategy INSTANCE = new LowerCaseStrategy();
+
+        @Override
+        public String convertEnumToExternalName(String enumName) {
+            return PropertyNamingStrategies.LowerCaseStrategy.INSTANCE.translate(toBeanName(enumName));
+        }
+    }
+
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.KebabCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanut-butter".
+     * And "peanut-butter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "user-name"</li>
+     * <li>"USER______NAME" is converted into "user-name"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "user-name"</li>
+     * <li>"_user_name" is converted into "user-name"</li>
+     * <li>"_user_name_s" is converted into "user-name-s"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class KebabCaseStrategy implements EnumNamingStrategy {
+
+        /**
+         * An instance of {@link KebabCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final KebabCaseStrategy INSTANCE = new KebabCaseStrategy();
+
+        @Override
+        public String convertEnumToExternalName(String enumName) {
+            return PropertyNamingStrategies.KebabCaseStrategy.INSTANCE.translate(toBeanName(enumName));
+        }
+    }
+
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to lower dot case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.LowerDotCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanut.butter".
+     * And "peanut.butter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "user.name"</li>
+     * <li>"USER______NAME" is converted into "user.name"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "user.name"</li>
+     * <li>"_user_name" is converted into "user.name"</li>
+     * <li>"_user_name_s" is converted into "user.name.s"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class LowerDotCaseStrategy implements EnumNamingStrategy {
+
+        /**
+         * An instance of {@link LowerDotCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final LowerDotCaseStrategy INSTANCE = new LowerDotCaseStrategy();
+
+        @Override
+        public String convertEnumToExternalName(String enumName) {
+            return PropertyNamingStrategies.LowerDotCaseStrategy.INSTANCE.translate(toBeanName(enumName));
+        }
+    }
+
+    /**
+     * Normalizes the enum name to lower camel case in order to be further processed by a PropertyNamingStrategy.
+     *
+     * @param enumName the enum name to be normalized
+     * @return the normalized enum name
+     */
+    private static String toBeanName(String enumName) {
+        if (enumName == null) {
+            return null;
+        }
+
+        final String UNDERSCORE = "_";
+        StringBuilder out = null;
+        int iterationCnt = 0;
+        int lastSeparatorIdx = -1;
+
+        do {
+            lastSeparatorIdx = nextIndexOfUnderscore(enumName, lastSeparatorIdx + 1);
+            if (lastSeparatorIdx != -1) {
+                if (iterationCnt == 0) {
+                    out = new StringBuilder(enumName.length() + 4 * UNDERSCORE.length());
+                    out.append(enumName.substring(iterationCnt, lastSeparatorIdx).toLowerCase());
+                } else {
+                    out.append(normalizeWord(enumName.substring(iterationCnt, lastSeparatorIdx)));
+                }
+                iterationCnt = lastSeparatorIdx + UNDERSCORE.length();
+            }
+        } while (lastSeparatorIdx != -1);
+
+        if (iterationCnt == 0) {
+            return enumName.toLowerCase();
+        }
+        out.append(normalizeWord(enumName.substring(iterationCnt)));
+        return out.toString();
+    }
+
+    private static int nextIndexOfUnderscore(CharSequence sequence, int start) {
+        int length = sequence.length();
+        for (int i = start; i < length; i++) {
+            if ('_' == sequence.charAt(i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Converts the first letter of the word to uppercase and the rest of the word to lowercase.
+     */
+    private static String normalizeWord(String word) {
+        int length = word.length();
+        if (length == 0) {
+            return word;
+        }
+        return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -14,6 +14,8 @@ public class EnumNamingStrategies {
      * See {@link EnumNamingStrategies.LowerCamelCaseStrategy} for details.
      *<p>
      * Example external property names would be "numberValue", "namingStrategy", "theDefiniteProof".
+     *
+     * @since 2.19
      */
     public static final EnumNamingStrategy LOWER_CAMEL_CASE = LowerCamelCaseStrategy.INSTANCE;
 
@@ -22,6 +24,8 @@ public class EnumNamingStrategies {
      * See {@link EnumNamingStrategies.UpperCamelCaseStrategy} for details.
      *<p>
      * Example external property names would be "NumberValue", "NamingStrategy", "TheDefiniteProof".
+     *
+     * @since 2.19
      */
     public static final EnumNamingStrategy UPPER_CAMEL_CASE = UpperCamelCaseStrategy.INSTANCE;
 
@@ -29,7 +33,7 @@ public class EnumNamingStrategies {
      * @since 2.15
      * @deprecated Since 2.19 use {@link LowerCamelCaseStrategy} instead.
      */
-    @Deprecated(since = "2.19", forRemoval = true)
+    @Deprecated
     public static class CamelCaseStrategy implements EnumNamingStrategy {
         /**
          * An instance of {@link LowerCamelCaseStrategy} for reuse.
@@ -202,7 +206,7 @@ public class EnumNamingStrategies {
 
         @Override
         public String convertEnumToExternalName(String enumName) {
-            var lowerCamelCase = LOWER_CAMEL_CASE.convertEnumToExternalName(enumName);
+            String lowerCamelCase = LOWER_CAMEL_CASE.convertEnumToExternalName(enumName);
             return PropertyNamingStrategies.UpperCamelCaseStrategy.INSTANCE.translate(lowerCamelCase);
         }
     }

--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -36,11 +36,11 @@ public class EnumNamingStrategies {
     @Deprecated
     public static class CamelCaseStrategy implements EnumNamingStrategy {
         /**
-         * An instance of {@link LowerCamelCaseStrategy} for reuse.
+         * An instance of {@link CamelCaseStrategy} for reuse.
          *
          * @since 2.15
          */
-        public static final LowerCamelCaseStrategy INSTANCE = new LowerCamelCaseStrategy();
+        public static final CamelCaseStrategy INSTANCE = new CamelCaseStrategy();
 
         @Override
         public String convertEnumToExternalName(String enumName) {

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -364,7 +364,7 @@ public abstract class PropertyNamingStrategies
      * Conversion from internal name like "someOtherValue" would be into external name
      * if "someothervalue".
      */
-    public static class  LowerCaseStrategy extends NamingBase
+    public static class LowerCaseStrategy extends NamingBase
     {
         private static final long serialVersionUID = 2L;
 

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -364,7 +364,7 @@ public abstract class PropertyNamingStrategies
      * Conversion from internal name like "someOtherValue" would be into external name
      * if "someothervalue".
      */
-    public static class LowerCaseStrategy extends NamingBase
+    public static class  LowerCaseStrategy extends NamingBase
     {
         private static final long serialVersionUID = 2L;
 

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/EnumNamingStrategiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/EnumNamingStrategiesTest.java
@@ -20,14 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class EnumNamingStrategiesTest extends DatabindTestUtil {
 
     /**
-     * Test casess for {@link com.fasterxml.jackson.databind.EnumNamingStrategies.CamelCaseStrategy}.
+     * Test cases for {@link com.fasterxml.jackson.databind.EnumNamingStrategies.LowerCamelCaseStrategy}.
      *
      * <p>
      * Each <code>Object[]</code> element is composed of <code>{input, expectedOutput}</code>.
      *
      * @since 2.15
      */
-    final static List<String[]> CAMEL_CASE_NAME_TRANSLATIONS = Arrays.asList(new String[][]{
+    final static List<String[]> LOWER_CAMEL_CASE_NAME_TRANSLATIONS = Arrays.asList(new String[][]{
             // Empty values
             {null, null},
             {"", ""},
@@ -116,18 +116,18 @@ public class EnumNamingStrategiesTest extends DatabindTestUtil {
 
     /**
      * Unit test to verify the implementation of
-     * {@link com.fasterxml.jackson.databind.EnumNamingStrategies.CamelCaseStrategy#convertEnumToExternalName(String)}
+     * {@link com.fasterxml.jackson.databind.EnumNamingStrategies.LowerCamelCaseStrategy#convertEnumToExternalName(String)}
      * without the context of an ObjectMapper.
      *
      * @since 2.15
      */
     @Test
-    public void testCamelCaseStrategyStandAlone() {
-        for (String[] pair : CAMEL_CASE_NAME_TRANSLATIONS) {
+    public void testLowerCamelCaseStrategyStandAlone() {
+        for (String[] pair : LOWER_CAMEL_CASE_NAME_TRANSLATIONS) {
             final String input = pair[0];
             final String expected = pair[1];
 
-            String actual = EnumNamingStrategies.CamelCaseStrategy.INSTANCE
+            String actual = EnumNamingStrategies.LOWER_CAMEL_CASE
                     .convertEnumToExternalName(input);
 
             assertEquals(expected, actual);

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/EnumNamingStrategiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/EnumNamingStrategiesTest.java
@@ -1,13 +1,14 @@
 package com.fasterxml.jackson.databind.introspect;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
-import com.fasterxml.jackson.databind.EnumNamingStrategies;
+import com.fasterxml.jackson.databind.EnumNamingStrategy;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.stream.Stream;
+
+import static com.fasterxml.jackson.databind.EnumNamingStrategies.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -17,120 +18,126 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @since 2.15
  */
-public class EnumNamingStrategiesTest extends DatabindTestUtil {
-
+class EnumNamingStrategiesTest extends DatabindTestUtil {
     /**
-     * Test cases for {@link com.fasterxml.jackson.databind.EnumNamingStrategies.LowerCamelCaseStrategy}.
+     * Test cases for {@link com.fasterxml.jackson.databind.EnumNamingStrategies}.
      *
-     * <p>
-     * Each <code>Object[]</code> element is composed of <code>{input, expectedOutput}</code>.
-     *
-     * @since 2.15
+     * @since 2.19
      */
-    final static List<String[]> LOWER_CAMEL_CASE_NAME_TRANSLATIONS = Arrays.asList(new String[][]{
-            // Empty values
-            {null, null},
-            {"", ""},
+    private static Stream<Arguments> enumNameConversionTestCases() {
+        return Stream.of(
+                // Empty values
+                Arguments.of(LOWER_CAMEL_CASE, null, null),
+                Arguments.of(UPPER_CAMEL_CASE, null, null),
+                Arguments.of(SNAKE_CASE, null, null),
+                Arguments.of(UPPER_SNAKE_CASE, null, null),
+                Arguments.of(LOWER_CASE, null, null),
+                Arguments.of(KEBAB_CASE, null, null),
+                Arguments.of(LOWER_DOT_CASE, null, null),
+                Arguments.of(LOWER_CAMEL_CASE, "", ""),
 
-            // input values with no underscores
-            {"a", "a"},
-            {"abc", "abc"},
-            {"A", "a"},
-            {"A1", "a1"},
-            {"1A", "1a"},
-            {"ABC", "abc"},
-            {"User", "user"},
-            {"Results", "results"},
-            {"WWW", "www"},
-            {"USER", "user"},
-            {"userName", "username"},
-            {"someURI", "someuri"},
-            {"someURIs", "someuris"},
-            {"theWWW", "thewww"},
-            {"uId", "uid"},
-            {"usId", "usid"},
-            {"UserName", "username"},
-            {"user", "user"},
-            {"xCoordinate", "xcoordinate"},
+                // input values with no underscores
+                Arguments.of(LOWER_CAMEL_CASE, "a", "a"),
+                Arguments.of(LOWER_CAMEL_CASE, "abc", "abc"),
+                Arguments.of(LOWER_CAMEL_CASE, "A", "a"),
+                Arguments.of(LOWER_CAMEL_CASE, "A1", "a1"),
+                Arguments.of(LOWER_CAMEL_CASE, "1A", "1a"),
+                Arguments.of(LOWER_CAMEL_CASE, "ABC", "abc"),
+                Arguments.of(LOWER_CAMEL_CASE, "User", "user"),
+                Arguments.of(LOWER_CAMEL_CASE, "Results", "results"),
+                Arguments.of(LOWER_CAMEL_CASE, "WWW", "www"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER", "user"),
+                Arguments.of(LOWER_CAMEL_CASE, "userName", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "someURI", "someuri"),
+                Arguments.of(LOWER_CAMEL_CASE, "someURIs", "someuris"),
+                Arguments.of(LOWER_CAMEL_CASE, "theWWW", "thewww"),
+                Arguments.of(LOWER_CAMEL_CASE, "uId", "uid"),
+                Arguments.of(LOWER_CAMEL_CASE, "usId", "usid"),
+                Arguments.of(LOWER_CAMEL_CASE, "UserName", "username"),
+                Arguments.of(KEBAB_CASE, "UserName", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "user", "user"),
+                Arguments.of(LOWER_CAMEL_CASE, "xCoordinate", "xcoordinate"),
 
-            // input values with single underscores
-            {"a_", "a"},
-            {"_A", "A"},
-            {"_a", "A"},
-            {"a_A", "aA"},
-            {"a_a", "aA"},
-            {"A_A", "aA"},
-            {"A_a", "aA"},
-            {"BARS_", "bars"},
-            {"BARS", "bars"},
-            {"THE_WWW", "theWww"},
-            {"U_ID", "uId"},
-            {"US_ID", "usId"},
-            {"X_COORDINATE", "xCoordinate"},
+                // input values with single underscores
+                Arguments.of(LOWER_CAMEL_CASE, "a_", "a"),
+                Arguments.of(LOWER_CAMEL_CASE, "_A", "A"),
+                Arguments.of(LOWER_CAMEL_CASE, "_a", "A"),
+                Arguments.of(LOWER_CAMEL_CASE, "a_A", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "a_a", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "A_A", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "A_a", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "BARS_", "bars"),
+                Arguments.of(LOWER_CAMEL_CASE, "BARS", "bars"),
+                Arguments.of(LOWER_CAMEL_CASE, "THE_WWW", "theWww"),
+                Arguments.of(LOWER_CAMEL_CASE, "U_ID", "uId"),
+                Arguments.of(LOWER_CAMEL_CASE, "US_ID", "usId"),
+                Arguments.of(LOWER_CAMEL_CASE, "X_COORDINATE", "xCoordinate"),
 
-            // heavy "username" example
-            {"USERNAME_", "username"},
-            {"_User_Name", "UserName"},
-            {"_UserName", "Username"},
-            {"_Username", "Username"},
-            {"_user_name", "UserName"},
-            {"_USERNAME", "Username"},
-            {"__USERNAME", "Username"},
-            {"__Username", "Username"},
-            {"__username", "Username"},
-            {"USER______NAME", "userName"},
-            {"USER_NAME", "userName"},
-            {"USER__NAME", "userName"},
-            {"USER_NAME_", "userName"},
-            {"User__Name", "userName"},
-            {"USER_NAME_S", "userNameS"},
-            {"_user_name_s", "UserNameS"},
-            {"USER_NAME_S", "userNameS"},
-            {"user__name", "userName"},
-            {"user_name", "userName"},
-            {"USERNAME", "username"},
-            {"username", "username"},
-            {"User_Name", "userName"},
-            {"User_Name_", "userName"},
-            {"User_Name_", "userName"},
-            {"User_Name__", "userName"},
-            {"user_name_", "userName"},
-            {"user_name__", "userName"},
+                // heavy "username" example
+                Arguments.of(LOWER_CAMEL_CASE, "USERNAME_", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "_User_Name", "UserName"),
+                Arguments.of(LOWER_CAMEL_CASE, "_UserName", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "_Username", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "_user_name", "UserName"),
+                Arguments.of(LOWER_CAMEL_CASE, "_USERNAME", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "__USERNAME", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "__Username", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "__username", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER______NAME", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME", "userName"),
+                Arguments.of(UPPER_CAMEL_CASE, "USER_NAME", "UserName"),
+                Arguments.of(SNAKE_CASE, "USER_NAME", "user_name"),
+                Arguments.of(UPPER_SNAKE_CASE, "USER_NAME", "USER_NAME"),
+                Arguments.of(LOWER_CASE, "USER_NAME", "username"),
+                Arguments.of(KEBAB_CASE, "USER_NAME", "user-name"),
+                Arguments.of(LOWER_DOT_CASE, "USER_NAME", "user.name"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER__NAME", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User__Name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME_S", "userNameS"),
+                Arguments.of(LOWER_CAMEL_CASE, "_user_name_s", "UserNameS"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME_S", "userNameS"),
+                Arguments.of(LOWER_CAMEL_CASE, "user__name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "user_name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USERNAME", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "username", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name__", "userName"),
+                Arguments.of(UPPER_SNAKE_CASE, "User_Name__", "USER_NAME"),
+                Arguments.of(LOWER_CAMEL_CASE, "user_name_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "user_name__", "userName"),
 
-            // additional variations
-            {"a$a", "a$a"},
-            {"A$A", "a$a"},
-            {"a_$", "a$"},
-            {"a$", "a$"},
-            {"a1", "a1"},
-            {"$", "$"},
-            {"A$", "a$"},
-            {"1", "1"},
-            {"$_A", "$A"},
-            {"$_a", "$A"},
-            {"1_A", "1A"},
-            {"1a", "1a"},
-            {"A_$", "a$"},
-            {"_123_41", "12341"},
-    });
+                // additional variations
+                Arguments.of(LOWER_CAMEL_CASE, "a$a", "a$a"),
+                Arguments.of(LOWER_CAMEL_CASE, "A$A", "a$a"),
+                Arguments.of(LOWER_CAMEL_CASE, "a_$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "a$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "a1", "a1"),
+                Arguments.of(LOWER_CAMEL_CASE, "$", "$"),
+                Arguments.of(LOWER_CAMEL_CASE, "A$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "1", "1"),
+                Arguments.of(LOWER_CAMEL_CASE, "$_A", "$A"),
+                Arguments.of(LOWER_CAMEL_CASE, "$_a", "$A"),
+                Arguments.of(LOWER_CAMEL_CASE, "1_A", "1A"),
+                Arguments.of(LOWER_CAMEL_CASE, "1a", "1a"),
+                Arguments.of(LOWER_CAMEL_CASE, "A_$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "_123_41", "12341")
+        );
+    }
 
     /**
-     * Unit test to verify the implementation of
-     * {@link com.fasterxml.jackson.databind.EnumNamingStrategies.LowerCamelCaseStrategy#convertEnumToExternalName(String)}
+     * Unit test to verify the implementations of
+     * {@link com.fasterxml.jackson.databind.EnumNamingStrategy#convertEnumToExternalName(String)}
      * without the context of an ObjectMapper.
      *
-     * @since 2.15
+     * @since 2.19
      */
-    @Test
-    public void testLowerCamelCaseStrategyStandAlone() {
-        for (String[] pair : LOWER_CAMEL_CASE_NAME_TRANSLATIONS) {
-            final String input = pair[0];
-            final String expected = pair[1];
-
-            String actual = EnumNamingStrategies.LOWER_CAMEL_CASE
-                    .convertEnumToExternalName(input);
-
-            assertEquals(expected, actual);
-        }
+    @ParameterizedTest
+    @MethodSource("enumNameConversionTestCases")
+    void testEnumNameConversions(EnumNamingStrategy strategy, String input, String output) {
+        String actual = strategy.convertEnumToExternalName(input);
+        assertEquals(output, actual);
     }
 }


### PR DESCRIPTION
Changes EnumNamingStrategies to provide all the same naming strategies as PropertyNamingStrategies. It accomplishes this by first normalizing the enum name to lowerCamelCase and then delegating to the various PropertyNamingStrategies implementations