### PR TITLE
Add more `EnumNamingStrategies`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1837,3 +1837,8 @@ Rikkarth (rikkarth@github)
 Maxim Valeev (@MaximValeev)
  * Reported #4508: Deserialized JsonAnySetter field in Kotlin data class is null
   (2.18.1)
+
+
+Lars Benedetto (@lbenedetto)
+ * Contributed #4676: Support other enum naming strategies than camelCase
+  (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,7 +6,9 @@ Project: jackson-databind
 
 2.19.0 (not yet released)
 
--
+#4676: Support other enum naming strategies than camelCase
+ (requested by @hajdamak)
+ (contributed by Lars B)
 
 2.18.1 (WIP-2024)
 

--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.databind;
 
-import com.fasterxml.jackson.databind.util.NamingStrategy;
+import com.fasterxml.jackson.databind.util.NamingStrategyImpls;
 
 import java.util.Locale;
 
@@ -86,9 +86,9 @@ public class EnumNamingStrategies
     public static final EnumNamingStrategy LOWER_DOT_CASE = LowerDotCaseStrategy.INSTANCE;
 
     public abstract static class DelegatingEnumNamingStrategy implements EnumNamingStrategy {
-        private final NamingStrategy strategy;
+        private final NamingStrategyImpls strategy;
 
-        protected DelegatingEnumNamingStrategy(NamingStrategy strategy) {
+        protected DelegatingEnumNamingStrategy(NamingStrategyImpls strategy) {
             this.strategy = strategy;
         }
 
@@ -169,7 +169,7 @@ public class EnumNamingStrategies
         public static final CamelCaseStrategy INSTANCE = new CamelCaseStrategy();
 
         protected CamelCaseStrategy() {
-            super(NamingStrategy.LOWER_CAMEL_CASE);
+            super(NamingStrategyImpls.LOWER_CAMEL_CASE);
         }
     }
 
@@ -218,7 +218,7 @@ public class EnumNamingStrategies
         public static final LowerCamelCaseStrategy INSTANCE = new LowerCamelCaseStrategy();
 
         protected LowerCamelCaseStrategy() {
-            super(NamingStrategy.LOWER_CAMEL_CASE);
+            super(NamingStrategyImpls.LOWER_CAMEL_CASE);
         }
     }
 
@@ -260,7 +260,7 @@ public class EnumNamingStrategies
         public static final UpperCamelCaseStrategy INSTANCE = new UpperCamelCaseStrategy();
 
         protected UpperCamelCaseStrategy() {
-            super(NamingStrategy.UPPER_CAMEL_CASE);
+            super(NamingStrategyImpls.UPPER_CAMEL_CASE);
         }
     }
 
@@ -302,7 +302,7 @@ public class EnumNamingStrategies
         public static final SnakeCaseStrategy INSTANCE = new SnakeCaseStrategy();
 
         protected SnakeCaseStrategy() {
-            super(NamingStrategy.SNAKE_CASE);
+            super(NamingStrategyImpls.SNAKE_CASE);
         }
     }
 
@@ -344,7 +344,7 @@ public class EnumNamingStrategies
         public static final UpperSnakeCaseStrategy INSTANCE = new UpperSnakeCaseStrategy();
 
         protected UpperSnakeCaseStrategy() {
-            super(NamingStrategy.UPPER_SNAKE_CASE);
+            super(NamingStrategyImpls.UPPER_SNAKE_CASE);
         }
     }
 
@@ -386,7 +386,7 @@ public class EnumNamingStrategies
         public static final LowerCaseStrategy INSTANCE = new LowerCaseStrategy();
 
         protected LowerCaseStrategy() {
-            super(NamingStrategy.LOWER_CASE);
+            super(NamingStrategyImpls.LOWER_CASE);
         }
     }
 
@@ -428,7 +428,7 @@ public class EnumNamingStrategies
         public static final KebabCaseStrategy INSTANCE = new KebabCaseStrategy();
 
         protected KebabCaseStrategy() {
-            super(NamingStrategy.KEBAB_CASE);
+            super(NamingStrategyImpls.KEBAB_CASE);
         }
     }
 
