### PR TITLE
Fix #5263: drop URL-taking methods from `ObjectMapper`, `ObjectReader`

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -5,6 +5,11 @@ Versions: 3.x (for earlier see VERSION-2.x)
 === Releases ===
 ------------------------------------------------------------------------
 
+3.0.0-rc9 (not yet released)
+
+#5263: Remove deprecated `URL`-taking `readValue()` methods in `ObjectMapper`,
+  `ObjectReader` from 3.0
+
 3.0.0-rc8 (13-Aug-2025)
 
 No changes since 3.0.0-rc7

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -2,7 +2,6 @@ package tools.jackson.databind;
 
 import java.io.*;
 import java.lang.reflect.Type;
-import java.net.URL;
 import java.nio.file.Path;
 import java.text.DateFormat;
 import java.util.Collection;
@@ -611,21 +610,6 @@ public class ObjectMapper
      * Factory method for constructing {@link JsonParser} that is properly
      * wired to allow callbacks for deserialization: basically
      * constructs a {@link ObjectReadContext} and then calls
-     * {@link TokenStreamFactory#createParser(ObjectReadContext,java.net.URL)}.
-     *
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    public JsonParser createParser(URL src) throws JacksonException {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return ctxt.assignAndReturnParser(_streamFactory.createParser(ctxt, src));
-    }
-
-    /**
-     * Factory method for constructing {@link JsonParser} that is properly
-     * wired to allow callbacks for deserialization: basically
-     * constructs a {@link ObjectReadContext} and then calls
      * {@link TokenStreamFactory#createParser(ObjectReadContext,InputStream)}.
      *
      * @since 3.0
@@ -1215,25 +1199,6 @@ public class ObjectMapper
 
     /**
      * Same as {@link #readTree(InputStream)} except content read from
-     * passed-in {@link URL}.
-     *<p>
-     * NOTE: handling of {@link java.net.URL} is delegated to
-     * {@link TokenStreamFactory#createParser(ObjectReadContext, java.net.URL)}s and usually simply
-     * calls {@link java.net.URL#openStream()}, meaning no special handling
-     * is done. If different HTTP connection options are needed you will need
-     * to create {@link java.io.InputStream} separately.
-     *
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    public JsonNode readTree(URL src) throws JacksonException {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return _readTreeAndClose(ctxt, _streamFactory.createParser(ctxt, src));
-    }
-
-    /**
-     * Same as {@link #readTree(InputStream)} except content read from
      * passed-in {@link TokenBuffer}.
      */
     public JsonNode readTree(TokenBuffer src) throws JacksonException {
@@ -1530,64 +1495,6 @@ public class ObjectMapper
         _assertNotNull("src", src);
         DeserializationContextExt ctxt = _deserializationContext();
         return (T) _readMapAndClose(ctxt, _streamFactory.createParser(ctxt, src), valueType);
-    }
-
-    /**
-     * Method to deserialize JSON content from given resource into given Java type.
-     *<p>
-     * NOTE: handling of {@link java.net.URL} is delegated to
-     * {@link TokenStreamFactory#createParser(ObjectReadContext, java.net.URL)} and usually simply
-     * calls {@link java.net.URL#openStream()}, meaning no special handling
-     * is done. If different HTTP connection options are needed you will need
-     * to create {@link java.io.InputStream} separately.
-     *
-     * @throws JacksonIOException if a low-level I/O problem (unexpected end-of-input,
-     *   network error) occurs (passed through as-is without additional wrapping -- note
-     *   that this is one case where {@link DeserializationFeature#WRAP_EXCEPTIONS}
-     *   does NOT result in wrapping of exception even if enabled)
-     * @throws StreamReadException if underlying input contains invalid content
-     *    of type {@link JsonParser} supports (JSON for default case)
-     * @throws DatabindException if the input JSON structure does not match structure
-     *   expected for result type (or has other mismatch issues)
-     *
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    @SuppressWarnings("unchecked")
-    public <T> T readValue(URL src, Class<T> valueType) throws JacksonException
-    {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return (T) _readMapAndClose(ctxt,
-                _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueType));
-    }
-
-    /**
-     * Same as {@link #readValue(java.net.URL, Class)} except that target specified by {@link TypeReference}.
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    @SuppressWarnings({ "unchecked" })
-    public <T> T readValue(URL src, TypeReference<T> valueTypeRef) throws JacksonException
-    {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return (T) _readMapAndClose(ctxt,
-                _streamFactory.createParser(ctxt, src), _typeFactory.constructType(valueTypeRef));
-    }
-
-    /**
-     * Same as {@link #readValue(java.net.URL, Class)} except that target specified by {@link JavaType}.
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    @SuppressWarnings("unchecked")
-    public <T> T readValue(URL src, JavaType valueType) throws JacksonException
-    {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return (T) _readMapAndClose(ctxt,
-                _streamFactory.createParser(ctxt, src), valueType);
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/ObjectReader.java
+++ b/src/main/java/tools/jackson/databind/ObjectReader.java
@@ -1,7 +1,6 @@
 package tools.jackson.databind;
 
 import java.io.*;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -836,22 +835,6 @@ public class ObjectReader
      * Factory method for constructing {@link JsonParser} that is properly
      * wired to allow callbacks for deserialization: basically
      * constructs a {@link ObjectReadContext} and then calls
-     * {@link TokenStreamFactory#createParser(ObjectReadContext,java.net.URL)}.
-     *
-     * @since 3.0
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    public JsonParser createParser(URL src) throws JacksonException {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return ctxt.assignAndReturnParser(_parserFactory.createParser(ctxt, src));
-    }
-
-    /**
-     * Factory method for constructing {@link JsonParser} that is properly
-     * wired to allow callbacks for deserialization: basically
-     * constructs a {@link ObjectReadContext} and then calls
      * {@link TokenStreamFactory#createParser(ObjectReadContext,InputStream)}.
      *
      * @since 3.0
@@ -1294,31 +1277,6 @@ public class ObjectReader
     }
 
     /**
-     * Method that binds content read from given input source,
-     * using configuration of this reader.
-     * Value return is either newly constructed, or root value that
-     * was specified with {@link #withValueToUpdate(Object)}.
-     *<p>
-     *<p>
-     * NOTE: handling of {@link java.net.URL} is delegated to
-     * {@link TokenStreamFactory#createParser(ObjectReadContext, java.net.URL)} and usually simply
-     * calls {@link java.net.URL#openStream()}, meaning no special handling
-     * is done. If different HTTP connection options are needed you will need
-     * to create {@link java.io.InputStream} separately.
-     *
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    @SuppressWarnings("unchecked")
-    public <T> T readValue(URL url) throws JacksonException
-    {
-        _assertNotNull("src", url);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return (T) _bindAndClose(ctxt,
-                _considerFilter(_parserFactory.createParser(ctxt, url), false));
-    }
-
-    /**
      * Convenience method for converting results from given JSON tree into given
      * value type. Basically short-cut for:
      *<pre>
@@ -1592,28 +1550,6 @@ public class ObjectReader
                 _considerFilter(_parserFactory.createParser(ctxt, src), true));
     }
 
-    /**
-     * Overloaded version of {@link #readValue(InputStream)}.
-     *<p>
-     * NOTE: handling of {@link java.net.URL} is delegated to
-     * {@link TokenStreamFactory#createParser(ObjectReadContext, java.net.URL)} and usually simply
-     * calls {@link java.net.URL#openStream()}, meaning no special handling
-     * is done. If different HTTP connection options are needed you will need
-     * to create {@link java.io.InputStream} separately.
-     *
-     * @param src URL to read to access JSON content to parse.
-     *
-     * @deprecated since 2.20 deprecated as it calls {@link TokenStreamFactory#createParser(URL)}.
-     */
-    @Deprecated // @since 2.20
-    public <T> MappingIterator<T> readValues(URL src) throws JacksonException
-    {
-        _assertNotNull("src", src);
-        DeserializationContextExt ctxt = _deserializationContext();
-        return _bindAndReadValues(ctxt,
-                _considerFilter(_parserFactory.createParser(ctxt, src), true));
-    }
-
     public <T> MappingIterator<T> readValues(DataInput src) throws JacksonException
     {
         _assertNotNull("src", src);
@@ -1856,14 +1792,6 @@ public class ObjectReader
     protected DeserializationContextExt _deserializationContext(JsonParser p) {
         return _contexts.createContext(_config, _schema, _injectableValues)
                 .assignParser(p);
-    }
-
-    protected InputStream _inputStream(URL src) throws JacksonException {
-        try {
-            return src.openStream();
-        } catch (IOException e) {
-            throw JacksonIOException.construct(e);
-        }
     }
 
     protected InputStream _inputStream(File f) throws JacksonException {

--- a/src/test/java/tools/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/tools/jackson/databind/ObjectMapperTest.java
@@ -368,16 +368,6 @@ public class ObjectMapperTest extends DatabindTestUtil
     }
 
     @Test
-    public void test_createParser_Url() throws Exception
-    {
-        Path path = Files.createTempFile("", "");
-        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
-        JsonParser jsonParser = MAPPER.createParser(path.toUri().toURL());
-
-        assertEquals(jsonParser.nextStringValue(), "value");
-    }
-
-    @Test
     public void test_createParser_Reader() throws Exception
     {
         Reader reader = new StringReader("\"value\"");
@@ -428,7 +418,6 @@ public class ObjectMapperTest extends DatabindTestUtil
         ObjectMapper objectMapper = MAPPER;
         test_method_failsIfArgumentIsNull(() -> objectMapper.createParser((InputStream) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.createParser((DataInput) null));
-        test_method_failsIfArgumentIsNull(() -> objectMapper.createParser((URL) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.createParser((Path) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.createParser((File) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.createParser((Reader) null));
@@ -551,16 +540,6 @@ public class ObjectMapperTest extends DatabindTestUtil
     }
 
     @Test
-    public void test_readTree_Url() throws Exception
-    {
-        Path path = Files.createTempFile("", "");
-        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
-        JsonNode jsonNode = MAPPER.readTree(path.toUri().toURL());
-
-        assertEquals(jsonNode.stringValue(), "value");
-    }
-
-    @Test
     public void test_readTree_Reader() throws Exception
     {
         Reader reader = new StringReader("\"value\"");
@@ -598,7 +577,6 @@ public class ObjectMapperTest extends DatabindTestUtil
     {
         ObjectMapper objectMapper = MAPPER;
         test_method_failsIfArgumentIsNull(() -> objectMapper.readTree((InputStream) null));
-        test_method_failsIfArgumentIsNull(() -> objectMapper.readTree((URL) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readTree((Path) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readTree((File) null));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readTree((Reader) null));
@@ -646,19 +624,6 @@ public class ObjectMapperTest extends DatabindTestUtil
         String result2 = MAPPER.readValue(path, SimpleType.constructUnsafe(String.class));
         assertEquals(result2, "value");
         String result3 = MAPPER.readValue(path, new TypeReference<String>() {});
-        assertEquals(result3, "value");
-    }
-
-    @Test
-    public void test_readValue_Url() throws Exception
-    {
-        Path path = Files.createTempFile("", "");
-        Files.write(path, "\"value\"".getBytes(StandardCharsets.UTF_8));
-        String result1 = MAPPER.readValue(path.toUri().toURL(), String.class);
-        assertEquals(result1, "value");
-        String result2 = MAPPER.readValue(path.toUri().toURL(), SimpleType.constructUnsafe(String.class));
-        assertEquals(result2, "value");
-        String result3 = MAPPER.readValue(path.toUri().toURL(), new TypeReference<String>() {});
         assertEquals(result3, "value");
     }
 
@@ -754,9 +719,6 @@ public class ObjectMapperTest extends DatabindTestUtil
         test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((DataInput) null, Map.class));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((DataInput) null, SimpleType.constructUnsafe(Map.class)));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((DataInput) null, new TypeReference<Map>() {}));
-        test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((URL) null, Map.class));
-        test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((URL) null, SimpleType.constructUnsafe(Map.class)));
-        test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((URL) null, new TypeReference<Map>() {}));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((Path) null, Map.class));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((Path) null, SimpleType.constructUnsafe(Map.class)));
         test_method_failsIfArgumentIsNull(() -> objectMapper.readValue((Path) null, new TypeReference<Map>() {}));

--- a/src/test/java/tools/jackson/databind/records/tofix/JsonIdentityOnRecord5238Test.java
+++ b/src/test/java/tools/jackson/databind/records/tofix/JsonIdentityOnRecord5238Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.databind.records;
+package tools.jackson.databind.records.tofix;
 
 import java.util.List;
 
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
+import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -49,6 +50,8 @@ public class JsonIdentityOnRecord5238Test
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    // [databind#5262]: Regression in 3.0?
+    @JacksonTestFailureExpected
     @Test
     void testIdentityWithPojo() throws Exception {
         ThingPojo t1 = new ThingPojo(1, "a");


### PR DESCRIPTION
Fix #5263