### PR TITLE
Improve test for #5398

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/introspect/JsonPropertyRename5398Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/JsonPropertyRename5398Test.java
@@ -12,10 +12,24 @@ import static org.junit.jupiter.api.Assertions.*;
 // causes deserialization to fail since 2.18.4
 public class JsonPropertyRename5398Test extends DatabindTestUtil
 {
-    static class Test5398 {
-        private String prop = "someValue";
+    static class TestRename5398 {
+        private String prop;
 
         @JsonProperty(value = "renamedProp")
+        public String getProp() {
+            return prop;
+        }
+
+        @JsonIgnore
+        public void setProp(String prop) {
+            this.prop = prop;
+        }
+    }
+
+	static class TestStd5398 {
+        private String prop;
+
+        @JsonProperty
         public String getProp() {
             return prop;
         }
@@ -31,16 +45,36 @@ public class JsonPropertyRename5398Test extends DatabindTestUtil
     @Test
     public void testRenamedPropertyWithIgnoredSetter5398() throws Exception
     {
-        Test5398 original = new Test5398();
+        TestRename5398 original = new TestRename5398();
+		original.setProp("someValue");
+
         String json = MAPPER.writeValueAsString(original);
 
         // Should serialize with renamed property
         assertEquals("{\"renamedProp\":\"someValue\"}", json);
 
         // Should be able to deserialize back (setter is ignored, so field remains default)
-        Test5398 result = MAPPER.readValue(json, Test5398.class);
+        TestRename5398 result = MAPPER.readValue(json, TestRename5398.class);
         assertNotNull(result);
-        // Since setter is ignored, the deserialized object should have the default value
-        assertEquals("someValue", result.getProp());
+        // The setter is ignored but the property is still considered read-write
+		assertEquals("someValue", result.getProp());
+    }
+
+    @Test
+    public void testStandardPropertyWithIgnoredSetter5398() throws Exception
+    {
+        TestStd5398 original = new TestStd5398();
+		original.setProp("someValue");
+
+        String json = MAPPER.writeValueAsString(original);
+
+        // Should serialize with renamed property
+        assertEquals("{\"prop\":\"someValue\"}", json);
+
+        // Should be able to deserialize back (setter is ignored, so field remains default)
+        TestStd5398 result = MAPPER.readValue(json, TestStd5398.class);
+        assertNotNull(result);
+		// The setter is ignored but the property is still considered read-write
+		assertEquals("someValue", result.getProp());
     }
 }


### PR DESCRIPTION
Hi, following my comment here: https://github.com/FasterXML/jackson-databind/pull/5410#pullrequestreview-3486262679

I took the liberty of improving the test and also add the standard behaviour for comparison.