### PR TITLE
Bugfix: 5 flaky test on AnyGetterOrdering4388Test

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/AnyGetterOrdering4388Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/AnyGetterOrdering4388Test.java
@@ -47,7 +47,8 @@ public class AnyGetterOrdering4388Test extends DatabindTestUtil {
     @JsonPropertyOrder({"entityId", "totalTests", "childEntities", "entityName", "products"})
     static class PojoUnwrappedVersion2 extends BaseWithProperties {
     }
-
+    
+    @JsonPropertyOrder({"child1", "child2"})
     static class Location {
         public int child1;
         public int child2;
@@ -60,6 +61,7 @@ public class AnyGetterOrdering4388Test extends DatabindTestUtil {
         public Map<String, Object> map = new HashMap<>();
     }
 
+    @JsonPropertyOrder({"a", "b"})
     static class IgnorePropertiesOnAnyGetterPojo {
         public int a = 1, b = 2;
         @JsonIgnoreProperties("b")


### PR DESCRIPTION
# Bugfix: 5 Flaky Test in `AnyGetterOrdering4388Test `

## What is the purpose of this PR?

This pull request addresses several flaky test, in the `jackson-databind` project. The test was failing intermittently due to assumptions about the ordering of fields returned by the code under test.

## Test Affected

- `com.fasterxml.jackson.databind.ser.AnyGetterOrdering4388Test#testSerializationOrderVersion1`
- `com.fasterxml.jackson.databind.ser.AnyGetterOrdering4388Test#testSerializationOrderUnwrappedVersion1`
- `com.fasterxml.jackson.databind.ser.AnyGetterOrdering4388Test#testSerializationOrderUnwrappedVersion2`
- `com.fasterxml.jackson.databind.ser.AnyGetterOrdering4388Test#testSerializationOrderVersion2`
- `com.fasterxml.jackson.databind.ser.AnyGetterOrdering4388Test#testIgnoreProperties`

## Why the test fails

The test compares the **exact string** representation of a serialized JSON object, which under serialization might return any possible ordering. Some of the test has been correctly annotated with JsonPropertyOrder and this one fixes several flaky test that has missing annotations. 

## How to reproduce the test failure

Use the [TestingResearchIllinois's NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run:

```shell
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=AnyGetterOrdering4388Test
```

Before the fix, the test failed intermittently with errors similar to:

```shell
org.opentest4j.AssertionFailedError: expected: <{"a":1,"b":2}> but was: <{"b":2,"a":1}>
```

## Expected results

The test should pass consistently, regardless of the order of fields in the returned response.

## Actual results

Before the fix, the test failed intermittently due to changes in the order of the returned response.

## Validation

### Test Results

- Tests run with **NonDex**: Passed consistently across multiple seeds
    
```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=AnyGetterOrdering4388Test
```

<img width="1175" height="78" alt="image" src="https://github.com/user-attachments/assets/bcad5721-c840-44b1-96ff-5510eaa38680" />

    

## Additional Notes

- The fix ensures the test is robust to non-deterministic behaviors and compatible with future updates to it or related dependencies.

Let me know if further improvements or clarifications are needed!