### PR TITLE
Fix #5393 `@JsonAnyGetter` property gets included in generated schema

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -5,6 +5,11 @@ Project: jackson-databind
 ------------------------------------------------------------------------
 
 2.19.4 (29-Oct-2025)
+
+#5393: `@JsonAnyGetter property gets included in generated schema since 2.19.0`
+ (reported by @victor-noel-pfx)
+ (fix by Joo-Hyuk K)
+
 2.19.3 (29-Oct-2025)
 
 No changes since 2.19.2

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,12 +4,13 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
-2.19.4 (29-Oct-2025)
+(not yet released)
 
 #5393: `@JsonAnyGetter property gets included in generated schema since 2.19.0`
  (reported by @victor-noel-pfx)
  (fix by Joo-Hyuk K)
 
+2.19.4 (29-Oct-2025)
 2.19.3 (29-Oct-2025)
 
 No changes since 2.19.2

--- a/src/main/java/com/fasterxml/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/AnyGetterWriter.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.ser.std.MapSerializer;
 
 /**
@@ -87,6 +88,12 @@ public class AnyGetterWriter extends BeanPropertyWriter
     @Override
     public void serializeAsField(Object bean, JsonGenerator gen, SerializerProvider prov) throws Exception {
         getAndSerialize(bean, gen, prov);
+    }
+
+    @Override
+    public void depositSchemaProperty(JsonObjectFormatVisitor v, SerializerProvider provider) throws JsonMappingException {
+        // since 2.19.4 [databind#5393] @JsonAnyGetter property gets included in generated schema since 2.19.0 #5393
+        // no-op
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/AnyGetterWriter.java
@@ -90,9 +90,10 @@ public class AnyGetterWriter extends BeanPropertyWriter
         getAndSerialize(bean, gen, prov);
     }
 
-    @Override
+    @Override // @since 2.20
     public void depositSchemaProperty(JsonObjectFormatVisitor v, SerializerProvider provider) throws JsonMappingException {
-        // since 2.19.4 [databind#5393] @JsonAnyGetter property gets included in generated schema since 2.19.0 #5393
+        // 18-Nov-2025: [databind#5393] @JsonAnyGetter was getting included in generated schema
+
         // no-op
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
@@ -37,7 +37,11 @@ public class FormatVisitor5393Test
     // [databind#5393], regression wrt JsonAnyGetter
     @Test
     public void testIgnoredPropertyAreIgnored() throws Exception {
-        final Set<String> properties = new TreeSet<>();
+        final TreeSet<String> expected = new TreeSet<> ();
+        expected.add("normalProperty");
+        expected.add("renamedProperty");
+
+        final Set<String> actual = new TreeSet<>();
         MAPPER.acceptJsonFormatVisitor(TestJsonIgnoredProperties.class,
                 new JsonFormatVisitorWrapper.Base() {
                     @Override
@@ -45,27 +49,27 @@ public class FormatVisitor5393Test
                         return new JsonObjectFormatVisitor.Base() {
                             @Override
                             public void property(BeanProperty prop) {
-                                properties.add(prop.getName());
+                                actual.add(prop.getName());
                             }
 
                             @Override
                             public void property(String name, JsonFormatVisitable handler, JavaType propertyTypeHint) {
-                                properties.add(name);
+                                actual.add(name);
                             }
 
                             @Override
                             public void optionalProperty(BeanProperty prop) {
-                                properties.add(prop.getName());
+                                actual.add(prop.getName());
                             }
 
                             @Override
                             public void optionalProperty(String name, JsonFormatVisitable handler, JavaType propertyTypeHint) {
-                                properties.add(name);
+                                actual.add(name);
                             }
                         };
                     }
                 });
 
-        assertEquals(new TreeSet<>(List.of("normalProperty", "renamedProperty")), properties);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
@@ -1,0 +1,70 @@
+package com.fasterxml.jackson.databind.jsonschema;
+
+import java.util.*;
+
+import com.fasterxml.jackson.annotation.*;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import static org.junit.jupiter.api.Assertions.*;
+
+// [databind#5393] @JsonAnyGetter property gets included in generated schema since 2.19.0
+public class FormatVisitor5393Test
+    extends DatabindTestUtil
+{
+    static class TestJsonIgnoredProperties {
+
+        @JsonIgnore
+        public String ignoredProp;
+
+        public String normalProperty;
+
+        @JsonProperty("renamedProperty")
+        public String someProperty;
+
+        // [databind#5393]
+        @JsonAnyGetter
+        public Map<String, Object> getMyProperties() {
+            return Map.of();
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // [databind#5393], regression wrt JsonAnyGetter
+    @Test
+    public void testIgnoredPropertyAreIgnored() throws Exception {
+        final Set<String> properties = new TreeSet<>();
+        MAPPER.acceptJsonFormatVisitor(TestJsonIgnoredProperties.class,
+                new JsonFormatVisitorWrapper.Base() {
+                    @Override
+                    public JsonObjectFormatVisitor expectObjectFormat(JavaType type) {
+                        return new JsonObjectFormatVisitor.Base() {
+                            @Override
+                            public void property(BeanProperty prop) {
+                                properties.add(prop.getName());
+                            }
+
+                            @Override
+                            public void property(String name, JsonFormatVisitable handler, JavaType propertyTypeHint) {
+                                properties.add(name);
+                            }
+
+                            @Override
+                            public void optionalProperty(BeanProperty prop) {
+                                properties.add(prop.getName());
+                            }
+
+                            @Override
+                            public void optionalProperty(String name, JsonFormatVisitable handler, JavaType propertyTypeHint) {
+                                properties.add(name);
+                            }
+                        };
+                    }
+                });
+
+        assertEquals(new TreeSet<>(List.of("normalProperty", "renamedProperty")), properties);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
@@ -3,11 +3,12 @@ package com.fasterxml.jackson.databind.jsonschema;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.*;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 // [databind#5393] @JsonAnyGetter property gets included in generated schema since 2.19.0

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
@@ -15,8 +15,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class FormatVisitor5393Test
     extends DatabindTestUtil
 {
-    static class TestJsonIgnoredProperties {
-
+    static class TestJsonIgnoredProperties
+    {
         @JsonIgnore
         public String ignoredProp;
 
@@ -27,17 +27,17 @@ public class FormatVisitor5393Test
 
         // [databind#5393]
         @JsonAnyGetter
-        public Map<String, Object> getMyProperties() {
+        public Map<String, Object> anyProperties() {
             return new TreeMap<>();
         }
     }
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    // [databind#5393], regression wrt JsonAnyGetter
+    // [databind#5393]: regression wrt `@JsonAnyGetter`
     @Test
-    public void testIgnoredPropertyAreIgnored() throws Exception {
-        final TreeSet<String> expected = new TreeSet<> ();
+    public void ignoreExplicitlyIgnoredAndAnyGetter() throws Exception {
+        final TreeSet<String> expected = new TreeSet<>();
         expected.add("normalProperty");
         expected.add("renamedProperty");
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
@@ -2,12 +2,12 @@ package com.fasterxml.jackson.databind.jsonschema;
 
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsonschema/FormatVisitor5393Test.java
@@ -28,7 +28,7 @@ public class FormatVisitor5393Test
         // [databind#5393]
         @JsonAnyGetter
         public Map<String, Object> getMyProperties() {
-            return Map.of();
+            return new TreeMap<>();
         }
     }
 


### PR DESCRIPTION
Fixes #5393.

Target version TBD