### PR TITLE
add regression test for issue 5008

### DIFF
--- a/src/test/java/tools/jackson/databind/deser/bean/BeanDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/deser/bean/BeanDeserializerTest.java
@@ -16,6 +16,7 @@ import tools.jackson.databind.deser.std.StdDeserializer;
 import tools.jackson.databind.deser.std.StdScalarDeserializer;
 import tools.jackson.databind.exc.InvalidDefinitionException;
 import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 import tools.jackson.databind.type.ArrayType;
 import tools.jackson.databind.type.CollectionType;
 import tools.jackson.databind.type.MapType;
@@ -527,6 +528,7 @@ public class BeanDeserializerTest
     }
 
     // https://github.com/FasterXML/jackson-databind/issues/5008
+    @JacksonTestFailureExpected
     @Test
     public void testSimpleValue5008Take2() throws Exception {
         // according to #5008, this only stopped working in v2.18.0

--- a/src/test/java/tools/jackson/databind/deser/bean/BeanDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/deser/bean/BeanDeserializerTest.java
@@ -344,6 +344,24 @@ public class BeanDeserializerTest
         }
     }
 
+    static class SimpleValue5008 {
+
+        private final String value;
+
+        public SimpleValue5008(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
     /*
     /********************************************************
     /* Test methods
@@ -498,4 +516,23 @@ public class BeanDeserializerTest
         Issue1912Bean result = mapper.readValue("{\"subBean\": {\"a\":\"foo\"}}", Issue1912Bean.class);
         assertEquals("foo_custom", result.subBean.a);
     }
+
+    // https://github.com/FasterXML/jackson-databind/issues/5008
+    @Test
+    public void testSimpleValue5008() throws Exception {
+        // according to #5008, this only started working in v2.18.0
+        SimpleValue5008 value = MAPPER.readValue(
+                a2q("{'value':'abc123'}"), SimpleValue5008.class);
+        assertEquals("abc123", value.value);
+    }
+
+    // https://github.com/FasterXML/jackson-databind/issues/5008
+    @Test
+    public void testSimpleValue5008Take2() throws Exception {
+        // according to #5008, this only stopped working in v2.18.0
+        SimpleValue5008 value = MAPPER.readValue(
+                a2q("'abc123'"), SimpleValue5008.class);
+        assertEquals("abc123", value.value);
+    }
+
 }

--- a/src/test/java/tools/jackson/databind/deser/bean/BeanDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/deser/bean/BeanDeserializerTest.java
@@ -16,7 +16,6 @@ import tools.jackson.databind.deser.std.StdDeserializer;
 import tools.jackson.databind.deser.std.StdScalarDeserializer;
 import tools.jackson.databind.exc.InvalidDefinitionException;
 import tools.jackson.databind.module.SimpleModule;
-import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 import tools.jackson.databind.type.ArrayType;
 import tools.jackson.databind.type.CollectionType;
 import tools.jackson.databind.type.MapType;
@@ -522,18 +521,11 @@ public class BeanDeserializerTest
     @Test
     public void testSimpleValue5008() throws Exception {
         // according to #5008, this only started working in v2.18.0
+        // in Jackson 2, you needed to add the ParameterNamesModule
+        // but this is part of Jackson 3
+        // pre Jackson 2.18, "abc123" is what the deserializer expected
         SimpleValue5008 value = MAPPER.readValue(
                 a2q("{'value':'abc123'}"), SimpleValue5008.class);
-        assertEquals("abc123", value.value);
-    }
-
-    // https://github.com/FasterXML/jackson-databind/issues/5008
-    @JacksonTestFailureExpected
-    @Test
-    public void testSimpleValue5008Take2() throws Exception {
-        // according to #5008, this only stopped working in v2.18.0
-        SimpleValue5008 value = MAPPER.readValue(
-                a2q("'abc123'"), SimpleValue5008.class);
         assertEquals("abc123", value.value);
     }
 


### PR DESCRIPTION
* #5008 
* Jackson 3 has ParameterNamesModule behaviour from Jackson2 pre-installed
* The 'broken' test would have passed in Jackson 2.17 - if ParameterNamesModule was registered
* Users who want the Jackson 2.17 behaviour need to use Jackson annotations
* adding as a regression test