### PR TITLE
Add #1496: test cases for Object Id with Builder-based deserialization

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -83,7 +83,7 @@ public class BuilderBasedDeserializer
         _targetType = targetType;
         _buildMethod = builder.getBuildMethod();
         // 05-Mar-2012, tatu: Cannot really make Object Ids work with builders, not yet anyway
-        if (_objectIdReader != null) {
+        if (_objectIdReader != null) { // it will be expected an issue?
             throw new IllegalArgumentException("Cannot use Object Id with Builder-based deserialization (type "
                     +beanDescRef.getType()+")");
         }

--- a/src/test/java/tools/jackson/databind/tofix/ObjectIdWithBuilder1496Test.java
+++ b/src/test/java/tools/jackson/databind/tofix/ObjectIdWithBuilder1496Test.java
@@ -14,7 +14,7 @@ import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ObjectIdWithBuilder1496Test extends DatabindTestUtil {
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")

--- a/src/test/java/tools/jackson/databind/tofix/ObjectIdWithBuilder1496Test.java
+++ b/src/test/java/tools/jackson/databind/tofix/ObjectIdWithBuilder1496Test.java
@@ -1,5 +1,6 @@
 package tools.jackson.databind.tofix;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.Test;
@@ -79,7 +80,53 @@ class ObjectIdWithBuilder1496Test extends DatabindTestUtil {
         }
     }
 
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    @JsonDeserialize(builder = EntityBuilder.class)
+    static class Entity
+    {
+        private long id;
+        private Entity ref;
+        private List<Entity> refs;
+
+        Entity(long id, Entity ref, List<Entity> refs) {
+            this.id = id;
+            this.ref = ref;
+            this.refs = refs;
+        }
+
+        public long getId() { return id; }
+        public Entity getRef() { return ref; }
+        public List<Entity> getRefs() { return refs; }
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    static class EntityBuilder
+    {
+        private long id;
+        private Entity ref;
+        private List<Entity> refs;
+
+        public EntityBuilder id(long id) { this.id = id; return this; }
+        public EntityBuilder ref(Entity ref) { this.ref = ref; return this; }
+        public EntityBuilder refs(List<Entity> refs) { this.refs = refs; return this; }
+
+        public Entity build() {
+            return new Entity(id, ref, refs);
+        }
+    }
+
+    static class EntityContainer
+    {
+        public List<Entity> entities;
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
+
+    /*
+    /**********************************************************************
+    /* Test cases
+    /**********************************************************************
+     */
 
     @JacksonTestFailureExpected
     @Test
@@ -88,5 +135,59 @@ class ObjectIdWithBuilder1496Test extends DatabindTestUtil {
         String json = MAPPER.writeValueAsString(input);
         POJO result = MAPPER.readValue(json, POJO.class);
         assertNotNull(result);
+    }
+
+    // Forward reference: first entity references second entity (which comes later)
+    @JacksonTestFailureExpected
+    @Test
+    public void testForwardReference() throws Exception
+    {
+        String json = a2q("{'entities':["
+                + "{'id':1,'ref':2,'refs':[]},"
+                + "{'id':2,'refs':[1]}"
+                + "]}");
+
+        EntityContainer container = MAPPER.readValue(json, EntityContainer.class);
+        assertNotNull(container);
+        assertEquals(2, container.entities.size());
+
+        Entity first = container.entities.get(0);
+        Entity second = container.entities.get(1);
+
+        assertEquals(1, first.getId());
+        assertEquals(2, second.getId());
+
+        // first.ref -> second (forward reference)
+        assertSame(second, first.getRef());
+        // second.refs[0] -> first (back reference in collection)
+        assertEquals(1, second.getRefs().size());
+        assertSame(first, second.getRefs().get(0));
+    }
+
+    // Back reference: second entity references first entity (which came earlier)
+    @JacksonTestFailureExpected
+    @Test
+    public void testBackReference() throws Exception
+    {
+        String json = a2q("{'entities':["
+                + "{'id':1,'refs':[2]},"
+                + "{'id':2,'ref':1,'refs':[]}"
+                + "]}");
+
+        EntityContainer container = MAPPER.readValue(json, EntityContainer.class);
+        assertNotNull(container);
+        assertEquals(2, container.entities.size());
+
+        Entity first = container.entities.get(0);
+        Entity second = container.entities.get(1);
+
+        assertEquals(1, first.getId());
+        assertEquals(2, second.getId());
+
+        // second.ref -> first (back reference)
+        assertSame(first, second.getRef());
+        // first.refs[0] -> second (forward reference in collection)
+        assertEquals(1, first.getRefs().size());
+        assertSame(second, first.getRefs().get(0));
     }
 }


### PR DESCRIPTION
Issue: #1496 

I added this case as it could also cause an error.