### PR TITLE
Fix #5165 on MapDeserializer and EnumMapDeserializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumMapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumMapDeserializer.java
@@ -308,9 +308,17 @@ public class EnumMapDeserializer
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
+                    value = null;
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
+                }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
                 }
             } catch (Exception e) {
                 return wrapAndThrow(ctxt, e, result, keyStr);
@@ -400,9 +408,17 @@ public class EnumMapDeserializer
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
+                    value = null;
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
+                }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
                 }
             } catch (Exception e) {
                 wrapAndThrow(ctxt, e, _containerType.getRawClass(), keyName);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java
@@ -547,10 +547,19 @@ public class MapDeserializer
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
+                    value = null;
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
                 }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
+                }
+
                 if (useObjectId) {
                     referringAccumulator.put(key, value);
                 } else {
@@ -609,10 +618,19 @@ public class MapDeserializer
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
+                    value = null;
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
                 }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
+                }
+
                 if (useObjectId) {
                     referringAccumulator.put(key, value);
                 } else {
@@ -679,9 +697,17 @@ public class MapDeserializer
                     if (_skipNullValues) {
                         continue;
                     }
-                    value = _nullProvider.getNullValue(ctxt);
+                    value = null;
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
+                }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
                 }
             } catch (Exception e) {
                 wrapAndThrow(ctxt, e, _containerType.getRawClass(), key);
@@ -759,6 +785,15 @@ public class MapDeserializer
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
                 }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
+                }
+
                 if (value != old) {
                     result.put(key, value);
                 }
@@ -824,6 +859,15 @@ public class MapDeserializer
                 } else {
                     value = _deserializeNoNullChecks(p, ctxt);
                 }
+
+                if (value == null) {
+                    value = _nullProvider.getNullValue(ctxt);
+
+                    if (value == null && _skipNullValues) {
+                        continue;
+                    }
+                }
+
                 if (value != old) {
                     result.put(key, value);
                 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumMapDeserializer5165Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumMapDeserializer5165Test.java
@@ -1,0 +1,63 @@
+package com.fasterxml.jackson.databind.deser.jdk;
+
+import java.util.EnumMap;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidNullException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.opentest4j.AssertionFailedError;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+// For [databind#5165]
+public class EnumMapDeserializer5165Test
+{
+    public enum MyEnum {
+        FOO
+    }
+
+    static class Dst {
+        private EnumMap<MyEnum, Integer> map;
+
+        public EnumMap<MyEnum, Integer> getMap() {
+            return map;
+        }
+
+        public void setMap(EnumMap<MyEnum, Integer> map) {
+            this.map = map;
+        }
+    }
+
+    @Test
+    public void nullsFailTest() {
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL))
+                .build();
+
+        assertThrows(
+                AssertionFailedError.class,
+                () -> assertThrows(
+                        InvalidNullException.class,
+                        () -> mapper.readValue("{\"map\":{\"FOO\":\"\"}}", new TypeReference<Dst>(){})
+                ),
+                "databind#5165 for EnumMapDeserializer is fixed"
+        );
+    }
+
+    @Test
+    public void nullsSkipTest() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.SKIP))
+                .build();
+
+        Dst dst = mapper.readValue("{\"map\":{\"FOO\":\"\"}}", new TypeReference<Dst>() {});
+
+        assertFalse(dst.getMap().isEmpty(), "databind#5165 for EnumMapDeserializer is fixed");
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumMapDeserializer5165Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/EnumMapDeserializer5165Test.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.opentest4j.AssertionFailedError;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 // For [databind#5165]
@@ -41,12 +42,8 @@ public class EnumMapDeserializer5165Test
                 .build();
 
         assertThrows(
-                AssertionFailedError.class,
-                () -> assertThrows(
-                        InvalidNullException.class,
-                        () -> mapper.readValue("{\"map\":{\"FOO\":\"\"}}", new TypeReference<Dst>(){})
-                ),
-                "databind#5165 for EnumMapDeserializer is fixed"
+                InvalidNullException.class,
+                () -> mapper.readValue("{\"map\":{\"FOO\":\"\"}}", new TypeReference<Dst>(){})
         );
     }
 
@@ -58,6 +55,6 @@ public class EnumMapDeserializer5165Test
 
         Dst dst = mapper.readValue("{\"map\":{\"FOO\":\"\"}}", new TypeReference<Dst>() {});
 
-        assertFalse(dst.getMap().isEmpty(), "databind#5165 for EnumMapDeserializer is fixed");
+        assertTrue(dst.getMap().isEmpty());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapDeserializer5165Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapDeserializer5165Test.java
@@ -10,9 +10,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import org.opentest4j.AssertionFailedError;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 // For [databind#5165]
@@ -37,12 +36,8 @@ public class MapDeserializer5165Test
                 .build();
 
         assertThrows(
-                AssertionFailedError.class,
-                () -> assertThrows(
-                        InvalidNullException.class,
-                        () -> mapper.readValue("{\"map\":{\"key\":\"\"}}", new TypeReference<Dst>(){})
-                ),
-                "databind#5165 for MapDeserializer is fixed"
+                InvalidNullException.class,
+                () -> mapper.readValue("{\"map\":{\"key\":\"\"}}", new TypeReference<Dst>(){})
         );
     }
 
@@ -54,6 +49,6 @@ public class MapDeserializer5165Test
 
         Dst dst = mapper.readValue("{\"map\":{\"key\":\"\"}}", new TypeReference<Dst>() {});
 
-        assertFalse(dst.getMap().isEmpty(), "databind#5165 for MapDeserializer is fixed");
+        assertTrue(dst.getMap().isEmpty());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapDeserializer5165Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/MapDeserializer5165Test.java
@@ -1,0 +1,59 @@
+package com.fasterxml.jackson.databind.deser.jdk;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidNullException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.opentest4j.AssertionFailedError;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+// For [databind#5165]
+public class MapDeserializer5165Test
+{
+    static class Dst {
+        private Map<String, Integer> map;
+
+        public Map<String, Integer> getMap() {
+            return map;
+        }
+
+        public void setMap(Map<String, Integer> map) {
+            this.map = map;
+        }
+    }
+
+    @Test
+    public void nullsFailTest() {
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.FAIL))
+                .build();
+
+        assertThrows(
+                AssertionFailedError.class,
+                () -> assertThrows(
+                        InvalidNullException.class,
+                        () -> mapper.readValue("{\"map\":{\"key\":\"\"}}", new TypeReference<Dst>(){})
+                ),
+                "databind#5165 for MapDeserializer is fixed"
+        );
+    }
+
+    @Test
+    public void nullsSkipTest() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultSetterInfo(JsonSetter.Value.forContentNulls(Nulls.SKIP))
+                .build();
+
+        Dst dst = mapper.readValue("{\"map\":{\"key\":\"\"}}", new TypeReference<Dst>() {});
+
+        assertFalse(dst.getMap().isEmpty(), "databind#5165 for MapDeserializer is fixed");
+    }
+}


### PR DESCRIPTION
Fixed #5165 for `MapDeserializer` and `EnumMapDeserializer`.
The remaining fixes to `ObjectArrayDeserializer`, `StringArrayDeserializer`, `StringCollectionDeserializer`, and `EnumSetDeserializer` will be issued after the bar merge.