### PR TITLE
Refactor for ObjectArrayDeserializer, StringArrayDeserializer, StringCollectionDeserializer and EnumSetDeserializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumSetDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumSetDeserializer.java
@@ -139,12 +139,9 @@ public class EnumSetDeserializer
     @Override
     public boolean isCachable() {
         // One caveat: content deserializer should prevent caching
-        if (_enumType.getValueHandler() != null) {
-            return false;
-        }
-        return true;
+        return _enumType.getValueHandler() == null;
     }
-    
+
     @Override // since 2.12
     public LogicalType logicalType() {
         return LogicalType.Collection;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -201,7 +201,6 @@ public class ObjectArrayDeserializer
         Object[] chunk = buffer.resetAndStart();
         int ix = 0;
         JsonToken t;
-        final TypeDeserializer typeDeser = _elementTypeDeserializer;
 
         try {
             while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
@@ -213,10 +212,8 @@ public class ObjectArrayDeserializer
                         continue;
                     }
                     value = _nullProvider.getNullValue(ctxt);
-                } else if (typeDeser == null) {
-                    value = _elementDeserializer.deserialize(p, ctxt);
                 } else {
-                    value = _elementDeserializer.deserializeWithType(p, ctxt, typeDeser);
+                    value = _deserializeNoNullChecks(p, ctxt);
                 }
                 if (ix >= chunk.length) {
                     chunk = buffer.appendCompletedChunk(chunk);
@@ -269,7 +266,6 @@ public class ObjectArrayDeserializer
         int ix = intoValue.length;
         Object[] chunk = buffer.resetAndStart(intoValue, ix);
         JsonToken t;
-        final TypeDeserializer typeDeser = _elementTypeDeserializer;
 
         try {
             while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
@@ -280,10 +276,8 @@ public class ObjectArrayDeserializer
                         continue;
                     }
                     value = _nullProvider.getNullValue(ctxt);
-                } else if (typeDeser == null) {
-                    value = _elementDeserializer.deserialize(p, ctxt);
                 } else {
-                    value = _elementDeserializer.deserializeWithType(p, ctxt, typeDeser);
+                    value = _deserializeNoNullChecks(p, ctxt);
                 }
                 if (ix >= chunk.length) {
                     chunk = buffer.appendCompletedChunk(chunk);
@@ -375,11 +369,7 @@ public class ObjectArrayDeserializer
                 // if coercion failed, we can still add it to a list
             }
 
-            if (_elementTypeDeserializer == null) {
-                value = _elementDeserializer.deserialize(p, ctxt);
-            } else {
-                value = _elementDeserializer.deserializeWithType(p, ctxt, _elementTypeDeserializer);
-            }
+            value = _deserializeNoNullChecks(p, ctxt);
         }
         // Ok: bit tricky, since we may want T[], not just Object[]
         Object[] result;
@@ -391,6 +381,22 @@ public class ObjectArrayDeserializer
         }
         result[0] = value;
         return result;
+    }
+
+    /**
+     * Deserialize the content of the map.
+     * If _elementTypeDeserializer is null, use _elementDeserializer.deserialize; if non-null,
+     * use _elementDeserializer.deserializeWithType to deserialize value.
+     * This method only performs deserialization and does not consider _skipNullValues, _nullProvider, etc.
+     * @since 2.19.2
+     */
+    protected Object _deserializeNoNullChecks(JsonParser p, DeserializationContext ctxt)
+            throws IOException
+    {
+        if (_elementTypeDeserializer == null) {
+            return _elementDeserializer.deserialize(p, ctxt);
+        }
+        return _elementDeserializer.deserializeWithType(p, ctxt, _elementTypeDeserializer);
     }
 }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -320,7 +320,7 @@ public class ObjectArrayDeserializer
         // But then need to convert to wrappers
         Byte[] result = new Byte[b.length];
         for (int i = 0, len = b.length; i < len; ++i) {
-            result[i] = Byte.valueOf(b[i]);
+            result[i] = b[i];
         }
         return result;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
