### PR TITLE
Fix minor typo in `PropertyBindingException.getMessageSuffix()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/exc/PropertyBindingException.java
+++ b/src/main/java/com/fasterxml/jackson/databind/exc/PropertyBindingException.java
@@ -108,7 +108,7 @@ public abstract class PropertyBindingException
                     }
                 }
             }
-            sb.append("])");
+            sb.append(")");
             _propertiesAsString = suffix = sb.toString();
         }
         return suffix;


### PR DESCRIPTION
This PR fixes a typo in the `PropertyBindingException.getMessageSuffix()` as it produces a spurious "]" as follows:

```
Unrecognized field "productId" (class com.example.Example$Pojo), not marked as ignorable (0 known properties: ])
```