### PR TITLE
Fix #1709: Deserializing empty JsonUnwrapped objects

### DIFF
--- a/src/main/java/tools/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/tools/jackson/databind/DeserializationFeature.java
@@ -418,6 +418,19 @@ public enum DeserializationFeature implements ConfigFeature
     ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT(false),
 
     /**
+     * Feature that determines whether a POJO property annotated with
+     * {@link com.fasterxml.jackson.annotation.JsonUnwrapped} should remain {@code null}
+     * if no corresponding unwrapped values are present in the input.
+     * If enabled, an unwrapped property is only instantiated when at least one
+     * matching property is encountered; if disabled, an empty instance may be created.
+     * <p>
+     * Feature is disabled by default.
+     *
+     * @since 3.1
+     */
+    ACCEPT_EMPTY_UNWRAPPED_AS_NULL(false),
+
+    /**
      * Feature that determines whether coercion from JSON floating point
      * number (anything with command (`.`) or exponent portion (`e` / `E'))
      * to an expected integral number (`int`, `long`, `java.lang.Integer`, `java.lang.Long`,

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -887,6 +887,10 @@ public class BeanDeserializer
         }
         final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
 
+        final Set<String> unwrappedPropertyNames  = _unwrappedPropertyNames;
+        // [databind#1709]: true if any unwrapped property has non-null value
+        boolean hasNonNullUnwrappedContent = false;
+
         for (int ix = p.currentNameMatch(_propNameMatcher); ; ix = p.nextNameMatch(_propNameMatcher)) {
             if (ix >= 0) { // common case
                 p.nextToken();
@@ -915,6 +919,15 @@ public class BeanDeserializer
                 handleIgnoredProperty(p, ctxt, bean, propName);
                 continue;
             }
+
+            // [databind#1709]: Track non-null unwrapped property
+            if (unwrappedPropertyNames != null
+                    && propName != null && unwrappedPropertyNames.contains(propName)) {
+                if (p.currentToken() != JsonToken.VALUE_NULL) {
+                    hasNonNullUnwrappedContent = true;
+                }
+            }
+
             // 29-Nov-2016, tatu: probably should try to avoid sending content
             //    both to any setter AND buffer... but, for now, the only thing
             //    we can do.
@@ -936,7 +949,14 @@ public class BeanDeserializer
             }
         }
         tokens.writeEndObject();
-        _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
+
+        // [databind#1709] :Skip processUnwrapped if empty, keeping unwrapped properties null
+        if (unwrappedPropertyNames != null && !hasNonNullUnwrappedContent) {
+            _unwrappedPropertyHandler.setAllPropertiesToNull(ctxt, bean);
+        } else {
+            _unwrappedPropertyHandler.processUnwrapped(p, ctxt, bean, tokens);
+        }
+
         return bean;
     }
 

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -161,6 +161,12 @@ public abstract class BeanDeserializerBase
      */
     protected final Map<String, SettableBeanProperty> _backRefs;
 
