### PR TITLE
Add explicit deserializer for `ThreadGroup`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,6 @@
               <release>17</release>
               <compilerArgs>
                 <arg>-parameters</arg>
-                <arg>--add-opens=java.base/java.util=ALL-UNNAMED</arg>
               </compilerArgs>
             </configuration>
           </plugin>
@@ -457,7 +456,6 @@
               <release>21</release>
               <compilerArgs>
                 <arg>-parameters</arg>
-                <arg>--add-opens=java.base/java.util=ALL-UNNAMED</arg>
               </compilerArgs>
             </configuration>
           </plugin>

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -48,6 +48,7 @@ Project: jackson-databind
  (reported by Floris W)
 #4953: Allow clearing all caches to avoid classloader leaks
  (contributed by Joren I)
+#4959: Add explicit deserializer for `ThreadGroup`
 
 2.18.3 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/JdkDeserializers.java
@@ -24,20 +24,11 @@ public class JdkDeserializers
                 AtomicLong.class,
                 StackTraceElement.class,
                 ByteBuffer.class,
-                Void.class
+                Void.class,
+                ThreadGroup.class // @since 2.19
         };
         for (Class<?> cls : types) { _classNames.add(cls.getName()); }
         for (Class<?> cls : FromStringDeserializer.types()) { _classNames.add(cls.getName()); }
-    }
-
-    /**
-     * @deprecated Since 2.14 use the variant that takes one more argument
-     */
-    @Deprecated // since 2.14
-    public static JsonDeserializer<?> find(Class<?> rawType, String clsName)
-        throws JsonMappingException
-    {
-        return find(null, rawType, clsName);
     }
 
     /**
@@ -72,6 +63,9 @@ public class JdkDeserializers
             }
             if (rawType == Void.class) {
                 return NullifyingDeserializer.instance;
+            }
+            if (rawType == ThreadGroup.class) { // @since 2.19
+                return new ThreadGroupDeserializer();
             }
         }
         return null;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ThreadGroupDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ThreadGroupDeserializer.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.databind.deser.std;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Deserializer for the {@link java.lang.ThreadGroup} class: due to limited access,
+ * will only try to extract {@code "name"} property and ignores everything else.
+ * This to match automatic serialization by Jackson which does write out
+ * all accessible properties.
+ *
+ * @since 2.19
+ */
+public class ThreadGroupDeserializer
+    extends StdNodeBasedDeserializer<ThreadGroup>
+{
+    protected ThreadGroupDeserializer() {
+        super(ThreadGroup.class);
+    }
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public ThreadGroup convert(JsonNode root, DeserializationContext ctxt) throws IOException {
+        String name = root.path("name").asText();
+        if (name == null) {
+            name = "";
+        }
+        return new ThreadGroup(name);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ThreadGroupDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ThreadGroupDeserTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ThreadGroupDeserTest extends DatabindTestUtil
@@ -16,5 +17,14 @@ public class ThreadGroupDeserTest extends DatabindTestUtil
     public void deserThreadGroupFromEmpty() throws Exception {
         ThreadGroup tg = MAPPER.readValue("{}", ThreadGroup.class);
         assertNotNull(tg);
+    }
+
+    @Test
+    public void roundtripThreadGroup() throws Exception {
+        ThreadGroup tg = new ThreadGroup("testTG");
+        String json = MAPPER.writeValueAsString(tg);
+        ThreadGroup tg2 = MAPPER.readValue(json, ThreadGroup.class);
+        assertNotNull(tg2);
+        assertEquals(tg.getName(), tg2.getName());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ThreadGroupDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ThreadGroupDeserTest.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.databind.deser.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ThreadGroupDeserTest extends DatabindTestUtil
+{
+    private final ObjectMapper MAPPER = sharedMapper();
+
+    // [databind#4939]
+    @Test
+    public void deserThreadGroupFromEmpty() throws Exception {
+        ThreadGroup tg = MAPPER.readValue("{}", ThreadGroup.class);
+        assertNotNull(tg);
+    }
+}


### PR DESCRIPTION
As per #4939 default POJO deserializer for `ThreadGroup` will try to force access to underlying fields; it should not. Let's add a limited deserializer that only uses public API. This means only "name" property can be deserialized back. But at least avoids warning/exception on later JDKs.