### PR TITLE
 Part of databind#3072: Make @JacksonInject not fail when there's no corresponding value

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1222,7 +1222,6 @@ Lavender Shannon (retrodaredevil@github)
   * Requested #3072: Allow specifying `@JacksonInject` does not fail when there's no
     corresponding value
   (2.20.0)
- (requested by Lavender S)
 
 Daniel Hrabovcak (TheSpiritXIII@github)
   * Reported #2796: `TypeFactory.constructType()` does not take `TypeBindings` correctly

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1215,10 +1215,14 @@ Oleg Chtchoukine (oshatrk@github)
     to incorrect output
   (2.11.1)
 
-Joshua Shannon (retrodaredevil@github)
+Lavender Shannon (retrodaredevil@github)
   * Reported, contributed fix for #2785: Polymorphic subtypes not registering on copied
     ObjectMapper (2.11.1)
   (2.11.2)
+  * Requested #3072: Allow specifying `@JacksonInject` does not fail when there's no
+    corresponding value
+  (2.20.0)
+ (requested by Lavender S)
 
 Daniel Hrabovcak (TheSpiritXIII@github)
   * Reported #2796: `TypeFactory.constructType()` does not take `TypeBindings` correctly
@@ -1940,3 +1944,8 @@ Will Paul (@dropofwill)
 Ryan Schmitt (@rschmitt)
  * Contributed #5099: Fix regression in `ObjectNode.with()`
   (2.19.0)
+
+Giulio Longfils (@giulong)
+ * Contributed #3072: Allow specifying `@JacksonInject` does not fail when there's no
+   corresponding value
+  (2.20.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,6 +6,10 @@ Project: jackson-databind
 
 2.20.0 (not yet released)
 
+#3072: Allow specifying `@JacksonInject` does not fail when there's no
+  corresponding value
+ (requested by Lavender S)
+ (contributed by Giulio L)
 #4136: Drop deprecated (in 2.12) `PropertyNamingStrategy` implementations
   from 2.20
 #5103: Use `writeStartObject(Object forValue, int size)` for `ObjectNode`

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -6,6 +6,7 @@ import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdResolver;
@@ -468,8 +469,14 @@ public abstract class DeserializationContext
         throws JsonMappingException
     {
         if (_injectableValues == null) {
-            return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
-"No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
+            final JacksonInject.Value injectableValue = getAnnotationIntrospector()
+                    .findInjectableValue(forProperty.getMember());
+
+            return injectableValue.getOptional()
+                    ? JacksonInject.Value.empty()
+                    : reportBadDefinition(ClassUtil.classOf(valueId), String.format(
+                            "No 'injectableValues' configured, " +
+                                    "cannot inject value with id [%s]", valueId));
         }
         return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -466,6 +466,9 @@ public abstract class DeserializationContext
      */
     public final JsonParser getParser() { return _parser; }
 
+    /**
+     * @since 2.20
+     */
     public final Object findInjectableValue(Object valueId,
             BeanProperty forProperty, Object beanInstance, Boolean optional)
         throws JsonMappingException
@@ -483,6 +486,7 @@ public abstract class DeserializationContext
     /**
      * @deprecated in 2.20
      */
+    @Deprecated // since 2.20
     public final Object findInjectableValue(Object valueId,
                                             BeanProperty forProperty, Object beanInstance)
             throws JsonMappingException

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -39,8 +39,6 @@ import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.*;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
-
 /**
  * Context for the process of deserialization a single root-level value.
  * Used to allow passing in configuration settings and reusable temporary
@@ -474,7 +472,7 @@ public abstract class DeserializationContext
             final JacksonInject.Value injectableValue = getAnnotationIntrospector()
                     .findInjectableValue(forProperty.getMember());
 
-            return injectableValue.getOptional() || !isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)
+            return injectableValue.getOptional() || !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
                     ? JacksonInject.Value.empty()
                     : reportBadDefinition(ClassUtil.classOf(valueId), String.format(
                             "No 'injectableValues' configured, " +

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -13,11 +13,7 @@ import com.fasterxml.jackson.annotation.ObjectIdResolver;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.util.JacksonFeatureSet;
-import com.fasterxml.jackson.databind.cfg.CoercionAction;
-import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
-import com.fasterxml.jackson.databind.cfg.ContextAttributes;
-import com.fasterxml.jackson.databind.cfg.DatatypeFeature;
-import com.fasterxml.jackson.databind.cfg.DatatypeFeatures;
+import com.fasterxml.jackson.databind.cfg.*;
 import com.fasterxml.jackson.databind.deser.*;
 import com.fasterxml.jackson.databind.deser.impl.ObjectIdReader;
 import com.fasterxml.jackson.databind.deser.impl.ReadableObjectId;
@@ -38,8 +34,6 @@ import com.fasterxml.jackson.databind.node.TreeTraversingParser;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.*;
-
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
 
 /**
  * Context for the process of deserialization a single root-level value.
@@ -474,7 +468,10 @@ public abstract class DeserializationContext
         throws JsonMappingException
     {
         if (_injectableValues == null) {
-            if (Boolean.TRUE.equals(optional) || !isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)) {
+            // `optional` comes from property annotation (if any); has precedence
+            // over global setting
+            if ((optional != null && optional)
+                    || !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)) {
                 return JacksonInject.Value.empty();
             }
             return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
@@ -488,10 +485,10 @@ public abstract class DeserializationContext
      */
     @Deprecated // since 2.20
     public final Object findInjectableValue(Object valueId,
-                                            BeanProperty forProperty, Object beanInstance)
-            throws JsonMappingException
+            BeanProperty forProperty, Object beanInstance)
+        throws JsonMappingException
     {
-        return this.findInjectableValue(valueId, forProperty, beanInstance, null);
+        return findInjectableValue(valueId, forProperty, beanInstance, null);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -469,13 +469,13 @@ public abstract class DeserializationContext
     {
         if (_injectableValues == null) {
             // `optional` comes from property annotation (if any); has precedence
-            // over global setting
+            // over global setting.
             if (Boolean.TRUE.equals(optional)
                     || (optional == null && !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
                 return JacksonInject.Value.empty();
             }
             return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
-"No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
+"No 'injectableValues' configured, cannot inject value with id '%s'", valueId));
         }
         return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance, optional);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -484,7 +484,7 @@ public abstract class DeserializationContext
                 return JacksonInject.Value.empty();
             }
             return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