@@ -40,7 +40,7 @@ public final class StringArrayDeserializer
     /**
      * Value serializer to use, if not the standard one (which is inlined)
      */
-    protected JsonDeserializer<String> _elementDeserializer;
+    protected final JsonDeserializer<String> _elementDeserializer;
 
     /**
      * Handler we need for dealing with null values as elements

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
@@ -40,14 +40,14 @@ public final class StringArrayDeserializer
     /**
      * Value serializer to use, if not the standard one (which is inlined)
      */
-    protected final JsonDeserializer<String> _elementDeserializer;
+    private final JsonDeserializer<String> _elementDeserializer;
 
     /**
      * Handler we need for dealing with null values as elements
      *
      * @since 2.9
      */
-    protected final NullValueProvider _nullProvider;
+    private final NullValueProvider _nullProvider;
 
     /**
      * Specific override for this instance (from proper, or global per-type overrides)
@@ -56,7 +56,7 @@ public final class StringArrayDeserializer
      *
      * @since 2.7
      */
-    protected final Boolean _unwrapSingle;
+    private final Boolean _unwrapSingle;
 
     /**
      * Marker flag set if the <code>_nullProvider</code> indicates that all null
@@ -64,15 +64,15 @@ public final class StringArrayDeserializer
      *
      * @since 2.9
      */
-    protected final boolean _skipNullValues;
+    private final boolean _skipNullValues;
 
     public StringArrayDeserializer() {
         this(null, null, null);
     }
 
     @SuppressWarnings("unchecked")
