### PR TITLE
Fix #5231 with MethodHandle with varargs in deserialization

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -9,6 +9,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 #5225: `NullPointerException` in `ObjectMapper.valueToTree(UUID)`
  (reported by @ kiryong-lee)
+#5231: Deserialization through setter with `vararg` parameter fails `ClassCastException`
+ (reported by @tsegall)
+ (contributed by Joo-Hyuk K)
 
 3.0.0-rc5 (22-May-2025)
 

--- a/src/main/java/tools/jackson/databind/deser/impl/MethodProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/MethodProperty.java
@@ -213,11 +213,10 @@ public final class MethodProperty
                 Method method = am.getAnnotated();
                 MethodHandle raw = MethodHandles.lookup().unreflect(method);
 
-                // If it's varargs, disable varargs handling
+                // [databind#5231] If it's varargs, disable varargs handling, 2025-July-25 (Since 3.0)
                 if (method.isVarArgs()) {
                     raw = raw.asFixedArity(); // disables argument spreading
                 }
-
                 return raw;
             } else {
                 AnnotatedField af = (AnnotatedField) _annotated;

--- a/src/main/java/tools/jackson/databind/deser/impl/MethodProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/MethodProperty.java
@@ -4,7 +4,6 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.reflect.Method;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
@@ -210,14 +209,9 @@ public final class MethodProperty
         protected MethodHandle unreflect() throws IllegalAccessException {
             if (_annotated instanceof AnnotatedMethod) {
                 AnnotatedMethod am = (AnnotatedMethod) _annotated;
-                Method method = am.getAnnotated();
-                MethodHandle raw = MethodHandles.lookup().unreflect(method);
-
-                // [databind#5231] If it's varargs, disable varargs handling, 2025-July-25 (Since 3.0)
-                if (method.isVarArgs()) {
-                    raw = raw.asFixedArity(); // disables argument spreading
-                }
-                return raw;
+                return MethodHandles.lookup().unreflect(am.getAnnotated())
+                        // [databind#5231] If it's varargs, disable varargs handling, 2025-July-25 (Since 3.0)
+                        .asFixedArity();
             } else {
                 AnnotatedField af = (AnnotatedField) _annotated;
                 return MethodHandles.lookup().unreflectSetter(af.getAnnotated());

--- a/src/main/java/tools/jackson/databind/deser/impl/MethodProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/MethodProperty.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
@@ -209,7 +210,15 @@ public final class MethodProperty
         protected MethodHandle unreflect() throws IllegalAccessException {
             if (_annotated instanceof AnnotatedMethod) {
                 AnnotatedMethod am = (AnnotatedMethod) _annotated;
-                return MethodHandles.lookup().unreflect(am.getAnnotated());
+                Method method = am.getAnnotated();
+                MethodHandle raw = MethodHandles.lookup().unreflect(method);
+
+                // If it's varargs, disable varargs handling
+                if (method.isVarArgs()) {
+                    raw = raw.asFixedArity(); // disables argument spreading
+                }
+
+                return raw;
             } else {
                 AnnotatedField af = (AnnotatedField) _annotated;
                 return MethodHandles.lookup().unreflectSetter(af.getAnnotated());

--- a/src/test/java/tools/jackson/databind/deser/jdk/JDKLocaleWithVargarg5231Test.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/JDKLocaleWithVargarg5231Test.java
@@ -1,17 +1,21 @@
 package tools.jackson.databind.deser.jdk;
 
-import java.util.Locale;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
+
 import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+// [databind#5231] Fix #5231 with MethodHandle with varargs in deserialization #5235
 public class JDKLocaleWithVargarg5231Test
+    extends DatabindTestUtil
 {
-
     public static class DateTimeParserConfig {
         public Locale[] locales;
         private Locale locale;
@@ -31,44 +35,46 @@ public class JDKLocaleWithVargarg5231Test
         }
 
         public Locale getLocale() {
-            if (locale != null)
-                return locale;
-
-            locales = new Locale[]{Locale.getDefault()};
-
-            return locales.length == 1 ? locales[0] : null;
+            return locale;
         }
 
     }
 
+    private final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+            .build();
+
     @Test
-    public void testSerializeAndDeserializeEmptyConfig() throws Exception {
-        ObjectMapper mapper = JsonMapper.builder()
-                .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
-                .build();
-
-        _testMultiple(mapper);
-        _testWithSingle(mapper);
-    }
-
-    private void _testMultiple(ObjectMapper mapper) {
+    public void multiple() {
         DateTimeParserConfig cfg = new DateTimeParserConfig();
         cfg.setLocales(new Locale[]{Locale.US, Locale.UK, Locale.ENGLISH});
-        String json = mapper.writeValueAsString(cfg);
+        String json = MAPPER.writeValueAsString(cfg);
 
-        DateTimeParserConfig result = mapper.readValue(json, DateTimeParserConfig.class);
+        DateTimeParserConfig result = MAPPER.readValue(json, DateTimeParserConfig.class);
 
         assertNotNull(result);
-        assertNotNull(result.locales); // Should fallback to Locale.getDefault()
+        assertThat(toList(result.locales))
+                .containsExactlyInAnyOrder(Locale.US, Locale.UK, Locale.ENGLISH);
     }
 
-    private void _testWithSingle(ObjectMapper mapper) {
+    @Test
+    public void withSingle() {
         DateTimeParserConfig cfg = new DateTimeParserConfig();
-        String json = mapper.writeValueAsString(cfg);
+        cfg.setLocales(new Locale[]{Locale.JAPANESE});
+        String json = MAPPER.writeValueAsString(cfg);
 
-        DateTimeParserConfig result = mapper.readValue(json, DateTimeParserConfig.class);
+        DateTimeParserConfig result = MAPPER.readValue(json, DateTimeParserConfig.class);
 
         assertNotNull(result);
-        assertNotNull(result.locales); // Should fallback to Locale.getDefault()
+        assertThat(toList(result.locales))
+                .containsExactlyInAnyOrder(Locale.JAPANESE);
+    }
+
+    private List<Locale> toList(Locale[] locales) {
+        List<Locale> list = new ArrayList<>();
+        for (Locale locale : locales) {
+            list.add(locale);
+        }
+        return list;
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/jdk/JDKLocaleWithVargarg5231Test.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/JDKLocaleWithVargarg5231Test.java
@@ -47,6 +47,22 @@ public class JDKLocaleWithVargarg5231Test
                 .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
                 .build();
 
+        _testMultiple(mapper);
+        _testWithSingle(mapper);
+    }
+
+    private void _testMultiple(ObjectMapper mapper) {
+        DateTimeParserConfig cfg = new DateTimeParserConfig();
+        cfg.setLocales(new Locale[]{Locale.US, Locale.UK, Locale.ENGLISH});
+        String json = mapper.writeValueAsString(cfg);
+
+        DateTimeParserConfig result = mapper.readValue(json, DateTimeParserConfig.class);
+
+        assertNotNull(result);
+        assertNotNull(result.locales); // Should fallback to Locale.getDefault()
+    }
+
+    private void _testWithSingle(ObjectMapper mapper) {
         DateTimeParserConfig cfg = new DateTimeParserConfig();
         String json = mapper.writeValueAsString(cfg);
 

--- a/src/test/java/tools/jackson/databind/deser/jdk/JDKLocaleWithVargarg5231Test.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/JDKLocaleWithVargarg5231Test.java
@@ -1,0 +1,58 @@
+package tools.jackson.databind.deser.jdk;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class JDKLocaleWithVargarg5231Test
+{
+
+    public static class DateTimeParserConfig {
+        public Locale[] locales;
+        private Locale locale;
+
+        public Locale[] getLocales() {
+            return locales;
+        }
+
+        public void setLocales(Locale... locales) {
+            this.locales = locales;
+            if (locales != null && locales.length == 1)
+                this.locale = this.locales[0];
+        }
+
+        protected void setLocale(final Locale locale) {
+            this.locale = locale;
+        }
+
+        public Locale getLocale() {
+            if (locale != null)
+                return locale;
+
+            locales = new Locale[]{Locale.getDefault()};
+
+            return locales.length == 1 ? locales[0] : null;
+        }
+
+    }
+
+    @Test
+    public void testSerializeAndDeserializeEmptyConfig() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+                .build();
+
+        DateTimeParserConfig cfg = new DateTimeParserConfig();
+        String json = mapper.writeValueAsString(cfg);
+
+        DateTimeParserConfig result = mapper.readValue(json, DateTimeParserConfig.class);
+
+        assertNotNull(result);
+        assertNotNull(result.locales); // Should fallback to Locale.getDefault()
+    }
+}


### PR DESCRIPTION
Fixes #5231 

### Conclusion

Problem is with **argument-spreading** (I think)

### Description

There seems to be issue with `MethodProperty` in the deserialization where setters with varargs (e.g. `setLocales(Locale... locales)`).

I am assuming the problem is caused by the setter method being varargs, the underlying `MethodHandle` created via `MethodHandles.unreflect()` retains the varargs behavior by default, which enables argument spreading. 

```
Cannot cast [Ljava.util.Locale; to java.util.Locale
```

The fix uses `.asFixedArity()` on the unreflected `MethodHandle` when the underlying method is varargs. This disables argument spreading, ensuring that the method handle treats the argument as a single array, matching Jackson’s calling convention.

### Refs

- [`MethodHandle.asFixedArity()` JavaDoc](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/invoke/MethodHandle.html#asFixedArity())