-                    "No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
+"No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
         }
         return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -465,28 +465,18 @@ public abstract class DeserializationContext
     public final JsonParser getParser() { return _parser; }
 
     public final Object findInjectableValue(Object valueId,
-            BeanProperty forProperty, Object beanInstance)
+            BeanProperty forProperty, Object beanInstance, Boolean optional)
         throws JsonMappingException
     {
         if (_injectableValues == null) {
-            final JacksonInject.Value injectableValue = getAnnotationIntrospector()
-                    .findInjectableValue(forProperty.getMember());
-            // Default optional-or-not from global setting:
-            boolean optional = !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
-            // but may be overridden on per-property basis:
-            if (injectableValue != null) {
-                // `null` means "use defaults" (global setting)
-                if (injectableValue.getOptional() != null) {
-                    optional = injectableValue.getOptional();
-                }
-            }
-            if (optional) {
+            if (!isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
+                    || Boolean.TRUE.equals(optional)) {
                 return JacksonInject.Value.empty();
             }
             return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
 "No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
         }
-        return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance);
+        return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance, optional);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -470,8 +470,8 @@ public abstract class DeserializationContext
         if (_injectableValues == null) {
             // `optional` comes from property annotation (if any); has precedence
             // over global setting
-            if ((optional != null && optional)
-                    || !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)) {
+            if (Boolean.TRUE.equals(optional)
+                    || (optional == null && !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
                 return JacksonInject.Value.empty();
             }
             return reportBadDefinition(ClassUtil.classOf(valueId), String.format(

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -471,12 +471,20 @@ public abstract class DeserializationContext
         if (_injectableValues == null) {
             final JacksonInject.Value injectableValue = getAnnotationIntrospector()
                     .findInjectableValue(forProperty.getMember());
-
-            return injectableValue.getOptional() || !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
-                    ? JacksonInject.Value.empty()
-                    : reportBadDefinition(ClassUtil.classOf(valueId), String.format(
-                            "No 'injectableValues' configured, " +
-                                    "cannot inject value with id [%s]", valueId));
+            // Default optional-or-not from global setting:
+            boolean optional = !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
+            // but may be overridden on per-property basis:
+            if (injectableValue != null) {
+                // `null` means "use defaults" (global setting)
+                if (injectableValue.getOptional() != null) {
+                    optional = injectableValue.getOptional();
+                }
+            }
+            if (optional) {
+                return JacksonInject.Value.empty();
+            }
+            return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
+                    "No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
         }
         return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.*;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
+
 /**
  * Context for the process of deserialization a single root-level value.
  * Used to allow passing in configuration settings and reusable temporary
@@ -469,14 +471,23 @@ public abstract class DeserializationContext
         throws JsonMappingException
     {
         if (_injectableValues == null) {
-            if (!isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
-                    || Boolean.TRUE.equals(optional)) {
+            if (Boolean.TRUE.equals(optional) || !isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)) {
                 return JacksonInject.Value.empty();
             }
             return reportBadDefinition(ClassUtil.classOf(valueId), String.format(
 "No 'injectableValues' configured, cannot inject value with id [%s]", valueId));
         }
         return _injectableValues.findInjectableValue(valueId, this, forProperty, beanInstance, optional);
+    }
+
+    /**
+     * @deprecated in 2.20
+     */
+    public final Object findInjectableValue(Object valueId,
+                                            BeanProperty forProperty, Object beanInstance)
+            throws JsonMappingException
+    {
+        return this.findInjectableValue(valueId, forProperty, beanInstance, null);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.*;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
+
 /**
  * Context for the process of deserialization a single root-level value.
  * Used to allow passing in configuration settings and reusable temporary
@@ -472,7 +474,7 @@ public abstract class DeserializationContext
             final JacksonInject.Value injectableValue = getAnnotationIntrospector()
                     .findInjectableValue(forProperty.getMember());
 
-            return injectableValue.getOptional()
+            return injectableValue.getOptional() || !isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)
                     ? JacksonInject.Value.empty()
                     : reportBadDefinition(ClassUtil.classOf(valueId), String.format(
                             "No 'injectableValues' configured, " +

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -267,7 +267,7 @@ public enum DeserializationFeature implements ConfigFeature
      * white space or comments, if supported by data format).
      *<p>
      * Feature is disabled by default (so that no check is made for possible trailing
-     * token(s)) for backwards compatibility reasons.
+     * token(s)) for backwards-compatibility reasons.
      *
      * @since 2.9
      */
@@ -331,7 +331,7 @@ public enum DeserializationFeature implements ConfigFeature
      * by ensuring that only the properties relevant to the active view are considered during
      * deserialization, thereby preventing unintended data from being processed.
      *<p>
-     * In Jackson 2.x, this feature is disabled by default to maintain backward compatibility.
+     * In Jackson 2.x, this feature is disabled by default to maintain backwards-compatibility.
      * In Jackson 3.x, this feature may be enabled by default.
      *
      * @since 2.17
@@ -346,7 +346,7 @@ public enum DeserializationFeature implements ConfigFeature
      * When disabled, no exception is thrown.
      * @see JacksonInject#optional() to configure the same behavior on single properties,
      *<p>
-     * In Jackson 2.x, this feature is enabled by default to maintain backward compatibility.
+     * In Jackson 2.x, this feature is enabled by default to maintain backwards-compatibility.
      *
      * @since 2.20
      */

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -340,13 +340,15 @@ public enum DeserializationFeature implements ConfigFeature
     /**
      * Feature that determines the handling of injected properties during deserialization.
      *<p>
-     * When enabled, if an injected property is not encountered during deserialization,
-     * an exception is thrown.
+     * When enabled, if an injected property without matching value is encountered
+     * during deserialization,  an exception is thrown.
      * When disabled, no exception is thrown.
-     * @see JacksonInject#optional() to configure the same behavior on single properties,
+     * See {@link JacksonInject#optional()} for per-property override
+     * of this setting.
      *<p>
-     * In Jackson 2.x, this feature is enabled by default to maintain backwards-compatibility.
+     * This feature is enabled by default to maintain backwards-compatibility.
      *
+     * @see JacksonInject#optional()
      * @since 2.20
      */
     FAIL_ON_UNKNOWN_INJECT_VALUE(true),

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationFeature.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.databind;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.cfg.ConfigFeature;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
 
@@ -336,6 +337,20 @@ public enum DeserializationFeature implements ConfigFeature
      * @since 2.17
      */
     FAIL_ON_UNEXPECTED_VIEW_PROPERTIES(false),
+
+    /**
+     * Feature that determines the handling of injected properties during deserialization.
+     *<p>
+     * When enabled, if an injected property is not encountered during deserialization,
+     * an exception is thrown.
+     * When disabled, no exception is thrown.
+     * @see JacksonInject#optional() to configure the same behavior on single properties,
+     *<p>
+     * In Jackson 2.x, this feature is enabled by default to maintain backward compatibility.
+     *
+     * @since 2.20
+     */
+    FAIL_ON_UNKNOWN_INJECT_VALUE(true),
 
     /*
     /******************************************************

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.databind;
 
 import java.util.*;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
@@ -26,6 +25,8 @@ public abstract class InjectableValues
      * @param forProperty Bean property in which value is to be injected
      * @param beanInstance Bean instance that contains property to inject,
      *    if available; null if bean has not yet been constructed.
+     * @param optional Flag used for configuring the behavior when the value
+     *    to inject is not found
      */
     public abstract Object findInjectableValue(Object valueId, DeserializationContext ctxt,
             BeanProperty forProperty, Object beanInstance, Boolean optional) throws JsonMappingException;
@@ -33,8 +34,9 @@ public abstract class InjectableValues
     /**
      * @deprecated in 2.20
      */
+    @Deprecated // since 2.20
     public abstract Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-                                               BeanProperty forProperty, Object beanInstance) throws JsonMappingException;
+            BeanProperty forProperty, Object beanInstance) throws JsonMappingException;
 
     /*
     /**********************************************************
@@ -72,6 +74,9 @@ public abstract class InjectableValues
             return this;
         }
 
+        /**
+         * @since 2.20
+         */
         @Override
         public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
                 BeanProperty forProperty, Object beanInstance, Boolean optional) throws JsonMappingException
@@ -97,6 +102,7 @@ public abstract class InjectableValues
          * @deprecated in 2.20
          */
         @Override
+        @Deprecated // since 2.20
         public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
                                           BeanProperty forProperty, Object beanInstance) throws JsonMappingException
         {

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -77,7 +77,8 @@ public abstract class InjectableValues
          */
         @Override
         public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-                BeanProperty forProperty, Object beanInstance, Boolean optional) throws JsonMappingException
+                BeanProperty forProperty, Object beanInstance, Boolean optional)
+            throws JsonMappingException
         {
             if (!(valueId instanceof String)) {
                 ctxt.reportBadDefinition(ClassUtil.classOf(valueId),
@@ -88,10 +89,12 @@ public abstract class InjectableValues
             String key = (String) valueId;
             Object ob = _values.get(key);
             if (ob == null && !_values.containsKey(key)) {
-                if (!Boolean.TRUE.equals(optional)
-                    && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)) {
-                    throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
-                            "found (for property '" + forProperty.getName() + "')");
+                if (Boolean.FALSE.equals(optional)
+                        || ((optional == null)
+                                && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
+                    return ctxt.reportBadDefinition(ClassUtil.classOf(valueId), String.format(
+                            "No injectable value with id '" + key + "' " +
+                            "found (for property '" + forProperty.getName() + "')"));
                 }
             }
             return ob;

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -5,8 +5,6 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
-
 /**
  * Abstract class that defines API for objects that provide value to
  * "inject" during deserialization. An instance of this object
@@ -81,9 +79,19 @@ public abstract class InjectableValues
             if (ob == null && !_values.containsKey(key)) {
                 final JacksonInject.Value injectableValue = ctxt.getAnnotationIntrospector()
                         .findInjectableValue(forProperty.getMember());
+                // Default optional-or-not from global setting:
+                boolean optional = !ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
+                // but may be overridden on per-property basis:
+                if (injectableValue != null) {
+                    // `null` means "use defaults" (global setting)
+                    if (injectableValue.getOptional() != null) {
+                        optional = injectableValue.getOptional();
+                    }
+                }
 
-                if (!injectableValue.getOptional() && ctxt.isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)) {
-                    throw new IllegalArgumentException("No injectable id with value '" + key + "' " +
+                
+                if (!optional) {
+                    throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
                             "found (for property '" + forProperty.getName() + "')");
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -4,8 +4,6 @@ import java.util.*;
 
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
-
 /**
  * Abstract class that defines API for objects that provide value to
  * "inject" during deserialization. An instance of this object
@@ -89,11 +87,12 @@ public abstract class InjectableValues
             }
             String key = (String) valueId;
             Object ob = _values.get(key);
-            if (ob == null && !_values.containsKey(key)
-                    && !Boolean.TRUE.equals(optional)
-                    && ctxt.isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)) {
-                throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
-                        "found (for property '" + forProperty.getName() + "')");
+            if (ob == null && !_values.containsKey(key)) {
+                if (!Boolean.TRUE.equals(optional)
+                    && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)) {
+                    throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
+                            "found (for property '" + forProperty.getName() + "')");
+                }
             }
             return ob;
         }
@@ -104,7 +103,7 @@ public abstract class InjectableValues
         @Override
         @Deprecated // since 2.20
         public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-                                          BeanProperty forProperty, Object beanInstance) throws JsonMappingException
+                BeanProperty forProperty, Object beanInstance) throws JsonMappingException
         {
             return this.findInjectableValue(valueId, ctxt, forProperty, beanInstance, null);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -5,6 +5,8 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
+
 /**
  * Abstract class that defines API for objects that provide value to
  * "inject" during deserialization. An instance of this object
@@ -27,6 +29,12 @@ public abstract class InjectableValues
      */
     public abstract Object findInjectableValue(Object valueId, DeserializationContext ctxt,
             BeanProperty forProperty, Object beanInstance, Boolean optional) throws JsonMappingException;
+
+    /**
+     * @deprecated in 2.20
+     */
+    public abstract Object findInjectableValue(Object valueId, DeserializationContext ctxt,
+                                               BeanProperty forProperty, Object beanInstance) throws JsonMappingException;
 
     /*
     /**********************************************************
@@ -77,12 +85,22 @@ public abstract class InjectableValues
             String key = (String) valueId;
             Object ob = _values.get(key);
             if (ob == null && !_values.containsKey(key)
-                    && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
-                    && !Boolean.TRUE.equals(optional)) {
+                    && !Boolean.TRUE.equals(optional)
+                    && ctxt.isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)) {
                 throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
                         "found (for property '" + forProperty.getName() + "')");
             }
             return ob;
+        }
+
+        /**
+         * @deprecated in 2.20
+         */
+        @Override
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
+                                          BeanProperty forProperty, Object beanInstance) throws JsonMappingException
+        {
+            return this.findInjectableValue(valueId, ctxt, forProperty, beanInstance, null);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -26,7 +26,7 @@ public abstract class InjectableValues
      *    if available; null if bean has not yet been constructed.
      */
     public abstract Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-            BeanProperty forProperty, Object beanInstance) throws JsonMappingException;
+            BeanProperty forProperty, Object beanInstance, Boolean optional) throws JsonMappingException;
 
     /*
     /**********************************************************
@@ -66,7 +66,7 @@ public abstract class InjectableValues
 
         @Override
         public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-                BeanProperty forProperty, Object beanInstance) throws JsonMappingException
+                BeanProperty forProperty, Object beanInstance, Boolean optional) throws JsonMappingException
         {
             if (!(valueId instanceof String)) {
                 ctxt.reportBadDefinition(ClassUtil.classOf(valueId),
@@ -76,24 +76,11 @@ public abstract class InjectableValues
             }
             String key = (String) valueId;
             Object ob = _values.get(key);
-            if (ob == null && !_values.containsKey(key)) {
-                final JacksonInject.Value injectableValue = ctxt.getAnnotationIntrospector()
-                        .findInjectableValue(forProperty.getMember());
-                // Default optional-or-not from global setting:
-                boolean optional = !ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
-                // but may be overridden on per-property basis:
-                if (injectableValue != null) {
-                    // `null` means "use defaults" (global setting)
-                    if (injectableValue.getOptional() != null) {
-                        optional = injectableValue.getOptional();
-                    }
-                }
-
-                
-                if (!optional) {
-                    throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
-                            "found (for property '" + forProperty.getName() + "')");
-                }
+            if (ob == null && !_values.containsKey(key)
+                    && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
+                    && !Boolean.TRUE.equals(optional)) {
+                throw new IllegalArgumentException("No injectable value with id '" + key + "' " +
+                        "found (for property '" + forProperty.getName() + "')");
             }
             return ob;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind;
 
 import java.util.*;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
 /**
@@ -76,7 +77,13 @@ public abstract class InjectableValues
             String key = (String) valueId;
             Object ob = _values.get(key);
             if (ob == null && !_values.containsKey(key)) {
-                throw new IllegalArgumentException("No injectable id with value '"+key+"' found (for property '"+forProperty.getName()+"')");
+                final JacksonInject.Value injectableValue = ctxt.getAnnotationIntrospector()
+                        .findInjectableValue(forProperty.getMember());
+
+                if (!injectableValue.getOptional()) {
+                    throw new IllegalArgumentException("No injectable id with value '" + key + "' " +
+                            "found (for property '" + forProperty.getName() + "')");
+                }
             }
             return ob;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -5,6 +5,8 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
+
 /**
  * Abstract class that defines API for objects that provide value to
  * "inject" during deserialization. An instance of this object
@@ -80,7 +82,7 @@ public abstract class InjectableValues
                 final JacksonInject.Value injectableValue = ctxt.getAnnotationIntrospector()
                         .findInjectableValue(forProperty.getMember());
 
-                if (!injectableValue.getOptional()) {
+                if (!injectableValue.getOptional() && ctxt.isEnabled(FAIL_ON_UNKNOWN_INJECT_VALUE)) {
                     throw new IllegalArgumentException("No injectable id with value '" + key + "' " +
                             "found (for property '" + forProperty.getName() + "')");
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -241,7 +241,7 @@ public class BeanDeserializerBuilder
 
     public void addInjectable(PropertyName propName, JavaType propType,
             Annotations contextAnnotations, AnnotatedMember member,
-            Object valueId)
+            Object valueId, Boolean optional)
         throws JsonMappingException
     {
         if (_injectables == null) {
@@ -254,7 +254,7 @@ public class BeanDeserializerBuilder
                 _handleBadAccess(e);
             }
         }
-        _injectables.add(new ValueInjector(propName, propType, member, valueId));
+        _injectables.add(new ValueInjector(propName, propType, member, valueId, optional));
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -258,6 +258,17 @@ public class BeanDeserializerBuilder
     }
 
     /**
+     * @deprecated in 2.20
+     */
+    public void addInjectable(PropertyName propName, JavaType propType,
+                              Annotations contextAnnotations, AnnotatedMember member,
+                              Object valueId)
+            throws JsonMappingException
+    {
+        this.addInjectable(propName, propType, contextAnnotations, member, valueId, null);
+    }
+
+    /**
      * Method that will add property name as one of properties that can
      * be ignored if not recognized.
      */

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -239,6 +239,9 @@ public class BeanDeserializerBuilder
         */
     }
 
