### PR TITLE
Optimize ConfigOverrides.toString() performance

### DIFF
--- a/src/main/java/tools/jackson/databind/cfg/ConfigOverrides.java
+++ b/src/main/java/tools/jackson/databind/cfg/ConfigOverrides.java
@@ -250,7 +250,7 @@ public class ConfigOverrides
             TreeMap<String, MutableConfigOverride> sorted = new TreeMap<>();
             _overrides.forEach((k, v) -> sorted.put(k.getName(), v));
             sorted.forEach((k, v) -> {
-                sb.append(String.format("'%s'->%s", k, v));
+                sb.append("'").append(k).append("'->").append(v);
             });
             sb.append("}");
         }


### PR DESCRIPTION
### Issue
Closes #5511 

### Description

This PR optimizes `ConfigOverrides.toString()` by replacing `String.format` usage inside the `forEach` loop with `StringBuilder` chaining.

Why this change?

The previous implementation invoked String.format for every entry in the map. This incurred overhead from:

1. **Allocation:** Creating a temporary `Object[]` array for varargs in each iteration.
2. **Parsing:** Parsing the format string `"'%s'->%s"` in each iteration.
**Summary of Results:**

By using `StringBuilder.append()` directly, we eliminate these overheads, resulting in significantly better throughput and reduced memory allocation.

### Changes

```java
// Before
sb.append(String.format("'%s'->%s", k, v));

// After (Zero allocation overhead)
sb.append("'").append(k).append("'->").append(v);
```

## Performance Verification

I conducted a JMH benchmark with various map sizes (1, 5, 10, 20).

The results show that the performance gap widens as the map size increases. For a map size of 20, the optimization yields a ~6.4x improvement in throughput and a ~77% reduction in memory allocation.

**Summary of Results:**

Size | Mode | Old Score (ns/op) | New Score (ns/op) | Improvement | Old Alloc (B/op) | New Alloc (B/op)
-- | -- | -- | -- | -- | -- | --
1 | avgt | 167 | 58 | ~2.9x | 472 | 192
5 | avgt | 743 | 139 | ~5.3x | 1,896 | 496
10 | avgt | 1,378 | 243 | ~5.6x | 3,672 | 872
20 | avgt | 2,702 | 422 | ~6.4x | 7,224 | 1,624

<details>

<summary><strong>JMH Benchmark Detail Result</strong></summary>

```java
Benchmark                                                                    (size)  Mode  Cnt     Score      Error   Units
ConfigOverridesToStringBenchMark.useStringFormat                                  1  avgt    3   167.229 ±  179.577   ns/op
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate                    1  avgt    3  2697.034 ± 2856.314  MB/sec
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate.norm               1  avgt    3   472.001 ±    0.001    B/op
ConfigOverridesToStringBenchMark.useStringFormat                                  5  avgt    3   743.192 ± 1010.735   ns/op
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate                    5  avgt    3  2440.806 ± 3184.976  MB/sec
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate.norm               5  avgt    3  1896.005 ±    0.007    B/op
ConfigOverridesToStringBenchMark.useStringFormat                                 10  avgt    3  1377.887 ± 1198.742   ns/op
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate                   10  avgt    3  2544.400 ± 2151.284  MB/sec
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate.norm              10  avgt    3  3672.009 ±    0.009    B/op
ConfigOverridesToStringBenchMark.useStringFormat                                 20  avgt    3  2702.522 ±  752.771   ns/op
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate                   20  avgt    3  2548.752 ±  715.368  MB/sec
ConfigOverridesToStringBenchMark.useStringFormat:gc.alloc.rate.norm              20  avgt    3  7224.019 ±    0.005    B/op

ConfigOverridesToStringBenchMark.userStringBuilderAppend                          1  avgt    3    58.270 ±   79.644   ns/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate            1  avgt    3  3152.781 ± 4138.155  MB/sec
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate.norm       1  avgt    3   192.000 ±    0.001    B/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend                          5  avgt    3   139.450 ±   48.584   ns/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate            5  avgt    3  3392.029 ± 1171.435  MB/sec
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate.norm       5  avgt    3   496.001 ±    0.001    B/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend                         10  avgt    3   243.202 ±  178.946   ns/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate           10  avgt    3  3422.096 ± 2501.706  MB/sec
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate.norm      10  avgt    3   872.002 ±    0.001    B/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend                         20  avgt    3   422.148 ±   53.279   ns/op
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate           20  avgt    3  3668.029 ±  463.883  MB/sec
ConfigOverridesToStringBenchMark.userStringBuilderAppend:gc.alloc.rate.norm      20  avgt    3  1624.003 ±    0.001    B/op
```

</details>

<details>

<summary><strong> JMH Benchmark Code</strong></summary>

```java
@State(Scope.Thread)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(1)
@Warmup(iterations = 2, time = 1)
@Measurement(iterations = 3, time = 1)
public class ConfigOverridesBenchmark {

    @Param({"1", "5", "10", "20"})
    private int size;
    private Map<String, Object> overrides;

    @Setup
    public void setup() {
        overrides = new TreeMap<>();
        for (int i = 0; i < size; i++) {
            overrides.put("key_" + i, "val_" + i);
        }
    }

    @Benchmark
    public String useStringFormat() {
        StringBuilder sb = new StringBuilder();
        sb.append("(").append(overrides.size()).append("){");
        overrides.forEach((k, v) -> {
            sb.append(String.format("'%s'->%s", k, v)); 
        });
        sb.append("}");
        return sb.toString();
    }

    @Benchmark
    public String userStringBuilderAppend() {
        StringBuilder sb = new StringBuilder();
        sb.append("(").append(overrides.size()).append("){");
        overrides.forEach((k, v) -> {
            sb.append("'").append(k).append("'->").append(v);
        });
        sb.append("}");
        return sb.toString();
    }
}
```

</details>

