### PR TITLE
Fix #2686: @JsonBackReference not working with Builder

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -127,6 +127,8 @@ Oliver Drotbohm (@odrotbohm)
  * Contributed fix for #1516: Problem with multi-argument Creator with
    `@JsonBackReference` property
   [3.1.0]
+ * Contributed fix for #2686: `@JsonBackReference` does not work with a builder
+  [3.1.0]
  * Contributed fix for #4629: `@JsonIncludeProperties` and `@JsonIgnoreProperties`
    ignored when deserializing Records
   [3.1.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -20,6 +20,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @cowtowncoder, @JacksonJang)
 #1980: Add method `remove(JsonPointer)` in `ContainerNode`
  (fix by @cowtowncoder, w/ Claude code)
+#2686: `@JsonBackReference` does not work with a builder
+ (reported by @janrieke)
+ (fix by @JacksonJang)
 #3964: Deserialization issue: MismatchedInputException, Bean not
   yet resolved
  (reported by @detomarco)

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -274,8 +274,8 @@ public class BeanDeserializerFactory
         addObjectIdReader(ctxt, beanDescRef, builder);
 
         // managed/back reference fields/setters need special handling... first part
-        // [databind#2686]: targetType For Builder pattern, this method is not using.
-        // So this value is null.
+        // [databind#2686]: Pass null for non-Builder deserialization (only Builder-based
+        // deserialization needs the target type for back-reference resolution)
         addBackReferenceProperties(ctxt, beanDescRef, builder, null);
         addInjectables(ctxt, beanDescRef, builder);
 
@@ -785,8 +785,8 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 } else {
                     if (targetType != null) {
                         ctxt.reportBadTypeDefinition(beanDescRef,
-                                "Cannot find back-reference field '%s' in target type '%s' for Builder-based deserialization",
-                                refProp.getName(), targetType.getRawClass().getName());
+                                "Cannot find back-reference field '%s' in target type %s for Builder-based deserialization: ensure the field exists in the target class, not just the Builder",
+                                refProp.getName(), ClassUtil.nameOf(targetType.getRawClass()));
                     } else {
                         ctxt.reportBadTypeDefinition(beanDescRef,
                                 "Cannot resolve back-reference property '%s'",

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -274,7 +274,9 @@ public class BeanDeserializerFactory
         addObjectIdReader(ctxt, beanDescRef, builder);
 
         // managed/back reference fields/setters need special handling... first part
-        addBackReferenceProperties(ctxt, beanDescRef, builder);
+        // [databind#2686]: targetType For Builder pattern, this method is not using.
+        // So this value is null.
+        addBackReferenceProperties(ctxt, beanDescRef, builder, null);
         addInjectables(ctxt, beanDescRef, builder);
 
         final DeserializationConfig config = ctxt.getConfig();
@@ -334,7 +336,8 @@ public class BeanDeserializerFactory
         addObjectIdReader(ctxt, builderDescRef, builder);
 
         // managed/back reference fields/setters need special handling... first part
-        addBackReferenceProperties(ctxt, builderDescRef, builder);
+        // [databind#2686]: For Builder pattern, pass target type so that back-reference
+        addBackReferenceProperties(ctxt, builderDescRef, builder, valueType);
         addInjectables(ctxt, builderDescRef, builder);
 
         JsonPOJOBuilder.Value builderConfig = ctxt.getAnnotationIntrospector()
@@ -736,7 +739,8 @@ ClassUtil.name(propName)));
      * and if so add them to bean, to be linked during resolution phase.
      */
     protected void addBackReferenceProperties(DeserializationContext ctxt,
-            BeanDescription.Supplier beanDescRef, BeanDeserializerBuilder builder)
+            BeanDescription.Supplier beanDescRef, BeanDeserializerBuilder builder,
+            JavaType targetType)
     {
         // and then back references, not necessarily found as regular properties
         List<BeanPropertyDefinition> refProps = beanDescRef.get().findBackReferences();
@@ -764,8 +768,31 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                             refProp.getName());
                 }
                 String refName = refProp.findReferenceName();
