### PR TITLE
doc(README.md): fix wrong variable declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ ObjectMapper mapper = ...;
 File jsonFile = new File("test.json");
 // note: method added in Jackson 2.11 (earlier would need to use
 // mapper.getFactory().createGenerator(...)
-JsonGenerator g = f.createGenerator(jsonFile, JsonEncoding.UTF8);
+JsonGenerator g = mapper.createGenerator(jsonFile, JsonEncoding.UTF8);
 // write JSON: { "message" : "Hello world!" }
 g.writeStartObject();
 g.writeStringField("message", "Hello world!");


### PR DESCRIPTION
## Description
* fix variable NOT declared

## How to review?
* Check https://github.com/FasterXML/jackson-databind/blob/2.19/README.md?plain=1#L238-L243
* `ObjectMapper` instance is named `mapper`, not `f`

## Note
* root cause of the commit https://github.com/FasterXML/jackson-databind/commit/1aeabb5a0d2241ae0beb3c111714c30369e777ae