### PR TITLE
Fix #2460: Address CVE-2019-17267 by updating SubTypeValidator (cherr…

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java
@@ -90,8 +90,9 @@ public class SubTypeValidator
         s.add("org.jdom.transform.XSLTransformer");
         s.add("org.jdom2.transform.XSLTransformer");
 
-        // [databind#2387]: EHCache
+        // [databind#2387], [databind#2460]: EHCache
         s.add("net.sf.ehcache.transaction.manager.DefaultTransactionManagerLookup");
+        s.add("net.sf.ehcache.hibernate.EhcacheJtaTransactionManagerLookup");
 
         // [databind#2389]: logback/jndi
         s.add("ch.qos.logback.core.db.JNDIConnectionSource");


### PR DESCRIPTION
Fix #2460: Address CVE-2019-17267 by updating SubTypeValidator

- Cherry-picked from commit 191a4cdf8
- Resolves CVE-2019-17267 security vulnerability