### PR TITLE
Fix #5078 `MonthSerializer` not affected by `DateTimeFeature.ONE_BASED_MONTHS` 

### DIFF
--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/MonthSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/MonthSerializer.java
@@ -78,11 +78,7 @@ public class MonthSerializer
             return;
         }
         if (ctxt.isEnabled(EnumFeature.WRITE_ENUMS_USING_INDEX)) {
-            if (ctxt.isEnabled(DateTimeFeature.ONE_BASED_MONTHS)) {
-                g.writeNumber(value.getValue());
-            } else {
-                g.writeNumber(value.getValue() - 1);
-            }
+            _serializeOneBased(g, value, ctxt);
             return;
         }
         if (ctxt.isEnabled(EnumFeature.WRITE_ENUMS_USING_TO_STRING)) {
@@ -90,7 +86,17 @@ public class MonthSerializer
             return;
         }
         // Fallback to default serialization
-        g.writeNumber(value.getValue());
+        _serializeOneBased(g, value, ctxt);
+    }
+
+    private void _serializeOneBased(JsonGenerator g, Month value, SerializationContext ctxt)
+            throws JacksonException
+    {
+        if (ctxt.isEnabled(DateTimeFeature.ONE_BASED_MONTHS)) {
+            g.writeNumber(value.getValue());
+        } else {
+            g.writeNumber(value.getValue() - 1);
+        }
     }
 
 }

--- a/src/test/java/tools/jackson/databind/ext/javatime/ser/MonthSerializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/ser/MonthSerializerTest.java
@@ -76,6 +76,17 @@ public class MonthSerializerTest extends DateTimeTestBase
         assertEquals(expectedJson, writer.writeValueAsString(input));
     }
 
+    @Test
+    public void testOneBasedSerialization() throws Exception
+    {
+        ObjectMapper mapper = mapperBuilder()
+                .disable(EnumFeature.WRITE_ENUMS_USING_INDEX)
+                .disable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
+                .build();
+
+        assertEquals("{\"month\":0}", mapper.writeValueAsString(new Wrapper(Month.JANUARY)));
+    }
+
     private static Stream<Arguments> oneBasedVsIndex() {
         return Stream.of(
                 // oneBased, writeIndex, expectedJson

--- a/src/test/java/tools/jackson/databind/ext/javatime/ser/MonthSerializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/ser/MonthSerializerTest.java
@@ -79,12 +79,21 @@ public class MonthSerializerTest extends DateTimeTestBase
     @Test
     public void testOneBasedSerialization() throws Exception
     {
-        ObjectMapper mapper = mapperBuilder()
+        ObjectMapper disabled = mapperBuilder()
                 .disable(EnumFeature.WRITE_ENUMS_USING_INDEX)
                 .disable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
+                .disable(DateTimeFeature.ONE_BASED_MONTHS)
                 .build();
 
-        assertEquals("{\"month\":0}", mapper.writeValueAsString(new Wrapper(Month.JANUARY)));
+        assertEquals("{\"month\":0}", disabled.writeValueAsString(new Wrapper(Month.JANUARY)));
+
+        ObjectMapper enabled = mapperBuilder()
+                .disable(EnumFeature.WRITE_ENUMS_USING_INDEX)
+                .disable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
+                .enable(DateTimeFeature.ONE_BASED_MONTHS)
+                .build();
+
+        assertEquals("{\"month\":1}", enabled.writeValueAsString(new Wrapper(Month.JANUARY)));
     }
 
     private static Stream<Arguments> oneBasedVsIndex() {


### PR DESCRIPTION
This is follow up wrt [comment](https://github.com/FasterXML/jackson-databind/pull/5124/files#r2062773588) from #5124 