+    /**
+     * Property names belonging to unwrapped properties.
+     * @since 3.1
+     */
+    protected Set<String> _unwrappedPropertyNames;
+
     /*
     /**********************************************************************
     /* Related handlers
@@ -284,6 +290,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _unwrappedPropertyNames = src._unwrappedPropertyNames;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -350,6 +357,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _unwrappedPropertyNames = src._unwrappedPropertyNames;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -394,6 +402,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _unwrappedPropertyNames = src._unwrappedPropertyNames;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -429,6 +438,7 @@ public abstract class BeanDeserializerBase
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
         _needViewProcesing = src._needViewProcesing;
+        _unwrappedPropertyNames = src._unwrappedPropertyNames;
         _serializationShape = src._serializationShape;
 
         _vanillaProcessing = src._vanillaProcessing;
@@ -638,6 +648,11 @@ ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiato
         _unwrappedPropertyHandler = unwrapped;
         if (unwrapped != null) { // we consider this non-standard, to offline handling
             _nonStandardCreation = true;
+
+            // [databind#1709]: Collect unwrapped property names
+            if (ctxt.isEnabled(DeserializationFeature.ACCEPT_EMPTY_UNWRAPPED_AS_NULL)) {
+                _unwrappedPropertyNames = _collectUnwrappedPropertyNames();
+            }
         }
         // may need to disable vanilla processing, if unwrapped handling was enabled...
         _vanillaProcessing = _vanillaProcessing && !_nonStandardCreation;
@@ -1888,5 +1903,11 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
             ClassUtil.throwIfRTE(t);
         }
         return ctxt.handleInstantiationProblem(_beanType.getRawClass(), null, t);
+    }
+
+    // [databind#1709]: Collect @JsonUnwrapped through handler
+    private Set<String> _collectUnwrappedPropertyNames() {
+        Set<String> names = _unwrappedPropertyHandler.collectUnwrappedPropertyNames();
+        return names.isEmpty() ? Collections.emptySet() : names;
     }
 }

--- a/src/main/java/tools/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/UnwrappedPropertyHandler.java
@@ -1,11 +1,12 @@
 package tools.jackson.databind.deser.impl;
 
+import java.io.IOException;
 import java.util.*;
 
 import tools.jackson.core.*;
-import tools.jackson.databind.DeserializationContext;
-import tools.jackson.databind.PropertyName;
+import tools.jackson.databind.*;
 import tools.jackson.databind.deser.SettableBeanProperty;
+import tools.jackson.databind.deser.bean.BeanDeserializerBase;
 import tools.jackson.databind.deser.bean.PropertyValueBuffer;
 import tools.jackson.databind.util.NameTransformer;
 import tools.jackson.databind.util.TokenBuffer;
@@ -108,5 +109,30 @@ public class UnwrappedPropertyHandler
      */
     public static PropertyName creatorParamName(int index) {
         return new PropertyName(JSON_UNWRAPPED_NAME_PREFIX + index);
+    }
+
+    /**
+     * Collect property names from unwrapped beans for {@code ACCEPT_EMPTY_UNWRAPPED_AS_NULL} feature.
+     *
+     * @since 3.1
+     */
+    public Set<String> collectUnwrappedPropertyNames() {
+        Set<String> names = new HashSet<>();
+        for (SettableBeanProperty prop : this._properties) {
+            ValueDeserializer<Object> deser = prop.getValueDeserializer();
+            if (deser instanceof BeanDeserializerBase beanDeser) {
+                Iterator<SettableBeanProperty> it = beanDeser.properties();
+                while (it.hasNext()) {
+                    names.add(it.next().getName());
+                }
+            }
+        }
+        return names;
+    }
+
+    public void setAllPropertiesToNull(DeserializationContext ctxt, Object bean) throws JacksonException {
+        for (SettableBeanProperty prop : _properties) {
+            prop.set(ctxt, bean, null);
+        }
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/UnwrappedEmptyAsNull1709Test.java
+++ b/src/test/java/tools/jackson/databind/deser/UnwrappedEmptyAsNull1709Test.java
@@ -1,0 +1,122 @@
+package tools.jackson.databind.deser;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UnwrappedEmptyAsNull1709Test extends DatabindTestUtil
+{
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    static class Container {
+        public String name;
+        @JsonUnwrapped
+        public Unwrapped u;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    static class Unwrapped {
+        public String s;
+        public Integer n;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    static class MultiUnwrappedContainer {
+        public String id;
+        @JsonUnwrapped(prefix = "a_")
+        public Unwrapped first;
+        @JsonUnwrapped(prefix = "b_")
+        public Unwrapped second;
+    }
+
+    private final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.ACCEPT_EMPTY_UNWRAPPED_AS_NULL)
+            .build();
+
+    @Test
+    public void testEmptyUnwrappedAsNull() throws Exception {
+        Container result = MAPPER.readValue("{\"name\":\"test\"}", Container.class);
+        assertNotNull(result);
+        assertEquals("test", result.name);
+        assertNull(result.u);
+    }
+
+    @Test
+    public void testEmptyJsonEmptyUnwrappedAsNull() throws Exception {
+        Container result = MAPPER.readValue("{}", Container.class);
+        assertNotNull(result);
+        assertNull(result.name);
+        assertNull(result.u);
+    }
+
+    @Test
+    public void testNonNullUnwrappedPreserved() throws Exception {
+        Container result = MAPPER.readValue("{\"name\":\"test\",\"s\":\"value\"}", Container.class);
+        assertNotNull(result);
+        assertEquals("test", result.name);
+        assertNotNull(result.u);
+        assertEquals("value", result.u.s);
+    }
+
+    @Test
+    public void testPartialNonNullUnwrappedPreserved() throws Exception {
+        Container result = MAPPER.readValue("{\"s\":\"value\"}", Container.class);
+        assertNotNull(result);
+        assertNotNull(result.u);
+        assertEquals("value", result.u.s);
+        assertNull(result.u.n);
+    }
+
+    @Test
+    public void testExplicitNullsTreatedAsEmpty() throws Exception {
+        Container result = MAPPER.readValue("{\"name\":\"test\",\"s\":null,\"n\":null}", Container.class);
+        assertNotNull(result);
+        assertEquals("test", result.name);
+        assertNull(result.u);
+    }
+
+    @Test
+    public void testFeatureDisabledCreatesInstance() throws Exception {
+        ObjectMapper defaultMapper = newJsonMapper();
+        Container result = defaultMapper.readValue("{\"name\":\"test\"}", Container.class);
+        assertNotNull(result);
+        assertEquals("test", result.name);
+        assertNotNull(result.u); // instance created with null fields
+        assertNull(result.u.s);
+    }
+
+    @Test
+    public void testMultipleUnwrappedBothEmpty() throws Exception {
+        MultiUnwrappedContainer result = MAPPER.readValue("{\"id\":\"123\"}", MultiUnwrappedContainer.class);
+        assertNotNull(result);
+        assertEquals("123", result.id);
+        assertNull(result.first);
+        assertNull(result.second);
+    }
+
+    @Test
+    public void testRoundTripSymmetry() throws Exception {
+        Container c1 = new Container();
+        c1.name = "test";
+        c1.u = new Unwrapped(); // empty unwrapped
+
+        Container c2 = new Container();
+        c2.name = "test";
+        c2.u = null;
+
+        String json1 = MAPPER.writeValueAsString(c1);
+        String json2 = MAPPER.writeValueAsString(c2);
+        assertEquals(json1, json2);
+
+        Container result = MAPPER.readValue(json1, Container.class);
+        assertNotNull(result);
+        assertEquals("test", result.name);
+        assertNull(result.u);
+    }
+}


### PR DESCRIPTION
Issue: #1709 

I’ve added `ACCEPT_EMPTY_UNWRAPPED_AS_NULL` to `DeserializationFeature`.

I think the responsibilities have been appropriately distributed across
`UnwrappedPropertyHandler`, `BeanDeserializerBase`, and `BeanDeserializer`.

I’ve also added test cases to cover this new feature, 
and verified that the tests pass in `jackson-module-kotlin` as well.

I would appreciate it if you could take a look when you have a moment :)