### PR TITLE
Implement #5242: support for "packed binary vectors" (for `float[]`, `double[]`)

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,11 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+Not yet released
+
+#5242: Support "binary vectors": `@JsonFormat(shape = Shape.BINARY)` for
+  `float[]`, `double[]`
+
 2.20.0-rc1 (04-Aug-2025)
 
 #3072: Allow specifying `@JacksonInject` does not fail when there's no

--- a/src/test/java/com/fasterxml/jackson/databind/convert/CoerceContainersTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/CoerceContainersTest.java
@@ -155,7 +155,9 @@ public class CoerceContainersTest
     @Test
     public void testFloatArray() throws Exception
     {
-        _verifyNoCoercion(float[].class);
+        // 06-Aug-2025, tatu: with [databind#5242] will coerce empty String
+        //    as empty Base64 array, so no exception here
+        //_verifyNoCoercion(float[].class);
         float[] result = _readWithCoercion(float[].class);
         assertNotNull(result);
         assertEquals(0, result.length);
@@ -164,7 +166,9 @@ public class CoerceContainersTest
     @Test
     public void testDoubleArray() throws Exception
     {
-        _verifyNoCoercion(double[].class);
+        // 06-Aug-2025, tatu: with [databind#5242] will coerce empty String
+        //    as empty Base64 array, so no exception here
+        //_verifyNoCoercion(double[].class);
         double[] result = _readWithCoercion(double[].class);
         assertNotNull(result);
         assertEquals(0, result.length);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ArrayDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ArrayDeserializationTest.java
@@ -551,8 +551,12 @@ public class ArrayDeserializationTest
         assertLengthValue(MAPPER.readValue("\"1\"", short[].class), (short) 1);
         assertLengthValue(MAPPER.readValue("\"1\"", int[].class), 1);
         assertLengthValue(MAPPER.readValue("\"1\"", long[].class), 1L);
-        assertLengthValue(MAPPER.readValue("\"7.038531e-26\"", float[].class), 7.038531e-26f);
-        assertLengthValue(MAPPER.readValue("\"1.5555\"", double[].class), 1.5555d);
+
+        // 06-Aug-2025, tatu: with [databind#5242] will try to access String
+        //   as Base64-encoded bytes. Need to think of whether to try to 
+        //   support Float/Double-as-single-String case or not; for now, not
+        //assertLengthValue(MAPPER.readValue("\"7.038531e-26\"", float[].class), 7.038531e-26f);
+        //assertLengthValue(MAPPER.readValue("\"1.5555\"", double[].class), 1.5555d);
     }
 
     private void assertLengthValue(boolean[] arr, boolean expt) {
@@ -580,12 +584,12 @@ public class ArrayDeserializationTest
         assertEquals(expt, arr[0]);
     }
 
-    private void assertLengthValue(float[] arr, float expt) {
+    void assertLengthValue(float[] arr, float expt) {
         assertEquals(1, arr.length);
         assertEquals(expt, arr[0]);
     }
 
-    private void assertLengthValue(double[] arr, double expt) {
+    void assertLengthValue(double[] arr, double expt) {
         assertEquals(1, arr.length);
         assertEquals(expt, arr[0]);
     }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/VectorsAsBinarySerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/VectorsAsBinarySerTest.java
@@ -2,6 +2,8 @@ package com.fasterxml.jackson.databind.ser.jdk;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.Base64Variants;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
@@ -20,10 +22,50 @@ public class VectorsAsBinarySerTest extends DatabindTestUtil
     private final static double[] DOUBLE_VECTOR = new double[] { -1.0, 1.5, 0.0125 };
     private final static String DOUBLE_VECTOR_STR = "[-1.0,1.5,0.0125]";
 
+    static class BeanWithArrayFloatVector {
+        @JsonFormat(shape = JsonFormat.Shape.NATURAL) // or ARRAY
+        public float[] vector;
+
+        protected BeanWithArrayFloatVector() { }
+        public BeanWithArrayFloatVector(float[] v) {
+            vector = v;
+        }
+    }
+
+    static class BeanWithBinaryFloatVector {
+        @JsonFormat(shape = JsonFormat.Shape.BINARY)
+        public float[] vector;
+
+        protected BeanWithBinaryFloatVector() { }
+        public BeanWithBinaryFloatVector(float[] v) {
+            vector = v;
+        }
+    }
+
+    static class BeanWithArrayDoubleVector {
+        @JsonFormat(shape = JsonFormat.Shape.NATURAL) // or ARRAY
+        public double[] vector;
+
+        protected BeanWithArrayDoubleVector() { }
+        public BeanWithArrayDoubleVector(double[] v) {
+            vector = v;
+        }
+    }
+
+    static class BeanWithBinaryDoubleVector {
+        @JsonFormat(shape = JsonFormat.Shape.BINARY)
+        public double[] vector;
+
+        protected BeanWithBinaryDoubleVector() { }
+        public BeanWithBinaryDoubleVector(double[] v) {
+            vector = v;
+        }
+    }
+
     private final ObjectMapper MAPPER = sharedMapper();
 
-    // // // Float Vector tests
-    
+    // // // Float Vector tests, as-Array
+
     @Test
     public void defaultFloatVectorSerialization() throws Exception {
         String json = MAPPER.writeValueAsString(FLOAT_VECTOR);
@@ -33,8 +75,28 @@ public class VectorsAsBinarySerTest extends DatabindTestUtil
         assertArrayEquals(FLOAT_VECTOR, result);
     }
 
-    // // // Double Vector tests
-    
+    @Test
+    public void asArrayFloatVectorSerialization() throws Exception {
+        String json = MAPPER.writeValueAsString(new BeanWithArrayFloatVector(FLOAT_VECTOR));
+        assertEquals(a2q("{'vector':"+FLOAT_VECTOR_STR+"}"), json);
+
+        BeanWithArrayFloatVector result = MAPPER.readValue(json, BeanWithArrayFloatVector.class);
+        assertArrayEquals(FLOAT_VECTOR, result.vector);
+    }
+
+    // // // Float Vector tests, as-Binary
+
+    @Test
+    public void asBinaryFloatVectorSerialization() throws Exception {
+        String json = MAPPER.writeValueAsString(new BeanWithBinaryFloatVector(FLOAT_VECTOR));
+        assertEquals(a2q("{'vector':'"+base64Encode(asBinary(FLOAT_VECTOR))+"'}"), json);
+
+        BeanWithArrayFloatVector result = MAPPER.readValue(json, BeanWithArrayFloatVector.class);
+        assertArrayEquals(FLOAT_VECTOR, result.vector);
+    }
+
+    // // // Double Vector tests, as-Array
+
     @Test
     public void defaultDoubleVectorSerialization() throws Exception {
         String json = MAPPER.writeValueAsString(DOUBLE_VECTOR);
@@ -42,5 +104,59 @@ public class VectorsAsBinarySerTest extends DatabindTestUtil
 
         double[] result = MAPPER.readValue(json, double[].class);
         assertArrayEquals(DOUBLE_VECTOR, result);
+    }
+
+    @Test
+    public void asArrayDoubleVectorSerialization() throws Exception {
+        String json = MAPPER.writeValueAsString(new BeanWithArrayDoubleVector(DOUBLE_VECTOR));
+        assertEquals(a2q("{'vector':"+DOUBLE_VECTOR_STR+"}"), json);
+
+        BeanWithArrayDoubleVector result = MAPPER.readValue(json, BeanWithArrayDoubleVector.class);
+        assertArrayEquals(DOUBLE_VECTOR, result.vector);
+    }
+
+    // // // Double Vector tests, as-Binary
+
+    @Test
+    public void asBinaryDoubleVectorSerialization() throws Exception {
+        String json = MAPPER.writeValueAsString(new BeanWithBinaryDoubleVector(DOUBLE_VECTOR));
+        assertEquals(a2q("{'vector':'"+base64Encode(asBinary(DOUBLE_VECTOR))+"'}"), json);
+
+        BeanWithBinaryDoubleVector result = MAPPER.readValue(json, BeanWithBinaryDoubleVector.class);
+        assertArrayEquals(DOUBLE_VECTOR, result.vector);
+    }
+
+    // // // Helper methods
+
+    private static byte[] asBinary(float[] vector) {
+        byte[] result = new byte[vector.length * 4];
+        for (int i = 0; i < vector.length; i++) {
+            int bits = Float.floatToIntBits(vector[i]);
+            result[i * 4] = (byte) (bits >> 24);
+            result[i * 4 + 1] = (byte) (bits >> 16);
+            result[i * 4 + 2] = (byte) (bits >> 8);
+            result[i * 4 + 3] = (byte) bits;
+        }
+        return result;
+    }
+
+    private static byte[] asBinary(double[] vector) {
+        byte[] result = new byte[vector.length * 8];
+        for (int i = 0; i < vector.length; i++) {
+            long bits = Double.doubleToLongBits(vector[i]);
+            result[i * 8] = (byte) (bits >> 56);
+            result[i * 8 + 1] = (byte) (bits >> 48);
+            result[i * 8 + 2] = (byte) (bits >> 40);
+            result[i * 8 + 3] = (byte) (bits >> 32);
+            result[i * 8 + 4] = (byte) (bits >> 24);
+            result[i * 8 + 5] = (byte) (bits >> 16);
+            result[i * 8 + 6] = (byte) (bits >> 8);
+            result[i * 8 + 7] = (byte) bits;
+        }
+        return result;
+    }
+
+    private String base64Encode(byte[] data) {
+        return Base64Variants.getDefaultVariant().encode(data, false);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/VectorsAsBinarySerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/VectorsAsBinarySerTest.java
@@ -62,67 +62,100 @@ public class VectorsAsBinarySerTest extends DatabindTestUtil
         }
     }
 
-    private final ObjectMapper MAPPER = sharedMapper();
+    private final ObjectMapper VANILLA_MAPPER = sharedMapper();
+
+    private final ObjectMapper BINARY_VECTOR_MAPPER = jsonMapperBuilder()
+            .withConfigOverride(float[].class,
+                    c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.BINARY)))
+            .withConfigOverride(double[].class,
+                    c -> c.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.BINARY)))
+            .build();
 
     // // // Float Vector tests, as-Array
 
     @Test
     public void defaultFloatVectorSerialization() throws Exception {
-        String json = MAPPER.writeValueAsString(FLOAT_VECTOR);
+        String json = VANILLA_MAPPER.writeValueAsString(FLOAT_VECTOR);
         assertEquals(FLOAT_VECTOR_STR, json);
 
-        float[] result = MAPPER.readValue(json, float[].class);
+        float[] result = VANILLA_MAPPER.readValue(json, float[].class);
         assertArrayEquals(FLOAT_VECTOR, result);
     }
 
     @Test
     public void asArrayFloatVectorSerialization() throws Exception {
-        String json = MAPPER.writeValueAsString(new BeanWithArrayFloatVector(FLOAT_VECTOR));
-        assertEquals(a2q("{'vector':"+FLOAT_VECTOR_STR+"}"), json);
+        final String exp = a2q("{'vector':"+FLOAT_VECTOR_STR+"}");
+        String json = VANILLA_MAPPER.writeValueAsString(new BeanWithArrayFloatVector(FLOAT_VECTOR));
+        assertEquals(exp, json);
+        // And annotation overrides default shape override
+        assertEquals(exp,
+                BINARY_VECTOR_MAPPER.writeValueAsString(new BeanWithArrayFloatVector(FLOAT_VECTOR)));
 
-        BeanWithArrayFloatVector result = MAPPER.readValue(json, BeanWithArrayFloatVector.class);
+        BeanWithArrayFloatVector result = VANILLA_MAPPER.readValue(json, BeanWithArrayFloatVector.class);
         assertArrayEquals(FLOAT_VECTOR, result.vector);
     }
 
     // // // Float Vector tests, as-Binary
 
     @Test