+    /**
+     * @since 2.20
+     */
     public void addInjectable(PropertyName propName, JavaType propType,
             Annotations contextAnnotations, AnnotatedMember member,
             Object valueId, Boolean optional)
@@ -260,6 +263,7 @@ public class BeanDeserializerBuilder
     /**
      * @deprecated in 2.20
      */
+    @Deprecated // since 2.20
     public void addInjectable(PropertyName propName, JavaType propType,
                               Annotations contextAnnotations, AnnotatedMember member,
                               Object valueId)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -248,7 +248,7 @@ public class BeanDeserializerBuilder
         throws JsonMappingException
     {
         if (_injectables == null) {
-            _injectables = new ArrayList<ValueInjector>();
+            _injectables = new ArrayList<>();
         }
         if ( _config.canOverrideAccessModifiers()) {
             try {
@@ -265,9 +265,9 @@ public class BeanDeserializerBuilder
      */
     @Deprecated // since 2.20
     public void addInjectable(PropertyName propName, JavaType propType,
-                              Annotations contextAnnotations, AnnotatedMember member,
-                              Object valueId)
-            throws JsonMappingException
+            Annotations contextAnnotations, AnnotatedMember member,
+            Object valueId)
+        throws JsonMappingException
     {
         this.addInjectable(propName, propType, contextAnnotations, member, valueId, null);
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -812,11 +812,15 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
     {
         Map<Object, AnnotatedMember> raw = beanDesc.findInjectables();
         if (raw != null) {
+            final AnnotationIntrospector introspector = ctxt.getAnnotationIntrospector();
             for (Map.Entry<Object, AnnotatedMember> entry : raw.entrySet()) {
                 AnnotatedMember m = entry.getValue();
+                final JacksonInject.Value injectableValue = introspector.findInjectableValue(m);
+                final Boolean optional = injectableValue == null ? null : injectableValue.getOptional();
+
                 builder.addInjectable(PropertyName.construct(m.getName()),
                         m.getType(),
-                        beanDesc.getClassAnnotations(), m, entry.getKey());
+                        beanDesc.getClassAnnotations(), m, entry.getKey(), optional);
             }
         }
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -813,6 +813,7 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
         Map<Object, AnnotatedMember> raw = beanDesc.findInjectables();
         if (raw != null) {
             final AnnotationIntrospector introspector = ctxt.getAnnotationIntrospector();
+
             for (Map.Entry<Object, AnnotatedMember> entry : raw.entrySet()) {
                 AnnotatedMember m = entry.getValue();
                 final JacksonInject.Value injectableValue = introspector.findInjectableValue(m);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/CreatorProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/CreatorProperty.java
@@ -103,7 +103,7 @@ public class CreatorProperty
     {
         this(name, type, wrapperName, typeDeser, contextAnnotations, param, index,
                 (injectableValueId == null) ? null
-                        : JacksonInject.Value.construct(injectableValueId, null),
+                        : JacksonInject.Value.construct(injectableValueId, null, null),
                 metadata);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -269,7 +269,7 @@ public class PropertyValueBuffer
         Object injectableValueId = prop.getInjectableValueId();
         if (injectableValueId != null) {
             return _context.findInjectableValue(prop.getInjectableValueId(),
-                    prop, null);
+                    prop, null, null);
         }
         // Second: required?
         if (prop.isRequired()) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
@@ -22,11 +22,27 @@ public class ValueInjector
      */
     protected final Object _valueId;
 
+    /**
+     * Flag used for configuring the behavior when the value to inject is not found
+     */
+    protected final Boolean _optional;
+
     public ValueInjector(PropertyName propName, JavaType type,
-            AnnotatedMember mutator, Object valueId)
+                         AnnotatedMember mutator, Object valueId, Boolean optional)
     {
         super(propName, type, null, mutator, PropertyMetadata.STD_OPTIONAL);
         _valueId = valueId;
+        _optional = optional;
+    }
+
+    /**
+     * @deprecated in 2.20 (remove from 3.0)
+     */
+    @Deprecated
+    public ValueInjector(PropertyName propName, JavaType type,
+            AnnotatedMember mutator, Object valueId)
+    {
+        this(propName, type, mutator, valueId, null);
     }
 
     /**
@@ -43,7 +59,7 @@ public class ValueInjector
     public Object findValue(DeserializationContext context, Object beanInstance)
         throws JsonMappingException
     {
-        return context.findInjectableValue(_valueId, this, beanInstance);
+        return context.findInjectableValue(_valueId, this, beanInstance, _optional);
     }
 
     public void inject(DeserializationContext context, Object beanInstance)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
@@ -27,8 +27,11 @@ public class ValueInjector
      */
     protected final Boolean _optional;
 
+    /**
+     * @since 2.20
+     */
     public ValueInjector(PropertyName propName, JavaType type,
-                         AnnotatedMember mutator, Object valueId, Boolean optional)
+            AnnotatedMember mutator, Object valueId, Boolean optional)
     {
         super(propName, type, null, mutator, PropertyMetadata.STD_OPTIONAL);
         _valueId = valueId;
@@ -38,7 +41,7 @@ public class ValueInjector
     /**
      * @deprecated in 2.20 (remove from 3.0)
      */
-    @Deprecated
+    @Deprecated // since 2.20
     public ValueInjector(PropertyName propName, JavaType type,
             AnnotatedMember mutator, Object valueId)
     {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.databind.deser.impl;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 
@@ -48,6 +49,9 @@ public class ValueInjector
     public void inject(DeserializationContext context, Object beanInstance)
         throws IOException
     {
-        _member.setValue(beanInstance, findValue(context, beanInstance));
+        final Object value = findValue(context, beanInstance);
+        if (!JacksonInject.Value.empty().equals(value)) {
+            _member.setValue(beanInstance, value);
+        }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
@@ -23,7 +23,9 @@ public class ValueInjector
     protected final Object _valueId;
 
     /**
-     * Flag used for configuring the behavior when the value to inject is not found
+     * Flag used for configuring the behavior when the value to inject is not found.
+     *
+     * @since 2.20
      */
     protected final Boolean _optional;
 
@@ -46,17 +48,6 @@ public class ValueInjector
             AnnotatedMember mutator, Object valueId)
     {
         this(propName, type, mutator, valueId, null);
-    }
-
-    /**
-     * @deprecated in 2.9 (remove from 3.0)
-     */
-    @Deprecated // see [databind#1835]
-    public ValueInjector(PropertyName propName, JavaType type,
-            com.fasterxml.jackson.databind.util.Annotations contextAnnotations, // removed from later versions
-            AnnotatedMember mutator, Object valueId)
-    {
-        this(propName, type, mutator, valueId);
     }
 
     public Object findValue(DeserializationContext context, Object beanInstance)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -673,7 +673,8 @@ public class StdValueInstantiator
                 if (prop == null) { // delegate
                     args[i] = delegate;
                 } else { // nope, injectable:
-                    args[i] = ctxt.findInjectableValue(prop.getInjectableValueId(), prop, null);
+                    args[i] = ctxt.findInjectableValue(prop.getInjectableValueId(), prop, null,
+                            null);
                 }
             }
             // and then try calling with full set of arguments

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -673,8 +673,7 @@ public class StdValueInstantiator
                 if (prop == null) { // delegate
                     args[i] = delegate;
                 } else { // nope, injectable:
-                    args[i] = ctxt.findInjectableValue(prop.getInjectableValueId(), prop, null,
-                            null);
+                    args[i] = ctxt.findInjectableValue(prop.getInjectableValueId(), prop, null, null);
                 }
             }
             // and then try calling with full set of arguments

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdValueInstantiator.java
@@ -673,6 +673,7 @@ public class StdValueInstantiator
                 if (prop == null) { // delegate
                     args[i] = delegate;
                 } else { // nope, injectable:
+                    // 09-May-2025, tatu: Not sure where to get "optional" (last arg) value...
                     args[i] = ctxt.findInjectableValue(prop.getInjectableValueId(), prop, null, null);
                 }
             }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.tofix;
+package com.fasterxml.jackson.databind.deser.inject;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.OptBoolean;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -75,7 +75,7 @@ class JacksonInject3072Test extends DatabindTestUtil
 
     // Test for case of `optional = OptBoolean.FALSE`
     @Test
-    void testRequiredAnnotatedField() {
+    void testRequiredAnnotatedField() throws Exception {
         // Should also fail even if DeserFeature disabled, if annotated
         ObjectReader reader = READER.forType(DtoWithRequired.class)
             .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
@@ -95,6 +95,12 @@ class JacksonInject3072Test extends DatabindTestUtil
 
         assertThat(exception.getMessage())
              .startsWith("No injectable value with id 'requiredValue' found (for property 'requiredField')");
+
+        // And finally, work if value injected
+        ObjectReader reader3 = reader.with(new InjectableValues.Std()
+                .addValue("requiredValue", "FOO"));
+        DtoWithRequired req = reader3.readValue("{}");
+        assertEquals("FOO", req.requiredField);
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JacksonInject3072Test extends DatabindTestUtil
 {
-    static class Dto {
+    static class DtoWithOptional {
         @JacksonInject("id")
         String id;
 
@@ -31,7 +31,12 @@ class JacksonInject3072Test extends DatabindTestUtil
         }
     }
 
-    private final ObjectReader READER = newJsonMapper().readerFor(Dto.class);
+    static class DtoWithRequired {
+        @JacksonInject(value = "requiredField", optional = OptBoolean.FALSE)
+        public String requiredField;
+    }
+
+    private final ObjectReader READER = newJsonMapper().readerFor(DtoWithOptional.class);
 
     @Test
     void testOptionalFieldFound() throws Exception {
@@ -40,7 +45,7 @@ class JacksonInject3072Test extends DatabindTestUtil
                         .addValue("id", "idValue")
                         .addValue("optionalField", "optionalFieldValue"));
 
-        Dto dto = reader.readValue("{}");
+        DtoWithOptional dto = reader.readValue("{}");
 
         assertEquals("idValue", dto.id);
         assertEquals("optionalFieldValue", dto.optionalField);
@@ -52,7 +57,7 @@ class JacksonInject3072Test extends DatabindTestUtil
                 .with(new InjectableValues.Std()
                         .addValue("id", "idValue"));
 
-        Dto dto = reader.readValue("{}");
+        DtoWithOptional dto = reader.readValue("{}");
 
         assertEquals("idValue", dto.id);
         assertNull(dto.optionalField);
@@ -66,6 +71,19 @@ class JacksonInject3072Test extends DatabindTestUtil
                 InvalidDefinitionException.class, () -> reader.readValue("{}"));
 
         assertEquals("No 'injectableValues' configured, cannot inject value with id [id]\n" +
+                " at [Source: (String)\"{}\"; line: 1, column: 2]", exception.getMessage());
+    }
+
+    @Test
+    void testRequiredAnnotatedFieldNotFound() {
+        // Should also fail even if DeserFeature disabled, if annotated
+        ObjectReader reader = READER.forType(DtoWithRequired.class)
+            .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
+
+        InvalidDefinitionException exception = assertThrows(
+                InvalidDefinitionException.class, () -> reader.readValue("{}"));
+
+        assertEquals("No 'injectableValues' configured, cannot inject value with id [requiredField]\n" +
                 " at [Source: (String)\"{}\"; line: 1, column: 2]", exception.getMessage());
     }
 
@@ -88,7 +106,7 @@ class JacksonInject3072Test extends DatabindTestUtil
                         .addValue("id", "idValue"))
                 .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        Dto dto = reader.readValue("{}");
+        DtoWithOptional dto = reader.readValue("{}");
 
         assertEquals("idValue", dto.id);
         assertNull(dto.optionalField);
@@ -100,7 +118,7 @@ class JacksonInject3072Test extends DatabindTestUtil
                 .with(new InjectableValues.Std())
                 .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        Dto dto = reader.readValue("{}");
+        DtoWithOptional dto = reader.readValue("{}");
 
         assertNull(dto.id);
         assertNull(dto.optionalField);
@@ -111,7 +129,7 @@ class JacksonInject3072Test extends DatabindTestUtil
         ObjectReader reader = READER
                 .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        Dto dto = reader.readValue("{}");
+        DtoWithOptional dto = reader.readValue("{}");
 
         assertNull(dto.id);
         assertNull(dto.optionalField);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,7 +33,7 @@ class JacksonInject3072Test extends DatabindTestUtil
     }
 
     static class DtoWithRequired {
-        @JacksonInject(value = "requiredField", optional = OptBoolean.FALSE)
+        @JacksonInject(value = "requiredValue", optional = OptBoolean.FALSE)
         public String requiredField;
     }
 
@@ -65,17 +66,16 @@ class JacksonInject3072Test extends DatabindTestUtil
 
     @Test
     void testMandatoryFieldNotFound() {
-        ObjectReader reader = READER;
-
         InvalidDefinitionException exception = assertThrows(
-                InvalidDefinitionException.class, () -> reader.readValue("{}"));
+                InvalidDefinitionException.class, () -> READER.readValue("{}"));
 
-        assertEquals("No 'injectableValues' configured, cannot inject value with id [id]\n" +
-                " at [Source: (String)\"{}\"; line: 1, column: 2]", exception.getMessage());
+        assertThat(exception.getMessage())
+            .startsWith("No 'injectableValues' configured, cannot inject value with id 'id'");
     }
 
