### PR TITLE
Minor tweak to #4836: "entryStream()" to "propertyStream()" for name unification towards Jackson 3.0

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -34,7 +34,7 @@ Project: jackson-databind
  (requested by @nathanukey)
 #4849 Not able to deserialize Enum with default typing after upgrading 2.15.4 -> 2.17.1
  (reported by Kornel Zemla)
-#4863: Add basic Stream support in `JsonNode`: `valueStream()`, `entryStream()`,
+#4863: Add basic Stream support in `JsonNode`: `valueStream()`, `propertyStream()`,
   `forEachEntry()`
 
 2.18.3 (not yet released)

--- a/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/JsonNode.java
@@ -1019,9 +1019,14 @@ public abstract class JsonNode
     }
 
     /**
+     * NOTE: This method is deprecated, use {@link #properties()} instead.
+     *
      * @return Iterator that can be used to traverse all key/value pairs for
      *   object nodes; empty iterator (no contents) for other types
+     *  
+     * @deprecated As of 2.19, replaced by {@link #properties()}
      */
+    @Deprecated // since 2.19
     public Iterator<Map.Entry<String, JsonNode>> fields() {
         return ClassUtil.emptyIterator();
     }
@@ -1030,6 +1035,7 @@ public abstract class JsonNode
      * Accessor that will return properties of {@code ObjectNode}
      * similar to how {@link Map#entrySet()} works; 
      * for other node types will return empty {@link java.util.Set}.
+     * Replacement for {@link JsonNode#fields()}.
      *
      * @return Set of properties, if this node is an {@code ObjectNode}
      * ({@link JsonNode#isObject()} returns {@code true}); empty
@@ -1054,24 +1060,26 @@ public abstract class JsonNode
     }
 
     /**
-     * Returns a stream of all value nodes of this Node, iff
-     * this node is an an {@code ObjectNode}.
+     * Returns a stream of all properties (key, value pairs) of this Node,
+     * iff this node is an an {@code ObjectNode}.
      * For other types of nodes, returns empty stream.
      *
      * @since 2.19
      */
-    public Stream<Map.Entry<String, JsonNode>> entryStream() {
+    public Stream<Map.Entry<String, JsonNode>> propertyStream() {
         return ClassUtil.emptyStream();
     }
 
     /**
-     * If this node is an {@code ObjectNode}, erforms the given action for each entry
+     * If this node is an {@code ObjectNode}, performs the given action for each
+     * property (key, value pair)
      * until all entries have been processed or the action throws an exception.
      * Exceptions thrown by the action are relayed to the caller.     
      * For other node types, no action is performed.
      *<p>
-     * Actions are performed in the order of entries, same as order returned by
+     * Actions are performed in the order of properties, same as order returned by
      * method {@link #properties()}.
+     * This is generally the document order of properties in JSON object.
      * 
      * @param action Action to perform for each entry
      */

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -338,7 +338,7 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     }
 
     @Override // @since 2.19
-    public Stream<Map.Entry<String, JsonNode>> entryStream() {
+    public Stream<Map.Entry<String, JsonNode>> propertyStream() {
         return _children.entrySet().stream();
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -315,7 +315,10 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
     /**
      * Method to use for accessing all properties (with both names
      * and values) of this JSON Object.
+     *
+     * @deprecated since 2.19 Use instead {@link #properties()}.
      */
+    @Deprecated // since 2.19
     @Override
     public Iterator<Map.Entry<String, JsonNode>> fields() {
         return _children.entrySet().iterator();

--- a/src/test/java/com/fasterxml/jackson/databind/node/ArrayNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ArrayNodeTest.java
@@ -495,9 +495,9 @@ public class ArrayNodeTest
                 arr.valueStream().collect(Collectors.toList()));
 
         // And then entryStream() (empty)
-        assertEquals(0, arr.entryStream().count());
+        assertEquals(0, arr.propertyStream().count());
         assertEquals(Arrays.asList(),
-                arr.entryStream().collect(Collectors.toList()));
+                arr.propertyStream().collect(Collectors.toList()));
 
         // And then empty forEachEntry()
         arr.forEachEntry((k, v) -> { throw new UnsupportedOperationException(); });

--- a/src/test/java/com/fasterxml/jackson/databind/node/NodeTestBase.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/NodeTestBase.java
@@ -41,7 +41,7 @@ abstract class NodeTestBase extends DatabindTestUtil
     protected void assertNonContainerStreamMethods(ValueNode n)
     {
         assertEquals(0, n.valueStream().count());
-        assertEquals(0, n.entryStream().count());
+        assertEquals(0, n.propertyStream().count());
 
         // And then empty forEachEntry()
         n.forEachEntry((k, v) -> { throw new UnsupportedOperationException(); });

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -571,9 +571,9 @@ public class ObjectNodeTest
                 obj.valueStream().collect(Collectors.toList()));
 
         // And then entryStream() (empty)
-        assertEquals(2, obj.entryStream().count());
+        assertEquals(2, obj.propertyStream().count());
         assertEquals(new ArrayList<>(obj.properties()),
-                obj.entryStream().collect(Collectors.toList()));
+                obj.propertyStream().collect(Collectors.toList()));
 
         // And then empty forEachEntry()
         final LinkedHashMap<String,JsonNode> map = new LinkedHashMap<>();


### PR DESCRIPTION
Also deprecate `JsonNode.fields()` method