### PR TITLE
Fixed problem in `StdDelegatingSerializer#serializeWithType` where final serializer lookup was done on the pre-converted value when `_delegateSerializer` was `null`.

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1840,3 +1840,7 @@ Rikkarth (rikkarth@github)
 Maxim Valeev (@MaximValeev)
  * Reported #4508: Deserialized JsonAnySetter field in Kotlin data class is null
   (2.18.1)
+
+wrongwrong (@k163377)
+ * Contributed #4749: Fixed problem in StdDelegatingSerializer#serializeWithType where final serializer lookup was done
+   on the pre-converted value when _delegateSerializer was null

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,6 +6,9 @@ Project: jackson-databind
 
 2.18.1 (WIP-2024)
 
+#4749: Fixed a problem with `StdDelegatingSerializer#serializeWithType` looking up the serializer
+  with the wrong argument
+ (fix by wrongwrong)
 #4508: Deserialized JsonAnySetter field in Kotlin data class is null
  (reported by @MaximValeev)
  (fix by Joo-Hyuk K)

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/StdDelegatingSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/StdDelegatingSerializer.java
@@ -181,7 +181,7 @@ public class StdDelegatingSerializer
         }
         JsonSerializer<Object> ser = _delegateSerializer;
         if (ser == null) {
-            ser = _findSerializer(value, provider);
+            ser = _findSerializer(delegateValue, provider);
         }
         ser.serializeWithType(delegateValue, gen, provider, typeSer);
     }


### PR DESCRIPTION
Since this was a minor bug fix, a PR has been issued to branch 2.18.

---

I discovered this problem while investigating the following issue
https://github.com/FasterXML/jackson-module-kotlin/issues/819

Line 165 seemed to be set correctly.
https://github.com/FasterXML/jackson-databind/blob/4a401237adfe3fd4e417504176171f76464aae96/src/main/java/com/fasterxml/jackson/databind/ser/std/StdDelegatingSerializer.java#L165