### PR TITLE
Fix #2438: Prevent use of setter/field in case Creator property already exists, duplicate value seen

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -579,6 +579,12 @@ public class BeanDeserializer
 
             // Creator property?
             if (creatorProp != null) {
+                // [databind#2438]: Creator property is set only using the first value
+                //  when duplicate fields are present.
+                if (!isRecord && buffer.hasParameter(creatorProp)) {
+                    p.skipChildren();
+                    continue;
+                }
                 if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
                     p.skipChildren();
                     continue;

--- a/src/test/java/tools/jackson/databind/deser/CreatorFallback2438Test.java
+++ b/src/test/java/tools/jackson/databind/deser/CreatorFallback2438Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.databind.tofix;
+package tools.jackson.databind.deser;
 
 import org.junit.jupiter.api.Test;
 
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import tools.jackson.databind.*;
 import tools.jackson.databind.testutil.DatabindTestUtil;
-import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -34,7 +33,6 @@ class CreatorFallback2438Test extends DatabindTestUtil {
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    @JacksonTestFailureExpected
     @Test
     void creator2438() throws Exception {
         // note: by default, duplicate-detection not enabled, so should not

--- a/src/test/java/tools/jackson/databind/records/DuplicatePropertyDeserializationRecord4690Test.java
+++ b/src/test/java/tools/jackson/databind/records/DuplicatePropertyDeserializationRecord4690Test.java
@@ -57,6 +57,6 @@ public class DuplicatePropertyDeserializationRecord4690Test
         final String json = a2q("{'first':'value','second':'test1','first':'value2'}");
 
         MyPojo result = mapper.readValue(json, MyPojo.class);
-        assertEquals("value2", result.getFirst());
+        assertEquals("value", result.getFirst());
     }
 }


### PR DESCRIPTION
Issue: https://github.com/FasterXML/jackson-databind/issues/2438

The issue occurs when `incoming JSON content has a duplicate value for a property that normally is passed via Creator parameter, and there is alternate setter or field that is discovered, second value is set via setter/field`.

I updated the logic to skip handling the second (duplicate) value.

While working on this, I noticed that in the test cases previously addressed in #4690, there is also a scenario corresponding to #2438. To align with the intended behavior, I updated the test to validate against the creator-assigned value rather than the second value (value2 -> value), which allows the test to pass.

Could you please review whether my understanding and this PR is correct?