### PR TITLE
Add copy-constructor for MappingIterator

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/MappingIterator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MappingIterator.java
@@ -163,6 +163,14 @@ public class MappingIterator<T> implements Iterator<T>, Closeable
     }
 
     /**
+     * Copy-constructor that sub-classes can use when creating new instances
+     * by fluent-style construction
+     */
+    protected MappingIterator(MappingIterator<T> src) {
+        this(src._type, src._parser, src._context, src._deserializer, src._closeParser, src._updatedValue);
+    }
+
+    /**
      * Method for getting an "empty" iterator instance: one that never
      * has more values; may be freely shared.
      *


### PR DESCRIPTION
I am currently trying to add a check process for `MappingIterator.nextValue`(to fix https://github.com/FasterXML/jackson-module-kotlin/issues/399).
https://github.com/FasterXML/jackson-module-kotlin/blob/1cf821da365093a23b2e7c21bf97d17ecc4ee112/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt#L54



A copy-constructor would be useful for this.
Could you please consider if this code could be merged?