### PR TITLE
add spliterator support to TreeNode implementations

### DIFF
--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -230,11 +230,6 @@ public abstract class JsonNode
         return ClassUtil.emptyIterator();
     }
 
-    @Override
-    public Spliterator<String> propertyNamesSpliterator() {
-        return Spliterators.emptySpliterator();
-    }
-
     /**
      * Method for locating node specified by given JSON pointer instances.
      * Method will never return null; if no matching node exists,
@@ -979,10 +974,10 @@ public abstract class JsonNode
     public final Iterator<JsonNode> iterator() { return values(); }
 
     /**
-     * Same as calling {@link #elementsSpliterator()}.
+     * Same as calling {@link #valuesSpliterator()}.
      */
     @Override
-    public final Spliterator<JsonNode> spliterator() { return elementsSpliterator(); }
+    public final Spliterator<JsonNode> spliterator() { return valuesSpliterator(); }
 
     /**
      * Method for accessing all value nodes of this Node, iff
@@ -1002,8 +997,8 @@ public abstract class JsonNode
      *
      * @since 3.0
      */
-    public Spliterator<JsonNode> elementsSpliterator() {
-        return Spliterators.emptySpliterator();
+    public Spliterator<JsonNode> valuesSpliterator() {
+        return Spliterators.spliteratorUnknownSize(values(), Spliterator.ORDERED);
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -974,10 +974,10 @@ public abstract class JsonNode
     public final Iterator<JsonNode> iterator() { return values(); }
 
     /**
-     * Same as calling {@link #valuesSpliterator()}.
+     * Same as calling {@link #valueSpliterator()}.
      */
     @Override
-    public final Spliterator<JsonNode> spliterator() { return valuesSpliterator(); }
+    public final Spliterator<JsonNode> spliterator() { return valueSpliterator(); }
 
     /**
      * Method for accessing all value nodes of this Node, iff
@@ -997,7 +997,7 @@ public abstract class JsonNode
      *
      * @since 3.0
      */
-    public Spliterator<JsonNode> valuesSpliterator() {
+    public Spliterator<JsonNode> valueSpliterator() {
         return Spliterators.spliteratorUnknownSize(values(), Spliterator.ORDERED);
     }
 
@@ -1011,16 +1011,7 @@ public abstract class JsonNode
      */
     @Deprecated // since 2.19
     public Iterator<Map.Entry<String, JsonNode>> fields() {
-        return ClassUtil.emptyIterator();
-    }
-
-    /**
-     * @return <code>Spliterator</code> that can be used to traverse all key/value pairs
-     *   for object nodes; empty spliterator (no contents) for other types
-     * @since 3.0
-     */
-    public Spliterator<Map.Entry<String, JsonNode>> fieldsSpliterator() {
-        return Spliterators.spliteratorUnknownSize(fields(), Spliterator.ORDERED);
+        return properties().iterator();
     }
 
     /**
@@ -1039,6 +1030,15 @@ public abstract class JsonNode
         return Collections.emptySet();
     }
 
+    /**
+     * @return {@code Spliterator} that can be used to traverse all key/value pairs
+     *   for object nodes; empty spliterator (no contents) for other types
+     * @since 3.0
+     */
+    public Spliterator<Map.Entry<String, JsonNode>> propertySpliterator() {
+        return properties().spliterator();
+    }
+    
     /**
      * Returns a stream of all value nodes of this Node, iff
      * this node is an {@code ArrayNode} or {@code ObjectNode}.

--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -230,6 +230,11 @@ public abstract class JsonNode
         return ClassUtil.emptyIterator();
     }
 
+    @Override
+    public Spliterator<String> propertyNamesSpliterator() {
+        return Spliterators.emptySpliterator();
+    }
+
     /**
      * Method for locating node specified by given JSON pointer instances.
      * Method will never return null; if no matching node exists,
@@ -974,6 +979,12 @@ public abstract class JsonNode
     public final Iterator<JsonNode> iterator() { return elements(); }
 
     /**
+     * Same as calling {@link #elementsSpliterator()}.
+     */
+    @Override
+    public final Spliterator<JsonNode> spliterator() { return elementsSpliterator(); }
+
+    /**
      * Method for accessing all value nodes of this Node, iff
      * this node is a JSON Array or Object node. In case of Object node,
      * field names (keys) are not included, only values.
@@ -984,11 +995,30 @@ public abstract class JsonNode
     }
 
     /**
+     * Method for accessing all value nodes of this Node, iff
+     * this node is a JSON Array or Object node. In case of Object node,
+     * field names (keys) are not included, only values.
+     * For other types of nodes, returns empty <code>Spliterator</code>.
+     */
+    public Spliterator<JsonNode> elementsSpliterator() {
+        return Spliterators.emptySpliterator();
+    }
+
+    /**
      * @return Iterator that can be used to traverse all key/value pairs for
      *   object nodes; empty iterator (no contents) for other types
      */
     public Iterator<Map.Entry<String, JsonNode>> fields() {
         return ClassUtil.emptyIterator();
+    }
+
+    /**
+     * @return <code>Spliterator</code> that can be used to traverse all key/value pairs
+     *   for object nodes; empty spliterator (no contents) for other types
+     * @since 3.0
+     */
+    public Spliterator<Map.Entry<String, JsonNode>> fieldsSpliterator() {
+        return Spliterators.spliteratorUnknownSize(fields(), Spliterator.ORDERED);
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -999,6 +999,8 @@ public abstract class JsonNode
      * this node is a JSON Array or Object node. In case of Object node,
      * field names (keys) are not included, only values.
      * For other types of nodes, returns empty <code>Spliterator</code>.
+     *
+     * @since 3.0
      */
     public Spliterator<JsonNode> elementsSpliterator() {
         return Spliterators.emptySpliterator();

--- a/src/main/java/tools/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/tools/jackson/databind/node/ArrayNode.java
@@ -230,6 +230,11 @@ public class ArrayNode
     }
 
     @Override
+    public Spliterator<JsonNode> elementsSpliterator() {
+        return _children.spliterator();
+    }
+
+    @Override
     public JsonNode get(int index) {
         if ((index >= 0) && (index < _children.size())) {
             return _children.get(index);

--- a/src/main/java/tools/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/tools/jackson/databind/node/ArrayNode.java
@@ -217,23 +217,6 @@ public class ArrayNode
     @Override // since 2.10
     public boolean isEmpty() { return _children.isEmpty(); }
 
-    /**
-     * {@inheritDoc}
-     *<p>
-     * NOTE: actual underlying implementation returns {@link java.util.ListIterator}
-     * from {@link java.util.List#listIterator()} that contains elements, since Jackson 2.18
-     * (before was only generic {@link java.util.Iterator}).
-     */
-    @Override
-    public Iterator<JsonNode> values() {
-        return _children.listIterator();
-    }
-
-    @Override
-    public Spliterator<JsonNode> valuesSpliterator() {
-        return _children.spliterator();
-    }
-
     @Override
     public JsonNode get(int index) {
         if ((index >= 0) && (index < _children.size())) {
@@ -265,6 +248,23 @@ public class ArrayNode
                 index, _children.size());
     }
 
+    /**
+     * {@inheritDoc}
+     *<p>
+     * NOTE: actual underlying implementation returns {@link java.util.ListIterator}
+     * from {@link java.util.List#listIterator()} that contains elements, since Jackson 2.18
+     * (before was only generic {@link java.util.Iterator}).
+     */
+    @Override
+    public Iterator<JsonNode> values() {
+        return _children.listIterator();
+    }
+
+    @Override
+    public Spliterator<JsonNode> valueSpliterator() {
+        return _children.spliterator();
+    }
+    
     @Override // @since 2.19
     public Stream<JsonNode> valueStream() {
         return _children.stream();

--- a/src/main/java/tools/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/tools/jackson/databind/node/ArrayNode.java
@@ -230,7 +230,7 @@ public class ArrayNode
     }
 
     @Override
-    public Spliterator<JsonNode> elementsSpliterator() {
+    public Spliterator<JsonNode> valuesSpliterator() {
         return _children.spliterator();
     }
 

--- a/src/main/java/tools/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/tools/jackson/databind/node/ObjectNode.java
@@ -231,31 +231,11 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     public boolean isEmpty() { return _children.isEmpty(); }
 
     @Override
-    public Iterator<JsonNode> values() {
-        return _children.values().iterator();
-    }
-
-    @Override
-    public Spliterator<JsonNode> valuesSpliterator() {
-        return _children.values().spliterator();
-    }
-
-    @Override
     public JsonNode get(int index) { return null; }
 
     @Override
     public JsonNode get(String propertyName) {
         return _children.get(propertyName);
-    }
-
-    @Override
-    public Iterator<String> propertyNames() {
-        return _children.keySet().iterator();
-    }
-
-    @Override
-    public Spliterator<String> propertyNamesSpliterator() {
-        return _children.keySet().spliterator();
     }
 
     @Override
@@ -282,21 +262,29 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
         return _reportRequiredViolation("No value for property '%s' of `ObjectNode`", propertyName);
     }
 
-    /**
-     * Method to use for accessing all properties (with both names
-     * and values) of this JSON Object.
-     *
-     * @deprecated since 2.19 Use instead {@link #properties()}.
-     */
-    @Deprecated // since 2.19
     @Override
-    public Iterator<Map.Entry<String, JsonNode>> fields() {
-        return _children.entrySet().iterator();
+    public Iterator<JsonNode> values() {
+        return _children.values().iterator();
     }
 
     @Override
-    public Spliterator<Map.Entry<String, JsonNode>> fieldsSpliterator() {
-        return _children.entrySet().spliterator();
+    public Spliterator<JsonNode> valueSpliterator() {
+        return _children.values().spliterator();
+    }
+
+    @Override // @since 2.19
+    public Stream<JsonNode> valueStream() {
+        return _children.values().stream();
+    }
+
+    @Override
+    public Iterator<String> propertyNames() {
+        return _children.keySet().iterator();
+    }
+
+    @Override
+    public Spliterator<String> propertyNameSpliterator() {
+        return _children.keySet().spliterator();
     }
 
     /**
@@ -310,9 +298,9 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
         return _children.entrySet();
     }
 
-    @Override // @since 2.19
-    public Stream<JsonNode> valueStream() {
-        return _children.values().stream();
+    @Override
+    public Spliterator<Map.Entry<String, JsonNode>> propertySpliterator() {
+        return _children.entrySet().spliterator();
     }
 
     @Override // @since 2.19

--- a/src/main/java/tools/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/tools/jackson/databind/node/ObjectNode.java
@@ -236,6 +236,11 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     }
 
     @Override
+    public Spliterator<JsonNode> elementsSpliterator() {
+        return _children.values().spliterator();
+    }
+
+    @Override
     public JsonNode get(int index) { return null; }
 
     @Override
@@ -246,6 +251,11 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     @Override
     public Iterator<String> propertyNames() {
         return _children.keySet().iterator();
+    }
+
+    @Override
+    public Spliterator<String> propertyNamesSpliterator() {
+        return _children.keySet().spliterator();
     }
 
     @Override
@@ -279,6 +289,11 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     @Override
     public Iterator<Map.Entry<String, JsonNode>> fields() {
         return _children.entrySet().iterator();
+    }
+
+    @Override
+    public Spliterator<Map.Entry<String, JsonNode>> fieldsSpliterator() {
+        return _children.entrySet().spliterator();
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/tools/jackson/databind/node/ObjectNode.java
@@ -236,7 +236,7 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     }
 
     @Override
-    public Spliterator<JsonNode> elementsSpliterator() {
+    public Spliterator<JsonNode> valuesSpliterator() {
         return _children.values().spliterator();
     }
 

--- a/src/test/java/tools/jackson/databind/node/ArrayNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/ArrayNodeTest.java
@@ -36,9 +36,9 @@ public class ArrayNodeTest
 
         assertStandardEquals(n);
         assertFalse(n.values().hasNext());
-        assertEquals(0, n.valuesSpliterator().estimateSize());
+        assertEquals(0, n.valueSpliterator().estimateSize());
         assertFalse(n.propertyNames().hasNext());
-        assertNotNull(n.propertyNamesSpliterator());
+        assertNotNull(n.propertyNameSpliterator());
         assertTrue(n.isEmpty());
         TextNode text = TextNode.valueOf("x");
         n.add(text);

--- a/src/test/java/tools/jackson/databind/node/ArrayNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/ArrayNodeTest.java
@@ -36,13 +36,15 @@ public class ArrayNodeTest
 
         assertStandardEquals(n);
         assertFalse(n.elements().hasNext());
+        assertEquals(0, n.elementsSpliterator().estimateSize());
         assertFalse(n.propertyNames().hasNext());
+        assertEquals(0, n.propertyNamesSpliterator().estimateSize());
         assertTrue(n.isEmpty());
         TextNode text = TextNode.valueOf("x");
         n.add(text);
         assertEquals(1, n.size());
         assertFalse(n.isEmpty());
-        assertFalse(0 == n.hashCode());
+        assertNotEquals(0, n.hashCode());
         assertTrue(n.elements().hasNext());
         // no field names for arrays
         assertFalse(n.propertyNames().hasNext());

--- a/src/test/java/tools/jackson/databind/node/ArrayNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/ArrayNodeTest.java
@@ -36,9 +36,9 @@ public class ArrayNodeTest
 
         assertStandardEquals(n);
         assertFalse(n.values().hasNext());
-        assertEquals(0, n.elementsSpliterator().estimateSize());
+        assertEquals(0, n.valuesSpliterator().estimateSize());
         assertFalse(n.propertyNames().hasNext());
-        assertEquals(0, n.propertyNamesSpliterator().estimateSize());
+        assertNotNull(n.propertyNamesSpliterator());
         assertTrue(n.isEmpty());
         TextNode text = TextNode.valueOf("x");
         n.add(text);


### PR DESCRIPTION
relates to https://github.com/FasterXML/jackson-core/pull/1369

* Probably needs the jackson-core PR merged first.
* I can add test coverage in a follow up PR or add it here if preferred.
* the initial state of the PR is for discussion about the source changes