-                builder.addBackReferenceProperty(refName, constructSettableProperty(ctxt,
-                        beanDescRef, refProp, refProp.getPrimaryType()));
+                SettableBeanProperty backRefProp;
+
+                if (targetType != null) {
+                    // [databind#2686]: Handle Builder
+                    backRefProp = constructBuilderBackRefProperty(ctxt,
+                            targetType, refProp);
+                } else {
+                    // normal
+                    backRefProp = constructSettableProperty(ctxt,
+                            beanDescRef, refProp, refProp.getPrimaryType());
+                }
+
+                if (backRefProp != null) {
+                    builder.addBackReferenceProperty(refName, backRefProp);
+                } else {
+                    if (targetType != null) {
+                        ctxt.reportBadTypeDefinition(beanDescRef,
+                                "Cannot find back-reference field '%s' in target type '%s' for Builder-based deserialization",
+                                refProp.getName(), targetType.getRawClass().getName());
+                    } else {
+                        ctxt.reportBadTypeDefinition(beanDescRef,
+                                "Cannot resolve back-reference property '%s'",
+                                refProp.getName());
+                    }
+                }
             }
         }
     }
@@ -1067,5 +1094,29 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
             BeanDescription.Supplier beanDescRef)
     {
         SubTypeValidator.instance().validateSubType(ctxt, type, beanDescRef);
+    }
+
+    /**
+     * Helper method for constructing back-reference property when using Builder pattern.
+     *
+     * @since 3.1
+     */
+    protected SettableBeanProperty constructBuilderBackRefProperty(DeserializationContext ctxt,
+            JavaType targetType, BeanPropertyDefinition builderRefProp)
+    {
+        BeanDescription.Supplier targetDescRef = ctxt.lazyIntrospectBeanDescription(targetType);
+        BeanDescription targetDesc = targetDescRef.get();
+
+        // find back reference with same field
+        String propName = builderRefProp.getName();
+        for (BeanPropertyDefinition propDef : targetDesc.findProperties()) {
+            if (propName.equals(propDef.getName()) && propDef.hasField()) {
+                AnnotatedField field = propDef.getField();
+                JavaType propertyType = field.getType();
+                return constructSettableProperty(ctxt, targetDescRef, propDef, propertyType);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -737,10 +737,13 @@ ClassUtil.name(propName)));
     /**
      * Method that will find if bean has any managed- or back-reference properties,
      * and if so add them to bean, to be linked during resolution phase.
+     *
+     * @param builtType Non-{@code null} for Builder-based POJOs, indicating type
+     *    of POJO (not Builder); {@code null} for regular POJOs
      */
     protected void addBackReferenceProperties(DeserializationContext ctxt,
-            BeanDescription.Supplier beanDescRef, BeanDeserializerBuilder builder,
-            JavaType targetType)
+            BeanDescription.Supplier beanDescRef, BeanDeserializerBuilder deserBuilder,
+            JavaType builtType)
     {
         // and then back references, not necessarily found as regular properties
         List<BeanPropertyDefinition> refProps = beanDescRef.get().findBackReferences();
@@ -770,29 +773,28 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 String refName = refProp.findReferenceName();
                 SettableBeanProperty backRefProp;
 
-                if (targetType != null) {
+                if (builtType != null) {
                     // [databind#2686]: Handle Builder
                     backRefProp = constructBuilderBackRefProperty(ctxt,
-                            targetType, refProp);
+                            builtType, refProp);
                 } else {
                     // normal
                     backRefProp = constructSettableProperty(ctxt,
                             beanDescRef, refProp, refProp.getPrimaryType());
                 }
 
-                if (backRefProp != null) {
-                    builder.addBackReferenceProperty(refName, backRefProp);
-                } else {
-                    if (targetType != null) {
+                if (backRefProp == null) {
+                    if (builtType != null) {
                         ctxt.reportBadTypeDefinition(beanDescRef,
                                 "Cannot find back-reference field '%s' in target type %s for Builder-based deserialization: ensure the field exists in the target class, not just the Builder",
-                                refProp.getName(), ClassUtil.nameOf(targetType.getRawClass()));
+                                refProp.getName(), ClassUtil.nameOf(builtType.getRawClass()));
                     } else {
                         ctxt.reportBadTypeDefinition(beanDescRef,
                                 "Cannot resolve back-reference property '%s'",
                                 refProp.getName());
                     }
                 }
+                deserBuilder.addBackReferenceProperty(refName, backRefProp);
             }
         }
     }

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -1091,7 +1091,6 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
         return status.booleanValue();
     }
 