+    // Test for case of `optional = OptBoolean.FALSE`
     @Test
-    void testRequiredAnnotatedFieldNotFound() {
+    void testRequiredAnnotatedField() {
         // Should also fail even if DeserFeature disabled, if annotated
         ObjectReader reader = READER.forType(DtoWithRequired.class)
             .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
@@ -83,8 +83,18 @@ class JacksonInject3072Test extends DatabindTestUtil
         InvalidDefinitionException exception = assertThrows(
                 InvalidDefinitionException.class, () -> reader.readValue("{}"));
 
-        assertEquals("No 'injectableValues' configured, cannot inject value with id [requiredField]\n" +
-                " at [Source: (String)\"{}\"; line: 1, column: 2]", exception.getMessage());
+        assertThat(exception.getMessage())
+            .startsWith("No 'injectableValues' configured, cannot inject value with id 'requiredValue'");
+
+        // Also check the other code path, with non-null Injectables
+        ObjectReader reader2 = reader.with(new InjectableValues.Std()
+                .addValue("id", "idValue"));
+
+        exception = assertThrows(
+                    InvalidDefinitionException.class, () -> reader2.readValue("{}"));
+
+        assertThat(exception.getMessage())
+             .startsWith("No injectable value with id 'requiredValue' found (for property 'requiredField')");
     }
 
     @Test
@@ -92,11 +102,11 @@ class JacksonInject3072Test extends DatabindTestUtil
         ObjectReader reader = READER
                 .with(new InjectableValues.Std());
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class, () -> reader.readValue("{}"));
+        InvalidDefinitionException exception = assertThrows(
+                InvalidDefinitionException.class, () -> reader.readValue("{}"));
 
