### PR TITLE
Allow default enums with `@JsonCreator`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1918,3 +1918,7 @@ Floris Westerman (@FWest98)
 Joren Inghelbrecht (@jin-harmoney)
  * Contributed #4953: Allow clearing all caches to avoid classloader leaks
   (2.19.0)
+
+Will Paul (@dropofwill)
+ * Contributed #4979: Allow default enums with `@JsonCreator`
+  (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -66,6 +66,8 @@ Project: jackson-databind
  (fix by Joo-Hyuk K)
 #4963: Serializing `Map.Entry` as Bean with `@JsonFormat.shape = Shape.OBJECT`
   fails on JDK 17+
+#4979: Allow default enums with `@JsonCreator`
+ (contributed by Will P)
 #4997: `ObjectNode` put methods should do null check for key
 #5006: Add `MapperFeature.REQUIRE_HANDLERS_FOR_JAVA8_OPTIONALS` to prevent
   failure of `java.util.Optional` (de)serialization without Java 8 module

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1087,7 +1087,9 @@ public abstract class BasicDeserializerFactory
 "Invalid `@JsonCreator` annotated Enum factory method [%s]: needs to return compatible type",
 factory.toString()));
                     }
-                    deser = EnumDeserializer.deserializerForCreator(config, enumClass, factory, valueInstantiator, creatorProps);
+                    deser = EnumDeserializer.deserializerForCreator(
+                        config, enumClass, factory, valueInstantiator, creatorProps,
+                        constructEnumResolver(enumClass, config, beanDesc));
                     break;
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -160,7 +160,7 @@ public class EnumDeserializer
     @Deprecated
     public static JsonDeserializer<?> deserializerForCreator(DeserializationConfig config,
             Class<?> enumClass, AnnotatedMethod factory) {
-        return deserializerForCreator(config, enumClass, factory, null, null);
+        return deserializerForCreator(config, enumClass, factory, null, null, null);
     }
 
     /**
@@ -172,16 +172,15 @@ public class EnumDeserializer
      * @since 2.8
      */
     public static JsonDeserializer<?> deserializerForCreator(DeserializationConfig config,
-            Class<?> enumClass, AnnotatedMethod factory,
-            ValueInstantiator valueInstantiator, SettableBeanProperty[] creatorProps)
+             Class<?> enumClass, AnnotatedMethod factory, ValueInstantiator valueInstantiator,
+             SettableBeanProperty[] creatorProps, EnumResolver byNameResolver)
     {
         if (config.canOverrideAccessModifiers()) {
             ClassUtil.checkAndFixAccess(factory.getMember(),
                     config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
         }
-        return new FactoryBasedEnumDeserializer(enumClass, factory,
-                factory.getParameterType(0),
-                valueInstantiator, creatorProps);
+        return new FactoryBasedEnumDeserializer(enumClass, factory, factory.getParameterType(0),
+            valueInstantiator, creatorProps, byNameResolver);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java
@@ -147,20 +147,20 @@ public class EnumDeserializer
     }
 
     /**
-     * @deprecated Since 2.9
-     */
-    @Deprecated
-    public EnumDeserializer(EnumResolver byNameResolver) {
-        this(byNameResolver, null);
-    }
-
-    /**
-     * @deprecated Since 2.8
+     * Factory method used when Enum instances are to be deserialized
+     * using a creator (static factory method)
+     *
+     * @return Deserializer based on given factory method
+     *
+     * @since 2.8
+     * @deprecated Since 2.19
      */
     @Deprecated
     public static JsonDeserializer<?> deserializerForCreator(DeserializationConfig config,
-            Class<?> enumClass, AnnotatedMethod factory) {
-        return deserializerForCreator(config, enumClass, factory, null, null, null);
+             Class<?> enumClass, AnnotatedMethod factory,
+             ValueInstantiator valueInstantiator, SettableBeanProperty[] creatorProps) {
+        return deserializerForCreator(config, enumClass, factory, valueInstantiator,
+                creatorProps, null);
     }
 
     /**
@@ -169,11 +169,12 @@ public class EnumDeserializer
      *
      * @return Deserializer based on given factory method
      *
-     * @since 2.8
+     * @since 2.19
      */
     public static JsonDeserializer<?> deserializerForCreator(DeserializationConfig config,
-             Class<?> enumClass, AnnotatedMethod factory, ValueInstantiator valueInstantiator,
-             SettableBeanProperty[] creatorProps, EnumResolver byNameResolver)
+            Class<?> enumClass, AnnotatedMethod factory,
+            ValueInstantiator valueInstantiator, SettableBeanProperty[] creatorProps,
+            EnumResolver byNameResolver)
     {
         if (config.canOverrideAccessModifiers()) {
             ClassUtil.checkAndFixAccess(factory.getMember(),

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.databind.deser.std;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -47,6 +46,20 @@ class FactoryBasedEnumDeserializer
      */
     private transient volatile PropertyBasedCreator _propCreator;
 
+    /**
+     * @since 2.8
+     * @deprecated since 2.19
+     */
+    @Deprecated
+    public FactoryBasedEnumDeserializer(Class<?> cls, AnnotatedMethod f, JavaType paramType,
+            ValueInstantiator valueInstantiator, SettableBeanProperty[] creatorProps)
+    {
+        this(cls, f, paramType, valueInstantiator, creatorProps, null);
+    }
+
+    /**
+     * @since 2.19
+     */
     public FactoryBasedEnumDeserializer(Class<?> cls, AnnotatedMethod f, JavaType paramType,
             ValueInstantiator valueInstantiator, SettableBeanProperty[] creatorProps,
             EnumResolver enumResolver)
@@ -60,13 +73,7 @@ class FactoryBasedEnumDeserializer
         _deser = null;
         _valueInstantiator = valueInstantiator;
         _creatorProps = creatorProps;
-        _defaultValue = Objects.nonNull(enumResolver)? enumResolver.getDefaultValue() : null;
-    }
-
-    public FactoryBasedEnumDeserializer(Class<?> cls, AnnotatedMethod f, JavaType paramType,
-            ValueInstantiator valueInstantiator, SettableBeanProperty[] creatorProps)
-    {
-        this(cls, f, paramType, valueInstantiator, creatorProps, null);
+        _defaultValue = (enumResolver == null) ? null : enumResolver.getDefaultValue();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -35,6 +35,8 @@ class FactoryBasedEnumDeserializer
     protected final JsonDeserializer<?> _deser;
     protected final ValueInstantiator _valueInstantiator;
     protected final SettableBeanProperty[] _creatorProps;
+
+    // @since 2.19
     protected final Enum<?> _defaultValue;
 
     protected final boolean _hasArgs;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FactoryBasedEnumDeserializer.java
@@ -220,13 +220,16 @@ class FactoryBasedEnumDeserializer
         } catch (Exception e) {
             Throwable t = ClassUtil.throwRootCauseIfIOE(e);
             if (t instanceof IllegalArgumentException) {
-                // [databind#1642]:
+                // [databind#4979]: unknown as default
+                if (ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)) {
+                    // ... only if we DO have a default
+                    if (_defaultValue != null) {
+                        return _defaultValue;
+                    }
+                }
+                // [databind#1642]: unknown as null
                 if (ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)) {
                     return null;
-                }
-
-                if (ctxt.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)) {
-                    return _defaultValue;
                 }
                 // 12-Oct-2021, tatu: Should probably try to provide better exception since
                 //   we likely hit argument incompatibility... Or can this happen?

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/EnumCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/EnumCreatorTest.java
@@ -125,7 +125,8 @@ public class EnumCreatorTest extends DatabindTestUtil
                 for (AnnotatedMethod am : factoryMethods) {
                     final JsonCreator creator = am.getAnnotation(JsonCreator.class);
                     if (creator != null) {
-                        return EnumDeserializer.deserializerForCreator(config, type, am, null, null);
+                        return EnumDeserializer.deserializerForCreator(
+                            config, type, am, null, null, null);
                     }
                 }
             }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