-    protected StringArrayDeserializer(JsonDeserializer<?> deser,
-            NullValueProvider nuller, Boolean unwrapSingle) {
+    private StringArrayDeserializer(JsonDeserializer<?> deser,
+                                    NullValueProvider nuller, Boolean unwrapSingle) {
         super(String[].class);
         _elementDeserializer = (JsonDeserializer<String>) deser;
         _nullProvider = nuller;
@@ -184,8 +184,8 @@ public final class StringArrayDeserializer
     /**
      * Offlined version used when we do not use the default deserialization method.
      */
-    protected final String[] _deserializeCustom(JsonParser p, DeserializationContext ctxt,
-            String[] old) throws IOException
+    private String[] _deserializeCustom(JsonParser p, DeserializationContext ctxt,
+                                        String[] old) throws IOException
     {
         final ObjectBuffer buffer = ctxt.leaseObjectBuffer();
         int ix;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringArrayDeserializer.java
@@ -72,7 +72,7 @@ public final class StringArrayDeserializer
 
     @SuppressWarnings("unchecked")
     private StringArrayDeserializer(JsonDeserializer<?> deser,
-                                    NullValueProvider nuller, Boolean unwrapSingle) {
+            NullValueProvider nuller, Boolean unwrapSingle) {
         super(String[].class);
         _elementDeserializer = (JsonDeserializer<String>) deser;
         _nullProvider = nuller;
@@ -185,7 +185,7 @@ public final class StringArrayDeserializer
      * Offlined version used when we do not use the default deserialization method.
      */
     private String[] _deserializeCustom(JsonParser p, DeserializationContext ctxt,
-                                        String[] old) throws IOException
+            String[] old) throws IOException
     {
         final ObjectBuffer buffer = ctxt.leaseObjectBuffer();
         int ix;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -37,20 +37,20 @@ public final class StringCollectionDeserializer
      * Value deserializer to use, if NOT the standard one
      * (if it is, will be null).
      */
-    protected final JsonDeserializer<String> _valueDeserializer;
+    private final JsonDeserializer<String> _valueDeserializer;
 
     // // Instance construction settings:
 
     /**
      * Instantiator used in case custom handling is needed for creation.
      */
-    protected final ValueInstantiator _valueInstantiator;
+    private final ValueInstantiator _valueInstantiator;
 
     /**
      * Deserializer that is used iff delegate-based creator is
      * to be used for deserializing from JSON Object.
      */
-    protected final JsonDeserializer<Object> _delegateDeserializer;
+    private final JsonDeserializer<Object> _delegateDeserializer;
 
     // NOTE: no PropertyBasedCreator, as JSON Arrays have no properties
 
@@ -67,10 +67,10 @@ public final class StringCollectionDeserializer
     }
 
     @SuppressWarnings("unchecked")
-    protected StringCollectionDeserializer(JavaType collectionType,
-            ValueInstantiator valueInstantiator, JsonDeserializer<?> delegateDeser,
-            JsonDeserializer<?> valueDeser,
-            NullValueProvider nuller, Boolean unwrapSingle)
+    private StringCollectionDeserializer(JavaType collectionType,
+                                         ValueInstantiator valueInstantiator, JsonDeserializer<?> delegateDeser,
+                                         JsonDeserializer<?> valueDeser,
+                                         NullValueProvider nuller, Boolean unwrapSingle)
     {
         super(collectionType, nuller, unwrapSingle);
         _valueDeserializer = (JsonDeserializer<String>) valueDeser;
@@ -78,9 +78,9 @@ public final class StringCollectionDeserializer
         _delegateDeserializer = (JsonDeserializer<Object>) delegateDeser;
     }
 
-    protected StringCollectionDeserializer withResolved(JsonDeserializer<?> delegateDeser,
-            JsonDeserializer<?> valueDeser,
-            NullValueProvider nuller, Boolean unwrapSingle)
+    private StringCollectionDeserializer withResolved(JsonDeserializer<?> delegateDeser,
+                                                      JsonDeserializer<?> valueDeser,
+                                                      NullValueProvider nuller, Boolean unwrapSingle)
     {
         if ((Objects.equals(_unwrapSingle, unwrapSingle)) && (_nullProvider == nuller)
                 && (_valueDeserializer == valueDeser) && (_delegateDeserializer == delegateDeser)) {

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StringCollectionDeserializer.java
@@ -68,9 +68,9 @@ public final class StringCollectionDeserializer
 
     @SuppressWarnings("unchecked")
     private StringCollectionDeserializer(JavaType collectionType,
-                                         ValueInstantiator valueInstantiator, JsonDeserializer<?> delegateDeser,
-                                         JsonDeserializer<?> valueDeser,
-                                         NullValueProvider nuller, Boolean unwrapSingle)
+            ValueInstantiator valueInstantiator, JsonDeserializer<?> delegateDeser,
+            JsonDeserializer<?> valueDeser,
+            NullValueProvider nuller, Boolean unwrapSingle)
     {
         super(collectionType, nuller, unwrapSingle);
         _valueDeserializer = (JsonDeserializer<String>) valueDeser;
@@ -79,8 +79,8 @@ public final class StringCollectionDeserializer
     }
 
     private StringCollectionDeserializer withResolved(JsonDeserializer<?> delegateDeser,
-                                                      JsonDeserializer<?> valueDeser,
-                                                      NullValueProvider nuller, Boolean unwrapSingle)
+            JsonDeserializer<?> valueDeser,
+            NullValueProvider nuller, Boolean unwrapSingle)
     {
         if ((Objects.equals(_unwrapSingle, unwrapSingle)) && (_nullProvider == nuller)
                 && (_valueDeserializer == valueDeser) && (_delegateDeserializer == delegateDeser)) {
@@ -107,6 +107,7 @@ public final class StringCollectionDeserializer
     /* Validation, post-processing
     /**********************************************************
      */
+
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
             BeanProperty property) throws JsonMappingException


### PR DESCRIPTION
The main objective is to merge d800e540f41cf984fd1a0900825a4279c9cd194d in preparation for fixing #5165.
These are referenced below.
https://github.com/FasterXML/jackson-databind/pull/5140/files#diff-692175612209d50652f1d14ffd325eb70cfdd282a6277f994207bfc63c0db515R490-R504

Each of the other changes resolves the warning.