### PR TITLE
Modify `ObjectReader._parserFactory` comment

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java
@@ -66,7 +66,7 @@ public class ObjectReader
     protected final DefaultDeserializationContext _context;
 
     /**
-     * Factory used for constructing {@link JsonGenerator}s
+     * Factory used for constructing {@link JsonParser}s
      */
     protected final JsonFactory _parserFactory;
 


### PR DESCRIPTION
### Summary

This PR corrects the misleading Javadoc comment for the `_parserFactory` field in `ObjectReader`.

### Description
`ObjectReader` is part of the read (deserialization) pipeline in Jackson.

It never constructs or uses `JsonGenerator`; that is the responsibility of `ObjectWriter`, which handles write (serialization) operations.

In `ObjectReader`, it is clearly used for constructing `JsonParser`, making the existing comment inaccurate and potentially confusing.