### PR TITLE
Remove commented-out dead code from #5514

### DIFF
--- a/src/main/java/tools/jackson/databind/DatabindContext.java
+++ b/src/main/java/tools/jackson/databind/DatabindContext.java
@@ -487,7 +487,6 @@ public abstract class DatabindContext
         }
         // !!! should we quote it? (in case there are control chars, linefeeds)
         return "\"" + _truncate(desc) + "\"";
-//       return String.format("\"%s\"", _truncate(desc));
     }
 
     protected String _colonConcat(String msgBase, String extra) {


### PR DESCRIPTION
### Description
I noticed that I accidentally left a commented-out line in my previous PR #5514.
This PR removes the dead code to keep the codebase clean.

Sorry for the oversight!

### Changes
* Removed the commented-out `String.format` line in DatabindContext