### PR TITLE
Implement forward reference resolution for ObjectArrayDeserializer (2.x backport)

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1982,3 +1982,7 @@ Michael Reiche (@mikereiche)
 Johnny Lim (@izeye)
  * Reported #5293: Fix minor typo in `PropertyBindingException.getMessageSuffix()`
   (2.21.0)
+
+Hélios Gilles (@RoiSoleil)
+ * Contributed #5413: Add/support forward reference resolution for array values
+  [2.21.0]

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -23,6 +23,8 @@ Project: jackson-databind
   anymore since 2.18.4
  (reported by @victor-noel-pfx)
  (fix by @cowtowncoder, w/ Claude code)
+#5413: Add/support forward reference resolution for array values
+ (contributed by Hélios G)
 
 2.20.2 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/CollectionDeserializer.java
@@ -537,7 +537,7 @@ _containerType,
         /**
          * A list of {@link CollectionReferring} to maintain ordering.
          */
-        private List<CollectionReferring> _accumulator = new ArrayList<CollectionReferring>();
+        private List<CollectionReferring> _accumulator = new ArrayList<>();
 
         public CollectionReferringAccumulator(Class<?> elementType, Collection<Object> result) {
             _elementType = elementType;
@@ -591,7 +591,7 @@ _containerType,
      */
     private final static class CollectionReferring extends Referring {
         private final CollectionReferringAccumulator _parent;
-        public final List<Object> next = new ArrayList<Object>();
+        public final List<Object> next = new ArrayList<>();
 
         CollectionReferring(CollectionReferringAccumulator parent,
                 UnresolvedForwardReference reference, Class<?> contentType)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -2,22 +2,33 @@ package com.fasterxml.jackson.databind.deser.std;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference;
+import com.fasterxml.jackson.databind.deser.impl.ReadableObjectId.Referring;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.ArrayType;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.databind.util.AccessPattern;
+import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.databind.util.ObjectBuffer;
 
 /**
@@ -196,10 +207,17 @@ public class ObjectArrayDeserializer
         if (!p.isExpectedStartArrayToken()) {
             return handleNonArray(p, ctxt);
         }
-
+        if (_elementDeserializer.getObjectIdReader() != null) {
+            return _deserializeWithObjectId(p, ctxt);
+        }
         final ObjectBuffer buffer = ctxt.leaseObjectBuffer();
         Object[] chunk = buffer.resetAndStart();
         int ix = 0;
+        return _deserialize(p, ctxt, buffer, ix, chunk);
+    }
+
+    protected Object[] _deserialize(JsonParser p, DeserializationContext ctxt,
+            final ObjectBuffer buffer, int ix, Object[] chunk) throws JsonMappingException {
         JsonToken t;
 
         try {
@@ -243,6 +261,54 @@ public class ObjectArrayDeserializer
         }
         ctxt.returnObjectBuffer(buffer);
         return result;
+    }
+
+    protected Object[] _deserializeWithObjectId(JsonParser p, DeserializationContext ctxt) throws JsonMappingException {
+        final ObjectArrayReferringAccumulator acc = new ObjectArrayReferringAccumulator(_untyped, _elementClass);
+
+        JsonToken t;
+
+        int ix = 0;
+        try {
+            while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
+                try {
+                    Object value;
+
+                    if (t == JsonToken.VALUE_NULL) {
+                        if (_skipNullValues) {
+                            continue;
+                        }
+                        value = null;
+                    } else {
+                        value = _deserializeNoNullChecks(p, ctxt);
+                    }
+
+                    if (value == null) {
+                        value = _nullProvider.getNullValue(ctxt);
+
+                        if (value == null && _skipNullValues) {
+                            continue;
+                        }
+                    }
+                    acc.add(value);
+                } catch (UnresolvedForwardReference reference) {
+                    if (acc == null) {
+                        throw reference;
+                    }
+                    ArrayReferring referring = new ArrayReferring(reference, _elementClass, acc);
+                    reference.getRoid().appendReferring(referring);
+                }
+                ++ix;
+            }
+        } catch (Exception e) {
+            boolean wrap = (ctxt == null) || ctxt.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS);
+            if (!wrap) {
+                ClassUtil.throwIfRTE(e);
+            }
+            throw JsonMappingException.wrapWithPath(e, acc.buildArray(), ix);
+        }
+
+        return acc.buildArray();
     }
 
     @Override
@@ -424,5 +490,60 @@ public class ObjectArrayDeserializer
             return _elementDeserializer.deserialize(p, ctxt);
         }
         return _elementDeserializer.deserializeWithType(p, ctxt, _elementTypeDeserializer);
+    }
+
+    // @since 2.21
+    private static class ObjectArrayReferringAccumulator {
+        private final boolean _untyped;
+        private final Class<?> _elementType;
+        private final List<Object> _accumulator = new ArrayList<>();
+
+        private Object[] _array;
+
+        ObjectArrayReferringAccumulator(boolean untyped, Class<?> elementType) {
+            _untyped = untyped;
+            _elementType = elementType;
+        }
+
+        void add(Object value) {
+            _accumulator.add(value);
+        }
+
+        Object[] buildArray() {
+            if (_untyped) {
+                _array = new Object[_accumulator.size()];
+            } else {
+                _array = (Object[]) Array.newInstance(_elementType, _accumulator.size());
+            }
+            for (int i = 0; i < _accumulator.size(); i++) {
+                if (!(_accumulator.get(i) instanceof ArrayReferring)) {
+                    _array[i] = _accumulator.get(i);
+                }
+            }
+            return _array;
+        }
+    }
+
+    private static class ArrayReferring extends Referring {
+        private final ObjectArrayReferringAccumulator _parent;
+
+        ArrayReferring(UnresolvedForwardReference ref,
+                Class<?> type,
+                ObjectArrayReferringAccumulator acc) {
+            super(ref, type);
+            _parent = acc;
+            _parent._accumulator.add(this);
+        }
+
+        @Override
+        public void handleResolvedForwardReference(Object id, Object value) throws JacksonException {
+            for (int i = 0; i < _parent._accumulator.size(); i++) {
+                if (_parent._accumulator.get(i) == this) {
+                    _parent._array[i] = value;
+                    return;
+                }
+            }
+            throw new IllegalArgumentException("Trying to resolve unknown reference: " + id);
+        }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -2,21 +2,13 @@ package com.fasterxml.jackson.databind.deser.std;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
+
+import com.fasterxml.jackson.core.*;
+
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JacksonStdImpl;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/ObjectIdInObjectArray5413Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/ObjectIdInObjectArray5413Test.java
@@ -1,0 +1,129 @@
+package com.fasterxml.jackson.databind.objectid;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+/**
+ * This unit test verifies that the "Native" java type mapper can properly deal with
+ * "forward reference resolution" for values in Object arrays (not just
+ * {@link java.util.Collection}s).
+ */
+public class ObjectIdInObjectArray5413Test extends DatabindTestUtil
+{
+    static final class Draw {
+        private Shape[] ashapes;
+        private Point[] points;
+
+        public Shape[] getAShapes() {
+            return ashapes;
+        }
+
+        public void setAShapes(Shape[] shapes) {
+            this.ashapes = shapes;
+        }
+
+        public Point[] getPoints() {
+            return points;
+        }
+
+        public void setPoints(Point[] points) {
+            this.points = points;
+        }
+    }
+
+    static final class Shape {
+        @JsonIdentityReference(alwaysAsId = true)
+        private Point[] points;
+
+        public Point[] getPoints() {
+            return points;
+        }
+
+        public void setPoints(Point[] points) {
+            this.points = points;
+        }
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    static final class Point {
+        private int id;
+        private int x;
+        private int y;
+
+        public Point() {
+        }
+
+        public Point(int id, int x, int y) {
+            this.id = id;
+            this.x = x;
+            this.y = y;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public int getX() {
+            return x;
+        }
+
+        public void setX(int x) {
+            this.x = x;
+        }
+
+        public int getY() {
+            return y;
+        }
+
+        public void setY(int y) {
+            this.y = y;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // [databind#5413]
+    @Test
+    public void testForwardReferenceResolution() throws JsonProcessingException
+    {
+        Draw draw = new Draw();
+        Point point_0_0 = new Point(1, 0, 0);
+        Point point_0_2 = new Point(2, 0, 2);
+        Point point_2_2 = new Point(3, 2, 2);
+        Point point_2_0 = new Point(4, 2, 0);
+        Point point_1_3 = new Point(5, 1, 3);
+        Shape square = new Shape();
+        square.setPoints(new Point[] { point_0_0, point_0_2, point_2_2, point_2_0 });
+        Shape triangle = new Shape();
+        triangle.setPoints(new Point[] { point_0_2, point_1_3, point_2_2 });
+        draw.setAShapes(new Shape[] { square, triangle });
+        draw.setPoints(new Point[] { point_0_0, point_0_2, point_2_2, point_2_0, point_1_3 });
+        final String JSON = MAPPER.writeValueAsString(draw);
+        draw = MAPPER.readValue(JSON, Draw.class);
+        assertNotNull(draw);
+        assertEquals(5, draw.points.length);
+        assertEquals(2, draw.ashapes.length);
+        assertEquals(4, draw.ashapes[0].points.length);
+        assertEquals(3, draw.ashapes[1].points.length);
+        assertSame(draw.points[0], draw.ashapes[0].points[0]);
+        assertSame(draw.points[1], draw.ashapes[0].points[1]);
+        assertSame(draw.points[2], draw.ashapes[0].points[2]);
+        assertSame(draw.points[3], draw.ashapes[0].points[3]);
+        assertSame(draw.points[1], draw.ashapes[1].points[0]);
+        assertSame(draw.points[4], draw.ashapes[1].points[1]);
+        assertSame(draw.points[2], draw.ashapes[1].points[2]);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/databind/objectid/ObjectIdInObjectArray5413Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/objectid/ObjectIdInObjectArray5413Test.java
@@ -1,15 +1,14 @@
 package com.fasterxml.jackson.databind.objectid;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This unit test verifies that the "Native" java type mapper can properly deal with
@@ -96,7 +95,7 @@ public class ObjectIdInObjectArray5413Test extends DatabindTestUtil
 
     // [databind#5413]
     @Test
-    public void testForwardReferenceResolution() throws JsonProcessingException
+    public void testForwardReferenceResolution() throws Exception
     {
         Draw draw = new Draw();
         Point point_0_0 = new Point(1, 0, 0);
@@ -125,5 +124,4 @@ public class ObjectIdInObjectArray5413Test extends DatabindTestUtil
         assertSame(draw.points[4], draw.ashapes[1].points[1]);
         assertSame(draw.points[2], draw.ashapes[1].points[2]);
     }
-
 }


### PR DESCRIPTION
This commit adds full forward-reference support to ObjectArrayDeserializer, mirroring the behavior already available for CollectionDeserializer.

Introduces ObjectArrayReferring and ObjectArrayReferringAccumulator Catches UnresolvedForwardReference during element deserialization Defers unresolved elements and resolves them once the target id is available
Ensures final array construction comes from the accumulator when used Adds comprehensive unit tests validating forward reference handling Fixes: #5413