### PR TITLE
Added a constructor to InvalidNullException that allows JsonParser to be passed directly

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/exc/InvalidNullException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/InvalidNullException.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.exc;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.PropertyName;
@@ -27,11 +28,15 @@ public class InvalidNullException
     /**********************************************************
      */
 
+    protected InvalidNullException(JsonParser p, String msg, PropertyName pname) {
+        super(p, msg);
+        _propertyName = pname;
+    }
+
     protected InvalidNullException(DeserializationContext ctxt, String msg,
             PropertyName pname)
     {
-        super(ctxt == null ? null : ctxt.getParser(), msg);
-        _propertyName = pname;
+        this(ctxt == null ? null : ctxt.getParser(), msg, pname);
     }
 
     public static InvalidNullException from(DeserializationContext ctxt,

--- a/src/main/java/com/fasterxml/jackson/databind/exc/InvalidNullException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/InvalidNullException.java
@@ -28,6 +28,9 @@ public class InvalidNullException
     /**********************************************************
      */
 
+    /**
+     * @since 2.19
+     */
     protected InvalidNullException(JsonParser p, String msg, PropertyName pname) {
         super(p, msg);
         _propertyName = pname;


### PR DESCRIPTION
First, the immediate purpose of this change is to migrate the base class for `MissingKotlinParameterException` implemented in `kotlin-module` to `InvalidNullException`.
https://github.com/FasterXML/jackson-module-kotlin/blob/2.19/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt

The `MissingKotlinParameterException` currently receives no `DeserializationContext` in its constructor and is also `public`.
An interface that directly accepts `JsonParser` is needed to migrate it without destructive changes.
It would also be useful as a common implementation of `databind`, given that `InvalidNullException` essentially only requires `JsonParser`.