### PR TITLE
Regression fix for #4741 `Include.NON_DEFAULT` setting used on POJO, empty values are not included in json if default is null

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,6 +6,10 @@ Project: jackson-databind
 
 2.18.1 (WIP-2024)
 
+#4741: When `Include.NON_DEFAULT` setting is used on POJO, empty values
+  are not included in json if default is `null`
+ (reported by @ragnhov)
+ (fix by Joo-Hyuk K)
 #4749: Fixed a problem with `StdDelegatingSerializer#serializeWithType` looking up the serializer
   with the wrong argument
  (fix by wrongwrong)

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -182,11 +182,9 @@ public class PropertyBuilder
             }
             if (valueToSuppress == null) {
                 suppressNulls = true;
-                // [databind#4471] Since 2.18.1 Different behavior when Include.NON_DEFAULT setting is used on
-                //                POJO vs global setting, as per documentation.
-                boolean isGloballyConfigured = _config.getDefaultInclusion(actualType.getRawClass(), rawPropertyType)
-                        .getValueInclusion() == JsonInclude.Include.NON_DEFAULT;
-                if (isGloballyConfigured) {
+                // [databind#4471] Different behavior when Include.NON_DEFAULT
+                //   setting is used on POJO vs global setting, as per documentation.
+                if (!_useRealPropertyDefaults) {
                     // [databind#4464] NON_DEFAULT does not work with NON_EMPTY for custom serializer
                     valueToSuppress = BeanPropertyWriter.MARKER_FOR_EMPTY;
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/PropertyBuilder.java
@@ -182,8 +182,14 @@ public class PropertyBuilder
             }
             if (valueToSuppress == null) {
                 suppressNulls = true;
-                // [databind#4464] NON_DEFAULT does not work with NON_EMPTY for custom serializer
-                valueToSuppress = BeanPropertyWriter.MARKER_FOR_EMPTY;
+                // [databind#4471] Since 2.18.1 Different behavior when Include.NON_DEFAULT setting is used on
+                //                POJO vs global setting, as per documentation.
+                boolean isGloballyConfigured = _config.getDefaultInclusion(actualType.getRawClass(), rawPropertyType)
+                        .getValueInclusion() == JsonInclude.Include.NON_DEFAULT;
+                if (isGloballyConfigured) {
+                    // [databind#4464] NON_DEFAULT does not work with NON_EMPTY for custom serializer
+                    valueToSuppress = BeanPropertyWriter.MARKER_FOR_EMPTY;
+                }
             } else {
                 if (valueToSuppress.getClass().isArray()) {
                     valueToSuppress = ArrayBuilders.getArrayComparator(valueToSuppress);

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonInclude4741Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonInclude4741Test.java
@@ -1,44 +1,34 @@
 package com.fasterxml.jackson.databind.ser.filter;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JsonInclude4741Test
-        extends DatabindTestUtil
+    extends DatabindTestUtil
 {
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public static class MyString {
+        public String value = null;
+    }
 
     private ObjectMapper MAPPER = newJsonMapper();
 
     @Test
-    void testSerialization() throws JsonProcessingException
+    void testSerialization() throws Exception
     {
         MyString input = new MyString();
-        input.setValue("");
+        input.value = "";
 
         String json = MAPPER.writeValueAsString(input);
+        assertEquals(a2q("{'value':''}"), json);
+
         MyString output = MAPPER.readValue(json, MyString.class);
 
-        assertEquals(input.getValue(), output.getValue());
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public static class MyString {
-        private String value = null;
-
-        // Getter
-        public String getValue() {
-            return value;
-        }
-
-        // Setter
-        public void setValue(String value) {
-            this.value = value;
-        }
+        assertEquals(input.value, output.value);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonInclude4741Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonInclude4741Test.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.databind.ser.filter;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonInclude4741Test
+        extends DatabindTestUtil
+{
+
+    private ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    void testSerialization() throws JsonProcessingException
+    {
+        MyString input = new MyString();
+        input.setValue("");
+
+        String json = MAPPER.writeValueAsString(input);
+        MyString output = MAPPER.readValue(json, MyString.class);
+
+        assertEquals(input.getValue(), output.getValue());
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public static class MyString {
+        private String value = null;
+
+        // Getter
+        public String getValue() {
+            return value;
+        }
+
+        // Setter
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonInclude4741Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/JsonInclude4741Test.java
@@ -16,7 +16,7 @@ public class JsonInclude4741Test
         public String value = null;
     }
 
-    private ObjectMapper MAPPER = newJsonMapper();
+    private final ObjectMapper MAPPER = newJsonMapper();
 
     @Test
     void testSerialization() throws Exception


### PR DESCRIPTION
demonstrates "possible" solution that resolves #4741