@@ -470,7 +470,7 @@ public class EnumNamingStrategies
         public static final LowerDotCaseStrategy INSTANCE = new LowerDotCaseStrategy();
 
         protected LowerDotCaseStrategy() {
-            super(NamingStrategy.LOWER_DOT_CASE);
+            super(NamingStrategyImpls.LOWER_DOT_CASE);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -1,5 +1,9 @@
 package com.fasterxml.jackson.databind;
 
+import com.fasterxml.jackson.databind.util.NamingStrategy;
+
+import java.util.Locale;
+
 /**
  * A container class for implementations of the {@link EnumNamingStrategy} interface.
  *
@@ -10,9 +14,169 @@ public class EnumNamingStrategies
     private EnumNamingStrategies() {}
 
     /**
+     * Words other than first are capitalized and no separator is used between words.
+     * See {@link EnumNamingStrategies.LowerCamelCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enumName".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy LOWER_CAMEL_CASE = LowerCamelCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention used in languages like Pascal, where all words are capitalized and no separator is used between
+     * words.
+     * See {@link EnumNamingStrategies.UpperCamelCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "EnumName".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy UPPER_CAMEL_CASE = UpperCamelCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention used in languages like C, where words are in lower-case letters, separated by underscores.
+     * See {@link EnumNamingStrategies.SnakeCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enum_name".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy SNAKE_CASE = SnakeCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention in which the words are in upper-case letters, separated by underscores.
+     * See {@link EnumNamingStrategies.UpperSnakeCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "ENUM_NAME", but "__ENUM_NAME_" would also be converted to "ENUM_NAME".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy UPPER_SNAKE_CASE = UpperSnakeCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention in which all words of the logical name are in lower case, and no separator is used between words.
+     * See {@link EnumNamingStrategies.LowerCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enumname".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy LOWER_CASE = LowerCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention used in languages like Lisp, where words are in lower-case letters, separated by hyphens.
+     * See {@link EnumNamingStrategies.KebabCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enum-name".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy KEBAB_CASE = KebabCaseStrategy.INSTANCE;
+
+    /**
+     * Naming convention widely used as configuration properties name, where words are in lower-case letters,
+     * separated by dots.
+     * See {@link EnumNamingStrategies.LowerDotCaseStrategy} for details.
+     * <p>
+     * Example "ENUM_NAME" would be converted to "enum.name".
+     *
+     * @since 2.19
+     */
+    public static final EnumNamingStrategy LOWER_DOT_CASE = LowerDotCaseStrategy.INSTANCE;
+
+    public abstract static class DelegatingEnumNamingStrategy implements EnumNamingStrategy {
+        private final NamingStrategy strategy;
+
+        protected DelegatingEnumNamingStrategy(NamingStrategy strategy) {
+            this.strategy = strategy;
+        }
+
+        @Override
+        public String convertEnumToExternalName(String enumName) {
+            return strategy.translate(toBeanName(enumName));
+        }
+
+        /**
+         * Normalizes the enum name to lower camel case in order to be further processed by a NamingStrategies
+         *
+         * @param enumName the enum name to be normalized
+         * @return the normalized enum name
+         */
+        protected static String toBeanName(String enumName) {
+            if (enumName == null) {
+                return null;
+            }
+
+            final String UNDERSCORE = "_";
+            StringBuilder out = null;
+            int iterationCnt = 0;
+            int lastSeparatorIdx = -1;
+
+            do {
+                lastSeparatorIdx = nextIndexOfUnderscore(enumName, lastSeparatorIdx + 1);
+                if (lastSeparatorIdx != -1) {
+                    if (iterationCnt == 0) {
+                        out = new StringBuilder(enumName.length() + 4 * UNDERSCORE.length());
+                        out.append(enumName.substring(iterationCnt, lastSeparatorIdx).toLowerCase(Locale.ROOT));
+                    } else {
+                        out.append(normalizeWord(enumName.substring(iterationCnt, lastSeparatorIdx)));
+                    }
+                    iterationCnt = lastSeparatorIdx + UNDERSCORE.length();
+                }
+            } while (lastSeparatorIdx != -1);
+
+            if (iterationCnt == 0) {
+                return enumName.toLowerCase(Locale.ROOT);
+            }
+            out.append(normalizeWord(enumName.substring(iterationCnt)));
+            return out.toString();
+        }
+
+        private static int nextIndexOfUnderscore(CharSequence sequence, int start) {
+            int length = sequence.length();
+            for (int i = start; i < length; i++) {
+                if ('_' == sequence.charAt(i)) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        /**
+         * Converts the first letter of the word to uppercase and the rest of the word to lowercase.
+         */
+        private static String normalizeWord(String word) {
+            int length = word.length();
+            if (length == 0) {
+                return word;
+            }
+            return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+        }
+    }
+
+    /**
+     * @since 2.15
+     * @deprecated Since 2.19 use {@link LowerCamelCaseStrategy} instead.
+     */
+    @Deprecated
+    public static class CamelCaseStrategy extends DelegatingEnumNamingStrategy {
+        /**
+         * An instance of {@link CamelCaseStrategy} for reuse.
+         *
+         * @since 2.15
+         */
+        public static final CamelCaseStrategy INSTANCE = new CamelCaseStrategy();
+
+        protected CamelCaseStrategy() {
+            super(NamingStrategy.LOWER_CAMEL_CASE);
+        }
+    }
+
+    /**
      * <p>
      * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
-     * snake case format to camel case format. This implementation follows three rules
+     * snake case format to lower camel case format. This implementation follows three rules
      * described below.
      *
      * <ol>
@@ -20,16 +184,15 @@ public class EnumNamingStrategies
      * regardless of its original case (upper or lower).</li>
      * <li>converts any character NOT preceded by an underscore into a lower case character,
      * regardless of its original case (upper or lower).</li>
-     * <li>converts contiguous sequence of underscores into a single underscore.</li>
+     * <li>removes all underscores.</li>
      * </ol>
-     *
+     * <p>
      * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
      * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanutButter".
      * And "peanutButter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
      *
      * <p>
-     * These rules result in the following example conversions from upper snakecase names
-     * to camelcase names.
+     * This results in the following example conversions:
      * <ul>
      * <li>"USER_NAME" is converted into "userName"</li>
      * <li>"USER______NAME" is converted into "userName"</li>
@@ -43,87 +206,271 @@ public class EnumNamingStrategies
      * <li>"Username" is converted into "username"</li>
      * </ul>
      *
-     * @since 2.15
+     * @since 2.19
      */
-    public static class CamelCaseStrategy implements EnumNamingStrategy
-    {
+    public static class LowerCamelCaseStrategy extends DelegatingEnumNamingStrategy {
+
         /**
-         * An instance of {@link CamelCaseStrategy} for reuse.
+         * An instance of {@link LowerCamelCaseStrategy} for reuse.
          *
-         * @since 2.15
+         * @since 2.19
          */
-        public static final CamelCaseStrategy INSTANCE = new CamelCaseStrategy();
+        public static final LowerCamelCaseStrategy INSTANCE = new LowerCamelCaseStrategy();
+
+        protected LowerCamelCaseStrategy() {
+            super(NamingStrategy.LOWER_CAMEL_CASE);
+        }
+    }
+
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.UpperCamelCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "PeanutButter".
+     * And "PeanutButter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "UserName"</li>
+     * <li>"USER______NAME" is converted into "UserName"</li>
+     * <li>"USERNAME" is converted into "Username"</li>
+     * <li>"User__Name" is converted into "UserName"</li>
+     * <li>"_user_name" is converted into "UserName"</li>
+     * <li>"_user_name_s" is converted into "UserNameS"</li>
+     * <li>"__Username" is converted into "Username"</li>
+     * <li>"__username" is converted into "Username"</li>
+     * <li>"username" is converted into "Username"</li>
+     * <li>"Username" is converted into "Username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class UpperCamelCaseStrategy extends DelegatingEnumNamingStrategy {
 
         /**
-         * @since 2.15
+         * An instance of {@link LowerCamelCaseStrategy} for reuse.
+         *
+         * @since 2.19
          */
-        @Override
-        public String convertEnumToExternalName(String enumName) {
-            if (enumName == null) {
-                return null;
-            }
+        public static final UpperCamelCaseStrategy INSTANCE = new UpperCamelCaseStrategy();
 
-            final String UNDERSCORE = "_";
-            StringBuilder out = null;
-            int iterationCnt = 0;
-            int lastSeparatorIdx = -1;
-
-            do {
-                lastSeparatorIdx = indexIn(enumName, lastSeparatorIdx + 1);
-                if (lastSeparatorIdx != -1) {
-                    if (iterationCnt == 0) {
-                        out = new StringBuilder(enumName.length() + 4 * UNDERSCORE.length());
-                        out.append(toLowerCase(enumName.substring(iterationCnt, lastSeparatorIdx)));
-                    } else {
-                        out.append(normalizeWord(enumName.substring(iterationCnt, lastSeparatorIdx)));
-                    }
-                    iterationCnt = lastSeparatorIdx + UNDERSCORE.length();
-                }
-            } while (lastSeparatorIdx != -1);
-
-            if (iterationCnt == 0) {
-                return toLowerCase(enumName);
-            }
-            out.append(normalizeWord(enumName.substring(iterationCnt)));
-            return out.toString();
+        protected UpperCamelCaseStrategy() {
+            super(NamingStrategy.UPPER_CAMEL_CASE);
         }
+    }
 
-        private static int indexIn(CharSequence sequence, int start) {
-            int length = sequence.length();
-            for (int i = start; i < length; i++) {
-                if ('_' == sequence.charAt(i)) {
-                    return i;
-                }
-            }
-            return -1;
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.SnakeCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanut_butter".
+     * And "peanut_butter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "user_name"</li>
+     * <li>"USER______NAME" is converted into "user_name"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "user_name"</li>
+     * <li>"_user_name" is converted into "user_name"</li>
+     * <li>"_user_name_s" is converted into "user_name_s"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class SnakeCaseStrategy extends DelegatingEnumNamingStrategy {
+
+        /**
+         * An instance of {@link SnakeCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final SnakeCaseStrategy INSTANCE = new SnakeCaseStrategy();
+
+        protected SnakeCaseStrategy() {
+            super(NamingStrategy.SNAKE_CASE);
         }
+    }
 
-        private static String normalizeWord(String word) {
-            int length = word.length();
-            if (length == 0) {
-                return word;
-            }
-            return new StringBuilder(length)
-                    .append(charToUpperCaseIfLower(word.charAt(0)))
-                    .append(toLowerCase(word.substring(1)))
-                    .toString();
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.UpperSnakeCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "PEANUT_BUTTER".
+     * And "PEANUT_BUTTER" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "USER_NAME"</li>
+     * <li>"USER______NAME" is converted into "USER_NAME"</li>
+     * <li>"USERNAME" is converted into "USERNAME"</li>
+     * <li>"User__Name" is converted into "USER_NAME"</li>
+     * <li>"_user_name" is converted into "USER_NAME"</li>
+     * <li>"_user_name_s" is converted into "USER_NAME_S"</li>
+     * <li>"__Username" is converted into "USERNAME"</li>
+     * <li>"__username" is converted into "USERNAME"</li>
+     * <li>"username" is converted into "USERNAME"</li>
+     * <li>"Username" is converted into "USERNAME"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class UpperSnakeCaseStrategy extends DelegatingEnumNamingStrategy {
+
+        /**
+         * An instance of {@link UpperSnakeCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final UpperSnakeCaseStrategy INSTANCE = new UpperSnakeCaseStrategy();
+
+        protected UpperSnakeCaseStrategy() {
+            super(NamingStrategy.UPPER_SNAKE_CASE);
         }
+    }
 
-        private static String toLowerCase(String string) {
-            int length = string.length();
-            StringBuilder builder = new StringBuilder(length);
-            for (int i = 0; i < length; i++) {
-                builder.append(charToLowerCaseIfUpper(string.charAt(i)));
-            }
-            return builder.toString();
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.LowerCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanutbutter".
+     * And "peanutbutter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "username"</li>
+     * <li>"USER______NAME" is converted into "username"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "username"</li>
+     * <li>"_user_name" is converted into "username"</li>
+     * <li>"_user_name_s" is converted into "usernames"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class LowerCaseStrategy extends DelegatingEnumNamingStrategy {
+
+        /**
+         * An instance of {@link LowerCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final LowerCaseStrategy INSTANCE = new LowerCaseStrategy();
+
+        protected LowerCaseStrategy() {
+            super(NamingStrategy.LOWER_CASE);
         }
+    }
 
-        private static char charToUpperCaseIfLower(char c) {
-            return Character.isLowerCase(c) ? Character.toUpperCase(c) : c;
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to upper camel case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.KebabCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanut-butter".
+     * And "peanut-butter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "user-name"</li>
+     * <li>"USER______NAME" is converted into "user-name"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "user-name"</li>
+     * <li>"_user_name" is converted into "user-name"</li>
+     * <li>"_user_name_s" is converted into "user-name-s"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class KebabCaseStrategy extends DelegatingEnumNamingStrategy {
+
+        /**
+         * An instance of {@link KebabCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final KebabCaseStrategy INSTANCE = new KebabCaseStrategy();
+
+        protected KebabCaseStrategy() {
+            super(NamingStrategy.KEBAB_CASE);
         }
+    }
 
-        private static char charToLowerCaseIfUpper(char c) {
-            return Character.isUpperCase(c) ? Character.toLowerCase(c) : c;
+    /**
+     * <p>
+     * An implementation of {@link EnumNamingStrategy} that converts enum names in the typical upper
+     * snake case format to lower dot case format.
+     * This implementation first normalizes to lower camel case using (see {@link LowerCamelCaseStrategy} for details)
+     * and then uses {@link PropertyNamingStrategies.LowerDotCaseStrategy} to finish converting the name.
+     * <p>
+     * WARNING: Naming conversion conflicts caused by underscore usage should be handled by client.
+     * e.g. Both <code>PEANUT_BUTTER</code>, <code>PEANUT__BUTTER</code> are converted into "peanut.butter".
+     * And "peanut.butter" will be deserialized into enum with smaller <code>Enum.ordinal()</code> value.
+     *
+     * <p>
+     * This results in the following example conversions:
+     * <ul>
+     * <li>"USER_NAME" is converted into "user.name"</li>
+     * <li>"USER______NAME" is converted into "user.name"</li>
+     * <li>"USERNAME" is converted into "username"</li>
+     * <li>"User__Name" is converted into "user.name"</li>
+     * <li>"_user_name" is converted into "user.name"</li>
+     * <li>"_user_name_s" is converted into "user.name.s"</li>
+     * <li>"__Username" is converted into "username"</li>
+     * <li>"__username" is converted into "username"</li>
+     * <li>"username" is converted into "username"</li>
+     * <li>"Username" is converted into "username"</li>
+     * </ul>
+     *
+     * @since 2.19
+     */
+    public static class LowerDotCaseStrategy extends DelegatingEnumNamingStrategy {
+
+        /**
+         * An instance of {@link LowerDotCaseStrategy} for reuse.
+         *
+         * @since 2.19
+         */
+        public static final LowerDotCaseStrategy INSTANCE = new LowerDotCaseStrategy();
+
+        protected LowerDotCaseStrategy() {
+            super(NamingStrategy.LOWER_DOT_CASE);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
+import com.fasterxml.jackson.databind.util.NamingStrategy;
 
 /**
  * Container for standard {@link PropertyNamingStrategy} implementations
@@ -124,42 +125,6 @@ public abstract class PropertyNamingStrategies
         }
 
         public abstract String translate(String propertyName);
-
-        /**
-         * Helper method to share implementation between snake and dotted case.
-         */
-        protected String translateLowerCaseWithSeparator(final String input, final char separator)
-        {
-            if (input == null || input.isEmpty()) {
-                return input;
-            }
-
-            final int length = input.length();
-            final StringBuilder result = new StringBuilder(length + (length >> 1));
-            int upperCount = 0;
-            for (int i = 0; i < length; ++i) {
-                char ch = input.charAt(i);
-                char lc = Character.toLowerCase(ch);
-
-                if (lc == ch) { // lower-case letter means we can get new word
-                    // but need to check for multi-letter upper-case (acronym), where assumption
-                    // is that the last upper-case char is start of a new word
-                    if (upperCount > 1) {
-                        // so insert hyphen before the last character now
-                        result.insert(result.length() - 1, separator);
-                    }
-                    upperCount = 0;
-                } else {
-                    // Otherwise starts new word, unless beginning of string
-                    if ((upperCount == 0) && (i > 0)) {
-                        result.append(separator);
-                    }
-                    ++upperCount;
-                }
-                result.append(lc);
-            }
-            return result.toString();
-        }
     }
 
     /*
@@ -230,35 +195,7 @@ public abstract class PropertyNamingStrategies
         @Override
         public String translate(String input)
         {
-            if (input == null) return input; // garbage in, garbage out
-            int length = input.length();
-            StringBuilder result = new StringBuilder(length * 2);
-            int resultLength = 0;
-            boolean wasPrevTranslated = false;
-            for (int i = 0; i < length; i++)
-            {
-                char c = input.charAt(i);
-                if (i > 0 || c != '_') // skip first starting underscore
-                {
-                    if (Character.isUpperCase(c))
-                    {
-                        if (!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_')
-                        {
-                            result.append('_');
-                            resultLength++;
-                        }
-                        c = Character.toLowerCase(c);
-                        wasPrevTranslated = true;
-                    }
-                    else
-                    {
-                        wasPrevTranslated = false;
-                    }
-                    result.append(c);
-                    resultLength++;
-                }
-            }
-            return resultLength > 0 ? result.toString() : input;
+            return NamingStrategy.SNAKE_CASE.translate(input);
         }
     }
 
@@ -281,11 +218,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            String output = super.translate(input);
-            if (output == null) {
-                return null;
-            }
-            return output.toUpperCase();
+            return NamingStrategy.UPPER_SNAKE_CASE.translate(input);
         }
     }
 
@@ -305,7 +238,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            return input;
+            return NamingStrategy.LOWER_CAMEL_CASE.translate(input);
         }
     }
 
@@ -343,18 +276,7 @@ public abstract class PropertyNamingStrategies
          */
         @Override
         public String translate(String input) {
-            if (input == null || input.isEmpty()){
-                return input; // garbage in, garbage out
-            }
-            // Replace first lower-case letter with upper-case equivalent
-            char c = input.charAt(0);
-            char uc = Character.toUpperCase(c);
-            if (c == uc) {
-                return input;
-            }
-            StringBuilder sb = new StringBuilder(input);
-            sb.setCharAt(0, uc);
-            return sb.toString();
+            return NamingStrategy.UPPER_CAMEL_CASE.translate(input);
         }
     }
 
@@ -376,10 +298,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            if (input == null || input.isEmpty()) {
-                return input;
-            }
-            return input.toLowerCase();
+            return NamingStrategy.LOWER_CASE.translate(input);
         }
     }
 
@@ -401,7 +320,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            return translateLowerCaseWithSeparator(input, '-');
+            return NamingStrategy.KEBAB_CASE.translate(input);
         }
     }
 
@@ -422,7 +341,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input){
-            return translateLowerCaseWithSeparator(input, '.');
+            return NamingStrategy.LOWER_DOT_CASE.translate(input);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategies.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
-import com.fasterxml.jackson.databind.util.NamingStrategy;
+import com.fasterxml.jackson.databind.util.NamingStrategyImpls;
 
 /**
  * Container for standard {@link PropertyNamingStrategy} implementations
@@ -195,7 +195,7 @@ public abstract class PropertyNamingStrategies
         @Override
         public String translate(String input)
         {
-            return NamingStrategy.SNAKE_CASE.translate(input);
+            return NamingStrategyImpls.SNAKE_CASE.translate(input);
         }
     }
 
@@ -218,7 +218,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            return NamingStrategy.UPPER_SNAKE_CASE.translate(input);
+            return NamingStrategyImpls.UPPER_SNAKE_CASE.translate(input);
         }
     }
 
@@ -238,7 +238,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            return NamingStrategy.LOWER_CAMEL_CASE.translate(input);
+            return NamingStrategyImpls.LOWER_CAMEL_CASE.translate(input);
         }
     }
 
@@ -276,7 +276,7 @@ public abstract class PropertyNamingStrategies
          */
         @Override
         public String translate(String input) {
-            return NamingStrategy.UPPER_CAMEL_CASE.translate(input);
+            return NamingStrategyImpls.UPPER_CAMEL_CASE.translate(input);
         }
     }
 
@@ -298,7 +298,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            return NamingStrategy.LOWER_CASE.translate(input);
+            return NamingStrategyImpls.LOWER_CASE.translate(input);
         }
     }
 
