### PR TITLE
Fix doc to pointing to right place regarding `getRegisteredModules()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java
@@ -1125,7 +1125,7 @@ public class ObjectMapper
      * module is NOT included in returned set.
      *<p>
      * NOTE: this method will be replaced in Jackson 3.0 with
-     * {@code Stream<JacksonModule> getRegisteredModules()} that will return actual Module
+     * {@code Collection<JacksonModule> registeredModules()} that will return actual Module
      * instances, instead of ids. Such method can not be backported in 2.x due to
      * differences in how Module registration works (2.x only has access to Module Ids)
      *


### PR DESCRIPTION
Just so we don't forget
#5300