### PR TITLE
add PolymorphicIdClassDeserTest that seems to not fail I would expect

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/deser/PolymorphicIdClassDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/PolymorphicIdClassDeserTest.java
@@ -1,0 +1,39 @@
+package com.fasterxml.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializeUsingJDKTest;
+import org.junit.jupiter.api.Test;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PolymorphicIdClassDeserTest {
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+    @JsonSubTypes({@JsonSubTypes.Type(value = FooClassImpl.class)})
+    static abstract class FooClass { }
+    static class FooClassImpl extends FooClass { }
+    static class FooClassImpl2 extends FooClass { }
+
+    /*
+    /************************************************************
+    /* Unit tests, valid
+    /************************************************************
+    */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void testDeserialization() throws Exception
+    {
+        //trying to test if JsonSubTypes enforced
+        final String foo1 = MAPPER.writeValueAsString(new FooClassImpl());
+        final String foo2 = MAPPER.writeValueAsString(new FooClassImpl2());
+        FooClass res1 = MAPPER.readValue(foo1, FooClass.class);
+        assertTrue(res1 instanceof FooClassImpl);
+        // next bit should in theory fail because FooClassImpl2 is not listed as a subtype
+        FooClass res2 = MAPPER.readValue(foo2, FooClass.class);
+        assertTrue(res2 instanceof FooClassImpl2);
+    }
+}


### PR DESCRIPTION
The test is about polymorphic types. FooClass has 2 defined subclasses but I only register one (via a JsonSubTypes annotation).
So in theory, when I deserialize, I should be an exception when I try the 2nd unregisered class.

@cowtowncoder could you have a look to see if I making an incorrect assumption about how this should work.