@@ -320,7 +320,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input) {
-            return NamingStrategy.KEBAB_CASE.translate(input);
+            return NamingStrategyImpls.KEBAB_CASE.translate(input);
         }
     }
 
@@ -341,7 +341,7 @@ public abstract class PropertyNamingStrategies
 
         @Override
         public String translate(String input){
-            return NamingStrategy.LOWER_DOT_CASE.translate(input);
+            return NamingStrategyImpls.LOWER_DOT_CASE.translate(input);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/util/NamingStrategy.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NamingStrategy.java
@@ -1,0 +1,152 @@
+package com.fasterxml.jackson.databind.util;
+
+public enum NamingStrategy {
+  /**
+   * beanName -> beanName
+   */
+  LOWER_CAMEL_CASE {
+    @Override
+    public String translate(String beanName) {
+      return beanName; // beanName is already in lower camel case
+    }
+  },
+
+  /**
+   * beanName -> BeanName
+   */
+  UPPER_CAMEL_CASE {
+    @Override
+    public String translate(String beanName) {
+      if (beanName == null || beanName.isEmpty()) {
+        return beanName; // garbage in, garbage out
+      }
+      // Replace first lower-case letter with upper-case equivalent
+      char c = beanName.charAt(0);
+      char uc = Character.toUpperCase(c);
+      if (c == uc) {
+        return beanName;
+      }
+      StringBuilder sb = new StringBuilder(beanName);
+      sb.setCharAt(0, uc);
+      return sb.toString();
+    }
+  },
+
+  /**
+   * beanName -> bean_name
+   */
+  SNAKE_CASE {
+    @Override
+    public String translate(String beanName) {
+      if (beanName == null) return beanName; // garbage in, garbage out
+      int length = beanName.length();
+      StringBuilder result = new StringBuilder(length * 2);
+      int resultLength = 0;
+      boolean wasPrevTranslated = false;
+      for (int i = 0; i < length; i++) {
+        char c = beanName.charAt(i);
+        if (i > 0 || c != '_') // skip first starting underscore
+        {
+          if (Character.isUpperCase(c)) {
+            if (!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_') {
+              result.append('_');
+              resultLength++;
+            }
+            c = Character.toLowerCase(c);
+            wasPrevTranslated = true;
+          } else {
+            wasPrevTranslated = false;
+          }
+          result.append(c);
+          resultLength++;
+        }
+      }
+      return resultLength > 0 ? result.toString() : beanName;
+    }
+  },
+
+  /**
+   * beanName -> BEAN_NAME
+   */
+  UPPER_SNAKE_CASE {
+    @Override
+    public String translate(String beanName) {
+      String output = SNAKE_CASE.translate(beanName);
+      if (output == null) {
+        return null;
+      }
+      return output.toUpperCase();
+    }
+  },
+
+  /**
+   * beanName -> beanname
+   */
+  LOWER_CASE {
+    @Override
+    public String translate(String beanName) {
+      if (beanName == null || beanName.isEmpty()) {
+        return beanName;
+      }
+      return beanName.toLowerCase();
+    }
+  },
+
+  /**
+   * beanName -> bean-name
+   */
+  KEBAB_CASE {
+    @Override
+    public String translate(String beanName) {
+      return translateLowerCaseWithSeparator(beanName, '-');
+    }
+  },
+
+  /**
+   * beanName -> bean.name
+   */
+  LOWER_DOT_CASE {
+    @Override
+    public String translate(String beanName) {
+      return translateLowerCaseWithSeparator(beanName, '.');
+    }
+  },
+  ;
+
+  public abstract String translate(final String beanName);
+
+  /**
+   * Helper method to share implementation between snake and dotted case.
+   */
+  private static String translateLowerCaseWithSeparator(final String beanName, final char separator) {
+    if (beanName == null || beanName.isEmpty()) {
+      return beanName;
+    }
+
+    final int length = beanName.length();
+    final StringBuilder result = new StringBuilder(length + (length >> 1));
+    int upperCount = 0;
+    for (int i = 0; i < length; ++i) {
+      char ch = beanName.charAt(i);
+      char lc = Character.toLowerCase(ch);
+
+      if (lc == ch) { // lower-case letter means we can get new word
+        // but need to check for multi-letter upper-case (acronym), where assumption
+        // is that the last upper-case char is start of a new word
+        if (upperCount > 1) {
+          // so insert hyphen before the last character now
+          result.insert(result.length() - 1, separator);
+        }
+        upperCount = 0;
+      } else {
+        // Otherwise starts new word, unless beginning of string
+        if ((upperCount == 0) && (i > 0)) {
+          result.append(separator);
+        }
+        ++upperCount;
+      }
+      result.append(lc);
+    }
+    return result.toString();
+  }
+}

--- a/src/main/java/com/fasterxml/jackson/databind/util/NamingStrategyImpls.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NamingStrategyImpls.java
@@ -1,6 +1,11 @@
 package com.fasterxml.jackson.databind.util;
 
-public enum NamingStrategy {
+/**
+ * Container for standard naming strategy implementations, specifically
+ * used by property naming strategies (see {@link com.fasterxml.jackson.databind.PropertyNamingStrategies})
+ * and enum naming strategies (see {@link com.fasterxml.jackson.databind.EnumNamingStrategies}).
+ */
+public enum NamingStrategyImpls {
   /**
    * beanName -> beanName
    */
@@ -118,7 +123,7 @@ public enum NamingStrategy {
   /**
    * Helper method to share implementation between snake and dotted case.
    */
-  private static String translateLowerCaseWithSeparator(final String beanName, final char separator) {
+  static String translateLowerCaseWithSeparator(final String beanName, final char separator) {
     if (beanName == null || beanName.isEmpty()) {
       return beanName;
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumNamingDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumNamingDeserializationTest.java
@@ -25,7 +25,7 @@ public class EnumNamingDeserializationTest
             .enable(ACCEPT_CASE_INSENSITIVE_ENUMS)
             .build();
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorA {
         PEANUT_BUTTER,
         SALTED_CARAMEL,
@@ -33,12 +33,12 @@ public class EnumNamingDeserializationTest
         VANILLA;
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorB {
         PEANUT_BUTTER,
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumSauceC {
         KETCH_UP,
         MAYO_NEZZ;
@@ -50,14 +50,14 @@ public class EnumNamingDeserializationTest
         SRIRACHA_MAYO;
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorE {
         _PEANUT_BUTTER,
         PEANUT__BUTTER,
         PEANUT_BUTTER
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorF {
         PEANUT_BUTTER,
         @JsonProperty("caramel")
@@ -89,7 +89,7 @@ public class EnumNamingDeserializationTest
         REAL_NAME
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum MixInEnum {
         REAL_NAME
     }
@@ -282,11 +282,11 @@ public class EnumNamingDeserializationTest
         ObjectMapper mapper = jsonMapperBuilder()
                 .addMixIn(BaseEnum.class, MixInEnum.class)
                 .build();
-        
+
         // serialization
         String ser = mapper.writeValueAsString(BaseEnum.REAL_NAME);
         assertEquals(q("realName"), ser);
-        
+
         // deserialization
         BaseEnum deser = mapper.readValue(q("realName"), BaseEnum.class);
         assertEquals(BaseEnum.REAL_NAME, deser);

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/EnumNamingStrategiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/EnumNamingStrategiesTest.java
@@ -1,13 +1,14 @@
 package com.fasterxml.jackson.databind.introspect;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
-import com.fasterxml.jackson.databind.EnumNamingStrategies;
+import com.fasterxml.jackson.databind.EnumNamingStrategy;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.stream.Stream;
+
+import static com.fasterxml.jackson.databind.EnumNamingStrategies.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -17,120 +18,126 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @since 2.15
  */
-public class EnumNamingStrategiesTest extends DatabindTestUtil {
-
+class EnumNamingStrategiesTest extends DatabindTestUtil {
     /**
-     * Test casess for {@link com.fasterxml.jackson.databind.EnumNamingStrategies.CamelCaseStrategy}.
+     * Test cases for {@link com.fasterxml.jackson.databind.EnumNamingStrategies}.
      *
-     * <p>
-     * Each <code>Object[]</code> element is composed of <code>{input, expectedOutput}</code>.
-     *
-     * @since 2.15
+     * @since 2.19
      */
-    final static List<String[]> CAMEL_CASE_NAME_TRANSLATIONS = Arrays.asList(new String[][]{
-            // Empty values
-            {null, null},
-            {"", ""},
+    private static Stream<Arguments> enumNameConversionTestCases() {
+        return Stream.of(
+                // Empty values
+                Arguments.of(LOWER_CAMEL_CASE, null, null),
+                Arguments.of(UPPER_CAMEL_CASE, null, null),
+                Arguments.of(SNAKE_CASE, null, null),
+                Arguments.of(UPPER_SNAKE_CASE, null, null),
+                Arguments.of(LOWER_CASE, null, null),
+                Arguments.of(KEBAB_CASE, null, null),
+                Arguments.of(LOWER_DOT_CASE, null, null),
+                Arguments.of(LOWER_CAMEL_CASE, "", ""),
 
-            // input values with no underscores
-            {"a", "a"},
-            {"abc", "abc"},
-            {"A", "a"},
-            {"A1", "a1"},
-            {"1A", "1a"},
-            {"ABC", "abc"},
-            {"User", "user"},
-            {"Results", "results"},
-            {"WWW", "www"},
-            {"USER", "user"},
-            {"userName", "username"},
-            {"someURI", "someuri"},
-            {"someURIs", "someuris"},
-            {"theWWW", "thewww"},
-            {"uId", "uid"},
-            {"usId", "usid"},
-            {"UserName", "username"},
-            {"user", "user"},
-            {"xCoordinate", "xcoordinate"},
+                // input values with no underscores
+                Arguments.of(LOWER_CAMEL_CASE, "a", "a"),
+                Arguments.of(LOWER_CAMEL_CASE, "abc", "abc"),
+                Arguments.of(LOWER_CAMEL_CASE, "A", "a"),
+                Arguments.of(LOWER_CAMEL_CASE, "A1", "a1"),
+                Arguments.of(LOWER_CAMEL_CASE, "1A", "1a"),
+                Arguments.of(LOWER_CAMEL_CASE, "ABC", "abc"),
+                Arguments.of(LOWER_CAMEL_CASE, "User", "user"),
+                Arguments.of(LOWER_CAMEL_CASE, "Results", "results"),
+                Arguments.of(LOWER_CAMEL_CASE, "WWW", "www"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER", "user"),
+                Arguments.of(LOWER_CAMEL_CASE, "userName", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "someURI", "someuri"),
+                Arguments.of(LOWER_CAMEL_CASE, "someURIs", "someuris"),
+                Arguments.of(LOWER_CAMEL_CASE, "theWWW", "thewww"),
+                Arguments.of(LOWER_CAMEL_CASE, "uId", "uid"),
+                Arguments.of(LOWER_CAMEL_CASE, "usId", "usid"),
+                Arguments.of(LOWER_CAMEL_CASE, "UserName", "username"),
+                Arguments.of(KEBAB_CASE, "UserName", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "user", "user"),
+                Arguments.of(LOWER_CAMEL_CASE, "xCoordinate", "xcoordinate"),
 
-            // input values with single underscores
-            {"a_", "a"},
-            {"_A", "A"},
-            {"_a", "A"},
-            {"a_A", "aA"},
-            {"a_a", "aA"},
-            {"A_A", "aA"},
-            {"A_a", "aA"},
-            {"BARS_", "bars"},
-            {"BARS", "bars"},
-            {"THE_WWW", "theWww"},
-            {"U_ID", "uId"},
-            {"US_ID", "usId"},
-            {"X_COORDINATE", "xCoordinate"},
+                // input values with single underscores
+                Arguments.of(LOWER_CAMEL_CASE, "a_", "a"),
+                Arguments.of(LOWER_CAMEL_CASE, "_A", "A"),
+                Arguments.of(LOWER_CAMEL_CASE, "_a", "A"),
+                Arguments.of(LOWER_CAMEL_CASE, "a_A", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "a_a", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "A_A", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "A_a", "aA"),
+                Arguments.of(LOWER_CAMEL_CASE, "BARS_", "bars"),
+                Arguments.of(LOWER_CAMEL_CASE, "BARS", "bars"),
+                Arguments.of(LOWER_CAMEL_CASE, "THE_WWW", "theWww"),
+                Arguments.of(LOWER_CAMEL_CASE, "U_ID", "uId"),
+                Arguments.of(LOWER_CAMEL_CASE, "US_ID", "usId"),
+                Arguments.of(LOWER_CAMEL_CASE, "X_COORDINATE", "xCoordinate"),
 
-            // heavy "username" example
-            {"USERNAME_", "username"},
-            {"_User_Name", "UserName"},
-            {"_UserName", "Username"},
-            {"_Username", "Username"},
-            {"_user_name", "UserName"},
-            {"_USERNAME", "Username"},
-            {"__USERNAME", "Username"},
-            {"__Username", "Username"},
-            {"__username", "Username"},
-            {"USER______NAME", "userName"},
-            {"USER_NAME", "userName"},
-            {"USER__NAME", "userName"},
-            {"USER_NAME_", "userName"},
-            {"User__Name", "userName"},
-            {"USER_NAME_S", "userNameS"},
-            {"_user_name_s", "UserNameS"},
-            {"USER_NAME_S", "userNameS"},
-            {"user__name", "userName"},
-            {"user_name", "userName"},
-            {"USERNAME", "username"},
-            {"username", "username"},
-            {"User_Name", "userName"},
-            {"User_Name_", "userName"},
-            {"User_Name_", "userName"},
-            {"User_Name__", "userName"},
-            {"user_name_", "userName"},
-            {"user_name__", "userName"},
+                // heavy "username" example
+                Arguments.of(LOWER_CAMEL_CASE, "USERNAME_", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "_User_Name", "UserName"),
+                Arguments.of(LOWER_CAMEL_CASE, "_UserName", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "_Username", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "_user_name", "UserName"),
+                Arguments.of(LOWER_CAMEL_CASE, "_USERNAME", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "__USERNAME", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "__Username", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "__username", "Username"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER______NAME", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME", "userName"),
+                Arguments.of(UPPER_CAMEL_CASE, "USER_NAME", "UserName"),
+                Arguments.of(SNAKE_CASE, "USER_NAME", "user_name"),
+                Arguments.of(UPPER_SNAKE_CASE, "USER_NAME", "USER_NAME"),
+                Arguments.of(LOWER_CASE, "USER_NAME", "username"),
+                Arguments.of(KEBAB_CASE, "USER_NAME", "user-name"),
+                Arguments.of(LOWER_DOT_CASE, "USER_NAME", "user.name"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER__NAME", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User__Name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME_S", "userNameS"),
+                Arguments.of(LOWER_CAMEL_CASE, "_user_name_s", "UserNameS"),
+                Arguments.of(LOWER_CAMEL_CASE, "USER_NAME_S", "userNameS"),
+                Arguments.of(LOWER_CAMEL_CASE, "user__name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "user_name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "USERNAME", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "username", "username"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "User_Name__", "userName"),
+                Arguments.of(UPPER_SNAKE_CASE, "User_Name__", "USER_NAME"),
+                Arguments.of(LOWER_CAMEL_CASE, "user_name_", "userName"),
+                Arguments.of(LOWER_CAMEL_CASE, "user_name__", "userName"),
 
-            // additional variations
-            {"a$a", "a$a"},
-            {"A$A", "a$a"},
-            {"a_$", "a$"},
-            {"a$", "a$"},
-            {"a1", "a1"},
-            {"$", "$"},
-            {"A$", "a$"},
-            {"1", "1"},
-            {"$_A", "$A"},
-            {"$_a", "$A"},
-            {"1_A", "1A"},
-            {"1a", "1a"},
-            {"A_$", "a$"},
-            {"_123_41", "12341"},
-    });
+                // additional variations
+                Arguments.of(LOWER_CAMEL_CASE, "a$a", "a$a"),
+                Arguments.of(LOWER_CAMEL_CASE, "A$A", "a$a"),
+                Arguments.of(LOWER_CAMEL_CASE, "a_$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "a$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "a1", "a1"),
+                Arguments.of(LOWER_CAMEL_CASE, "$", "$"),
+                Arguments.of(LOWER_CAMEL_CASE, "A$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "1", "1"),
+                Arguments.of(LOWER_CAMEL_CASE, "$_A", "$A"),
+                Arguments.of(LOWER_CAMEL_CASE, "$_a", "$A"),
+                Arguments.of(LOWER_CAMEL_CASE, "1_A", "1A"),
+                Arguments.of(LOWER_CAMEL_CASE, "1a", "1a"),
+                Arguments.of(LOWER_CAMEL_CASE, "A_$", "a$"),
+                Arguments.of(LOWER_CAMEL_CASE, "_123_41", "12341")
+        );
+    }
 
     /**
-     * Unit test to verify the implementation of
-     * {@link com.fasterxml.jackson.databind.EnumNamingStrategies.CamelCaseStrategy#convertEnumToExternalName(String)}
+     * Unit test to verify the implementations of
+     * {@link com.fasterxml.jackson.databind.EnumNamingStrategy#convertEnumToExternalName(String)}
      * without the context of an ObjectMapper.
      *
-     * @since 2.15
+     * @since 2.19
      */
-    @Test
-    public void testCamelCaseStrategyStandAlone() {
-        for (String[] pair : CAMEL_CASE_NAME_TRANSLATIONS) {
-            final String input = pair[0];
-            final String expected = pair[1];
-
-            String actual = EnumNamingStrategies.CamelCaseStrategy.INSTANCE
-                    .convertEnumToExternalName(input);
-
-            assertEquals(expected, actual);
-        }
+    @ParameterizedTest
+    @MethodSource("enumNameConversionTestCases")
+    void testEnumNameConversions(EnumNamingStrategy strategy, String input, String output) {
+        String actual = strategy.convertEnumToExternalName(input);
+        assertEquals(output, actual);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/EnumNamingSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/EnumNamingSerializationTest.java
@@ -23,7 +23,7 @@ public class EnumNamingSerializationTest extends DatabindTestUtil {
 
     final ObjectMapper MAPPER = newJsonMapper();
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorA {
         CHOCOLATE_CHIPS,
         HOT_CHEETOS;
@@ -34,7 +34,7 @@ public class EnumNamingSerializationTest extends DatabindTestUtil {
         }
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumSauceB {
         KETCH_UP,
         MAYO_NEZZ;
@@ -46,14 +46,14 @@ public class EnumNamingSerializationTest extends DatabindTestUtil {
         SRIRACHA_MAYO;
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorD {
         _PEANUT_BUTTER,
         PEANUT__BUTTER,
         PEANUT_BUTTER
     }
 
-    @EnumNaming(EnumNamingStrategies.CamelCaseStrategy.class)
+    @EnumNaming(EnumNamingStrategies.LowerCamelCaseStrategy.class)
     static enum EnumFlavorE {
         PEANUT_BUTTER,
         @JsonProperty("almond")


### PR DESCRIPTION
Implements https://github.com/FasterXML/jackson-databind/issues/4676

As discussed, extracted the common logic of PropertyNamingStrategies and EnumNamingStrategies to a common util class. In this case, an Enum called `NamingStrategy`