@@ -161,7 +161,7 @@ public class EnumDeserializationTest
     }
 
     static enum StrictEnumCreator {
-        A, B;
+        A, B, @JsonEnumDefaultValue UNKNOWN;
 
         @JsonCreator public static StrictEnumCreator fromId(String value) {
             for (StrictEnumCreator e: values()) {
@@ -453,7 +453,7 @@ public class EnumDeserializationTest
         assertNull(reader.forType(TestEnum.class).readValue(" 4343 "));
     }
 
-    // Ability to ignore unknown Enum values:
+    // Ability to ignore unknown Enum values as null:
 
     // [databind#1642]
     @Test
@@ -481,6 +481,19 @@ public class EnumDeserializationTest
         ClassWithEnumMapKey result = reader.forType(ClassWithEnumMapKey.class)
                 .readValue("{\"map\":{\"NO-SUCH-VALUE\":\"val\"}}");
         assertTrue(result.map.containsKey(null));
+    }
+
+    // Ability to ignore unknown Enum values as a defined default:
+
+    // [databind#4979]
+    @Test
+    public void testAllowUnknownEnumValuesReadAsDefaultWithCreatorMethod4979(() throws Exception
+    {
+        ObjectReader reader = MAPPER.reader(
+            DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+        assertEquals(
+            StrictEnumCreator.UNKNOWN,
+            reader.forType(StrictEnumCreator.class).readValue("\"NO-SUCH-VALUE\""));
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java
@@ -487,7 +487,7 @@ public class EnumDeserializationTest
 
     // [databind#4979]
     @Test
-    public void testAllowUnknownEnumValuesReadAsDefaultWithCreatorMethod4979(() throws Exception
+    public void testAllowUnknownEnumValuesReadAsDefaultWithCreatorMethod4979() throws Exception
     {
         ObjectReader reader = MAPPER.reader(
             DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);


### PR DESCRIPTION
This follows the pattern for READ_UNKNOWN_ENUM_VALUES_AS_NULL from here: 

https://github.com/FasterXML/jackson-databind/pull/1642/files

but for READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE

It's more tricky because it wasn't immediately apparent how to get the configured default value on the Creator impl side. I decided to try using the EnumResolver, which works, but am not sure what the repercussions of that are fully though.

It works the same way, so only IllegalArgumentExceptions will trigger default behavior, so if you have some other custom creator exception logic that will be unaffected.

There may be a better way to do this, just wanted to open this POC to see what you think. This would be useful in a couple scenarios for apps I work on, but I can work around it if this is not desired/too risky.