### PR TITLE
Fix #2882: make naming rules for getters stricter

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.0.0-rc2 (not yet released)
 
+#2882: Tighten accessor naming rules to not allow leading lower-case or
+  non-letter character for getters/setters
 #5003: Extend, improve set of `JsonNode.asXxx()` methods for number types
 #5025: Add support for automatic detection of subtypes (like `@JsonSubTypes`)
   from Java 17 sealed types

--- a/src/main/java/tools/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
+++ b/src/main/java/tools/jackson/databind/introspect/DefaultAccessorNamingStrategy.java
@@ -436,8 +436,10 @@ public class DefaultAccessorNamingStrategy
      * {@link FirstCharBasedValidator#forFirstNameRule}.
      */
     public static class FirstCharBasedValidator
-        implements BaseNameValidator
+        implements BaseNameValidator, java.io.Serializable
     {
+        private static final long serialVersionUID = 3L;
+
         private final boolean _allowLowerCaseFirstChar;
         private final boolean _allowNonLetterFirstChar;
 

--- a/src/main/java/tools/jackson/databind/util/BeanUtil.java
+++ b/src/main/java/tools/jackson/databind/util/BeanUtil.java
@@ -21,6 +21,11 @@ public class BeanUtil
     /**********************************************************************
      */
 
+    /**
+     * @deprecated since 3.0.0-rc2 Use {@link tools.jackson.databind.introspect.DefaultAccessorNamingStrategy}
+     *    instead
+     */
+    @Deprecated // since 3.0.0-rc2
     public static String stdManglePropertyName(final String basename, final int offset)
     {
         final int end = basename.length();

--- a/src/test/java/tools/jackson/databind/introspect/AccessorNamingForBuilderTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AccessorNamingForBuilderTest.java
@@ -64,6 +64,7 @@ public class AccessorNamingForBuilderTest extends DatabindTestUtil
                 .accessorNaming(new DefaultAccessorNamingStrategy.Provider()
                         .withBuilderPrefix("")
                 )
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
         ValueClassXY xy = customMapper.readValue(json, ValueClassXY.class);
         assertEquals(29, xy._x);

--- a/src/test/java/tools/jackson/databind/introspect/AccessorNamingStrategyTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AccessorNamingStrategyTest.java
@@ -217,18 +217,19 @@ public class AccessorNamingStrategyTest extends DatabindTestUtil
     public void testFirstLetterConfigs() throws Exception
     {
         final FirstLetterVariesBean input = new FirstLetterVariesBean();
-        final String STD_EXP = a2q("{'4Roses':42,'land':true,'value':31337}");
 
-        // First: vanilla? About anything goes
-        ObjectMapper mapper = newJsonMapper();
-        assertEquals(STD_EXP, mapper.writeValueAsString(input));
+        // First: new (3.0) defaults -- no weird stuff
+        assertEquals(a2q("{'value':31337}"),
+                MAPPER.writeValueAsString(input));
 
+        // First: let's configure with "anything goes" (2.x default):
         // also if explicitly configured as default:
-        mapper = JsonMapper.builder()
+        ObjectMapper mapper = JsonMapper.builder()
                 .accessorNaming(new DefaultAccessorNamingStrategy.Provider()
                         .withFirstCharAcceptance(true, true))
                 .build();
-        assertEquals(STD_EXP, mapper.writeValueAsString(input));
+        assertEquals(a2q("{'4Roses':42,'land':true,'value':31337}"),
+                mapper.writeValueAsString(input));
 
         // But we can vary it
         mapper = JsonMapper.builder()
@@ -246,5 +247,7 @@ public class AccessorNamingStrategyTest extends DatabindTestUtil
                 .build();
         assertEquals(a2q("{'4Roses':42,'value':31337}"),
                 mapper.writeValueAsString(input));
+
+        
     }
 }

--- a/src/test/java/tools/jackson/databind/introspect/AccessorNamingStrategyTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AccessorNamingStrategyTest.java
@@ -113,7 +113,7 @@ public class AccessorNamingStrategyTest extends DatabindTestUtil
     /********************************************************
      */
 
-    private final ObjectMapper MAPPER = JsonMapper.builder()
+    private final ObjectMapper ACCNAMING2800_MAPPER = JsonMapper.builder()
             .accessorNaming(new AccNaming2800Provider())
             .build();
 
@@ -121,13 +121,13 @@ public class AccessorNamingStrategyTest extends DatabindTestUtil
     public void testGetterNaming() throws Exception
     {
         assertEquals(a2q("{'X':3,'Z':true}"),
-                MAPPER.writeValueAsString(new GetterBean2800_XZ()));
+                ACCNAMING2800_MAPPER.writeValueAsString(new GetterBean2800_XZ()));
     }
 
     @Test
     public void testSetterNaming() throws Exception
     {
-        SetterBean2800_Y result = MAPPER.readValue(a2q("{'Y':42}"), SetterBean2800_Y.class);
+        SetterBean2800_Y result = ACCNAMING2800_MAPPER.readValue(a2q("{'Y':42}"), SetterBean2800_Y.class);
         assertEquals(42, result.yyy);
     }
 
@@ -136,10 +136,10 @@ public class AccessorNamingStrategyTest extends DatabindTestUtil
     {
         // first serialization
         assertEquals(a2q("{'x':1}"),
-                MAPPER.writeValueAsString(new FieldBean2800_X()));
+                ACCNAMING2800_MAPPER.writeValueAsString(new FieldBean2800_X()));
 
         // then deserialization
-        FieldBean2800_X result = MAPPER.readValue(a2q("{'x':28}"),
+        FieldBean2800_X result = ACCNAMING2800_MAPPER.readValue(a2q("{'x':28}"),
                 FieldBean2800_X.class);
         assertEquals(28, result._x);
         assertEquals(2, result.y);
@@ -220,7 +220,7 @@ public class AccessorNamingStrategyTest extends DatabindTestUtil
 
         // First: new (3.0) defaults -- no weird stuff
         assertEquals(a2q("{'value':31337}"),
-                MAPPER.writeValueAsString(input));
+                newJsonMapper().writeValueAsString(input));
 
         // First: let's configure with "anything goes" (2.x default):
         // also if explicitly configured as default:

--- a/src/test/java/tools/jackson/databind/introspect/BeanNamingTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/BeanNamingTest.java
@@ -3,9 +3,11 @@ package tools.jackson.databind.introspect;
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.databind.*;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // Tests for [databind#653]
 public class BeanNamingTest extends DatabindTestUtil
@@ -22,15 +24,55 @@ public class BeanNamingTest extends DatabindTestUtil
         }
     }
 
