### PR TITLE
Re-enable setting of final instance fields

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -939,10 +939,6 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
         JavaType type = resolveMemberAndTypeAnnotations(ctxt, mutator, propType0);
         // Does the Method specify the deserializer to use? If so, let's use it.
         TypeDeserializer typeDeser = (TypeDeserializer) type.getTypeHandler();
-        // 05-May-2025, tatu: [databind#5090]/[databind#2083] Need to skip these for some reason
-        if (isFinalField(mutator)) {
-            return null;
-        }
         ValueDeserializer<?> deser = findDeserializerFromAnnotation(ctxt, mutator);
         if (deser == null) {
             deser = (ValueDeserializer<?>) type.getValueHandler();
@@ -963,11 +959,6 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
             prop.setObjectIdInfo(objectIdInfo);
         }
         return prop;
-    }
-
-    private boolean isFinalField(AnnotatedMember am) {
-        return am instanceof AnnotatedField
-                && Modifier.isFinal(am.getMember().getModifiers());
     }
 
     /**


### PR DESCRIPTION
Turns out this is currently necessary for Scala and Kotlin data classes.
Mutating `final` fields will still eventually go away once the JVM forbids it, but we don't necessarily have to force the issue now.

Followup to #5090