### PR TITLE
allow container deserializer to treat null as empty

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
@@ -59,7 +59,7 @@ public abstract class ContainerDeserializerBase<T>
     }
 
     protected ContainerDeserializerBase(JavaType selfType,
-                                        NullValueProvider nuller, Boolean unwrapSingle) {
+            NullValueProvider nuller, Boolean unwrapSingle) {
         this(selfType, nuller, unwrapSingle, false);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ContainerDeserializerBase.java
@@ -48,7 +48,7 @@ public abstract class ContainerDeserializerBase<T>
     protected final Boolean _unwrapSingle;
 
     /**
-     * When true, nulls are treated as empty values containers.
+     * When true, nulls are treated as empty containers.
      *
      * @since 2.19
      */


### PR DESCRIPTION
Relates to #5056 - tries to solve the same issue that I have in jackson-module-scala but that should work in Jackson 2 and 3.

In Scala, nulls are regarded as a bad thing. Best to deserialize a null container in Scala usage as an empty container instead of a null.

The _nullProvider is only used in 1 place in the base class but I was thinking for getNullValue that if you provide a NullProvider then it should be used for getNullValue. I'm willing to remove this if it is too risky to change this.

I can add some tests if this looks like a reasonable change.