### PR TITLE
Fix #5244: add replacement for `AnnotatedMember.getAllAnnotations()`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -63,3 +63,8 @@ Guillaume Smet (@gsmet)
  * Requested #4907: Reduce/eliminate introspection on `java.*` classes
   [3.0.0]
 
+David Nault (@dnault)
+ * Requested #5244: Support accessing annotations via `AnnotatedMember.annotations()`
+  [3.0.0]
+
+

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.0.0-rc9 (not yet released)
 
+#5244: Support accessing annotations via `AnnotatedMember.annotations()`
+ (requested by David N)
 #5263: Remove deprecated `URL`-taking `readValue()` methods in `ObjectMapper`,
   `ObjectReader` from 3.0
 

--- a/src/main/java/tools/jackson/databind/introspect/Annotated.java
+++ b/src/main/java/tools/jackson/databind/introspect/Annotated.java
@@ -3,11 +3,12 @@ package tools.jackson.databind.introspect;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Modifier;
+import java.util.stream.Stream;
 
 import tools.jackson.databind.JavaType;
 
 /**
- * Shared base class used for anything on which annotations (included
+ * Shared base class used for anything that has associated annotations (included
  * within a {@link AnnotationMap}).
  */
 public abstract class Annotated
@@ -16,7 +17,12 @@ public abstract class Annotated
 
     public abstract <A extends Annotation> A getAnnotation(Class<A> acls);
 
-    public abstract boolean hasAnnotation(Class<?> acls);
+    /**
+     * @since 3.0
+     */
+    public abstract Stream<Annotation> annotations();
+    
+    public abstract boolean hasAnnotation(Class<? extends Annotation> acls);
 
     public abstract boolean hasOneOf(Class<? extends Annotation>[] annoClasses);
 

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedClass.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedClass.java
@@ -3,6 +3,7 @@ package tools.jackson.databind.introspect;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.stream.Stream;
 
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.cfg.MapperConfig;
@@ -183,13 +184,18 @@ public final class AnnotatedClass
     }
 
     @Override
-    public boolean hasAnnotation(Class<?> acls) {
+    public boolean hasAnnotation(Class<? extends Annotation> acls) {
         return _classAnnotations.has(acls);
     }
 
     @Override
     public boolean hasOneOf(Class<? extends Annotation>[] annoClasses) {
         return _classAnnotations.hasOneOf(annoClasses);
+    }
+
+    @Override
+    public Stream<Annotation> annotations() {
+        return _classAnnotations.values();
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedMember.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedMember.java
@@ -2,6 +2,7 @@ package tools.jackson.databind.introspect;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
+import java.util.stream.Stream;
 
 import tools.jackson.databind.util.ClassUtil;
 
@@ -62,7 +63,7 @@ public abstract class AnnotatedMember
     }
 
     @Override
-    public final boolean hasAnnotation(Class<?> acls) {
+    public final boolean hasAnnotation(Class<? extends Annotation> acls) {
         if (_annotations == null) {
             return false;
         }
@@ -77,12 +78,9 @@ public abstract class AnnotatedMember
         return _annotations.hasOneOf(annoClasses);
     }
 
-    /**
-     * @deprecated Since 3.0
-     */
-    @Deprecated
-    public AnnotationMap getAllAnnotations() { // alas, used by at least one module, hence public
-        return _annotations;
+    @Override
+    public Stream<Annotation> annotations() {
+        return _annotations.values();
     }
 
     /**
@@ -125,4 +123,19 @@ public abstract class AnnotatedMember
      */
     public abstract Object getValue(Object pojo)
         throws UnsupportedOperationException, IllegalArgumentException;
+
+    /**
+     * Internal method used by {@code POJOProperiesCollector} to
+     * merge annotations from this member with those from another
+     * member.
+     *<p>
+     * NOTE: NOT to be used by code outside jackson-databind (but has to be
+     * public to be accessible from POJOPropertiesCollector).
+     * 
+     * @deprecated Not to be used by code outside jackson-databind.
+     */
+    @Deprecated
+    public AnnotationMap _annotationMap() {
+        return _annotations;
+    }
 }

--- a/src/main/java/tools/jackson/databind/introspect/AnnotationCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotationCollector.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import tools.jackson.databind.util.Annotations;
 
@@ -187,7 +188,7 @@ public abstract class AnnotationCollector
         }
 
         @Override
-        public boolean has(Class<?> cls) {
+        public boolean has(Class<? extends Annotation> cls) {
             return false;
         }
 
@@ -199,6 +200,11 @@ public abstract class AnnotationCollector
         @Override
         public int size() {
             return 0;
+        }
+
+        @Override
+        public Stream<Annotation> values() {
+            return Stream.empty();
         }
     }
 
@@ -225,7 +231,7 @@ public abstract class AnnotationCollector
         }
 
         @Override