-    // @since 2.8.11
     protected void _validateSubType(DeserializationContext ctxt, JavaType type,
             BeanDescription.Supplier beanDescRef)
     {
@@ -1104,9 +1103,9 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
      * @since 3.1
      */
     protected SettableBeanProperty constructBuilderBackRefProperty(DeserializationContext ctxt,
-            JavaType targetType, BeanPropertyDefinition builderRefProp)
+            JavaType builtType, BeanPropertyDefinition builderRefProp)
     {
-        BeanDescription.Supplier targetDescRef = ctxt.lazyIntrospectBeanDescription(targetType);
+        BeanDescription.Supplier targetDescRef = ctxt.lazyIntrospectBeanDescription(builtType);
         BeanDescription targetDesc = targetDescRef.get();
 
         // find back reference with same field

--- a/src/test/java/tools/jackson/databind/struct/BuilderWithBackRef2686Test.java
+++ b/src/test/java/tools/jackson/databind/struct/BuilderWithBackRef2686Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.databind.tofix;
+package tools.jackson.databind.struct;
 
 import java.beans.ConstructorProperties;
 
@@ -11,7 +11,6 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import tools.jackson.databind.testutil.DatabindTestUtil;
-import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -91,7 +90,6 @@ class BuilderWithBackRef2686Test extends DatabindTestUtil {
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    @JacksonTestFailureExpected
     @Test
     void buildWithBackRefs2686() throws Exception {
         Container container = new Container();

--- a/src/test/java/tools/jackson/databind/struct/BuilderWithBackRef2686Test.java
+++ b/src/test/java/tools/jackson/databind/struct/BuilderWithBackRef2686Test.java
@@ -1,7 +1,5 @@
 package tools.jackson.databind.struct;
 
-import java.beans.ConstructorProperties;
-
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
@@ -12,13 +10,12 @@ import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// [databind#2686]: Not sure if this can ever be solved as
-//  setter/builder is on Builder class, but it is called after
-//  building completes, i.e. on wrong class.
-
-class BuilderWithBackRef2686Test extends DatabindTestUtil {
+// [databind#2686]: Back References for Builder-based POJOs
+class BuilderWithBackRef2686Test extends DatabindTestUtil
+{
     // [databind#2686]
     public static class Container {
         Content forward;
@@ -51,7 +48,6 @@ class BuilderWithBackRef2686Test extends DatabindTestUtil {
 
         private String contentValue;
 
-        @ConstructorProperties({"back", "contentValue"})
         public Content(Container back, String contentValue) {
             this.back = back;
             this.contentValue = contentValue;
@@ -98,8 +94,10 @@ class BuilderWithBackRef2686Test extends DatabindTestUtil {
         container.forward = content;
 
         String json = MAPPER.writeValueAsString(container);
-        Container result = MAPPER.readValue(json, Container.class); // Exception here
+        Container result = MAPPER.readValue(json, Container.class);
 
         assertNotNull(result);
+        assertNotNull(result.getForward());
+        assertEquals("contentValue", result.getForward().getContentValue());
     }
 }


### PR DESCRIPTION
Issue: #2686

I initially considered handling this problem in `ManagedReferenceProperty`,
but resolving it in `BeanDeserializerFactory` during construction seemed 
more appropriate as it addresses the root cause directly.