+    // [databind#2882]
+    static class Bean2882 {
+        // These should NOT be detected as "getters" due to naming conventions
+        public boolean island() { return true; }
+        public boolean is_bad() { return true; }
+
+        public int get_value() { return -2; }
+        public int getter() { return -3; }
+
+        // This is regular and should be detected
+        public int getX() { return 1; }
+
+        // And bad "setter" too
+        public void setter(int x) {
+            throw new IllegalStateException("Should not get called");
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+    
     // 24-Sep-2017, tatu: Used to test for `MapperFeature.USE_STD_BEAN_NAMING`, but with 3.x
     //    that is always enabled.
     @Test
     public void testMultipleLeadingCapitalLetters() throws Exception
     {
-        ObjectMapper mapper = newJsonMapper();
         assertEquals(a2q("{'URL':'http:'}"),
-                mapper.writeValueAsString(new URLBean()));
+                MAPPER.writeValueAsString(new URLBean()));
         assertEquals(a2q("{'a':3}"),
-                mapper.writeValueAsString(new ABean()));
+                MAPPER.writeValueAsString(new ABean()));
+    }
+
+    // [databind#2882]
+    @Test
+    void testBadCasingForGetters() throws Exception
+    {
+        assertEquals(a2q("{'x':1}"),
+                MAPPER.writeValueAsString(new Bean2882()));
+    }
+
+    @Test
+    void testBadCasingForSetters() throws Exception
+    {
+        try {
+            MAPPER.readerFor(Bean2882.class)
+                .with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .readValue(a2q("{'ter':1}"));
+            fail("Should not pass");
+        } catch (UnrecognizedPropertyException e) {
+            verifyException(e, "Unrecognized property \"ter\"");
+        }
     }
 }

--- a/src/test/java/tools/jackson/databind/introspect/TestPropertyConflicts.java
+++ b/src/test/java/tools/jackson/databind/introspect/TestPropertyConflicts.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.*;
 import tools.jackson.databind.*;
 import tools.jackson.databind.cfg.MapperConfig;
 import tools.jackson.databind.exc.InvalidDefinitionException;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -99,8 +100,13 @@ public class TestPropertyConflicts extends DatabindTestUtil
     public void testFailWithDupProps() throws Exception
     {
         BeanWithConflict bean = new BeanWithConflict();
+        // Must allow "getx"
+        JsonMapper mapper = JsonMapper.builder()
+                .accessorNaming(new DefaultAccessorNamingStrategy.Provider()
+                        .withFirstCharAcceptance(true, false))
+                .build();
         try {
-            String json = MAPPER.writer().writeValueAsString(bean);
+            String json = mapper.writeValueAsString(bean);
             fail("Should have failed due to conflicting accessor definitions; got JSON = "+json);
         } catch (InvalidDefinitionException e) {
             verifyException(e, "Conflicting getter definitions");


### PR DESCRIPTION
Note: Interestingly enough, new `DefaultAccessorNamingStrategy.BaseNameValidator` allows changing rules just like that -- so just need to use/provide default implementation it seems...

And that functionality has been around since Jackson 2.12.... :-D
