### PR TITLE
guava-testlib dependency 31.1 -> 32.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
+      <version>32.0.1-jre</version>
       <scope>test</scope>
     </dependency>
     <!-- For testing TestNoClassDefFoundDeserializer -->


### PR DESCRIPTION
updating guava-testlib (scope:test) dependency: from 31.1 to 32.0.1 to resolve CVE-2020-8908 and CVE-2023-2976.
Testing passes, build successful after update.
No CVEs reported after update.