### PR TITLE
use Class#isRecord if available

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,9 @@ Project: jackson-databind
 #5151: Add new exception type, `MissingInjectValueException`, to be used
   for failed `@JacksonInject`
 #5179: Add "current token" info into `MismatchedInputException`
+#5192: Record types are broken on Android when using R8
+ (reported by @HelloOO7)
+ (fix by @pjfanning)
 - Generate SBOMs [JSTEP-14]
 
 2.19.1 (13-Jun-2025)

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -24,9 +24,9 @@ public final class ClassUtil
 
     private final static Iterator<Object> EMPTY_ITERATOR = Collections.emptyIterator();
 
-    // Class#isRecord() was added in JDK 16, earlier versions do not have it, so this will eval as null
+    // 16-Jun-2025: [databind#5195]: we will dynamically access `Class.isRecord()`
+    //    added in JDK 16, earlier versions do not have it; will eval as `null`.
     private final static Method IS_RECORD;
-
     static {
         Method m = null;
         try {
@@ -312,6 +312,10 @@ public final class ClassUtil
      * @since 2.12
      */
     public static boolean isRecordType(Class<?> cls) {
+        // 16-Jun-2025: [databind#5195]: implementation changed from 2.19
+        //   where we checked if `cls.getParent() == "java.lang.Record" which
+        //   caused issues on Android, desugared cases. This is a more reliable
+        //   method for checking.
         if (IS_RECORD == null) {
             return false;
         }

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -313,22 +313,14 @@ public final class ClassUtil
      */
     public static boolean isRecordType(Class<?> cls) {
         if (IS_RECORD == null) {
-            // Class#isRecord() method was only added in JDK16
-            // JDK 14 and 15 do not have it, so this fallback is useful
-            // even if these non-LTS versions of Java are no longer supported
-            return fallbackCheckForRecordType(cls);
+            return false;
         }
         try {
             return (Boolean) IS_RECORD.invoke(cls);
         } catch (Exception e) {
             // hopefully, this is not going to happen
-            return fallbackCheckForRecordType(cls);
+            return false;
         }
-    }
-
-    private static boolean fallbackCheckForRecordType(Class<?> cls) {
-        Class<?> parent = cls.getSuperclass();
-        return (parent != null) && "java.lang.Record".equals(parent.getName());
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/ClassUtil.java
@@ -24,6 +24,19 @@ public final class ClassUtil
 
     private final static Iterator<Object> EMPTY_ITERATOR = Collections.emptyIterator();
 
+    // Class#isRecord() was added in JDK 16, earlier versions do not have it, so this will eval as null
+    private final static Method IS_RECORD;
+
+    static {
+        Method m = null;
+        try {
+            m = Class.class.getMethod("isRecord");
+        } catch (NoSuchMethodException e) {
+            // no-op, will be null
+        }
+        IS_RECORD = m;
+    }
+
     /*
     /**********************************************************
     /* Simple factory methods
@@ -299,6 +312,21 @@ public final class ClassUtil
      * @since 2.12
      */
     public static boolean isRecordType(Class<?> cls) {
+        if (IS_RECORD == null) {
+            // Class#isRecord() method was only added in JDK16
+            // JDK 14 and 15 do not have it, so this fallback is useful
+            // even if these non-LTS versions of Java are no longer supported
+            return fallbackCheckForRecordType(cls);
+        }
+        try {
+            return (Boolean) IS_RECORD.invoke(cls);
+        } catch (Exception e) {
+            // hopefully, this is not going to happen
+            return fallbackCheckForRecordType(cls);
+        }
+    }
+
+    private static boolean fallbackCheckForRecordType(Class<?> cls) {
         Class<?> parent = cls.getSuperclass();
         return (parent != null) && "java.lang.Record".equals(parent.getName());
     }


### PR DESCRIPTION
* see #5192 
* Jackson 3 does not need this as it already uses Class#isRecord because it only supports JDK17+