### PR TITLE
Add any-setter handling in `PropertyValueBuffer` post #562

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1834,3 +1834,6 @@ Rikkarth (rikkarth@github)
  * Contributed #4709: Add `JacksonCollectors` with `toArrayNode()` implementation
   (2.18.0)
 
+Maxim Valeev (@MaximValeev)
+ * Reported #4508: Deserialized JsonAnySetter field in Kotlin data class is null
+  (2.18.1)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,7 +6,7 @@ Project: jackson-databind
 
 2.18.1 (WIP-2024)
 
-#4508: Deserialized JsonAnySetter field in Kotlin data class is null #4508
+#4508: Deserialized JsonAnySetter field in Kotlin data class is null
  (reported by @MaximValeev)
  (fix by Joo-Hyuk K)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,12 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.18.1 (WIP-2024)
+
+#4508: Deserialized JsonAnySetter field in Kotlin data class is null #4508
+ (reported by @MaximValeev)
+ (fix by Joo-Hyuk K)
+
 2.18.0 (26-Sep-2024)
 
 #562: Allow `@JsonAnySetter` to flow through Creators
@@ -81,9 +87,6 @@ Project: jackson-databind
  (contributed by @pjfanning)
 #4709: Add `JacksonCollectors` with `toArrayNode()` implementation
  (contributed by @rikkarth)
-#4508: Deserialized JsonAnySetter field in Kotlin data class is null #4508
- (reported by @MaximValeev)
- (fix by Joo-Hyuk K)
 
 2.17.2 (05-Jul-2024)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -81,6 +81,9 @@ Project: jackson-databind
  (contributed by @pjfanning)
 #4709: Add `JacksonCollectors` with `toArrayNode()` implementation
  (contributed by @rikkarth)
+#4508: Deserialized JsonAnySetter field in Kotlin data class is null #4508
+ (reported by @MaximValeev)
+ (fix by Joo-Hyuk K)
 
 2.17.2 (05-Jul-2024)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -233,8 +233,6 @@ public class PropertyValueBuffer
 
     /**
      * Helper method called to create and set any values buffered for "any setter"
-     *
-     * @since 2.18
      */
     private Object _createAndSetAnySetterValue() throws IOException
     {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -137,6 +137,7 @@ public class PropertyValueBuffer
      */
     public final boolean hasParameter(SettableBeanProperty prop)
     {
+        // 28-Sep-2024 : [databind#4508] Support any-setter flowing through creator
         if (_anyParamSetter != null) {
             if (prop.getCreatorIndex() == _anyParamSetter.getParameterIndex()) {
                 return true;


### PR DESCRIPTION
fixes #4508 

This sort of adds missing handling in addition to #4508. Where we should also consider situations like #4508, where extensions (like Kotlin module) iterates through parameters one by one, via `hasParmeter()` and `getParameter()`, unlike StdValueInstantiator going through all parameters at once via `getParameters(SettableBeanProperty[])`.

### Reproduction with fix

1. pull : https://github.com/JooHyukKim/jackson-module-kotlin/tree/test-databind-4508
2. then pull : https://github.com/JooHyukKim/jackson-databind/tree/DEMO-fix-4508 (or directly pull the branch in this PR, just make sure to update the pom.xml in kotlin module accordingly.
3. build the databind module
4. run [Github562Test](https://github.com/JooHyukKim/jackson-module-kotlin/blob/test-databind-4508/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github562Test.kt)
