### PR TITLE
Implement new `SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_INCOMPARABLE_KEYS`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -434,6 +434,17 @@ public enum SerializationFeature implements ConfigFeature
      */
     ORDER_MAP_ENTRIES_BY_KEYS(false),
 
+    /**
+     * Feature that determines whether to try to ignore failure to order map entries by keys.
+     * This feature will apply only when serialization is to order its serialize output, configured
+     * through annotation or enabling {@link #ORDER_MAP_ENTRIES_BY_KEYS}.
+     * <p>
+     * Feature is disabled by default and will default true in Jackson 3 and later.
+     *
+     * @since 2.19
+     */
+    IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_KEYS(false),
+
     /*
     /******************************************************
     /* Other

--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -435,15 +435,19 @@ public enum SerializationFeature implements ConfigFeature
     ORDER_MAP_ENTRIES_BY_KEYS(false),
 
     /**
-     * Feature that determines whether to try to ignore failure to order map entries by keys.
-     * This feature will apply only when serialization is to order its serialize output, configured
+     * Feature that determines whether to try to ignore failure to order map entries by incomparable keys.
+     * If enabled, will not throw an exception when ordering fails due to keys with incomparable key type
+     * and instead just return the original map.
+     * If disabled, will simply fail by throwing an exception.
+     * <p>
+     * Note that this feature will apply only when configured to order map entries by keys, either
      * through annotation or enabling {@link #ORDER_MAP_ENTRIES_BY_KEYS}.
      * <p>
      * Feature is disabled by default and will default true in Jackson 3 and later.
      *
      * @since 2.19
      */
-    IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_KEYS(false),
+    IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_INCOMPARABLE_KEYS(false),
 
     /*
     /******************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/MapSerializer.java
@@ -1172,7 +1172,7 @@ public class MapSerializer
             // we may catch ClassCastException and handle it gracefully.
             if (cce.getMessage() != null
                 && cce.getMessage().contains("cannot be cast to class java.lang.Comparable")
-                && provider.isEnabled(SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_KEYS)
+                && provider.isEnabled(SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_INCOMPARABLE_KEYS)
             ) {
                 return input;
             }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/OrderMapEntriesByKeysSerializationFeature4773Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/OrderMapEntriesByKeysSerializationFeature4773Test.java
@@ -44,7 +44,7 @@ public class OrderMapEntriesByKeysSerializationFeature4773Test
         // com.fasterxml.jackson.databind.JsonMappingException: class java.util.Currency cannot be cast to class java.lang.Comparable
         try {
             objectMapper.writer()
-                .without(SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_KEYS)
+                .without(SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_INCOMPARABLE_KEYS)
                 .writeValueAsString(entity);
             fail("Should not pass");
         } catch (JsonMappingException e) {
@@ -92,7 +92,7 @@ public class OrderMapEntriesByKeysSerializationFeature4773Test
 
         // When
         String jsonResult = objectMapper.writer()
-                .with(SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_KEYS)
+                .with(SerializationFeature.IGNORE_FAILURE_TO_ORDER_MAP_ENTRIES_BY_INCOMPARABLE_KEYS)
                 .writeValueAsString(entity);
 
         // Then


### PR DESCRIPTION
resolves #4773