### PR TITLE
Fixed problem in `CollectionDeserializer` where `_nullProvider` was not used if it was not `JsonToken.VALUE_NULL`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1860,6 +1860,9 @@ wrongwrong (@k163377)
    `@JsonDeserialize(keyUsing = ...)` is overwritten by the `KeyDeserializer`
     specified in the `ObjectMapper`.
   (2.18.3)
+ * Contributed fix for #5139: In `CollectionDeserializer`, `JsonSetter.contentNulls`
+   is sometimes ignored
+  (2.19.1)
 
 Bernd Ahlers (@bernd)
  * Reported #4742: Deserialization with Builder, External type id, `@JsonCreator` failing

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,11 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.19.1 (not yet released)
+
+#5139: In `CollectionDeserializer`, `JsonSetter.contentNulls` is sometimes ignored
+ (contributed by @wrongwrong)
+
 2.19.0 (24-Apr-2025)
 
 #1467: Support `@JsonUnwrapped` with `@JsonCreator`

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -360,13 +360,14 @@ _containerType,
 
                 if (value == null) {
                     value = _nullProvider.getNullValue(ctxt);
+
+                    // _skipNullValues is checked by _tryToAddNull.
+                    if (value == null) {
+                        _tryToAddNull(p, ctxt, result);
+                        continue;
+                    }
                 }
 
