### PR TITLE
add test for a Java Record with an Optional param

### DIFF
--- a/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
+++ b/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
@@ -1,7 +1,9 @@
 package tools.jackson.databind.records;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import java.util.Optional;
@@ -54,4 +56,19 @@ public class RecordWithOptionalParamTest
         assertNotNull(output.optional());
         assertEquals(Optional.empty(), output.optional());
     }
+
+    @Test
+    void deserializeIssue5335() throws Exception
+    {
+        String json = a2q("{'name':'v1','optional':null}");
+        JsonMapper mapper = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(
+                    v -> JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS))
+            .build();
+        RecordWithOptionalParam output = mapper.readValue(json, RecordWithOptionalParam.class);
+        assertEquals("v1", output.name());
+        assertNotNull(output.optional());
+        assertEquals(Optional.empty(), output.optional());
+    }
+
 }

--- a/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
+++ b/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
@@ -1,0 +1,57 @@
+package tools.jackson.databind.records;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [databind#53355] When deserializing records, java.util.Optional parameters should be not be
+// deserialized as null (Optional.empty() should be used instead)
+public class RecordWithOptionalParamTest
+    extends DatabindTestUtil
+{
+    record RecordWithOptionalParam(String name, Optional<String> optional) { }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    void serialize() throws Exception
+    {
+        RecordWithOptionalParam input = new RecordWithOptionalParam("v1", Optional.of("v2"));
+        String json = MAPPER.writeValueAsString(input);
+        String expected = a2q("{'name':'v1','optional':'v2'}");
+        assertEquals(expected, json);
+    }
+
+    @Test
+    void serializeEmpty() throws Exception
+    {
+        RecordWithOptionalParam input = new RecordWithOptionalParam("v1", Optional.empty());
+        String json = MAPPER.writeValueAsString(input);
+        String expected = a2q("{'name':'v1','optional':null}");
+        assertEquals(expected, json);
+    }
+
+    @Test
+    void deserializeNonEmpty() throws Exception
+    {
+        String json = a2q("{'name':'v1','optional':'v2'}");
+        RecordWithOptionalParam output = MAPPER.readValue(json, RecordWithOptionalParam.class);
+        assertEquals("v1", output.name());
+        assertEquals(Optional.of("v2"), output.optional());
+    }
+
+    @Test
+    void deserializeEmpty() throws Exception
+    {
+        String json = a2q("{'name':'v1','optional':null}");
+        RecordWithOptionalParam output = MAPPER.readValue(json, RecordWithOptionalParam.class);
+        assertEquals("v1", output.name());
+        assertNotNull(output.optional());
+        assertEquals(Optional.empty(), output.optional());
+    }
+}

--- a/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
+++ b/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
@@ -1,13 +1,11 @@
 package tools.jackson.databind.records;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,18 +23,16 @@ public class RecordWithOptionalParamTest
     void serialize() throws Exception
     {
         RecordWithOptionalParam input = new RecordWithOptionalParam("v1", Optional.of("v2"));
-        String json = MAPPER.writeValueAsString(input);
-        String expected = a2q("{'name':'v1','optional':'v2'}");
-        assertEquals(expected, json);
+        assertEquals(a2q("{'name':'v1','optional':'v2'}"),
+                MAPPER.writeValueAsString(input));
     }
 
     @Test
     void serializeEmpty() throws Exception
     {
         RecordWithOptionalParam input = new RecordWithOptionalParam("v1", Optional.empty());
-        String json = MAPPER.writeValueAsString(input);
-        String expected = a2q("{'name':'v1','optional':null}");
-        assertEquals(expected, json);
+        assertEquals(a2q("{'name':'v1','optional':null}"),
+                MAPPER.writeValueAsString(input));
     }
 
     @Test
@@ -62,26 +58,10 @@ public class RecordWithOptionalParamTest
     @Test
     void deserializeMissing() throws Exception
     {
-        String json = a2q("{'name':'v1'}");
-        RecordWithOptionalParam output = MAPPER.readValue(json, RecordWithOptionalParam.class);
+        RecordWithOptionalParam output = MAPPER.readValue(a2q("{'name':'v1'}"),
+                RecordWithOptionalParam.class);
         assertEquals("v1", output.name());
         assertNotNull(output.optional());
         assertEquals(Optional.empty(), output.optional());
     }
-
-    @JacksonTestFailureExpected // [databind#5335]
-    @Test
-    void deserializeIssue5335Config() throws Exception
-    {
-        String json = a2q("{'name':'v1'}");
-        JsonMapper mapper = JsonMapper.builder()
-            .changeDefaultPropertyInclusion(
-                    v -> JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS))
-            .build();
-        RecordWithOptionalParam output = mapper.readValue(json, RecordWithOptionalParam.class);
-        assertEquals("v1", output.name());
-        assertNotNull(output.optional());
-        assertEquals(Optional.empty(), output.optional());
-    }
-
 }

--- a/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
+++ b/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
+import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import java.util.Optional;
 
@@ -48,7 +49,7 @@ public class RecordWithOptionalParamTest
     }
 
     @Test
-    void deserializeEmpty() throws Exception
+    void deserializeExplicitNull() throws Exception
     {
         String json = a2q("{'name':'v1','optional':null}");
         RecordWithOptionalParam output = MAPPER.readValue(json, RecordWithOptionalParam.class);
@@ -57,10 +58,22 @@ public class RecordWithOptionalParamTest
         assertEquals(Optional.empty(), output.optional());
     }
 
+    @JacksonTestFailureExpected // [databind#5335]
     @Test
-    void deserializeIssue5335() throws Exception
+    void deserializeMissing() throws Exception
     {
-        String json = a2q("{'name':'v1','optional':null}");
+        String json = a2q("{'name':'v1'}");
+        RecordWithOptionalParam output = MAPPER.readValue(json, RecordWithOptionalParam.class);
+        assertEquals("v1", output.name());
+        assertNotNull(output.optional());
+        assertEquals(Optional.empty(), output.optional());
+    }
+
+    @JacksonTestFailureExpected // [databind#5335]
+    @Test
+    void deserializeIssue5335Config() throws Exception
+    {
+        String json = a2q("{'name':'v1'}");
         JsonMapper mapper = JsonMapper.builder()
             .changeDefaultPropertyInclusion(
                     v -> JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS))

--- a/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
+++ b/src/test/java/tools/jackson/databind/records/RecordWithOptionalParamTest.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// [databind#53355] When deserializing records, java.util.Optional parameters should be not be
+// [databind#5335] When deserializing records, java.util.Optional parameters should be not be
 // deserialized as null (Optional.empty() should be used instead)
 public class RecordWithOptionalParamTest
     extends DatabindTestUtil


### PR DESCRIPTION
* relates to #5335 but these tests pass - meaning that 5335 may relate to non-default ObjectMapper setup
* I think it is useful to add some extra record tests nonetheless