### PR TITLE
Fix regression in `ObjectNode.with()`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1930,3 +1930,7 @@ Joren Inghelbrecht (@jin-harmoney)
 Will Paul (@dropofwill)
  * Contributed #4979: Allow default enums with `@JsonCreator`
   (2.19.0)
+
+Ryan Schmitt (@rschmitt)
+ * Contributed #5099: Fix regression in `ObjectNode.with()`
+  (2.19.0)

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -87,7 +87,8 @@ public class ObjectNode
                 .getClass().getName() + "`)");
         }
         ObjectNode result = objectNode();
-        return _put(exprOrProperty, result);
+        _put(exprOrProperty, result);
+        return result;
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -291,11 +291,11 @@ public class ObjectNodeTest
 
         assertThrows(NullPointerException.class, () -> src.set(null, BooleanNode.TRUE));
         assertThrows(NullPointerException.class, () -> src.replace(null, BooleanNode.TRUE));
-        
+
         assertThrows(NullPointerException.class, () -> src.setAll(Collections.singletonMap(null,
                 MAPPER.createArrayNode())));
     }
-    
+
     @Test
     public void testRemove()
     {
@@ -332,6 +332,23 @@ public class ObjectNodeTest
         JsonNode child = root.withObject("/prop");
         assertTrue(child instanceof ObjectNode);
         assertEquals("{\"prop\":{}}", MAPPER.writeValueAsString(root));
+    }
+
+    @Test
+    public void testValidWith() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        assertEquals("{}", MAPPER.writeValueAsString(root));
+
+        ObjectNode withResult = root.with( "with" );
+        withResult.put( "key", "value" );
+
+        ObjectNode withObjectResult = root.withObject( "withObject" );
+        withObjectResult.put( "key", "value" );
+
+        assertEquals("{\"key\":\"value\"}", MAPPER.writeValueAsString(withObjectResult));
+        assertEquals("{\"key\":\"value\"}", MAPPER.writeValueAsString(withResult));
+        assertEquals(withResult, withObjectResult);
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -334,12 +334,14 @@ public class ObjectNodeTest
         assertEquals("{\"prop\":{}}", MAPPER.writeValueAsString(root));
     }
 
+    // for [databind#5099]
     @Test
     public void testValidWith() throws Exception
     {
         ObjectNode root = MAPPER.createObjectNode();
         assertEquals("{}", MAPPER.writeValueAsString(root));
 
+        @SuppressWarnings("deprecation")
         ObjectNode withResult = root.with( "with" );
         withResult.put( "key", "value" );
 


### PR DESCRIPTION
This fixes a regression that seems to have been introduced in d7adffa7bd9f1882ec3db3c431f74d92502049ab.