### PR TITLE
Doc : Resolve #4570  explain more on `ObjectMapper.canDeserialize()`/`ObjectMapper.canSerialize()` deprecation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -3637,7 +3637,7 @@ public class ObjectMapper
      *  serializable)
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
-     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * It is recommended to try directly testing serialization using actual JSON inputs and outputs
      * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
@@ -3653,7 +3653,7 @@ public class ObjectMapper
      * @since 2.3
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
-     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * It is recommended to try directly testing serialization using actual JSON inputs and outputs
      * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
@@ -3679,7 +3679,7 @@ public class ObjectMapper
      *  serializable)
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
-     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * It is recommended to try directly testing deserialization using actual JSON inputs and outputs
      * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
@@ -3697,7 +3697,7 @@ public class ObjectMapper
      * @since 2.3
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
-     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * It is recommended to try directly testing deserialization using actual JSON inputs and outputs
      * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -3637,6 +3637,8 @@ public class ObjectMapper
      *  serializable)
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
+     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
     public boolean canSerialize(Class<?> type) {
@@ -3651,6 +3653,8 @@ public class ObjectMapper
      * @since 2.3
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
+     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
     public boolean canSerialize(Class<?> type, AtomicReference<Throwable> cause) {
@@ -3675,6 +3679,8 @@ public class ObjectMapper
      *  serializable)
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
+     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
     public boolean canDeserialize(JavaType type)
@@ -3691,6 +3697,8 @@ public class ObjectMapper
      * @since 2.3
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
+     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
     public boolean canDeserialize(JavaType type, AtomicReference<Throwable> cause)

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -1215,7 +1215,7 @@ public class ObjectWriter
      * it could serialize an instance of given Class.
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
-     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * It is recommended to try directly testing serialization using actual JSON inputs and outputs
      * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
@@ -1231,7 +1231,7 @@ public class ObjectWriter
      * @since 2.3
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
-     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * It is recommended to try directly testing serialization using actual JSON inputs and outputs
      * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18

--- a/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectWriter.java
@@ -1215,6 +1215,8 @@ public class ObjectWriter
      * it could serialize an instance of given Class.
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
+     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
     public boolean canSerialize(Class<?> type) {
@@ -1229,6 +1231,8 @@ public class ObjectWriter
      * @since 2.3
      *
      * @deprecated Since 2.18 use discouraged; method to be removed from Jackson 3.0
+     * It is recommended to try directly testing de/serialization using actual JSON inputs and outputs
+     * in test cases to ensure correctness and compatibility with real-world use cases.
      */
     @Deprecated // @since 2.18
     public boolean canSerialize(Class<?> type, AtomicReference<Throwable> cause) {


### PR DESCRIPTION
resolves #4570

Let's tell users something more than "use discouraged".