### PR TITLE
Fix #1654: handle properties annotated with @JsonTypeInfo(use = NONE)

### DIFF
--- a/src/main/java/tools/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
@@ -1,5 +1,6 @@
 package tools.jackson.databind.jsontype.impl;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
 import tools.jackson.core.JacksonException;
@@ -169,8 +170,10 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
         // genuine, or faked for "dont fail on bad type id")
         ValueDeserializer<Object> deser = _findDefaultImplDeserializer(ctxt);
         if (deser == null) {
-            JavaType t = _strictTypeIdHandling
-                    ? _handleMissingTypeId(ctxt, priorFailureMsg) : _baseType;
+            JavaType t = isStrictTypeIdHandlingForProperty()
+                    ? _handleMissingTypeId(ctxt, priorFailureMsg)
+                    : _baseType;
+
             if (t == null) {
                 // 09-Mar-2017, tatu: Is this the right thing to do?
                 return null;
@@ -203,6 +206,17 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
         return deserializeTypedFromObject(p, ctxt);
     }
 
+    // [databind#1654]: Determine whether strict type-id handling should apply for this property.
+    private boolean isStrictTypeIdHandlingForProperty() {
+        if (!_strictTypeIdHandling) {
+            return false;
+        }
+        if (_property == null) {
+            return true;
+        }
+        JsonTypeInfo typeInfo = _property.getAnnotation(JsonTypeInfo.class);
+        return typeInfo == null || typeInfo.use() != JsonTypeInfo.Id.NONE;
+    }
     // These are fine from base class:
     //public Object deserializeTypedFromArray(JsonParser p, DeserializationContext ctxt)
     //public Object deserializeTypedFromScalar(JsonParser p, DeserializationContext ctxt)

--- a/src/main/java/tools/jackson/databind/jsontype/impl/TypeSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/TypeSerializerBase.java
@@ -44,6 +44,16 @@ public abstract class TypeSerializerBase extends TypeSerializer
             WritableTypeId idMetadata) throws JacksonException
     {
         _generateTypeId(ctxt, idMetadata);
+
+        // [databind#1654]: If the property overrides type info with @JsonTypeInfo(use = NONE),
+        // skip writing a type id for this property.
+        if (_property != null) {
+            JsonTypeInfo typeInfo = _property.getAnnotation(JsonTypeInfo.class);
+            if (typeInfo != null && typeInfo.use() == JsonTypeInfo.Id.NONE) {
+                idMetadata.id = null;
+            }
+        }
+
         // 16-Jan-2022, tatu: As per [databind#3373], skip for null typeId.
         //    And return "null" to avoid matching "writeTypeSuffix" as well.
         // 15-Jun-2024, tatu: [databind#4407] Not so fast! Output wrappers

--- a/src/test/java/tools/jackson/databind/NoTypeInfo1654Test.java
+++ b/src/test/java/tools/jackson/databind/NoTypeInfo1654Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.databind.tofix;
+package tools.jackson.databind;
 
 import java.util.*;
 
@@ -7,10 +7,8 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import tools.jackson.core.JsonParser;
-import tools.jackson.databind.*;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.testutil.DatabindTestUtil;
-import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -77,24 +75,22 @@ class NoTypeInfo1654Test extends DatabindTestUtil {
     }
 
     // [databind#1654]
-    @JacksonTestFailureExpected
     @Test
     void noTypeInfoOverrideSer() throws Exception {
         Value1654UntypedContainer cont = new Value1654UntypedContainer(
                 new Value1654(3),
                 new Value1654(7)
         );
-        assertEquals(a2q("{'values':[{'x':3},{'x': 7}] }"),
+        assertEquals(a2q("{'values':[{'x':3},{'x':7}]}"),
                 MAPPER.writeValueAsString(cont));
     }
 
     // [databind#1654]
-    @JacksonTestFailureExpected
     @Test
     void noTypeInfoOverrideDeser() throws Exception {
         // and then actual failing case
         final String noTypeJson = a2q(
-                "{'values':[{'x':3},{'x': 7}] }"
+                "{'values':[{'x':3},{'x':7}]}"
         );
         Value1654UntypedContainer unResult = MAPPER.readValue(noTypeJson, Value1654UntypedContainer.class);
         assertEquals(2, unResult.values.size());


### PR DESCRIPTION
Issue: https://github.com/FasterXML/jackson-databind/issues/1654

I resolved it.