### PR TITLE
Fix #4771: Support OBJECT shape for QNAME serialization and deserialization.

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -31,7 +31,8 @@ Project: jackson-databind
  (reported by @devdanylo)
  (fix by Joo-Hyuk K)
 #4771: `QName` (de)serialization ignores prefix
- (contributed by @mcvayc)
+ (reported by @jpraet)
+ (fix contributed by @mcvayc)
 #4772: Serialization and deserialization issue of sub-types used with
   `JsonTypeInfo.Id.DEDUCTION` where sub-types are Object and Array
  (reported by Eduard G)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -30,6 +30,8 @@ Project: jackson-databind
   Map object is ignored when Map key type not defined
  (reported by @devdanylo)
  (fix by Joo-Hyuk K)
+#4771: `QName` (de)serialization ignores prefix
+ (contributed by @mcvayc)
 #4772: Serialization and deserialization issue of sub-types used with
   `JsonTypeInfo.Id.DEDUCTION` where sub-types are Object and Array
  (reported by Eduard G)

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
@@ -115,11 +115,13 @@ public class CoreXMLDeserializers extends Deserializers.Base
 
             JsonNode localPart = tree.get("localPart");
             if (localPart == null) {
-                ctxt.reportInputMismatch(this, "QName is missing required property: 'localPart'");
+                ctxt.reportInputMismatch(this,
+                        "Object value for `QName` is missing required property 'localPart'");
             }
 
             if (!localPart.isTextual()) {
-                ctxt.reportInputMismatch(this, "QName property 'localPart' must be a STRING, not %s",
+                ctxt.reportInputMismatch(this,
+                        "Object value property 'localPart' for `QName` must be of type STRING, not %s",
                         localPart.getNodeType());
             }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
@@ -16,7 +16,8 @@ import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
  * JDK 1.5. Types are directly needed by JAXB, but may be unavailable on some
  * limited platforms; hence separate out from basic deserializer factory.
  */
-public class CoreXMLDeserializers extends Deserializers.Base {
+public class CoreXMLDeserializers extends Deserializers.Base
+{
     protected final static QName EMPTY_QNAME = QName.valueOf("");
 
     /**
@@ -25,7 +26,6 @@ public class CoreXMLDeserializers extends Deserializers.Base {
      * introspection) can be expensive we better reuse the instance.
      */
     final static DatatypeFactory _dataTypeFactory;
-
     static {
         try {
             _dataTypeFactory = DatatypeFactory.newInstance();
@@ -36,7 +36,8 @@ public class CoreXMLDeserializers extends Deserializers.Base {
 
     @Override
     public JsonDeserializer<?> findBeanDeserializer(JavaType type,
-                                                    DeserializationConfig config, BeanDescription beanDesc) {
+        DeserializationConfig config, BeanDescription beanDesc)
+    {
         Class<?> raw = type.getRawClass();
         if (raw == QName.class) {
             return new Std(raw, TYPE_QNAME);
@@ -76,7 +77,8 @@ public class CoreXMLDeserializers extends Deserializers.Base {
      *
      * @since 2.4
      */
-    public static class Std extends FromStringDeserializer<Object> {
+    public static class Std extends FromStringDeserializer<Object>
+    {
         private static final long serialVersionUID = 1L;
 
         protected final int _kind;
@@ -88,7 +90,8 @@ public class CoreXMLDeserializers extends Deserializers.Base {
 
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt)
-                throws IOException {
+            throws IOException
+        {
             // GregorianCalendar also allows integer value (timestamp),
             // which needs separate handling
             if (_kind == TYPE_G_CALENDAR) {
@@ -105,7 +108,9 @@ public class CoreXMLDeserializers extends Deserializers.Base {
             return super.deserialize(p, ctxt);
         }
 
-        private QName _parseQNameObject(JsonParser p, DeserializationContext ctxt) throws IOException {
+        private QName _parseQNameObject(JsonParser p, DeserializationContext ctxt)
+            throws IOException
+        {
             JsonNode tree = ctxt.readTree(p);
 
             if (!tree.has("localPart")) {
@@ -133,22 +138,24 @@ public class CoreXMLDeserializers extends Deserializers.Base {
 
         @Override
         protected Object _deserialize(String value, DeserializationContext ctxt)
-                throws IOException {
+            throws IOException
+        {
             switch (_kind) {
-                case TYPE_DURATION:
-                    return _dataTypeFactory.newDuration(value);
-                case TYPE_QNAME:
-                    return QName.valueOf(value);
-                case TYPE_G_CALENDAR:
-                    Date d;
-                    try {
-                        d = _parseDate(value, ctxt);
-                    } catch (JsonMappingException e) {
-                        // try to parse from native XML Schema 1.0 lexical representation String,
-                        // which includes time-only formats not handled by parseXMLGregorianCalendarFromJacksonFormat(...)
-                        return _dataTypeFactory.newXMLGregorianCalendar(value);
-                    }
-                    return _gregorianFromDate(ctxt, d);
+            case TYPE_DURATION:
+                return _dataTypeFactory.newDuration(value);
+            case TYPE_QNAME:
+                return QName.valueOf(value);
+            case TYPE_G_CALENDAR:
+                Date d;
+                try {
+                    d = _parseDate(value, ctxt);
+                }
+                catch (JsonMappingException e) {
+                    // try to parse from native XML Schema 1.0 lexical representation String,
+                    // which includes time-only formats not handled by parseXMLGregorianCalendarFromJacksonFormat(...)
+                    return _dataTypeFactory.newXMLGregorianCalendar(value);
+                }
+                return _gregorianFromDate(ctxt, d);
             }
             throw new IllegalStateException();
         }
@@ -162,7 +169,8 @@ public class CoreXMLDeserializers extends Deserializers.Base {
         }
 
         protected XMLGregorianCalendar _gregorianFromDate(DeserializationContext ctxt,
-                                                          Date d) {
+                Date d)
+        {
             if (d == null) {
                 return null;
             }
@@ -174,6 +182,5 @@ public class CoreXMLDeserializers extends Deserializers.Base {
             }
             return _dataTypeFactory.newXMLGregorianCalendar(calendar);
         }
-
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
@@ -113,27 +113,25 @@ public class CoreXMLDeserializers extends Deserializers.Base
         {
             JsonNode tree = ctxt.readTree(p);
 
-            if (!tree.has("localPart")) {
-                throw new JsonParseException("QName is missing required field: localPart");
-            }
-
             JsonNode localPart = tree.get("localPart");
-            if (!localPart.isTextual()) {
-                throw new JsonParseException("QName field \"localPart\" must be of type String.");
+            if (localPart == null) {
+                ctxt.reportInputMismatch(this, "QName is missing required property: 'localPart'");
             }
 
-            if (tree.has("namespaceURI")) {
-                JsonNode namespaceURI = tree.get("namespaceURI");
+            if (!localPart.isTextual()) {
+                ctxt.reportInputMismatch(this, "QName property 'localPart' must be a STRING, not %s",
+                        localPart.getNodeType());
+            }
 
+            JsonNode namespaceURI = tree.get("namespaceURI");
+            if (namespaceURI != null) {
                 if (tree.has("prefix")) {
                     JsonNode prefix = tree.get("prefix");
                     return new QName(namespaceURI.asText(), localPart.asText(), prefix.asText());
                 }
-
                 return new QName(namespaceURI.asText(), localPart.asText());
-            } else {
-                return new QName(localPart.asText());
             }
+            return new QName(localPart.asText());
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.databind.ext;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.util.Calendar;
 
 import javax.xml.datatype.Duration;
@@ -14,11 +13,11 @@ import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
-import com.fasterxml.jackson.databind.ser.BeanSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
-import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import com.fasterxml.jackson.databind.ser.Serializers;
-import com.fasterxml.jackson.databind.ser.std.*;
+import com.fasterxml.jackson.databind.ser.std.CalendarSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 /**
  * Provider for serializers of XML types that are part of full JDK 1.5, but
@@ -123,8 +122,8 @@ public class CoreXMLSerializers extends Serializers.Base
     }
 
     public static class QNameSerializer
-            extends StdSerializer<QName>
-            implements ContextualSerializer
+        extends StdSerializer<QName>
+        implements ContextualSerializer
     {
         private static final long serialVersionUID = 1L;
 
@@ -136,7 +135,7 @@ public class CoreXMLSerializers extends Serializers.Base
 
         @Override
         public JsonSerializer<?> createContextual(SerializerProvider serializers, BeanProperty property)
-                throws JsonMappingException
+            throws JsonMappingException
         {
             JsonFormat.Value format = findFormatOverrides(serializers, property, handledType());
             if (format != null) {
@@ -149,7 +148,9 @@ public class CoreXMLSerializers extends Serializers.Base
         }
 
         @Override
-        public void serialize(QName value, JsonGenerator g, SerializerProvider provider) throws IOException {
+        public void serialize(QName value, JsonGenerator g, SerializerProvider provider)
+            throws IOException
+        {
             g.writeStartObject();
             g.writeObjectField("localPart", value.getLocalPart());
             if(!value.getNamespaceURI().isEmpty()) g.writeObjectField("namespaceURI", value.getNamespaceURI());
@@ -159,7 +160,8 @@ public class CoreXMLSerializers extends Serializers.Base
 
         @Override
         public final void serializeWithType(QName value, JsonGenerator g, SerializerProvider provider,
-                                            TypeSerializer typeSer) throws IOException
+                                            TypeSerializer typeSer)
+            throws IOException
         {
             g.writeObject(value);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
@@ -121,6 +121,9 @@ public class CoreXMLSerializers extends Serializers.Base
         }
     }
 
+    /**
+     * @since 2.19
+     */
     public static class QNameSerializer
         extends StdSerializer<QName>
         implements ContextualSerializer
@@ -148,27 +151,42 @@ public class CoreXMLSerializers extends Serializers.Base
         }
 
         @Override
-        public void serialize(QName value, JsonGenerator g, SerializerProvider provider)
+        public void serialize(QName value, JsonGenerator g, SerializerProvider ctxt)
             throws IOException
         {
-            g.writeStartObject();
-            g.writeObjectField("localPart", value.getLocalPart());
-            if(!value.getNamespaceURI().isEmpty()) g.writeObjectField("namespaceURI", value.getNamespaceURI());
-            if(!value.getPrefix().isEmpty()) g.writeObjectField("prefix", value.getPrefix());
+            g.writeStartObject(value);
+            serializeProperties(value, g, ctxt);
             g.writeEndObject();
         }
 
         @Override
-        public final void serializeWithType(QName value, JsonGenerator g, SerializerProvider provider,
-                                            TypeSerializer typeSer)
+        public final void serializeWithType(QName value, JsonGenerator g, SerializerProvider ctxt,
+                TypeSerializer typeSer)
             throws IOException
         {
-            g.writeObject(value);
+            WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
+                    typeSer.typeId(value, JsonToken.START_OBJECT));
+            serializeProperties(value, g, ctxt);
+            typeSer.writeTypeSuffix(g, typeIdDef);
+        }
+
+        private void serializeProperties(QName value, JsonGenerator g, SerializerProvider ctxt)
+            throws IOException
+        {
+            g.writeStringField("localPart", value.getLocalPart());
+            if (!value.getNamespaceURI().isEmpty()) {
+                g.writeStringField("namespaceURI", value.getNamespaceURI());
+            }
+            if (!value.getPrefix().isEmpty()) {
+                g.writeStringField("prefix", value.getPrefix());
+            }
         }
 
         @Override
-        public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) throws JsonMappingException {
-            visitor.expectBooleanFormat(typeHint);
+        public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint)
+                throws JsonMappingException {
+            /*JsonObjectFormatVisitor v =*/ visitor.expectObjectFormat(typeHint);
+            // TODO: would need to visit properties too, see `BeanSerializerBase`
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLSerializers.java
@@ -130,7 +130,7 @@ public class CoreXMLSerializers extends Serializers.Base
     {
         private static final long serialVersionUID = 1L;
 
-        public static JsonSerializer<?> instance = new QNameSerializer();
+        public final static JsonSerializer<?> instance = new QNameSerializer();
 
         public QNameSerializer() {
             super(QName.class);

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -194,7 +194,6 @@ public class MiscJavaXMLTypesReadWriteTest
     /**********************************************************************
      */
 
-
     @Test
     public void testPolymorphicXMLGregorianCalendar() throws Exception
     {

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind.ext;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import javax.xml.datatype.*;
 import javax.xml.namespace.QName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,17 @@ public class MiscJavaXMLTypesReadWriteTest
     {
         QName qn = new QName("http://abc", "tag", "prefix");
         assertEquals(q(qn.toString()), MAPPER.writeValueAsString(qn));
+    }
+
+    @Test
+    public void testQNameSerToObject() throws Exception {
+        QName qn = new QName("http://abc", "tag", "prefix");
+
+        ObjectMapper mapper = jsonMapperBuilder()
+                .withConfigOverride(QName.class, cfg -> cfg.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.OBJECT)))
+                .build();
+
+        assertEquals(a2q("{'localPart':'tag','namespaceURI':'http://abc','prefix':'prefix'}"), mapper.writeValueAsString(qn));
     }
 
     @Test
@@ -119,6 +131,21 @@ public class MiscJavaXMLTypesReadWriteTest
         qn = MAPPER.readValue(q(""), QName.class);
         assertNotNull(qn);
         assertEquals("", qn.getLocalPart());
+    }
+
+    @Test
+    public void testQNameDeserFromObject() throws Exception
+    {
+        String qstr = a2q("{'namespaceURI':'http://abc','localPart':'tag','prefix':'prefix'}");
+        ObjectMapper mapper = jsonMapperBuilder()
+                .withConfigOverride(QName.class, cfg -> cfg.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.OBJECT)))
+                .build();
+
+        QName qn = mapper.readValue(qstr, QName.class);
+
+        assertEquals("http://abc", qn.getNamespaceURI());
+        assertEquals("tag", qn.getLocalPart());
+        assertEquals("prefix", qn.getPrefix());
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -1,10 +1,10 @@
 package com.fasterxml.jackson.databind.ext;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import javax.xml.datatype.*;
 import javax.xml.namespace.QName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.testutil.NoCheckSubTypeValidator;
@@ -42,7 +42,8 @@ public class MiscJavaXMLTypesReadWriteTest
     }
 
     @Test
-    public void testQNameSerToObject() throws Exception {
+    public void testQNameSerToObject() throws Exception
+    {
         QName qn = new QName("http://abc", "tag", "prefix");
 
         ObjectMapper mapper = jsonMapperBuilder()

--- a/src/test/java/com/fasterxml/jackson/databind/ext/QNameAsObjectReadWrite4771Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/QNameAsObjectReadWrite4771Test.java
@@ -1,35 +1,35 @@
 package com.fasterxml.jackson.databind.ext;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import java.util.stream.Stream;
+import javax.xml.namespace.QName;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.xml.namespace.QName;
-import java.util.stream.Stream;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class QNameAsObjectReadWrite4771Test extends DatabindTestUtil
 {
-
     private final ObjectMapper MAPPER = newJsonMapper();
 
     static class BeanWithQName {
         @JsonFormat(shape = JsonFormat.Shape.OBJECT)
         public QName qname;
 
-        public BeanWithQName() {
-        }
+        BeanWithQName() { }
 
         public BeanWithQName(QName qName) {
             this.qname = qName;
         }
     }
-
 
     @ParameterizedTest
     @MethodSource("provideAllPerumtationsOfQNameConstructor")
@@ -54,5 +54,4 @@ class QNameAsObjectReadWrite4771Test extends DatabindTestUtil
                 Arguments.of(new QName("test-namespace-uri", "test-local-part", "test-prefix"))
         );
     }
-
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ext/QNameAsObjectReadWrite4771Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/QNameAsObjectReadWrite4771Test.java
@@ -33,7 +33,8 @@ class QNameAsObjectReadWrite4771Test extends DatabindTestUtil
 
     @ParameterizedTest
     @MethodSource("provideAllPerumtationsOfQNameConstructor")
-    void testQNameWithObjectSerialization(QName originalQName) throws JsonProcessingException {
+    void testQNameWithObjectSerialization(QName originalQName) throws JsonProcessingException
+    {
         BeanWithQName bean = new BeanWithQName(originalQName);
 
         String json = MAPPER.writeValueAsString(bean);
@@ -45,7 +46,8 @@ class QNameAsObjectReadWrite4771Test extends DatabindTestUtil
         assertEquals(originalQName.getPrefix(), deserializedQName.getPrefix());
     }
 
-    static Stream<Arguments> provideAllPerumtationsOfQNameConstructor() {
+    static Stream<Arguments> provideAllPerumtationsOfQNameConstructor()
+    {
         return Stream.of(
                 Arguments.of(new QName("test-local-part")),
                 Arguments.of(new QName("test-namespace-uri", "test-local-part")),

--- a/src/test/java/com/fasterxml/jackson/databind/ext/QNameAsObjectReadWrite4771Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/QNameAsObjectReadWrite4771Test.java
@@ -1,0 +1,56 @@
+package com.fasterxml.jackson.databind.ext;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.xml.namespace.QName;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QNameAsObjectReadWrite4771Test extends DatabindTestUtil
+{
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    static class BeanWithQName {
+        @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+        public QName qname;
+
+        public BeanWithQName() {
+        }
+
+        public BeanWithQName(QName qName) {
+            this.qname = qName;
+        }
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("provideAllPerumtationsOfQNameConstructor")
+    void testQNameWithObjectSerialization(QName originalQName) throws JsonProcessingException {
+        BeanWithQName bean = new BeanWithQName(originalQName);
+
+        String json = MAPPER.writeValueAsString(bean);
+
+        QName deserializedQName = MAPPER.readValue(json, BeanWithQName.class).qname;
+
+        assertEquals(originalQName.getLocalPart(), deserializedQName.getLocalPart());
+        assertEquals(originalQName.getNamespaceURI(), deserializedQName.getNamespaceURI());
+        assertEquals(originalQName.getPrefix(), deserializedQName.getPrefix());
+    }
+
+    static Stream<Arguments> provideAllPerumtationsOfQNameConstructor() {
+        return Stream.of(
+                Arguments.of(new QName("test-local-part")),
+                Arguments.of(new QName("test-namespace-uri", "test-local-part")),
+                Arguments.of(new QName("test-namespace-uri", "test-local-part", "test-prefix"))
+        );
+    }
+
+}


### PR DESCRIPTION
This commit fixes #4771 by supporting the JsonFormat OBJECT shape during serialization and deserialization.