-                // _skipNullValues is checked by _tryToAddNull.
-                if (value == null) {
-                    _tryToAddNull(p, ctxt, result);
-                    continue;
-                }
                 result.add(value);
 
                 /* 17-Dec-2017, tatu: should not occur at this level...
@@ -418,12 +419,12 @@ _containerType,
 
             if (value == null) {
                 value = _nullProvider.getNullValue(ctxt);
-            }
 
-            // _skipNullValues is checked by _tryToAddNull.
-            if (value == null) {
-                _tryToAddNull(p, ctxt, result);
-                return result;
+                // _skipNullValues is checked by _tryToAddNull.
+                if (value == null) {
+                    _tryToAddNull(p, ctxt, result);
+                    return result;
+                }
             }
         } catch (Exception e) {
             boolean wrap = ctxt.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS);
@@ -467,10 +468,10 @@ _containerType,
 
                 if (value == null) {
                     value = _nullProvider.getNullValue(ctxt);
-                }
 
-                if (value == null && _skipNullValues) {
-                    continue;
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
                 }
                 referringAccumulator.add(value);
             } catch (UnresolvedForwardReference reference) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -341,12 +341,10 @@ _containerType,
         // [databind#631]: Assign current value, to be accessible by custom serializers
         p.assignCurrentValue(result);
 
-        JsonDeserializer<Object> valueDes = _valueDeserializer;
         // Let's offline handling of values with Object Ids (simplifies code here)
-        if (valueDes.getObjectIdReader() != null) {
+        if (_valueDeserializer.getObjectIdReader() != null) {
             return _deserializeWithObjectId(p, ctxt, result);
         }
-        final TypeDeserializer typeDeser = _valueTypeDeserializer;
         JsonToken t;
         while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
             try {
@@ -355,12 +353,16 @@ _containerType,
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
-                } else if (typeDeser == null) {
-                    value = valueDes.deserialize(p, ctxt);
+                    value = null;
                 } else {
-                    value = valueDes.deserializeWithType(p, ctxt, typeDeser);
+                    value = _deserializeRawContentValue(p, ctxt);
                 }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+                }
+
+                // _skipNullValues is checked by _tryToAddNull.
                 if (value == null) {
                     _tryToAddNull(p, ctxt, result);
                     continue;
@@ -400,8 +402,6 @@ _containerType,
         if (!canWrap) {
             return (Collection<Object>) ctxt.handleUnexpectedToken(_containerType, p);
         }
-        JsonDeserializer<Object> valueDes = _valueDeserializer;
-        final TypeDeserializer typeDeser = _valueTypeDeserializer;
 
         Object value;
 
@@ -411,12 +411,16 @@ _containerType,
                 if (_skipNullValues) {
                     return result;
                 }
-                value = _nullProvider.getNullValue(ctxt);
-            } else if (typeDeser == null) {
-                value = valueDes.deserialize(p, ctxt);
+                value = null;
             } else {
-                value = valueDes.deserializeWithType(p, ctxt, typeDeser);
+                value = _deserializeRawContentValue(p, ctxt);
             }
+
+            if (value == null) {
+                value = _nullProvider.getNullValue(ctxt);
+            }
+
+            // _skipNullValues is checked by _tryToAddNull.
             if (value == null) {
                 _tryToAddNull(p, ctxt, result);
                 return result;
@@ -444,8 +448,6 @@ _containerType,
         // [databind#631]: Assign current value, to be accessible by custom serializers
         p.assignCurrentValue(result);
 
-        final JsonDeserializer<Object> valueDes = _valueDeserializer;
-        final TypeDeserializer typeDeser = _valueTypeDeserializer;
         CollectionReferringAccumulator referringAccumulator =
                 new CollectionReferringAccumulator(_containerType.getContentType().getRawClass(), result);
 
@@ -453,16 +455,20 @@ _containerType,
         while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
             try {
                 Object value;
+
                 if (t == JsonToken.VALUE_NULL) {
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
-                } else if (typeDeser == null) {
-                    value = valueDes.deserialize(p, ctxt);
+                    value = null;
                 } else {
-                    value = valueDes.deserializeWithType(p, ctxt, typeDeser);
+                    value = _deserializeRawContentValue(p, ctxt);
                 }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+                }
+
                 if (value == null && _skipNullValues) {
                     continue;
                 }
@@ -479,6 +485,22 @@ _containerType,
             }
         }
         return result;
+    }
+
+    /**
+     * Deserialize the content of the collection.
+     * If _valueTypeDeserializer is null, use _valueDeserializer.deserialize; if non-null,
+     * use _valueDeserializer.deserializeWithType to deserialize value.
+     * This method only performs deserialization and does not consider _skipNullValues, _nullProvider, etc.
+     * @since 2.19.1
+     */
+    protected Object _deserializeRawContentValue(
+            JsonParser p,
+            DeserializationContext ctxt
+    ) throws IOException {
+        return _valueTypeDeserializer == null
+                ? _valueDeserializer.deserialize(p, ctxt)
+                : _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -355,7 +355,7 @@ _containerType,
                     }
                     value = null;
                 } else {
-                    value = _deserializeRawContentValue(p, ctxt);
+                    value = _deserializeNoNullChecks(p, ctxt);
                 }
 
                 if (value == null) {
@@ -414,7 +414,7 @@ _containerType,
                 }
                 value = null;
             } else {
-                value = _deserializeRawContentValue(p, ctxt);
+                value = _deserializeNoNullChecks(p, ctxt);
             }
 
             if (value == null) {
@@ -463,12 +463,11 @@ _containerType,
                     }
                     value = null;
                 } else {
-                    value = _deserializeRawContentValue(p, ctxt);
+                    value = _deserializeNoNullChecks(p, ctxt);
                 }
 
                 if (value == null) {
                     value = _nullProvider.getNullValue(ctxt);
-
                     if (value == null && _skipNullValues) {
                         continue;
                     }
@@ -495,13 +494,13 @@ _containerType,
      * This method only performs deserialization and does not consider _skipNullValues, _nullProvider, etc.
      * @since 2.19.1
      */
-    protected Object _deserializeRawContentValue(
-            JsonParser p,
-            DeserializationContext ctxt
-    ) throws IOException {
-        return _valueTypeDeserializer == null
-                ? _valueDeserializer.deserialize(p, ctxt)
-                : _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
+    protected Object _deserializeNoNullChecks(JsonParser p,DeserializationContext ctxt)
+        throws IOException
+    {
+        if (_valueTypeDeserializer == null) {
+            return _valueDeserializer.deserialize(p, ctxt);
+        }
+        return _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
     }
 
     /**

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
@@ -1,19 +1,22 @@
 package com.fasterxml.jackson.databind.deser.jdk;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CollectionDeserializer5139Test {
+// For [databind#5139]
+public class CollectionDeserializer5139Test
+{
     static class Dst {
         private List<Integer> list;
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.databind.deser.std;
+package com.fasterxml.jackson.databind.deser.jdk;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.databind.deser.jdk;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
@@ -40,7 +39,7 @@ public class CollectionDeserializer5139Test {
     }
 
     @Test
-    public void nullsSkipTest() throws JsonProcessingException {
+    public void nullsSkipTest() throws Exception {
         ObjectMapper mapper = JsonMapper.builder()
                 .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL))
                 .build();

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
@@ -41,7 +41,7 @@ public class CollectionDeserializer5139Test {
     @Test
     public void nullsSkipTest() throws Exception {
         ObjectMapper mapper = JsonMapper.builder()
-                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL))
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.SKIP))
                 .build();
 
         Dst dst = mapper.readValue("{\"list\":[\"\"]}", new TypeReference<Dst>() {});

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/CollectionDeserializer5139Test.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -28,8 +29,9 @@ public class CollectionDeserializer5139Test {
 
     @Test
     public void nullsFailTest() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL));
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL))
+                .build();
 
         assertThrows(
                 InvalidNullException.class,
@@ -39,8 +41,9 @@ public class CollectionDeserializer5139Test {
 
     @Test
     public void nullsSkipTest() throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.SKIP));
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL))
+                .build();
 
         Dst dst = mapper.readValue("{\"list\":[\"\"]}", new TypeReference<Dst>() {});
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer5139Test.java
@@ -42,7 +42,7 @@ public class CollectionDeserializer5139Test {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.SKIP));
 
-        Dst dst = mapper.readValue("{\"list\":[\"\"]}", new TypeReference<>() {});
+        Dst dst = mapper.readValue("{\"list\":[\"\"]}", new TypeReference<Dst>() {});
 
         assertTrue(dst.getList().isEmpty());
     }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer5139Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer5139Test.java
@@ -1,0 +1,49 @@
+package com.fasterxml.jackson.databind.deser.std;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidNullException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CollectionDeserializer5139Test {
+    static class Dst {
+        private List<Integer> list;
+
+        public List<Integer> getList() {
+            return list;
+        }
+
+        public void setList(List<Integer> list) {
+            this.list = list;
+        }
+    }
+
+    @Test
+    public void nullsFailTest() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL));
+
+        assertThrows(
+                InvalidNullException.class,
+                () -> mapper.readValue("{\"list\":[\"\"]}", new TypeReference<Dst>(){})
+        );
+    }
+
+    @Test
+    public void nullsSkipTest() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.SKIP));
+
+        Dst dst = mapper.readValue("{\"list\":[\"\"]}", new TypeReference<>() {});
+
+        assertTrue(dst.getList().isEmpty());
+    }
+}


### PR DESCRIPTION
SSIA

fix for https://github.com/FasterXML/jackson-databind/issues/5139

It was a bit complicated, so I apologize if there are any problems with the modifications.