### PR TITLE
Refactor helper methods to replace String.format with concatenation

### DIFF
--- a/src/main/java/tools/jackson/databind/DatabindContext.java
+++ b/src/main/java/tools/jackson/databind/DatabindContext.java
@@ -486,7 +486,8 @@ public abstract class DatabindContext
             return "[N/A]";
         }
         // !!! should we quote it? (in case there are control chars, linefeeds)
-        return String.format("\"%s\"", _truncate(desc));
+        return "\"" + _truncate(desc) + "\"";
+//       return String.format("\"%s\"", _truncate(desc));
     }
 
     protected String _colonConcat(String msgBase, String extra) {

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -2812,7 +2812,7 @@ public class ObjectMapper
 
     protected final void _assertNotNull(String paramName, Object src) {
         if (src == null){
-            throw new IllegalArgumentException(String.format("argument \"%s\" is null", paramName));
+            throw new IllegalArgumentException("argument \"" + paramName + "\" is null");
         }
     }
 }

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -1246,7 +1246,7 @@ public class ObjectWriter
 
     protected final void _assertNotNull(String paramName, Object src) {
         if (src == null){
-            throw new IllegalArgumentException(String.format("argument \"%s\" is null", paramName));
+            throw new IllegalArgumentException("argument \"" + paramName + "\" is null");
         }
     }
 

--- a/src/main/java/tools/jackson/databind/node/StringNode.java
+++ b/src/main/java/tools/jackson/databind/node/StringNode.java
@@ -63,7 +63,7 @@ public class StringNode
     protected String _valueDesc() {
         String s = _value;
         if (s.length() > 100) {
-             return String.format("\"%s\"[...]", s.substring(0, 100));
+             return "\"" + s.substring(0, 100) + "\"[...]";
         }
         return "\""+_value+"\"";
     }

--- a/src/main/java/tools/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/tools/jackson/databind/util/ClassUtil.java
@@ -545,7 +545,7 @@ public final class ClassUtil
         if (str == null) {
             return forNull;
         }
-        return String.format("\"%s\"", str);
+        return "\"" + str + "\"";
     }
 
     /*


### PR DESCRIPTION
### Issue 
Closes #5513 

### Description

This PR replaces `String.format` with simple string concatenation (`+`) in several helper methods and exception message constructors.

Why this change?

Using String.format for simple string operations (like wrapping a value in quotes) incurs unnecessary implementation overhead:

1. **Varargs Allocation:** Creates a temporary `Object[]` array.
2. **Parsing:** Parses the format string internally.

For trivial cases, simple concatenation is more efficient and produces less garbage.

### Changes

- **Helper Methods:** `StringNode`, `DatabindContext`, `ClassUtil`
- **Exception Messages:** `ObjectMapper`, `ObjectWriter` (Also aligns consistency with other exception helpers).

> Note: I intentionally retained String.format in places where multiple arguments are formatted or where the template structure significantly aids readability. This change targets only simple cases where the overhead outweighs the benefit.
> 

### Performance Verification

I measured the overhead difference using JMH. While the impact per call is smaller compared to hot-path loops, replacing `String.format` with concatenation consistently reduces execution time and allocation.

- **Speed:** ~14% improvement per operation.
- **Allocation:** Reduced overhead (avoids `Object[]` creation).

<details>

<summary><strong> JMH Benchmark Results</strong></summary>

```java
Benchmark                                                                    (size)  Mode  Cnt     Score     Error   Units
StringAddBenchmark.stringFormat                                                 N/A  avgt    3  1012.321 ± 134.808   ns/op
StringAddBenchmark.stringFormat:gc.alloc.rate                                   N/A  avgt    3  1031.916 ± 145.150  MB/sec
StringAddBenchmark.stringFormat:gc.alloc.rate.norm                              N/A  avgt    3  1096.007 ±   0.001    B/op
StringAddBenchmark.stringFormat:gc.count                                        N/A  avgt    3    13.000            counts
StringAddBenchmark.stringFormat:gc.time                                         N/A  avgt    3    12.000                ms
StringAddBenchmark.stringOperator                                               N/A  avgt    3   872.312 ± 262.949   ns/op
StringAddBenchmark.stringOperator:gc.alloc.rate                                 N/A  avgt    3   874.570 ± 261.175  MB/sec
StringAddBenchmark.stringOperator:gc.alloc.rate.norm                            N/A  avgt    3   800.006 ±   0.002    B/op
StringAddBenchmark.stringOperator:gc.count                                      N/A  avgt    3    10.000            counts
StringAddBenchmark.stringOperator:gc.time                                       N/A  avgt    3     8.000                ms

```

</details>

<details>

<summary><strong>JMH Benchmark Code</strong></summary>

```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Thread)
@Fork(1)
@Warmup(iterations = 2, time = 1)
@Measurement(iterations = 3, time = 1)
public class StringAddBenchmark {

    private String paramName = "myParam"
  
    @Benchmark
    public void stringFormat(Blackhole bh) {
        try {
            throw new IllegalArgumentException(String.format("argument \"%s\" is null", paramName));
        } catch (IllegalArgumentException e) {
            bh.consume(e); 
        }
    }

    @Benchmark
    public void stringOperator(Blackhole bh) {
        try {  
            throw new IllegalArgumentException("argument \"" + paramName + "\" is null");
        } catch (IllegalArgumentException e) {
            bh.consume(e);
        }
    }
}
```

</details>