### PR TITLE
Fix issues wrt #1381

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -6,7 +6,6 @@ import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdResolver;

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -475,7 +475,7 @@ public abstract class DeserializationContext
                     || Boolean.TRUE.equals(optional)
                     || ((useInput == null || optional == null)
                             && !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
-                return JacksonInject.Value.empty();
+                return null;
             }
             throw missingInjectableValueException(String.format(
 "No 'injectableValues' configured, cannot inject value with id '%s'", valueId),

--- a/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
+++ b/src/main/java/com/fasterxml/jackson/databind/DeserializationContext.java
@@ -467,20 +467,11 @@ public abstract class DeserializationContext
             BeanProperty forProperty, Object beanInstance, Boolean optional, Boolean useInput)
         throws JsonMappingException
     {
-        if (_injectableValues == null) {
-            // `useInput` and `optional` come from property annotation (if any);
-            // they have precedence over global setting.
-            if (Boolean.TRUE.equals(useInput)
-                    || Boolean.TRUE.equals(optional)
-                    || ((useInput == null || optional == null)
-                            && !isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
-                return null;
-            }
-            throw missingInjectableValueException(String.format(
-"No 'injectableValues' configured, cannot inject value with id '%s'", valueId),
-                    valueId, forProperty, beanInstance);
+        InjectableValues injectables = _injectableValues;
+        if (injectables == null) {
+            injectables = InjectableValues.empty();
         }
-        return _injectableValues.findInjectableValue(this, valueId, forProperty, beanInstance,
+        return injectables.findInjectableValue(this, valueId, forProperty, beanInstance,
                 optional, useInput);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -11,6 +11,13 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 public abstract class InjectableValues
 {
     /**
+     * @since 2.21
+     */
+    public static InjectableValues empty() {
+        return InjectableValues.Empty.INSTANCE;
+    }
+
+    /**
      * Method called to find value identified by id <code>valueId</code> to
      * inject as value of specified property during deserialization, passing
      * POJO instance in which value will be injected if it is available
@@ -78,18 +85,35 @@ public abstract class InjectableValues
 
         protected Object _handleMissingValue(DeserializationContext ctxt, String key,
                 BeanProperty forProperty, Object beanInstance,
-                Boolean optional, Boolean useInput)
-                        throws JsonMappingException
+                Boolean optionalConfig, Boolean useInputConfig)
+            throws JsonMappingException
         {
-            if (Boolean.FALSE.equals(optional)
-                    || ((optional == null)
-                            && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
-                throw ctxt.missingInjectableValueException(
-                        String.format("No injectable value with id '%s' found (for property '%s')",
-                        key, forProperty.getName()),
-                        key, forProperty, beanInstance);
+            // Different defaulting fo "optional" (default to FALSE) and
+            // "useInput" (default to TRUE)
+
+            final boolean optional = Boolean.TRUE.equals(optionalConfig);
+            final boolean useInput = Boolean.TRUE.equals(useInputConfig);
+
+            // [databind#1381]: 14-Nov-2025, tatu: This is a mess: (1) and (2) make sense
+            //   but (3) is debatable. However, for backward compatibility this is what
+            //   passes tests we have.
+
+            // Missing ok if:
+            //
+            // 1. `optional` is TRUE
+            // 2. FAIL_ON_UNKNOWN_INJECT_VALUE is disabled
+            // 3. `useInput` is TRUE and injection is NOT via constructor (implied
+            //    by beanInstance being non-null)
+            if (optional
+                    || !ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
+                    || (useInput && beanInstance != null)
+                    ) {
+                return null;
             }
-            return null;
+            throw ctxt.missingInjectableValueException(
+                    String.format("No injectable value with id '%s' found (for property '%s')",
+                    key, forProperty.getName()),
+                    key, forProperty, beanInstance);
         }
 
         /**
@@ -109,11 +133,13 @@ public abstract class InjectableValues
     /**
      * @since 2.21
      */
-    public static class Empty
+    private static final class Empty
         extends Base
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;
+
+        final static Empty INSTANCE = new Empty();
 
         @Override
         public Object findInjectableValue(DeserializationContext ctxt, Object valueId,

--- a/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
+++ b/src/main/java/com/fasterxml/jackson/databind/InjectableValues.java
@@ -46,17 +46,93 @@ public abstract class InjectableValues
         throws JsonMappingException;
 
     /*
-    /**********************************************************
-    /* Standard implementation
-    /**********************************************************
+    /**********************************************************************
+    /* Standard implementations
+    /**********************************************************************
      */
+
+    /**
+     * Shared intermediate base class for standard implementations.
+     *
+     * @since 2.21
+     */
+    public abstract static class Base
+        extends InjectableValues
+        implements java.io.Serializable
+    {
+        private static final long serialVersionUID = 1L;
+
+        protected String _validateKey(DeserializationContext ctxt, Object valueId,
+                BeanProperty forProperty, Object beanInstance)
+            throws JsonMappingException
+        {
+            if (!(valueId instanceof String)) {
+                throw ctxt.missingInjectableValueException(
+                        String.format(
+                        "Unsupported injectable value id type (%s), expecting String",
+                        ClassUtil.classNameOf(valueId)),
+                        valueId, forProperty, beanInstance);
+            }
+            return (String) valueId;
+        }
+
+        protected Object _handleMissingValue(DeserializationContext ctxt, String key,
+                BeanProperty forProperty, Object beanInstance,
+                Boolean optional, Boolean useInput)
+                        throws JsonMappingException
+        {
+            if (Boolean.FALSE.equals(optional)
+                    || ((optional == null)
+                            && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
+                throw ctxt.missingInjectableValueException(
+                        String.format("No injectable value with id '%s' found (for property '%s')",
+                        key, forProperty.getName()),
+                        key, forProperty, beanInstance);
+            }
+            return null;
+        }
+
+        /**
+         * @deprecated in 2.20
+         */
+        @Override
+        @Deprecated // since 2.20
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
+                BeanProperty forProperty, Object beanInstance)
+            throws JsonMappingException
+        {
+            return this.findInjectableValue(ctxt, valueId, forProperty, beanInstance,
+                    null, null);
+        }
+    }
+
+    /**
+     * @since 2.21
+     */
+    public static class Empty
+        extends Base
+        implements java.io.Serializable
+    {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object findInjectableValue(DeserializationContext ctxt, Object valueId,
+                BeanProperty forProperty, Object beanInstance,
+                Boolean optional, Boolean useInput)
+            throws JsonMappingException
+        {
+            final String key = _validateKey(ctxt, valueId, forProperty, beanInstance);
+            return _handleMissingValue(ctxt, key, forProperty, beanInstance,
+                    optional, useInput);
+        }
+    }
 
     /**
      * Simple standard implementation which uses a simple Map to
      * store values to inject, identified by simple String keys.
      */
     public static class Std
-        extends InjectableValues
+        extends Base
         implements java.io.Serializable
     {
         private static final long serialVersionUID = 1L;
@@ -64,7 +140,7 @@ public abstract class InjectableValues
         protected final Map<String,Object> _values;
 
         public Std() {
-            this(new HashMap<String,Object>());
+            this(new HashMap<>());
         }
 
         public Std(Map<String,Object> values) {
@@ -81,48 +157,19 @@ public abstract class InjectableValues
             return this;
         }
 
-        /**
-         * @since 2.20
-         */
         @Override
         public Object findInjectableValue(DeserializationContext ctxt, Object valueId,
                 BeanProperty forProperty, Object beanInstance,
                 Boolean optional, Boolean useInput)
             throws JsonMappingException
         {
-            if (!(valueId instanceof String)) {
-                throw ctxt.missingInjectableValueException(
-                        String.format(
-                        "Unsupported injectable value id type (%s), expecting String",
-                        ClassUtil.classNameOf(valueId)),
-                        valueId, forProperty, beanInstance);
-            }
-            String key = (String) valueId;
+            String key = _validateKey(ctxt, valueId, forProperty, beanInstance);
             Object ob = _values.get(key);
             if (ob == null && !_values.containsKey(key)) {
-                if (Boolean.FALSE.equals(optional)
-                        || ((optional == null)
-                                && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE))) {
-                    throw ctxt.missingInjectableValueException(
-                            String.format("No injectable value with id '%s' found (for property '%s')",
-                            key, forProperty.getName()),
-                            valueId, forProperty, beanInstance);
-                }
+                return _handleMissingValue(ctxt, key, forProperty, beanInstance,
+                        optional, useInput);
             }
             return ob;
-        }
-
-        /**
-         * @deprecated in 2.20
-         */
-        @Override
-        @Deprecated // since 2.20
-        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-                BeanProperty forProperty, Object beanInstance)
-            throws JsonMappingException
-        {
-            return this.findInjectableValue(ctxt, valueId, forProperty, beanInstance,
-                    null, null);
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/PropertyValueBuffer.java
@@ -291,12 +291,12 @@ public class PropertyValueBuffer
         }
 
         // First: do we have injectable value?
-        Object injectableValueId = prop.getInjectableValueId();
-        if (injectableValueId != null) {
+        final JacksonInject.Value injection = prop.getInjectionDefinition();
+        if (injection != null) {
             // 10-Nov-2025: [databind#1381] Is this needed?
             _injectablePropIndexes.clear(prop.getCreatorIndex());
             return _context.findInjectableValue(prop.getInjectableValueId(),
-                    prop, null, null, null);
+                    prop, null, injection.getOptional(), injection.getUseInput());
         }
         // Second: required?
         if (prop.isRequired()) {
@@ -345,7 +345,7 @@ public class PropertyValueBuffer
                 final Object value = _context.findInjectableValue(injection.getId(),
                         prop, prop.getMember(), injection.getOptional(), useInput);
 
-                if (value != JacksonInject.Value.empty()) {
+                if (value != null) {
                     int ix = prop.getCreatorIndex();
                     _creatorParameters[ix] = value;
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ValueInjector.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.databind.deser.impl;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 
@@ -70,7 +69,7 @@ public class ValueInjector
     {
         final Object value = findValue(context, beanInstance);
 
-        if (value == JacksonInject.Value.empty()) {
+        if (value == null) {
             if (Boolean.FALSE.equals(_optional)) {
                 throw context.missingInjectableValueException(
                         String.format("No injectable value with id '%s' found (for property '%s')",

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381DeserializationFeatureDisabledTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381DeserializationFeatureDisabledTest.java
@@ -1,19 +1,17 @@
 package com.fasterxml.jackson.databind.deser.inject;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.OptBoolean;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
-import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.*;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class JacksonInject1381DeserializationFeatureDisabledTest extends DatabindTestUtil {
     static class InputDefault {
@@ -115,23 +113,16 @@ class JacksonInject1381DeserializationFeatureDisabledTest extends DatabindTestUt
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
             .build();
 
+    // If we are not to fail on unknown injectable values, no exception either
     @Test
     @DisplayName("FAIL_ON_UNKNOWN_INJECT_VALUE NO, input NO, injectable NO, useInput DEFAULT|TRUE|FALSE => exception")
-    void test1() {
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputDefault.class));
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputDefaultConstructor.class));
-
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputTrue.class));
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputTrueConstructor.class));
-
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputFalse.class));
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputFalseConstructor.class));
+    void test1() throws Exception {
+        assertNull(plainMapper.readValue(empty, InputDefault.class).getField());
+        assertNull(plainMapper.readValue(empty, InputDefaultConstructor.class).getField());
+        assertNull(plainMapper.readValue(empty, InputTrue.class).getField());
+        assertNull(plainMapper.readValue(empty, InputTrueConstructor.class).getField());
+        assertNull(plainMapper.readValue(empty, InputFalse.class).getField());
+        assertNull(plainMapper.readValue(empty, InputFalseConstructor.class).getField());
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381Test.java
@@ -3,11 +3,8 @@ package com.fasterxml.jackson.databind.deser.inject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.OptBoolean;
-
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MissingInjectableValueExcepion;
@@ -117,6 +114,7 @@ class JacksonInject1381Test extends DatabindTestUtil
 
     private final ObjectMapper plainMapper = newJsonMapper();
     private final ObjectMapper injectedMapper = jsonMapperBuilder()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
             .injectableValues(new InjectableValues.Std().addValue("key", "injected"))
             .build();
 

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381WithOptionalDeserializationFeatureDisabledTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381WithOptionalDeserializationFeatureDisabledTest.java
@@ -7,13 +7,12 @@ import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class JacksonInject1381WithOptionalDeserializationFeatureDisabledTest extends DatabindTestUtil
 {
@@ -122,23 +121,16 @@ class JacksonInject1381WithOptionalDeserializationFeatureDisabledTest extends Da
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE)
             .build();
 
+    // When optional = YES, missing injectable should NOT fail
     @Test
     @DisplayName("FAIL_ON_UNKNOWN_INJECT_VALUE NO, optional YES, input NO, injectable NO, useInput DEFAULT|TRUE|FALSE => exception")
-    void test1() {
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputDefault.class));
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputDefaultConstructor.class));
-
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputTrue.class));
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputTrueConstructor.class));
-
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputFalse.class));
-        assertThrows(ValueInstantiationException.class,
-                () -> plainMapper.readValue(empty, InputFalseConstructor.class));
+    void test1() throws Exception {
+        assertNull(plainMapper.readValue(empty, InputDefault.class).getField());
+        assertNull(plainMapper.readValue(empty, InputDefaultConstructor.class).getField());
+        assertNull(plainMapper.readValue(empty, InputTrue.class).getField());
+        assertNull(plainMapper.readValue(empty, InputTrueConstructor.class).getField());
+        assertNull(plainMapper.readValue(empty, InputFalse.class).getField());
+        assertNull(plainMapper.readValue(empty, InputFalseConstructor.class).getField());
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381WithOptionalDeserializationFeatureDisabledTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381WithOptionalDeserializationFeatureDisabledTest.java
@@ -1,15 +1,12 @@
 package com.fasterxml.jackson.databind.deser.inject;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.OptBoolean;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.*;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381WithOptionalTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject1381WithOptionalTest.java
@@ -1,18 +1,15 @@
 package com.fasterxml.jackson.databind.deser.inject;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.OptBoolean;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.MissingInjectableValueExcepion;
-import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class JacksonInject1381WithOptionalTest extends DatabindTestUtil
 {
@@ -118,23 +115,16 @@ class JacksonInject1381WithOptionalTest extends DatabindTestUtil
             .injectableValues(new InjectableValues.Std().addValue("key", "injected"))
             .build();
 
+    // Optional=true so should NOT throw exceptions
     @Test
     @DisplayName("optional YES, input NO, injectable NO, useInput DEFAULT|TRUE|FALSE => exception")
-    void test1() {
-        assertThrows(MissingInjectableValueExcepion.class,
-                () -> plainMapper.readValue(empty, InputDefault.class));
-        assertThrows(MissingInjectableValueExcepion.class,
-                () -> plainMapper.readValue(empty, InputDefaultConstructor.class));
-
-        assertThrows(MissingInjectableValueExcepion.class,
-                () -> plainMapper.readValue(empty, InputTrue.class));
-        assertThrows(MissingInjectableValueExcepion.class,
-                () -> plainMapper.readValue(empty, InputTrueConstructor.class));
-
-        assertThrows(MissingInjectableValueExcepion.class,
-                () -> plainMapper.readValue(empty, InputFalse.class));
-        assertThrows(MissingInjectableValueExcepion.class,
-                () -> plainMapper.readValue(empty, InputFalseConstructor.class));
+    void test1() throws Exception {
+        assertNull(plainMapper.readValue(empty, InputDefault.class).getField());
+        assertNull(plainMapper.readValue(empty, InputDefaultConstructor.class).getField());
+        assertNull(plainMapper.readValue(empty, InputTrue.class).getField());
+        assertNull(plainMapper.readValue(empty, InputTrueConstructor.class).getField());
+        assertNull(plainMapper.readValue(empty, InputFalse.class).getField());
+        assertNull(plainMapper.readValue(empty, InputFalseConstructor.class).getField());
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -62,7 +62,7 @@ class JacksonInject3072Test extends DatabindTestUtil
                 MissingInjectableValueExcepion.class, () -> READER.readValue("{}"));
 
         assertThat(exception.getMessage())
-            .startsWith("No 'injectableValues' configured, cannot inject value with id 'id'");
+            .startsWith("No injectable value with id 'id' found (for property 'id')");
     }
 
     // Test for case of `optional = OptBoolean.FALSE`


### PR DESCRIPTION
Realized (due to gnarly 3.0 merging) that the original implementation had issue mis-using sentinel value `JacksonInject.Value.empty()` that needs undoing...
