### PR TITLE
upgrade mockito on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['17', '21', '22']
+        java_version: ['17', '21', '23']
         os: ['ubuntu-22.04']
         include:
           - java_version: '17'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['17', '21', '23']
+        java_version: ['17', '21', '22']
         os: ['ubuntu-22.04']
         include:
           - java_version: '17'

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <version.android.sdk>34</version.android.sdk>
     <version.android.sdk.signature>0.10.0</version.android.sdk.signature>
 
-    <version.bytebuddy>1.14.13</version.bytebuddy>
+    <version.bytebuddy>1.15.10</version.bytebuddy>
     <version.mockito>5.14.2</version.mockito>
 
     <!-- Can not use default, since group id != Java package name here -->

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,6 @@
       <version>${version.mockito}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${version.mockito}</version>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <version.android.sdk.signature>0.10.0</version.android.sdk.signature>
 
     <version.bytebuddy>1.14.13</version.bytebuddy>
-    <version.mockito>4.11.0</version.mockito>
+    <version.mockito>5.14.2</version.mockito>
 
     <!-- Can not use default, since group id != Java package name here -->
     <osgi.export>tools.jackson.databind.*;version=${project.version}</osgi.export>


### PR DESCRIPTION
We are using an old version of mockito in 2.x branches because latest mockito does not support java 8.
mockito-inline was merged into mockito-core in newer versions of mockito 5