### PR TITLE
[Jackson3.0] Fix #4845: change `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` to `false` in 3.0 

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -87,6 +87,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #4820: Change JDK baseline for Jackson 3.0 from Java 8 to Java 17
 #4835: Remove dynamic work-arounds wrt accessing `Record` definition
 #4840: Increase minimum Android SDK required to 34 for Jackson 3.0
+#4845: Change default of `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS`
+  to `false` in 3.0
 #4846: Change default of `SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS`
   to `false` in 3.0
 #4858: Change default of `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES`

--- a/src/main/java/tools/jackson/databind/SerializationFeature.java
+++ b/src/main/java/tools/jackson/databind/SerializationFeature.java
@@ -193,10 +193,10 @@ public enum SerializationFeature implements ConfigFeature
      * or not is controlled using {@link #WRITE_DATE_KEYS_AS_TIMESTAMPS} instead of
      * this feature.
      *<p>
-     * Feature is enabled by default, so that date/time are by default
-     * serialized as time stamps.
+     * Feature is disabled by default as of Jackson 3.0 (in 2.x it was enabled),
+     * so that date/time are by default serialized as textual values NOT timestamps.
      */
-    WRITE_DATES_AS_TIMESTAMPS(true),
+    WRITE_DATES_AS_TIMESTAMPS(false),
 
     /**
      * Feature that determines whether {@link java.util.Date}s

--- a/src/test/java/tools/jackson/databind/ext/sql/SqlDateSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ext/sql/SqlDateSerializationTest.java
@@ -44,6 +44,8 @@ public class SqlDateSerializationTest extends DatabindTestUtil
     @Test
     public void testSqlDate() throws Exception
     {
+        ObjectWriter writer = MAPPER.writer()
+                .with(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         // use date 1999-04-01 (note: months are 0-based, use constant)
         final java.sql.Date date99 = javaSqlDate(1999, Calendar.APRIL, 1);
         final java.sql.Date date0 = new java.sql.Date(0);
@@ -52,14 +54,14 @@ public class SqlDateSerializationTest extends DatabindTestUtil
         //   defaults in 2.9, even if this changes behavior.
 
         assertEquals(String.valueOf(date99.getTime()),
-                MAPPER.writeValueAsString(date99));
+                writer.writeValueAsString(date99));
 
         assertEquals(a2q("{'date':0}"),
-                MAPPER.writeValueAsString(new SqlDateAsDefaultBean(0L)));
+                writer.writeValueAsString(new SqlDateAsDefaultBean(0L)));
 
         // but may explicitly force timestamp too
         assertEquals(a2q("{'date':0}"),
-                MAPPER.writeValueAsString(new SqlDateAsNumberBean(0L)));
+                writer.writeValueAsString(new SqlDateAsNumberBean(0L)));
 
         // And also should be able to use String output as need be:
         ObjectWriter w = MAPPER.writer().without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -54,16 +54,17 @@ public class MiscJavaXMLTypesReadWriteTest
     @Test
     public void testXMLGregorianCalendarSerAndDeser() throws Exception
     {
+        ObjectMapper withMapper = jsonMapperBuilder().enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).build();
         DatatypeFactory dtf = DatatypeFactory.newInstance();
         XMLGregorianCalendar cal = dtf.newXMLGregorianCalendar
             (1974, 10, 10, 18, 15, 17, 123, 0);
 
         long timestamp = cal.toGregorianCalendar().getTimeInMillis();
         String numStr = String.valueOf(timestamp);
-        assertEquals(numStr, MAPPER.writeValueAsString(cal));
+        assertEquals(numStr, withMapper.writeValueAsString(cal));
 
         // [JACKSON-403] Needs to come back ok as well:
-        XMLGregorianCalendar calOut = MAPPER.readValue(numStr, XMLGregorianCalendar.class);
+        XMLGregorianCalendar calOut = withMapper.readValue(numStr, XMLGregorianCalendar.class);
         assertNotNull(calOut);
         assertEquals(timestamp, calOut.toGregorianCalendar().getTimeInMillis());
 

--- a/src/test/java/tools/jackson/databind/jsontype/TestPolymorphicDeserialization676.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestPolymorphicDeserialization676.java
@@ -86,6 +86,7 @@ public class TestPolymorphicDeserialization676 extends DatabindTestUtil
     public void testDeSerFail() throws IOException {
         final ObjectMapper mapper = jsonMapperBuilder()
                 .polymorphicTypeValidator(new NoCheckSubTypeValidator())
+                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build();
 
         MapContainer deserMapBad = createDeSerMapContainer(originMap, mapper);
@@ -99,6 +100,7 @@ public class TestPolymorphicDeserialization676 extends DatabindTestUtil
         final ObjectMapper mapper = jsonMapperBuilder()
                 .polymorphicTypeValidator(new NoCheckSubTypeValidator())
                 .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build();
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("1", 1);

--- a/src/test/java/tools/jackson/databind/jsontype/deftyping/TestDefaultForScalars.java
+++ b/src/test/java/tools/jackson/databind/jsontype/deftyping/TestDefaultForScalars.java
@@ -50,6 +50,7 @@ public class TestDefaultForScalars
 
     private final ObjectMapper DEFAULT_TYPING_MAPPER = jsonMapperBuilder()
                     .activateDefaultTyping(NoCheckSubTypeValidator.instance)
+                    .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                     .build();
 
     /**

--- a/src/test/java/tools/jackson/databind/jsontype/deftyping/TestDefaultForScalars.java
+++ b/src/test/java/tools/jackson/databind/jsontype/deftyping/TestDefaultForScalars.java
@@ -106,6 +106,7 @@ public class TestDefaultForScalars
         ObjectMapper mapper = jsonMapperBuilder()
                 .activateDefaultTyping(NoCheckSubTypeValidator.instance,
                         DefaultTyping.JAVA_LANG_OBJECT)
+                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build();
         Object[] input = new Object[] {
                 "abc", new Date(1234567), null, Integer.valueOf(456)

--- a/src/test/java/tools/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
@@ -493,13 +493,16 @@ public class ExternalTypeIdTest extends DatabindTestUtil
     @Test
     public void testWithAsValue() throws Exception
     {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
         ExternalTypeWithNonPOJO input = new ExternalTypeWithNonPOJO(new AsValueThingy(12345L));
-        String json = MAPPER.writeValueAsString(input);
+        String json = mapper.writeValueAsString(input);
         assertNotNull(json);
         assertEquals("{\"value\":12345,\"type\":\"thingy\"}", json);
 
         // and get it back too:
-        ExternalTypeWithNonPOJO result = MAPPER.readValue(json, ExternalTypeWithNonPOJO.class);
+        ExternalTypeWithNonPOJO result = mapper.readValue(json, ExternalTypeWithNonPOJO.class);
         assertNotNull(result);
         assertNotNull(result.value);
         assertEquals(AsValueThingy.class, result.value.getClass());

--- a/src/test/java/tools/jackson/databind/ser/SerializationConfigTest.java
+++ b/src/test/java/tools/jackson/databind/ser/SerializationConfigTest.java
@@ -80,7 +80,7 @@ public class SerializationConfigTest
         assertTrue(cfg.isEnabled(MapperFeature.USE_ANNOTATIONS));
         assertTrue(cfg.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS));
 
-        assertTrue(cfg.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
+        assertFalse(cfg.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
 
         assertEquals(MapperFeature.DEFAULT_VIEW_INCLUSION.enabledByDefault(),
                 cfg.isEnabled(MapperFeature.DEFAULT_VIEW_INCLUSION));

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeTest.java
@@ -405,6 +405,8 @@ public class JsonIncludeTest
     @Test
     public void testInclusionOfCalendar() throws Exception
     {
+        ObjectWriter writerWithout = MAPPER.writer().without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
         final Calendar input = new GregorianCalendar();
         input.setTimeInMillis(0L);
         assertEquals(a2q("{'value':0}"),

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeTest.java
@@ -392,11 +392,13 @@ public class JsonIncludeTest
     @Test
     public void testInclusionOfDate() throws Exception
     {
+        ObjectWriter writerWith = MAPPER.writer().with(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
         final Date input = new Date(0L);
         assertEquals(a2q("{'value':0}"),
-                MAPPER.writeValueAsString(new NonEmptyDate(input)));
+                writerWith.writeValueAsString(new NonEmptyDate(input)));
         assertEquals("{}",
-                MAPPER.writeValueAsString(new NonDefaultDate(input)));
+                writerWith.writeValueAsString(new NonDefaultDate(input)));
 
 
     }
@@ -405,13 +407,13 @@ public class JsonIncludeTest
     @Test
     public void testInclusionOfCalendar() throws Exception
     {
-        ObjectWriter writerWithout = MAPPER.writer().without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        ObjectWriter writerWith = MAPPER.writer().with(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         final Calendar input = new GregorianCalendar();
         input.setTimeInMillis(0L);
         assertEquals(a2q("{'value':0}"),
-                MAPPER.writeValueAsString(new NonEmptyCalendar(input)));
+                writerWith.writeValueAsString(new NonEmptyCalendar(input)));
         assertEquals("{}",
-                MAPPER.writeValueAsString(new NonDefaultCalendar(input)));
+                writerWith.writeValueAsString(new NonDefaultCalendar(input)));
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
@@ -103,7 +103,7 @@ public class JavaUtilDateSerializationTest
     public void testDateNumeric() throws IOException
     {
         // default is to output time stamps...
-        assertTrue(MAPPER.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
+        assertFalse(MAPPER.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
         // shouldn't matter which offset we give...
         String json = MAPPER.writeValueAsString(new Date(199L));
         assertEquals("199", json);

--- a/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
@@ -105,7 +105,8 @@ public class JavaUtilDateSerializationTest
         // default is to output time stamps...
         assertFalse(MAPPER.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
         // shouldn't matter which offset we give...
-        String json = MAPPER.writeValueAsString(new Date(199L));
+        String json = MAPPER.writer().with(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .writeValueAsString(new Date(199L));
         assertEquals("199", json);
     }
 


### PR DESCRIPTION
resolves #4845