### PR TITLE
Allow for format modules that don't yet call `_assignGenerator`

### DIFF
--- a/src/main/java/tools/jackson/databind/SerializationContext.java
+++ b/src/main/java/tools/jackson/databind/SerializationContext.java
@@ -493,6 +493,11 @@ public abstract class SerializationContext
      * @return True if input format has specified capability; false if not
      */
     public final boolean isEnabled(StreamWriteCapability cap) {
+        // PJF: Not all modules have been updated to use _assignGenerator directly
+        // https://github.com/FasterXML/jackson-dataformat-xml/issues/793
+        if (_writeCapabilities == null && _generator != null) {
+            _assignGenerator(_generator);
+        }
         Objects.requireNonNull(_writeCapabilities,
                 "_writeCapabilities not set for `SerializationContext`");
         return _writeCapabilities.isEnabled(cap);


### PR DESCRIPTION
see https://github.com/FasterXML/jackson-dataformat-xml/issues/793

I had a look at the some Jackson modules and the XML module might be only one that has its own custom SerializationContext and therefore, it might be the only module affected. In which case https://github.com/FasterXML/jackson-dataformat-xml/pull/794 would be enough.