### PR TITLE
(WIP) Try to make JaCoCo work with JDK 17; odd failure still

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,15 +210,30 @@
         <groupId>org.apache.maven.plugins</groupId>
         <version>${version.plugin.surefire}</version>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- 13-Feb-2025, tatu: Try to make JaCoCo work -->
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>1.3.2</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <!-- Needed by some of the tests -->
           <argLine>--add-opens=java.base/java.util=tools.jackson.databind
           </argLine>
+          <!-- 13-Feb-2025, tatu: Try to make JaCoCo work -->
+          <forkCount>1</forkCount> <!-- Use single JVM -->
+          <reuseForks>true</reuseForks>
+
           <!-- 26-Nov-2019, tatu: moar parallelism! Per-class basis, safe, efficient enough
                   ... although not 100% sure this makes much difference TBH
             -->
-          <threadCount>4</threadCount>
+          <!-- 13-Feb-2025, tatu: Seems to make no difference, remove -->
+          <!--
+          <threadCount>1</threadCount>
           <parallel>classes</parallel>
+            -->
         </configuration>
       </plugin>
 
@@ -238,13 +253,17 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
             <id>report</id>
-            <phase>test</phase>
+            <!-- 13-Feb-2025, tatu: was "test" in 2.x but for some reason JDK 17
+                needs this
+              -->
+            <phase>verify</phase>
             <goals>
               <goal>report</goal>
             </goals>


### PR DESCRIPTION
For some reason, JaCoCo only works with JDK 8, even in Jackson 2.x branch. JDK 17 run has

```
[INFO] --- jacoco:0.8.12:report (report) @ jackson-databind ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
```

At first I thought this might be due to either:

1. Jackson 2.x uses separate profile for JDK 17 (but 3.x does not)
2. Jackson 3.x might have different pom.xml settings than 2.x

but it looks like both fail in similar way. Trying out things suggested by search results as well as ChatGPT (which gives coherent suggestions here) produces different kind of failures but no functioning set up. :-(

