### PR TITLE
Bugfix: Flaky Test in EnumDefaultReadTest and EnumAsFormatObject4654Test

### DIFF
--- a/src/test/java/tools/jackson/databind/deser/enums/EnumDefaultReadTest.java
+++ b/src/test/java/tools/jackson/databind/deser/enums/EnumDefaultReadTest.java
@@ -1,6 +1,7 @@
 package tools.jackson.databind.deser.enums;
 
 import java.io.IOException;
+import java.util.EnumSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -82,7 +83,6 @@ public class EnumDefaultReadTest
         B,
         @JsonEnumDefaultValue
         C,
-        @JsonEnumDefaultValue
         Z;
     }
 
@@ -309,7 +309,12 @@ public class EnumDefaultReadTest
                 .addMixIn(BaseOverloaded.class, MixinOverloadedDefault.class)
                 .build();
         
-        assertEquals(BaseOverloaded.A, 
-                mixinMapper.readValue(q("UNKNOWN"), BaseOverloaded.class));
+        BaseOverloaded result = mixinMapper.readValue(q("UNKNOWN"), BaseOverloaded.class);
+        
+        // If the more than one enum value is marked with this annotation
+        // the first to be detected will be used. Which one exactly is undetermined.
+        EnumSet<BaseOverloaded> annotatedDefaults =
+                EnumSet.of(BaseOverloaded.A, BaseOverloaded.B, BaseOverloaded.C);
+        assertTrue(annotatedDefaults.contains(result));
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/enums/EnumAsFormatObject4564Test.java
+++ b/src/test/java/tools/jackson/databind/ser/enums/EnumAsFormatObject4564Test.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -19,6 +20,7 @@ public class EnumAsFormatObject4564Test
 
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"label", "sublevel"})
     public enum Level {
         LEVEL1("level1"),
         LEVEL2("level2"),


### PR DESCRIPTION
# Bugfix: Flaky Test in `EnumDefaultReadTest` and `EnumAsFormatObject4654Test`

## What is the purpose of this PR?

This pull request addresses several flaky test, in the `jackson-databind` project. The test was failing intermittently due to assumptions about the ordering of fields returned by the code under test.

## Test Affected

- `com.fasterxml.jackson.databind.ser.enums.EnumAsFormatObject4564Test#testEnumAsFormatObject`
- `com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest#testFirstEnumDefaultValueViaMixin`

## Why the test fails

1. In the first one, the test compares the **exact string** representation of a serialized JSON object, which under serialization might return any possible ordering. I put a `@JsonPropertyOrder({"label", "sublevel"})` annotation to make sure that the JSON Fields are ordered.

2. In the second one, it is related to the `@JsonEnumDefaultValue` annotation, which according to the [documentations](https://fasterxml.github.io/jackson-annotations/javadoc/2.12/com/fasterxml/jackson/annotation/JsonEnumDefaultValue.html) are undetermined if there are multiple annotated fields. Previously the test only matches to `BaseOverloaded.A` and this fix will make the test non-flaky and follow the documentations.

## How to reproduce the test failure

Use the [TestingResearchIllinois's NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run:

```shell
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=EnumAsFormatObject4564Test
```

Before the fix, the test failed intermittently with errors similar to:

```shell
EnumAsFormatObject4564Test.testEnumAsFormatObject:55 expected: <[{"label":"level1"},{"label":"level2"},{"label":"level3","sublevel":{"label":"level1"}}]> but was: <[{"label":"level1"},{"label":"level2"},{"sublevel":{"label":"level1"},"label":"level3"}]>
```

## Expected results

The test should pass consistently, regardless of the order of fields in the returned response.

## Actual results

Before the fix, the test failed intermittently due to changes in the order of the returned response.

## Validation

### Test Results

- Tests run with **NonDex**: Passed consistently across multiple seeds
    
```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=EnumDefaultReadTest
```

<img width="1313" height="183" alt="image" src="https://github.com/user-attachments/assets/84fd9a98-7a26-4b7f-803c-7d9d60d43c9e" />

```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=EnumDefaultReadTest#testEnumAsFormatObject
```

<img width="1313" height="75" alt="image" src="https://github.com/user-attachments/assets/9d91974e-d42d-4626-87da-52510c2ec876" />


    

## Additional Notes

- The fix ensures the test is robust to non-deterministic behaviors and compatible with future updates to it or related dependencies.

Let me know if further improvements or clarifications are needed!