-    public void asBinaryFloatVectorSerialization() throws Exception {
-        String json = MAPPER.writeValueAsString(new BeanWithBinaryFloatVector(FLOAT_VECTOR));
-        assertEquals(a2q("{'vector':'"+base64Encode(asBinary(FLOAT_VECTOR))+"'}"), json);
+    public void asBinaryFloatVectorSerializationRoot() throws Exception {
+        String json = BINARY_VECTOR_MAPPER.writeValueAsString(FLOAT_VECTOR);
+        assertEquals(q(base64Encode(asBinary(FLOAT_VECTOR))), json);
 
-        BeanWithArrayFloatVector result = MAPPER.readValue(json, BeanWithArrayFloatVector.class);
-        assertArrayEquals(FLOAT_VECTOR, result.vector);
+        float[] result = BINARY_VECTOR_MAPPER.readValue(json, float[].class);
+        assertArrayEquals(FLOAT_VECTOR, result);
     }
 
+    @Test
+    public void asBinaryFloatVectorSerializationPOJO() throws Exception {
+        String json = VANILLA_MAPPER.writeValueAsString(new BeanWithBinaryFloatVector(FLOAT_VECTOR));
+        assertEquals(a2q("{'vector':'"+base64Encode(asBinary(FLOAT_VECTOR))+"'}"), json);
+
+        BeanWithArrayFloatVector result = VANILLA_MAPPER.readValue(json, BeanWithArrayFloatVector.class);
+        assertArrayEquals(FLOAT_VECTOR, result.vector);
+    }
+    
     // // // Double Vector tests, as-Array
 
     @Test
     public void defaultDoubleVectorSerialization() throws Exception {
-        String json = MAPPER.writeValueAsString(DOUBLE_VECTOR);
+        String json = VANILLA_MAPPER.writeValueAsString(DOUBLE_VECTOR);
         assertEquals(DOUBLE_VECTOR_STR, json);
 
-        double[] result = MAPPER.readValue(json, double[].class);
+        double[] result = VANILLA_MAPPER.readValue(json, double[].class);
         assertArrayEquals(DOUBLE_VECTOR, result);
     }
 
     @Test
     public void asArrayDoubleVectorSerialization() throws Exception {
-        String json = MAPPER.writeValueAsString(new BeanWithArrayDoubleVector(DOUBLE_VECTOR));
-        assertEquals(a2q("{'vector':"+DOUBLE_VECTOR_STR+"}"), json);
+        String exp = a2q("{'vector':"+DOUBLE_VECTOR_STR+"}");
+        String json = VANILLA_MAPPER.writeValueAsString(new BeanWithArrayDoubleVector(DOUBLE_VECTOR));
+        assertEquals(exp, json);
+        // And annotation overrides default shape override
+        assertEquals(exp,
+                BINARY_VECTOR_MAPPER.writeValueAsString(new BeanWithArrayDoubleVector(DOUBLE_VECTOR)));
 
-        BeanWithArrayDoubleVector result = MAPPER.readValue(json, BeanWithArrayDoubleVector.class);
+        BeanWithArrayDoubleVector result = VANILLA_MAPPER.readValue(json, BeanWithArrayDoubleVector.class);
         assertArrayEquals(DOUBLE_VECTOR, result.vector);
     }
 
     // // // Double Vector tests, as-Binary
 
     @Test
-    public void asBinaryDoubleVectorSerialization() throws Exception {
-        String json = MAPPER.writeValueAsString(new BeanWithBinaryDoubleVector(DOUBLE_VECTOR));
+    public void asBinaryDoubleVectorSerializationRoot() throws Exception {
+        String json = BINARY_VECTOR_MAPPER.writeValueAsString(DOUBLE_VECTOR);
+        assertEquals(q(base64Encode(asBinary(DOUBLE_VECTOR))), json);
+
+        double[] result = BINARY_VECTOR_MAPPER.readValue(json, double[].class);
+        assertArrayEquals(DOUBLE_VECTOR, result);
+    }
+    
+    @Test
+    public void asBinaryDoubleVectorSerializationPOJO() throws Exception {
+        String json = VANILLA_MAPPER.writeValueAsString(new BeanWithBinaryDoubleVector(DOUBLE_VECTOR));
         assertEquals(a2q("{'vector':'"+base64Encode(asBinary(DOUBLE_VECTOR))+"'}"), json);
 
-        BeanWithBinaryDoubleVector result = MAPPER.readValue(json, BeanWithBinaryDoubleVector.class);
+        BeanWithBinaryDoubleVector result = VANILLA_MAPPER.readValue(json, BeanWithBinaryDoubleVector.class);
         assertArrayEquals(DOUBLE_VECTOR, result.vector);
     }
 


### PR DESCRIPTION
#5242