### PR TITLE
Add #518: test any-getter entries are sorted before bean fields

### DIFF
--- a/src/test/java/tools/jackson/databind/tofix/AnyGetterSorting518Test.java
+++ b/src/test/java/tools/jackson/databind/tofix/AnyGetterSorting518Test.java
@@ -36,6 +36,25 @@ class AnyGetterSorting518Test extends DatabindTestUtil
         public Map<String,Object> getExtra() { return extra; }
     }
 
+    @JsonPropertyOrder(alphabetic = true)
+    static class AnyGetterBeforeFieldsBean
+    {
+        public int x;
+
+        protected Map<String,Object> extra = new HashMap<>();
+
+        public int y;
+
+        public AnyGetterBeforeFieldsBean(int x, int y, Map<String,Object> a) {
+            this.x = x;
+            this.y = y;
+            extra = a;
+        }
+
+        @JsonAnyGetter
+        public Map<String,Object> getExtra() { return extra; }
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -44,7 +63,6 @@ class AnyGetterSorting518Test extends DatabindTestUtil
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    @JacksonTestFailureExpected
     @Test
     void anyBeanWithSort() throws Exception
     {
@@ -53,5 +71,15 @@ class AnyGetterSorting518Test extends DatabindTestUtil
         extra.put("x", 3);
         String json = MAPPER.writeValueAsString(new Bean(1, 2, extra));
         assertEquals(a2q("{'a':1,'b':2,'x':3,'y':4}"), json);
+    }
+
+    @Test
+    void anyGetterSortingBeforeFields() throws Exception
+    {
+        Map<String,Object> extra = new LinkedHashMap<>();
+        extra.put("b", 4);
+        extra.put("a", 3);
+        String json = MAPPER.writeValueAsString(new AnyGetterBeforeFieldsBean(1, 2, extra));
+        assertEquals(a2q("{'a':3,'b':4,'x':1,'y':2}"), json);
     }
 }

--- a/src/test/java/tools/jackson/databind/tofix/AnyGetterSorting518Test.java
+++ b/src/test/java/tools/jackson/databind/tofix/AnyGetterSorting518Test.java
@@ -63,6 +63,7 @@ class AnyGetterSorting518Test extends DatabindTestUtil
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    @JacksonTestFailureExpected
     @Test
     void anyBeanWithSort() throws Exception
     {
@@ -73,6 +74,7 @@ class AnyGetterSorting518Test extends DatabindTestUtil
         assertEquals(a2q("{'a':1,'b':2,'x':3,'y':4}"), json);
     }
 
+    @JacksonTestFailureExpected
     @Test
     void anyGetterSortingBeforeFields() throws Exception
     {


### PR DESCRIPTION
I just added the `anyGetterSortingBeforeFields` test for issue #518 to document the expected sorting behavior between any-getter properties and regular fields.