-        assertEquals("No injectable value with id 'id' found (for property 'id')",
-                exception.getMessage());
+        assertThat(exception.getMessage())
+            .startsWith("No injectable value with id 'id' found (for property 'id')");
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -1,63 +1,58 @@
 package com.fasterxml.jackson.databind.deser.inject;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.OptBoolean;
+
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
-import org.junit.jupiter.api.Test;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class JacksonInject3072Test extends DatabindTestUtil {
-
+class JacksonInject3072Test extends DatabindTestUtil
+{
     static class Dto {
-
         @JacksonInject("id")
         String id;
 
         @JacksonInject(value = "optionalField", optional = OptBoolean.TRUE)
         String optionalField;
 
-        @SuppressWarnings("unused")
         public String getId() {
             return id;
         }
 
-        @SuppressWarnings("unused")
         public String getOptionalField() {
             return optionalField;
         }
     }
 
-    private ObjectReader newReader() {
-        return newJsonMapper().readerFor(Dto.class);
-    }
+    private final ObjectReader READER = newJsonMapper().readerFor(Dto.class);
 
     @Test
-    void testOptionalFieldFound() {
-        ObjectReader reader = newReader()
+    void testOptionalFieldFound() throws Exception {
+        ObjectReader reader = READER
                 .with(new InjectableValues.Std()
                         .addValue("id", "idValue")
                         .addValue("optionalField", "optionalFieldValue"));
 
-        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+        Dto dto = reader.readValue("{}");
 
         assertEquals("idValue", dto.id);
         assertEquals("optionalFieldValue", dto.optionalField);
     }
 
     @Test
-    void testOptionalFieldNotFound() {
-        ObjectReader reader = newReader()
+    void testOptionalFieldNotFound() throws Exception {
+        ObjectReader reader = READER
                 .with(new InjectableValues.Std()
                         .addValue("id", "idValue"));
 
-        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+        Dto dto = reader.readValue("{}");
 
         assertEquals("idValue", dto.id);
         assertNull(dto.optionalField);
@@ -65,7 +60,7 @@ class JacksonInject3072Test extends DatabindTestUtil {
 
     @Test
     void testMandatoryFieldNotFound() {
-        ObjectReader reader = newReader();
+        ObjectReader reader = READER;
 
         InvalidDefinitionException exception = assertThrows(
                 InvalidDefinitionException.class, () -> reader.readValue("{}"));
@@ -76,7 +71,7 @@ class JacksonInject3072Test extends DatabindTestUtil {
 
     @Test
     void testMandatoryFieldNotFoundWithInjectableValues() {
-        ObjectReader reader = newReader()
+        ObjectReader reader = READER
                 .with(new InjectableValues.Std());
 
         IllegalArgumentException exception = assertThrows(
@@ -87,36 +82,36 @@ class JacksonInject3072Test extends DatabindTestUtil {
     }
 
     @Test
-    void testMandatoryFieldNotFoundWithoutDeserializationFeature() {
-        ObjectReader reader = newReader()
+    void testMandatoryFieldNotFoundWithoutDeserializationFeature() throws Exception {
+        ObjectReader reader = READER
                 .with(new InjectableValues.Std()
                         .addValue("id", "idValue"))
-                .without(FAIL_ON_UNKNOWN_INJECT_VALUE);
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+        Dto dto = reader.readValue("{}");
 
         assertEquals("idValue", dto.id);
         assertNull(dto.optionalField);
     }
 
     @Test
-    void testMandatoryFieldNotFoundWithInjectableValuesWithoutDeserializationFeature() {
-        ObjectReader reader = newReader()
+    void testMandatoryFieldNotFoundWithInjectableValuesWithoutDeserializationFeature() throws Exception {
+        ObjectReader reader = READER
                 .with(new InjectableValues.Std())
-                .without(FAIL_ON_UNKNOWN_INJECT_VALUE);
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+        Dto dto = reader.readValue("{}");
 
         assertNull(dto.id);
         assertNull(dto.optionalField);
     }
 
     @Test
-    void testOptionalFieldNotFoundWithoutInjectableValuesWithDeserializationFeature() {
-        ObjectReader reader = newReader()
-                .without(FAIL_ON_UNKNOWN_INJECT_VALUE);
+    void testOptionalFieldNotFoundWithoutInjectableValuesWithDeserializationFeature() throws Exception {
+        ObjectReader reader = READER
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+        Dto dto = reader.readValue("{}");
 
         assertNull(dto.id);
         assertNull(dto.optionalField);

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
@@ -697,7 +697,7 @@ public class IntrospectorPairTest extends DatabindTestUtil
 
     static class TestInjector extends InjectableValues {
         @Override
-        public Object findInjectableValue(Object valueId, DeserializationContext ctxt, BeanProperty forProperty, Object beanInstance) {
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt, BeanProperty forProperty, Object beanInstance, Boolean optional) {
             if (valueId == "jjj") {
                 UnreadableBean bean = new UnreadableBean();
                 bean.setValue(1);

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
@@ -705,6 +705,11 @@ public class IntrospectorPairTest extends DatabindTestUtil
             }
             return null;
         }
+
+        @Override
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt, BeanProperty forProperty, Object beanInstance) {
+            return this.findInjectableValue(valueId, ctxt, forProperty, beanInstance, null);
+        }
     }
 
     enum SimpleEnum { ONE, TWO }

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/IntrospectorPairTest.java
@@ -697,7 +697,8 @@ public class IntrospectorPairTest extends DatabindTestUtil
 
     static class TestInjector extends InjectableValues {
         @Override
-        public Object findInjectableValue(Object valueId, DeserializationContext ctxt, BeanProperty forProperty, Object beanInstance, Boolean optional) {
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
+                BeanProperty forProperty, Object beanInstance, Boolean optional) {
             if (valueId == "jjj") {
                 UnreadableBean bean = new UnreadableBean();
                 bean.setValue(1);
@@ -707,8 +708,10 @@ public class IntrospectorPairTest extends DatabindTestUtil
         }
 
         @Override
-        public Object findInjectableValue(Object valueId, DeserializationContext ctxt, BeanProperty forProperty, Object beanInstance) {
-            return this.findInjectableValue(valueId, ctxt, forProperty, beanInstance, null);
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
+                BeanProperty forProperty, Object beanInstance) {
+            throw new IllegalStateException("Deprecated: should not get called");
+            //return this.findInjectableValue(valueId, ctxt, forProperty, beanInstance, null);
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject3072Test.java
@@ -82,7 +82,7 @@ class JacksonInject3072Test extends DatabindTestUtil {
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class, () -> reader.readValue("{}"));
 
-        assertEquals("No injectable id with value 'id' found (for property 'id')",
+        assertEquals("No injectable value with id 'id' found (for property 'id')",
                 exception.getMessage());
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject3072Test.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import org.junit.jupiter.api.Test;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,10 +34,13 @@ class JacksonInject3072Test extends DatabindTestUtil {
         }
     }
 
+    private ObjectReader newReader() {
+        return newJsonMapper().readerFor(Dto.class);
+    }
+
     @Test
     void testOptionalFieldFound() {
-        ObjectReader reader = newJsonMapper()
-                .readerFor(Dto.class)
+        ObjectReader reader = newReader()
                 .with(new InjectableValues.Std()
                         .addValue("id", "idValue")
                         .addValue("optionalField", "optionalFieldValue"));
@@ -49,8 +53,7 @@ class JacksonInject3072Test extends DatabindTestUtil {
 
     @Test
     void testOptionalFieldNotFound() {
-        ObjectReader reader = newJsonMapper()
-                .readerFor(Dto.class)
+        ObjectReader reader = newReader()
                 .with(new InjectableValues.Std()
                         .addValue("id", "idValue"));
 
@@ -62,8 +65,7 @@ class JacksonInject3072Test extends DatabindTestUtil {
 
     @Test
     void testMandatoryFieldNotFound() {
-        ObjectReader reader = newJsonMapper()
-                .readerFor(Dto.class);
+        ObjectReader reader = newReader();
 
         InvalidDefinitionException exception = assertThrows(
                 InvalidDefinitionException.class, () -> reader.readValue("{}"));
@@ -74,8 +76,7 @@ class JacksonInject3072Test extends DatabindTestUtil {
 
     @Test
     void testMandatoryFieldNotFoundWithInjectableValues() {
-        ObjectReader reader = newJsonMapper()
-                .readerFor(Dto.class)
+        ObjectReader reader = newReader()
                 .with(new InjectableValues.Std());
 
         IllegalArgumentException exception = assertThrows(
@@ -83,5 +84,41 @@ class JacksonInject3072Test extends DatabindTestUtil {
 
         assertEquals("No injectable id with value 'id' found (for property 'id')",
                 exception.getMessage());
+    }
+
+    @Test
+    void testMandatoryFieldNotFoundWithoutDeserializationFeature() {
+        ObjectReader reader = newReader()
+                .with(new InjectableValues.Std()
+                        .addValue("id", "idValue"))
+                .without(FAIL_ON_UNKNOWN_INJECT_VALUE);
+
+        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+
+        assertEquals("idValue", dto.id);
+        assertNull(dto.optionalField);
+    }
+
+    @Test
+    void testMandatoryFieldNotFoundWithInjectableValuesWithoutDeserializationFeature() {
+        ObjectReader reader = newReader()
+                .with(new InjectableValues.Std())
+                .without(FAIL_ON_UNKNOWN_INJECT_VALUE);
+
+        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+
+        assertNull(dto.id);
+        assertNull(dto.optionalField);
+    }
+
+    @Test
+    void testOptionalFieldNotFoundWithoutInjectableValuesWithDeserializationFeature() {
+        ObjectReader reader = newReader()
+                .without(FAIL_ON_UNKNOWN_INJECT_VALUE);
+
+        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+
+        assertNull(dto.id);
+        assertNull(dto.optionalField);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject3072Test.java
@@ -1,0 +1,87 @@
+package com.fasterxml.jackson.databind.tofix;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.OptBoolean;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JacksonInject3072Test extends DatabindTestUtil {
+
+    static class Dto {
+
+        @JacksonInject("id")
+        String id;
+
+        @JacksonInject(value = "optionalField", optional = OptBoolean.TRUE)
+        String optionalField;
+
+        @SuppressWarnings("unused")
+        public String getId() {
+            return id;
+        }
+
+        @SuppressWarnings("unused")
+        public String getOptionalField() {
+            return optionalField;
+        }
+    }
+
+    @Test
+    void testOptionalFieldFound() {
+        ObjectReader reader = newJsonMapper()
+                .readerFor(Dto.class)
+                .with(new InjectableValues.Std()
+                        .addValue("id", "idValue")
+                        .addValue("optionalField", "optionalFieldValue"));
+
+        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+
+        assertEquals("idValue", dto.id);
+        assertEquals("optionalFieldValue", dto.optionalField);
+    }
+
+    @Test
+    void testOptionalFieldNotFound() {
+        ObjectReader reader = newJsonMapper()
+                .readerFor(Dto.class)
+                .with(new InjectableValues.Std()
+                        .addValue("id", "idValue"));
+
+        Dto dto = assertDoesNotThrow(() -> reader.readValue("{}"));
+
+        assertEquals("idValue", dto.id);
+        assertNull(dto.optionalField);
+    }
+
+    @Test
+    void testMandatoryFieldNotFound() {
+        ObjectReader reader = newJsonMapper()
+                .readerFor(Dto.class);
+
+        InvalidDefinitionException exception = assertThrows(
+                InvalidDefinitionException.class, () -> reader.readValue("{}"));
+
+        assertEquals("No 'injectableValues' configured, cannot inject value with id [id]\n" +
+                " at [Source: (String)\"{}\"; line: 1, column: 2]", exception.getMessage());
+    }
+
+    @Test
+    void testMandatoryFieldNotFoundWithInjectableValues() {
+        ObjectReader reader = newJsonMapper()
+                .readerFor(Dto.class)
+                .with(new InjectableValues.Std());
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class, () -> reader.readValue("{}"));
+
+        assertEquals("No injectable id with value 'id' found (for property 'id')",
+                exception.getMessage());
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject4218Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/tofix/JacksonInject4218Test.java
@@ -39,12 +39,13 @@ class JacksonInject4218Test extends DatabindTestUtil
                 Object valueId,
                 DeserializationContext ctxt,
                 BeanProperty forProperty,
-                Object beanInstance
+                Object beanInstance,
+                Boolean optional
         ) throws JsonMappingException {
             if (valueId.equals("id")) {
                 return "id" + nextId++;
             } else {
-                return super.findInjectableValue(valueId, ctxt, forProperty, beanInstance);
+                return super.findInjectableValue(valueId, ctxt, forProperty, beanInstance, optional);
             }
         }
     }


### PR DESCRIPTION
As requested in #3072, deserialization will not fail if the injectable values provided to the object reader does not contain a property and:
- that property is explicitly annotated with `@JacksonInject(optional = OptBoolean.TRUE)` or
- the `DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE` is switched off, i.e.:

  ```java
  new ObjectMapper()
      .reader()
      .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
  ```
<br>

> ⚠️ Depends on [jackson-annotations#291](https://github.com/FasterXML/jackson-annotations/pull/291)