### PR TITLE
update javadoc in SerializationContext to mention SerializerProvider

### DIFF
--- a/src/main/java/tools/jackson/databind/SerializationContext.java
+++ b/src/main/java/tools/jackson/databind/SerializationContext.java
@@ -43,7 +43,10 @@ import tools.jackson.databind.util.TokenBuffer;
  *<p>
  * Provider handles caching aspects of serializer handling; all construction
  * details are delegated to {@link SerializerFactory} instance.
+ *</p>
  *<p>
+ * The equivalent class in Jackson 2 was called SerializerProvider.
+ *</p>
  */
 public abstract class SerializationContext
     extends DatabindContext

--- a/src/main/java/tools/jackson/databind/SerializationContext.java
+++ b/src/main/java/tools/jackson/databind/SerializationContext.java
@@ -45,7 +45,7 @@ import tools.jackson.databind.util.TokenBuffer;
  * details are delegated to {@link SerializerFactory} instance.
  *</p>
  *<p>
- * The equivalent class in Jackson 2 was called SerializerProvider.
+ * NOTE: In Jackson 2.x this class was called {@code SerializerProvider}.
  *</p>
  */
 public abstract class SerializationContext


### PR DESCRIPTION
I think it is useful to note the old name of the class.