### PR TITLE
test case for serializing custom numbers with config overrides

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/NumberSerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/NumberSerTest.java
@@ -229,6 +229,15 @@ public class NumberSerTest extends DatabindTestUtil
     }
 
     @Test
+    public void testConfigOverrideJdkNumber() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder().withConfigOverride(BigDecimal.class,
+                        c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))
+                .build();
+        String value = mapper.writeValueAsString(new BigDecimal("123.456"));
+        assertEquals(a2q("'123.456'"), value);
+    }
+
+    @Test
     public void testConfigOverrideNonJdkNumber() throws Exception {
         ObjectMapper mapper = jsonMapperBuilder().withConfigOverride(MyBigDecimal.class,
                 c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/NumberSerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/NumberSerTest.java
@@ -117,6 +117,12 @@ public class NumberSerTest extends DatabindTestUtil
         }
     }
 
+    static class MyBigDecimal extends BigDecimal {
+        public MyBigDecimal(String value) {
+            super(value);
+        }
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -220,6 +226,15 @@ public class NumberSerTest extends DatabindTestUtil
         module.addSerializer(BigDecimal.class, new BigDecimalAsNumberSerializer());
         ObjectMapper mapper = jsonMapperBuilder().addModule(module).build();
         assertEquals(a2q("{'value':2.0}"), mapper.writeValueAsString(new BigDecimalHolder("2")));
+    }
+
+    @Test
+    public void testConfigOverrideNonJdkNumber() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder().withConfigOverride(MyBigDecimal.class,
+                c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)))
+                .build();
+        String value = mapper.writeValueAsString(new MyBigDecimal("123.456"));
+        assertEquals(a2q("'123.456'"), value);
     }
 
     // default locale is en_US


### PR DESCRIPTION
the same as #5198 (3.x branch equivalent) but this works in 2.x