### PR TITLE
Fix #4688 2.18.0-rc1 Regression deserializing with no-arg delegating JsonCreator

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -849,6 +849,8 @@ Carter Kozak (carterkozak@github)
   * Contributed #3876: `TypeFactory` cache performance degradation with
     `constructSpecializedType()`
    (2.15.0)
+  * Contributed #4688: Should allow deserializing with no-arg `@JsonCreator(mode = DELEGATING)`
+   (2.18.0)
 
 Reinhard Prechtl (dnno@github)
   * Reported #2034: Serialization problem with type specialization of nested generic types

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -70,6 +70,8 @@ Project: jackson-databind
  (contributed by Sim Y-T)
 #4678: Java records don't serialize with `MapperFeature.REQUIRE_SETTERS_FOR_GETTERS`
  (reported by Mathijs V)
+#4688: Should allow deserializing with no-arg `@JsonCreator(mode = DELEGATING)`
+ (contributed by Carter K)
 
 2.17.2 (05-Jul-2024)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -468,6 +468,10 @@ public abstract class BasicDeserializerFactory
         int ix = -1;
         final int argCount = candidate.paramCount();
         SettableBeanProperty[] properties = new SettableBeanProperty[argCount];
+        if (argCount == 0) {
+            creators.addPropertyCreator(candidate.creator(), true, properties);
+            return true;
+        }
         for (int i = 0; i < argCount; ++i) {
             AnnotatedParameter param = candidate.parameter(i);
             JacksonInject.Value injectId = candidate.injection(i);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -468,7 +468,10 @@ public abstract class BasicDeserializerFactory
         int ix = -1;
         final int argCount = candidate.paramCount();
         SettableBeanProperty[] properties = new SettableBeanProperty[argCount];
+        // [databind#4688]: Should still accept 0-arg (explicitly delegated) creator
+        //   for backwards-compatibility (worked in 2.17 and before)
         if (argCount == 0) {
+            // "Convert" to property-based since that works well
             creators.addPropertyCreator(candidate.creator(), true, properties);
             return true;
         }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/SingletonDelegatingCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/SingletonDelegatingCreatorTest.java
@@ -1,0 +1,78 @@
+package com.fasterxml.jackson.databind.deser.creators;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+// [databind#4688]
+public class SingletonDelegatingCreatorTest
+{
+
+    static final class NoFieldSingletonWithDelegatingCreator {
+        private static final NoFieldSingletonWithDelegatingCreator INSTANCE = new NoFieldSingletonWithDelegatingCreator();
+
+        private NoFieldSingletonWithDelegatingCreator() {}
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static NoFieldSingletonWithDelegatingCreator of() {
+            return INSTANCE;
+        }
+    }
+
+    static final class NoFieldSingletonWithPropertiesCreator {
+        private static final NoFieldSingletonWithPropertiesCreator INSTANCE = new NoFieldSingletonWithPropertiesCreator();
+
+        private NoFieldSingletonWithPropertiesCreator() {}
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        static NoFieldSingletonWithPropertiesCreator of() {
+            return INSTANCE;
+        }
+    }
+
+    static final class NoFieldSingletonWithDefaultCreator {
+        private static final NoFieldSingletonWithDefaultCreator INSTANCE = new NoFieldSingletonWithDefaultCreator();
+
+        private NoFieldSingletonWithDefaultCreator() {}
+
+        @JsonCreator
+        static NoFieldSingletonWithDefaultCreator of() {
+            return INSTANCE;
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void testNoFieldSingletonWithDelegatingCreator() throws Exception
+    {
+        NoFieldSingletonWithDelegatingCreator deserialized = MAPPER.readValue("{}",
+                NoFieldSingletonWithDelegatingCreator.class);
+        assertSame(NoFieldSingletonWithDelegatingCreator.INSTANCE, deserialized);
+    }
+
+    @Test
+    public void testNoFieldSingletonWithPropertiesCreator() throws Exception
+    {
+        NoFieldSingletonWithPropertiesCreator deserialized = MAPPER.readValue("{}",
+                NoFieldSingletonWithPropertiesCreator.class);
+        assertSame(NoFieldSingletonWithPropertiesCreator.INSTANCE, deserialized);
+    }
+
+    @Test
+    public void testNoFieldSingletonWithDefaultCreator() throws Exception
+    {
+        NoFieldSingletonWithDefaultCreator deserialized = MAPPER.readValue("{}",
+                NoFieldSingletonWithDefaultCreator.class);
+        assertSame(NoFieldSingletonWithDefaultCreator.INSTANCE, deserialized);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/SingletonDelegatingCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/SingletonDelegatingCreatorTest.java
@@ -1,18 +1,18 @@
 package com.fasterxml.jackson.databind.deser.creators;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 // [databind#4688]
-public class SingletonDelegatingCreatorTest
+public class SingletonDelegatingCreatorTest extends DatabindTestUtil
 {
-
     static final class NoFieldSingletonWithDelegatingCreator {
-        private static final NoFieldSingletonWithDelegatingCreator INSTANCE = new NoFieldSingletonWithDelegatingCreator();
+        static final NoFieldSingletonWithDelegatingCreator INSTANCE = new NoFieldSingletonWithDelegatingCreator();
 
         private NoFieldSingletonWithDelegatingCreator() {}
 
@@ -23,7 +23,7 @@ public class SingletonDelegatingCreatorTest
     }
 
     static final class NoFieldSingletonWithPropertiesCreator {
-        private static final NoFieldSingletonWithPropertiesCreator INSTANCE = new NoFieldSingletonWithPropertiesCreator();
+        static final NoFieldSingletonWithPropertiesCreator INSTANCE = new NoFieldSingletonWithPropertiesCreator();
 
         private NoFieldSingletonWithPropertiesCreator() {}
 
@@ -34,7 +34,7 @@ public class SingletonDelegatingCreatorTest
     }
 
     static final class NoFieldSingletonWithDefaultCreator {
-        private static final NoFieldSingletonWithDefaultCreator INSTANCE = new NoFieldSingletonWithDefaultCreator();
+        static final NoFieldSingletonWithDefaultCreator INSTANCE = new NoFieldSingletonWithDefaultCreator();
 
         private NoFieldSingletonWithDefaultCreator() {}
 


### PR DESCRIPTION
(fixes #4688)

The refactor to bean property introspection in #4515 caused existing no-arg delegatring constructors to fail deserialization.

Example from this branch where we test RC releases: https://github.com/palantir/conjure-java/pull/2349 specifically this test:
https://github.com/palantir/conjure-java/blob/19d7f54eb0001c49b5d8a4bb897b9ad4cb5a28de/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NoFieldBeanTests.java#L36-L39 Using this type:
https://github.com/palantir/conjure-java/blob/19d7f54eb0001c49b5d8a4bb897b9ad4cb5a28de/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
```
InvalidDefinitionException: Invalid type definition for type `com.palantir.product.EmptyObjectExample`: No argument left as delegating for Creator [method com.palantir.product.EmptyObjectExample#of()]: exactly one required
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1]
	at app//com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:62)
	at app//com.fasterxml.jackson.databind.DeserializationContext.reportBadTypeDefinition(DeserializationContext.java:1866)
	at app//com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._addExplicitDelegatingCreator(BasicDeserializerFactory.java:489)
	at app//com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._addExplicitDelegatingCreators(BasicDeserializerFactory.java:365)
	at app//com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._constructDefaultValueInstantiator(BasicDeserializerFactory.java:270)
	at app//com.fasterxml.jackson.databind.deser.BasicDeserializerFactory.findValueInstantiator(BasicDeserializerFactory.java:219)
	at app//com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.buildBeanDeserializer(BeanDeserializerFactory.java:262)
	at app//com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:151)
	at app//com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer2(DeserializerCache.java:471)
	at app//com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:415)
	at app//com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:317)
	at app//com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:284)
	at app//com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:174)
	at app//com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:669)
	at app//com.fasterxml.jackson.databind.ObjectMapper._findRootDeserializer(ObjectMapper.java:5048)
	at app//com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4918)
	at app//com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3860)
	at app//com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3828)
	at app//com.palantir.conjure.java.types.NoFieldBeanTests.testDeserializeUsesSingleton(NoFieldBeanTests.java:38)
```

It's not entirely clear that we are correctly using the `DELEGATING` type here, perhaps the `PROPERTIES` type would be a better fit, however neither necessarily document support for a no-arg constructor. In general we prefer `DELEGATING` when possible to avoid ambiguity with potential property sources -- we want the ability to fail deserialization in this case when any properties are included in the incoming object.

In 2.17.2, this branch allowed the code to functiona as we desired: https://github.com/FasterXML/jackson-databind/blob/091d968751ef00150d22a788fe7f45b7cdcb337a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java#L658-L662

Is there any chance we could allow the previous DELEGATING behavior to continue to handle the no-arg case? If we'd prefer to move away from `DELEGATING` for that case, is there any chance we could emit a deprecation warning for some time?

I've included a potential patch which recovers the previous behavior.