### PR TITLE
test case for serializing custom numbers with config overrides

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/BasicSerializerFactory.java
+++ b/src/main/java/tools/jackson/databind/ser/BasicSerializerFactory.java
@@ -313,7 +313,7 @@ public abstract class BasicSerializerFactory
 
         if (type.isTypeOrSubTypeOf(Number.class)) {
             JsonFormat.Value format = _calculateEffectiveFormat(ctxt,
-                    beanDescRef, Number.class, formatOverrides);
+                    beanDescRef, type.getRawClass(), formatOverrides);
 
             // 21-May-2014, tatu: Couple of alternatives actually
             switch (format.getShape()) {

--- a/src/main/java/tools/jackson/databind/ser/BasicSerializerFactory.java
+++ b/src/main/java/tools/jackson/databind/ser/BasicSerializerFactory.java
@@ -313,7 +313,7 @@ public abstract class BasicSerializerFactory
 
         if (type.isTypeOrSubTypeOf(Number.class)) {
             JsonFormat.Value format = _calculateEffectiveFormat(ctxt,
-                    beanDescRef, type.getRawClass(), formatOverrides);
+                    beanDescRef, Number.class, formatOverrides);
 
             // 21-May-2014, tatu: Couple of alternatives actually
             switch (format.getShape()) {

--- a/src/main/java/tools/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanSerializerFactory.java
@@ -161,6 +161,9 @@ public class BeanSerializerFactory
                 beanDescRef = ctxt.lazyIntrospectBeanDescription(type);
             }
         }
+        if (formatOverrides == null) {
+            formatOverrides = _calculateEffectiveFormat(ctxt, beanDescRef, type.getRawClass(), JsonFormat.Value.empty());
+        }
         // Slight detour: do we have a Converter to consider?
         Converter<Object,Object> conv = config.findSerializationConverter(beanDescRef.getClassInfo());
         if (conv != null) { // yup, need converter

--- a/src/test/java/tools/jackson/databind/ser/jdk/NumberSerTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/NumberSerTest.java
@@ -17,6 +17,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
@@ -114,6 +115,12 @@ public class NumberSerTest extends DatabindTestUtil
         @Override
         public void serialize(BigDecimal value, JsonGenerator gen, SerializationContext serializers) {
             gen.writeNumber(df.format(value));
+        }
+    }
+
+    static class MyBigDecimal extends BigDecimal {
+        public MyBigDecimal(String value) {
+            super(value);
         }
     }
 
@@ -223,6 +230,15 @@ public class NumberSerTest extends DatabindTestUtil
         module.addSerializer(BigDecimal.class, new BigDecimalAsNumberSerializer());
         ObjectMapper mapper = jsonMapperBuilder().addModule(module).build();
         assertEquals(a2q("{'value':2.0}"), mapper.writeValueAsString(new BigDecimalHolder("2")));
+    }
+
+    @Test
+    public void testConfigOverrideNonJdkNumber() throws Exception {
+        JsonMapper mapper = jsonMapperBuilder().withConfigOverride(MyBigDecimal.class,
+                c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))
+                .build();
+        String value = mapper.writeValueAsString(new MyBigDecimal("123.456"));
+        assertEquals(a2q("'123.456'"), value);
     }
 
     // default locale is en_US

--- a/src/test/java/tools/jackson/databind/ser/jdk/NumberSerTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/NumberSerTest.java
@@ -233,9 +233,18 @@ public class NumberSerTest extends DatabindTestUtil
     }
 
     @Test
+    public void testConfigOverrideJdkNumber() throws Exception {
+        JsonMapper mapper = jsonMapperBuilder().withConfigOverride(BigDecimal.class,
+                c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))
+                .build();
+        String value = mapper.writeValueAsString(new BigDecimal("123.456"));
+        assertEquals(a2q("'123.456'"), value);
+    }
+
+    @Test
     public void testConfigOverrideNonJdkNumber() throws Exception {
         JsonMapper mapper = jsonMapperBuilder().withConfigOverride(MyBigDecimal.class,
-                c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))
+                        c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))
                 .build();
         String value = mapper.writeValueAsString(new MyBigDecimal("123.456"));
         assertEquals(a2q("'123.456'"), value);


### PR DESCRIPTION
* relates to a broken test in jackson-module-scala - https://github.com/FasterXML/jackson-module-scala/pull/748 - that 748 test basically works with Jackson 2 (and is merged in jackson-module-scala 2.x branch)
* Scala has scala.math.BigDecimal which is a wrapper on java.math.BigDecimal but we don't want test cases in jackson-databind that bring in outside dependencies. The MyBigDecimal class in this PR is enough to trigger the issue
* of the 2 unit tests, the BigDecimal one already works but the MyBigDecimal one fails
* I did a little debugging and the code in BasicSerializerFactory.java to check the config overrides has changed quite a bit in Jackson 3 and the changes cause this test case to fail
    * I think the issue is around here: https://github.com/FasterXML/jackson-databind/blob/3.x/src/main/java/tools/jackson/databind/ser/BasicSerializerFactory.java#L314-L316
    * the formatOverrides passed in is null and the hardcoded Number.class in the _check call leads to the formatOverrides for MyBigDecimal.class not being found
    * there are a few changes that I have tried that fix the test. I have included 1 in this PR for illustration