-        public boolean has(Class<?> cls) {
+        public boolean has(Class<? extends Annotation> cls) {
             return (_type == cls);
         }
 
@@ -239,6 +245,11 @@ public abstract class AnnotationCollector
             return false;
         }
 
+        @Override
+        public Stream<Annotation> values() {
+            return Stream.of(_value);
+        }
+        
         @Override
         public int size() {
             return 1;
@@ -274,7 +285,7 @@ public abstract class AnnotationCollector
         }
 
         @Override
-        public boolean has(Class<?> cls) {
+        public boolean has(Class<? extends Annotation> cls) {
             return (_type1 == cls) || (_type2 == cls);
         }
 
@@ -286,6 +297,11 @@ public abstract class AnnotationCollector
                 }
             }
             return false;
+        }
+
+        @Override
+        public Stream<Annotation> values() {
+            return Stream.of(_value1, _value2);
         }
 
         @Override

--- a/src/main/java/tools/jackson/databind/introspect/AnnotationMap.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotationMap.java
@@ -2,6 +2,7 @@ package tools.jackson.databind.introspect;
 
 import java.lang.annotation.Annotation;
 import java.util.*;
+import java.util.stream.Stream;
 
 import tools.jackson.databind.util.Annotations;
 
@@ -60,7 +61,7 @@ public final class AnnotationMap implements Annotations
     }
 
     @Override
-    public boolean has(Class<?> cls)
+    public boolean has(Class<? extends Annotation> cls)
     {
         if (_annotations == null) {
             return false;
@@ -84,18 +85,19 @@ public final class AnnotationMap implements Annotations
         return false;
     }
 
+    @Override
+    public Stream<Annotation> values() {
+        if (_annotations == null || _annotations.size() == 0) {
+            return Stream.empty();
+        }
+        return _annotations.values().stream();
+    }
+    
     /*
     /**********************************************************
     /* Other API
     /**********************************************************
      */
-
-    public Iterable<Annotation> annotations() {
-        if (_annotations == null || _annotations.size() == 0) {
-            return Collections.emptyList();
-        }
-        return _annotations.values();
-    }
 
     public static AnnotationMap merge(AnnotationMap primary, AnnotationMap secondary)
     {

--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -1094,15 +1094,13 @@ public class POJOPropertyBuilder
      * does "deep merge" if an as necessary, across alternate accessors of same type:
      * most importantly, "is-getter vs regular getter"
      */
+    @SuppressWarnings("deprecation") // only marked to prevent external use
     private AnnotationMap _getAllAnnotations(Linked<? extends AnnotatedMember> node) {
         if (node == null) {
             return null;
         }
-        AnnotationMap ann = node.value.getAllAnnotations();
-        if (node.next != null) {
-            ann = AnnotationMap.merge(ann, _getAllAnnotations(node.next));
-        }
-        return ann;
+        AnnotationMap ann = node.value._annotationMap();
+        return AnnotationMap.merge(ann, _getAllAnnotations(node.next));
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/util/Annotations.java
+++ b/src/main/java/tools/jackson/databind/util/Annotations.java
@@ -1,6 +1,7 @@
 package tools.jackson.databind.util;
 
 import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
 
 /**
  * Interface that defines interface for accessing contents of a
@@ -18,13 +19,14 @@ public interface Annotations
     public <A extends Annotation> A get(Class<A> cls);
 
     /**
-     * @since 2.9
+     * Access method that returns a stream of all annotations contained.
+     *
+     * @since 3.0
      */
-    public boolean has(Class<?> cls);
+    public abstract Stream<Annotation> values();
+    
+    public boolean has(Class<? extends Annotation> cls);
 
-    /**
-     * @since 2.9
-     */
     public boolean hasOneOf(Class<? extends Annotation>[] annoClasses);
 
     /**


### PR DESCRIPTION
Fixes #5244