### PR TITLE
CI: test with java 23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['8', '11', '17', '21', '22']
+        java_version: ['8', '11', '17', '21', '23']
         os: ['ubuntu-22.04']
         include:
           - java_version: '8'


### PR DESCRIPTION
Java 22 is not LTS and Java 23 is out. Java 23 contains a fix for #4848 so it is useful to know if this module works ok with Java 23.