### PR TITLE
Remove unused JsonParser parameter from processUnwrapped method from UnwrappedPropertyHandler

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -936,7 +936,7 @@ public class BeanDeserializer
             }
         }
         tokens.writeEndObject();
-        _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
+        _unwrappedPropertyHandler.processUnwrapped(ctxt, bean, tokens);
         return bean;
     }
 
@@ -1000,7 +1000,7 @@ public class BeanDeserializer
             }
         }
         tokens.writeEndObject();
-        _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
+        _unwrappedPropertyHandler.processUnwrapped(ctxt, bean, tokens);
         return bean;
     }
 
@@ -1108,7 +1108,7 @@ public class BeanDeserializer
             return ctxt.reportInputMismatch(_beanType,
                     "Cannot create polymorphic instances with unwrapped values");
         }
-        return _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
+        return _unwrappedPropertyHandler.processUnwrapped(ctxt, bean, tokens);
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -696,7 +696,7 @@ public class BuilderBasedDeserializer
             }
         }
         tokens.writeEndObject();
-        return _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
+        return _unwrappedPropertyHandler.processUnwrapped(ctxt, bean, tokens);
     }
 
     protected Object deserializeWithUnwrapped(JsonParser p,
@@ -740,7 +740,7 @@ public class BuilderBasedDeserializer
             }
         }
         tokens.writeEndObject();
-        return _unwrappedPropertyHandler.processUnwrapped(p, ctxt, builder, tokens);
+        return _unwrappedPropertyHandler.processUnwrapped(ctxt, builder, tokens);
     }
 
     @SuppressWarnings("resource")
@@ -816,7 +816,7 @@ public class BuilderBasedDeserializer
             return wrapInstantiationProblem(ctxt, e);
 
         }
-        return _unwrappedPropertyHandler.processUnwrapped(p, ctxt, builder, tokens);
+        return _unwrappedPropertyHandler.processUnwrapped(ctxt, builder, tokens);
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
@@ -90,7 +90,7 @@ public class UnwrappedPropertyHandler
     }
 
     @SuppressWarnings("resource")
-    public Object processUnwrapped(JsonParser originalParser, DeserializationContext ctxt,
+    public Object processUnwrapped(DeserializationContext ctxt,
             Object bean, TokenBuffer buffered)
     {
         for (SettableBeanProperty prop : _properties) {


### PR DESCRIPTION
If the preferred approach is to use `JsonParser` within `UnwrappedPropertyHandler`,
please let me know and I can close this PR accordingly.