### PR TITLE
Fix wrapped array hanlding wrt `null` by `StdDeserializer`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -360,6 +360,9 @@ public abstract class StdDeserializer<T>
             T result = (T) handleNestedArrayForSingle(p, ctxt);
             return result;
         }
+        if (p.currentToken() == JsonToken.VALUE_NULL) {
+            return getNullValue(ctxt);
+        }
         return (T) deserialize(p, ctxt);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java
@@ -360,7 +360,8 @@ public abstract class StdDeserializer<T>
             T result = (T) handleNestedArrayForSingle(p, ctxt);
             return result;
         }
-        if (p.currentToken() == JsonToken.VALUE_NULL) {
+        // 11-Dec-2024: [databind#4844] Caller needs to handle nulls before delegating
+        if (p.hasToken(JsonToken.VALUE_NULL)) {
             return getNullValue(ctxt);
         }
         return (T) deserialize(p, ctxt);

--- a/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
@@ -83,14 +83,15 @@ public class UnwrapSingleArrayMiscTest extends DatabindTestUtil
     }
 
     @Test
-    public void mytest() throws IOException {
+    public void testDeserializeArrayWithNullElement() throws IOException {
         String json = "{\"value\": [null]}";
 
         ObjectReader r = UNWRAPPING_MAPPER.readerFor(StringWrapper.class);
         JsonFactory factory = new JsonFactory();
         JsonParser p = factory.createParser(json);
-        StringWrapper m = r.readValue(p);
-        System.out.println(m);
+        StringWrapper v = r.readValue(p);
+        assertNotNull(v);
+        assertNull(v.value);
     }
 
 

--- a/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
@@ -1,14 +1,13 @@
 package com.fasterxml.jackson.databind.struct;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -21,6 +20,10 @@ public class UnwrapSingleArrayMiscTest extends DatabindTestUtil
     private final ObjectMapper UNWRAPPING_MAPPER = jsonMapperBuilder()
             .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
             .build();
+
+    public static class StringWrapper {
+        public String value;
+    }
 
     /*
     /**********************************************************
@@ -83,19 +86,16 @@ public class UnwrapSingleArrayMiscTest extends DatabindTestUtil
     }
 
     @Test
-    public void testDeserializeArrayWithNullElement() throws IOException {
+    public void testDeserializeArrayWithNullElement() throws Exception
+    {
         String json = "{\"value\": [null]}";
 
         ObjectReader r = UNWRAPPING_MAPPER.readerFor(StringWrapper.class);
         JsonFactory factory = new JsonFactory();
         JsonParser p = factory.createParser(json);
         StringWrapper v = r.readValue(p);
+
         assertNotNull(v);
         assertNull(v.value);
-    }
-
-
-    public static class StringWrapper {
-        public String value;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
@@ -1,9 +1,12 @@
 package com.fasterxml.jackson.databind.struct;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -77,5 +80,21 @@ public class UnwrapSingleArrayMiscTest extends DatabindTestUtil
         } catch (MismatchedInputException e) {
             verifyException(e, "more than one value");
         }
+    }
+
+    @Test
+    public void mytest() throws IOException {
+        String json = "{\"value\": [null]}";
+
+        ObjectReader r = UNWRAPPING_MAPPER.readerFor(StringWrapper.class);
+        JsonFactory factory = new JsonFactory();
+        JsonParser p = factory.createParser(json);
+        StringWrapper m = r.readValue(p);
+        System.out.println(m);
+    }
+
+
+    public static class StringWrapper {
+        public String value;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/UnwrapSingleArrayMiscTest.java
@@ -21,7 +21,7 @@ public class UnwrapSingleArrayMiscTest extends DatabindTestUtil
             .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
             .build();
 
-    public static class StringWrapper {
+    static class StringWrapper {
         public String value;
     }
 
@@ -85,16 +85,14 @@ public class UnwrapSingleArrayMiscTest extends DatabindTestUtil
         }
     }
 
+    // [databind#4844]: should work for wrapped null values too
     @Test
     public void testDeserializeArrayWithNullElement() throws Exception
     {
-        String json = "{\"value\": [null]}";
-
-        ObjectReader r = UNWRAPPING_MAPPER.readerFor(StringWrapper.class);
-        JsonFactory factory = new JsonFactory();
-        JsonParser p = factory.createParser(json);
-        StringWrapper v = r.readValue(p);
-
+        StringWrapper v = UNWRAPPING_MAPPER
+            .readerFor(StringWrapper.class)
+            .readValue("{\"value\": [null]}");
+        
         assertNotNull(v);
         assertNull(v.value);
     }


### PR DESCRIPTION
Motivation: We encountered a bug in Micronaut Framework, when json parsing was rewritten so that any value is wrapped in an array(micronaut-projects/micronaut-core#10070) for the convenience of parsing multi values with one key, then the behavior when parsing null values began to throw an error, because jackson does not handle VALUE_NULL cases separately when parsing from a wrapped array. this pr is needed to fix this. 

fix issue: micronaut-projects/micronaut-core#11420