### PR TITLE
Implement #5519 (msec truncate on read/write)

### DIFF
--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -227,17 +227,17 @@ public enum DateTimeFeature implements DatatypeFeature
 
     /**
      * Feature that determines whether time values with nanosecond precision
-     * should have their nanoseconds truncated to milliseconds AFTER deserialization,
+     * should have their nanoseconds truncated to milliseconds <b>after</b> deserialization,
      * before returning the value to the caller.
      * <p>
-     * When enabled, any java.time type with nanosecond precision
+     * When enabled, all {@code java.time} types with nanosecond precision
      * ({@link java.time.Instant}, {@link java.time.LocalDateTime}, {@link java.time.LocalTime},
      * {@link java.time.OffsetDateTime}, {@link java.time.OffsetTime}, {@link java.time.ZonedDateTime},
      * {@link java.time.Duration}) will have nanoseconds beyond millisecond precision cleared
      * (nanoseconds 0-999,999,999 will become 0-999,000,000 in multiples of 1,000,000).
      * <p>
      * This feature works independently of {@link #READ_DATE_TIMESTAMPS_AS_NANOSECONDS}
-     * and affects ALL deserialization paths (numeric timestamps AND textual ISO-8601 strings).
+     * and affects all deserialization paths (numeric timestamps AND textual ISO-8601 strings).
      * <p>
      * Feature is disabled by default to preserve full nanosecond precision.
      *
@@ -247,16 +247,16 @@ public enum DateTimeFeature implements DatatypeFeature
 
     /**
      * Feature that determines whether time values with nanosecond precision
-     * should have their nanoseconds truncated to milliseconds BEFORE serialization.
+     * should have their nanoseconds truncated to milliseconds <b>before</b> serialization.
      * <p>
-     * When enabled, any java.time type with nanosecond precision
+     * When enabled, all {@code java.time} types with nanosecond precision
      * ({@link java.time.Instant}, {@link java.time.LocalDateTime}, {@link java.time.LocalTime},
      * {@link java.time.OffsetDateTime}, {@link java.time.OffsetTime}, {@link java.time.ZonedDateTime},
      * {@link java.time.Duration}) will have nanoseconds beyond millisecond precision cleared
      * before serialization (nanoseconds 0-999,999,999 will become 0-999,000,000 in multiples of 1,000,000).
      * <p>
      * This feature works independently of {@link #WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS}
-     * and affects ALL serialization paths (numeric timestamps AND textual ISO-8601 strings).
+     * and affects all serialization paths (numeric timestamps AND textual ISO-8601 strings).
      * <p>
      * Feature is disabled by default to preserve full nanosecond precision.
      *
@@ -282,8 +282,10 @@ public enum DateTimeFeature implements DatatypeFeature
 
     @Override
     public boolean enabledByDefault() { return _enabledByDefault; }
+
     @Override
     public boolean enabledIn(int flags) { return (flags & _mask) != 0; }
+
     @Override
     public int getMask() { return _mask; }
 

--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -224,7 +224,46 @@ public enum DateTimeFeature implements DatatypeFeature
      * NOT timestamps.
      */
     WRITE_DURATIONS_AS_TIMESTAMPS(false),
-    
+
+    /**
+     * Feature that determines whether time values with nanosecond precision
+     * should have their nanoseconds truncated to milliseconds AFTER deserialization,
+     * before returning the value to the caller.
+     * <p>
+     * When enabled, any java.time type with nanosecond precision
+     * ({@link java.time.Instant}, {@link java.time.LocalDateTime}, {@link java.time.LocalTime},
+     * {@link java.time.OffsetDateTime}, {@link java.time.OffsetTime}, {@link java.time.ZonedDateTime},
+     * {@link java.time.Duration}) will have nanoseconds beyond millisecond precision cleared
+     * (nanoseconds 0-999,999,999 will become 0-999,000,000 in multiples of 1,000,000).
+     * <p>
+     * This feature works independently of {@link #READ_DATE_TIMESTAMPS_AS_NANOSECONDS}
+     * and affects ALL deserialization paths (numeric timestamps AND textual ISO-8601 strings).
+     * <p>
+     * Feature is disabled by default to preserve full nanosecond precision.
+     *
+     * @since 3.1
+     */
+    TRUNCATE_TO_MSECS_ON_READ(false),
+
+    /**
+     * Feature that determines whether time values with nanosecond precision
+     * should have their nanoseconds truncated to milliseconds BEFORE serialization.
+     * <p>
+     * When enabled, any java.time type with nanosecond precision
+     * ({@link java.time.Instant}, {@link java.time.LocalDateTime}, {@link java.time.LocalTime},
+     * {@link java.time.OffsetDateTime}, {@link java.time.OffsetTime}, {@link java.time.ZonedDateTime},
+     * {@link java.time.Duration}) will have nanoseconds beyond millisecond precision cleared
+     * before serialization (nanoseconds 0-999,999,999 will become 0-999,000,000 in multiples of 1,000,000).
+     * <p>
+     * This feature works independently of {@link #WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS}
+     * and affects ALL serialization paths (numeric timestamps AND textual ISO-8601 strings).
+     * <p>
+     * Feature is disabled by default to preserve full nanosecond precision.
+     *
+     * @since 3.1
+     */
+    TRUNCATE_TO_MSECS_ON_WRITE(false),
+
     ;
 
     private final static int FEATURE_INDEX = DatatypeFeatures.FEATURE_INDEX_DATETIME;

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/DurationDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/DurationDeserializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.deser;
 import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -143,33 +144,48 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
     public Duration deserialize(JsonParser parser, DeserializationContext context)
         throws JacksonException
     {
+        Duration result;
         switch (parser.currentTokenId())
         {
             case JsonTokenId.ID_NUMBER_FLOAT:
                 BigDecimal value = parser.getDecimalValue();
                 // [modules-java8#337] since 2.19, Duration does not need negative adjustment
-                return DecimalUtils.extractSecondsAndNanos(value, Duration::ofSeconds, false);
+                result = DecimalUtils.extractSecondsAndNanos(value, Duration::ofSeconds, false);
+                break;
             case JsonTokenId.ID_NUMBER_INT:
-                return _fromTimestamp(context, parser.getLongValue());
+                result = _fromTimestamp(context, parser.getLongValue());
+                break;
             case JsonTokenId.ID_STRING:
-                return _fromString(parser, context, parser.getString());
+                result = _fromString(parser, context, parser.getString());
+                break;
             case JsonTokenId.ID_EMBEDDED_OBJECT:
                 // 20-Apr-2016, tatu: Related to [databind#1208], can try supporting embedded
                 //    values quite easily
-                return (Duration) parser.getEmbeddedObject();
+                result = (Duration) parser.getEmbeddedObject();
+                break;
             case JsonTokenId.ID_START_ARRAY:
-                return _deserializeFromArray(parser, context);
+                result = _deserializeFromArray(parser, context);
+                break;
             // 30-Sep-2020, tatu: New! "Scalar from Object" (mostly for XML)
             case JsonTokenId.ID_START_OBJECT:
                 String str = context.extractScalarFromObject(parser, this, handledType());
                 // 17-May-2025, tatu: [databind#4656] need to check for `null`
                 if (str != null) {
-                    return _fromString(parser, context, str);
+                    result = _fromString(parser, context, str);
+                    break;
                 }
                 // fall through
+            default:
+                return _handleUnexpectedToken(context, parser, JsonToken.VALUE_STRING,
+                        JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
         }
-        return _handleUnexpectedToken(context, parser, JsonToken.VALUE_STRING,
-                JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
+
+        // Apply millisecond truncation if enabled
+        if (result != null && context.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)) {
+            result = result.truncatedTo(ChronoUnit.MILLIS);
+        }
+
+        return result;
     }
 
     protected Duration _fromString(JsonParser parser, DeserializationContext ctxt,

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/DurationDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/DurationDeserializer.java
@@ -35,7 +35,7 @@ import tools.jackson.databind.ext.javatime.util.DecimalUtils;
 import tools.jackson.databind.ext.javatime.util.DurationUnitConverter;
 
 /**
- * Deserializer for Java 8 temporal {@link Duration}s.
+ * Deserializer for {@code java.time} temporal {@link Duration}s.
  */
 public class DurationDeserializer extends JSR310DeserializerBase<Duration>
 {
@@ -55,8 +55,6 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
 
     /**
      * Flag for <code>JsonFormat.Feature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS</code>
-     *
-     * @since 2.16
      */
     protected final Boolean _readTimestampsAsNanosOverride;
 
@@ -66,27 +64,18 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
         _readTimestampsAsNanosOverride = null;
     }
 
-    /**
-     * @since 2.11
-     */
     protected DurationDeserializer(DurationDeserializer base, Boolean leniency) {
         super(base, leniency);
         _durationUnitConverter = base._durationUnitConverter;
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
     }
 
-    /**
-     * @since 2.12
-     */
     protected DurationDeserializer(DurationDeserializer base, DurationUnitConverter converter) {
         super(base, base._isLenient);
         _durationUnitConverter = converter;
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
     }
 
-    /**
-     * @since 2.16
-     */
     protected DurationDeserializer(DurationDeserializer base,
         Boolean leniency,
         DurationUnitConverter converter,
@@ -176,7 +165,7 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
                 }
                 // fall through
             default:
-                return _handleUnexpectedToken(context, parser, JsonToken.VALUE_STRING,
+                result = _handleUnexpectedToken(context, parser, JsonToken.VALUE_STRING,
                         JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
         }
 

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
@@ -283,7 +283,7 @@ public class InstantDeserializer<T extends Temporal>
                 }
                 // fall through
             default:
-                return _handleUnexpectedToken(ctxt, p, JsonToken.VALUE_STRING,
+                result = _handleUnexpectedToken(ctxt, p, JsonToken.VALUE_STRING,
                         JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
         }
 
@@ -298,12 +298,12 @@ public class InstantDeserializer<T extends Temporal>
     @SuppressWarnings("unchecked")
     protected T _truncateToMillis(T value) {
         // Handle concrete types that support truncation
-        if (value instanceof java.time.Instant) {
-            return (T) ((java.time.Instant) value).truncatedTo(ChronoUnit.MILLIS);
-        } else if (value instanceof java.time.OffsetDateTime) {
-            return (T) ((java.time.OffsetDateTime) value).truncatedTo(ChronoUnit.MILLIS);
-        } else if (value instanceof java.time.ZonedDateTime) {
-            return (T) ((java.time.ZonedDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+        if (value instanceof java.time.Instant inst) {
+            return (T) inst.truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.OffsetDateTime odt) {
+            return (T) odt.truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.ZonedDateTime zdt) {
+            return (T) zdt.truncatedTo(ChronoUnit.MILLIS);
         }
         // Return as-is if type doesn't support truncation
         return value;

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.deser;
 import java.math.BigDecimal;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.util.Objects;
@@ -251,32 +252,61 @@ public class InstantDeserializer<T extends Temporal>
     {
         //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
         //string values have to be adjusted to the configured TZ.
+        T result;
         switch (p.currentTokenId())
         {
             case JsonTokenId.ID_NUMBER_FLOAT:
-                return _fromDecimal(ctxt, p.getDecimalValue());
+                result = _fromDecimal(ctxt, p.getDecimalValue());
+                break;
             case JsonTokenId.ID_NUMBER_INT:
-                return _fromLong(ctxt, p.getLongValue());
+                result = _fromLong(ctxt, p.getLongValue());
+                break;
             case JsonTokenId.ID_STRING:
-                return _fromString(p, ctxt, p.getString());
+                result = _fromString(p, ctxt, p.getString());
+                break;
             case JsonTokenId.ID_EMBEDDED_OBJECT:
                 // 20-Apr-2016, tatu: Related to [databind#1208], can try supporting embedded
                 //    values quite easily
-                return (T) p.getEmbeddedObject();
+                result = (T) p.getEmbeddedObject();
+                break;
 
             case JsonTokenId.ID_START_ARRAY:
-                return _deserializeFromArray(p, ctxt);
+                result = _deserializeFromArray(p, ctxt);
+                break;
             // 30-Sep-2020, tatu: New! "Scalar from Object" (mostly for XML)
             case JsonTokenId.ID_START_OBJECT:
                 final String str = ctxt.extractScalarFromObject(p, this, handledType());
                 // 17-May-2025, tatu: [databind#4656] need to check for `null`
                 if (str != null) {
-                    return _fromString(p, ctxt, str);
+                    result = _fromString(p, ctxt, str);
+                    break;
                 }
                 // fall through
+            default:
+                return _handleUnexpectedToken(ctxt, p, JsonToken.VALUE_STRING,
+                        JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
         }
-        return _handleUnexpectedToken(ctxt, p, JsonToken.VALUE_STRING,
-                JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
+
+        // Apply millisecond truncation if enabled
+        if (result != null && ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)) {
+            result = _truncateToMillis(result);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected T _truncateToMillis(T value) {
+        // Handle concrete types that support truncation
+        if (value instanceof java.time.Instant) {
+            return (T) ((java.time.Instant) value).truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.OffsetDateTime) {
+            return (T) ((java.time.OffsetDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.ZonedDateTime) {
+            return (T) ((java.time.ZonedDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+        }
+        // Return as-is if type doesn't support truncation
+        return value;
     }
 
     protected boolean shouldAdjustToContextTimezone(DeserializationContext context) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateTimeDeserializer.java
@@ -20,6 +20,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -97,17 +98,20 @@ public class LocalDateTimeDeserializer
     public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt)
         throws JacksonException
     {
+        LocalDateTime result;
+
         if (p.hasTokenId(JsonTokenId.ID_STRING)) {
-            return _fromString(p, ctxt, p.getString());
+            result = _fromString(p, ctxt, p.getString());
         }
         // 30-Sep-2020, tatu: New! "Scalar from Object" (mostly for XML)
-        if (p.isExpectedStartObjectToken()) {
+        else if (p.isExpectedStartObjectToken()) {
             final String str = ctxt.extractScalarFromObject(p, this, handledType());
             // 17-May-2025, tatu: [databind#4656] need to check for `null`
             if (str != null) {
-                return _fromString(p, ctxt, str);
+                result = _fromString(p, ctxt, str);
+            } else {
+                return _handleUnexpectedToken(ctxt, p, "Expected array or string");
             }
-            // fall through
         } else if (p.isExpectedStartArrayToken()) {
             JsonToken t = p.nextToken();
             if (t == JsonToken.END_ARRAY) {
@@ -119,11 +123,9 @@ public class LocalDateTimeDeserializer
                 if (p.nextToken() != JsonToken.END_ARRAY) {
                     handleMissingEndArrayForSingle(p, ctxt);
                 }
-                return parsed;            
+                return parsed;
             }
             if (t == JsonToken.VALUE_NUMBER_INT) {
-                LocalDateTime result;
-
                 int year = p.getIntValue();
                 int month = p.nextIntValue(-1);
                 int day = p.nextIntValue(-1);
@@ -149,17 +151,27 @@ public class LocalDateTimeDeserializer
                         result = LocalDateTime.of(year, month, day, hour, minute, second, partialSecond);
                     }
                 }
-                return result;
+            } else {
+                ctxt.reportInputMismatch(handledType(),
+                        "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
+                        t);
+                return null; // Unreachable but satisfies compiler
             }
-            ctxt.reportInputMismatch(handledType(),
-                    "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
-                    t);
         } else if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {
-            return (LocalDateTime) p.getEmbeddedObject();
+            result = (LocalDateTime) p.getEmbeddedObject();
         } else if (p.hasToken(JsonToken.VALUE_NUMBER_INT)) {
             _throwNoNumericTimestampNeedTimeZone(p, ctxt);
+            return null; // Unreachable but satisfies compiler
+        } else {
+            return _handleUnexpectedToken(ctxt, p, "Expected array or string");
         }
-        return _handleUnexpectedToken(ctxt, p, "Expected array or string");
+
+        // Apply millisecond truncation if enabled
+        if (result != null && ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)) {
+            result = result.truncatedTo(ChronoUnit.MILLIS);
+        }
+
+        return result;
     }
 
     protected boolean shouldReadTimestampsAsNanoseconds(DeserializationContext context) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateTimeDeserializer.java
@@ -110,11 +110,12 @@ public class LocalDateTimeDeserializer
             if (str != null) {
                 result = _fromString(p, ctxt, str);
             } else {
-                return _handleUnexpectedToken(ctxt, p, "Expected array or string");
+                result = _handleUnexpectedToken(ctxt, p, "Expected array or string");
             }
         } else if (p.isExpectedStartArrayToken()) {
             JsonToken t = p.nextToken();
             if (t == JsonToken.END_ARRAY) {
+                // 22-Dec-2025, tatu: Has been like this but seems inconsistent?
                 return null;
             }
             if ((t == JsonToken.VALUE_STRING || t == JsonToken.VALUE_EMBEDDED_OBJECT)
@@ -123,6 +124,7 @@ public class LocalDateTimeDeserializer
                 if (p.nextToken() != JsonToken.END_ARRAY) {
                     handleMissingEndArrayForSingle(p, ctxt);
                 }
+                // Since we got it via `deserialize()`, possible truncation already applied
                 return parsed;
             }
             if (t == JsonToken.VALUE_NUMBER_INT) {
@@ -152,10 +154,9 @@ public class LocalDateTimeDeserializer
                     }
                 }
             } else {
-                ctxt.reportInputMismatch(handledType(),
+                result = ctxt.reportInputMismatch(handledType(),
                         "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
                         t);
-                return null; // Unreachable but satisfies compiler
             }
         } else if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {
             result = (LocalDateTime) p.getEmbeddedObject();
@@ -163,7 +164,7 @@ public class LocalDateTimeDeserializer
             _throwNoNumericTimestampNeedTimeZone(p, ctxt);
             return null; // Unreachable but satisfies compiler
         } else {
-            return _handleUnexpectedToken(ctxt, p, "Expected array or string");
+            result = _handleUnexpectedToken(ctxt, p, "Expected array or string");
         }
 
         // Apply millisecond truncation if enabled

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalTimeDeserializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.deser;
 import java.time.DateTimeException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -103,17 +104,20 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
     @Override
     public LocalTime deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException
     {
+        LocalTime result;
+
         if (p.hasToken(JsonToken.VALUE_STRING)) {
-            return _fromString(p, ctxt, p.getString());
+            result = _fromString(p, ctxt, p.getString());
         }
         // 30-Sep-2020, tatu: New! "Scalar from Object" (mostly for XML)
-        if (p.isExpectedStartObjectToken()) {
+        else if (p.isExpectedStartObjectToken()) {
             final String str = ctxt.extractScalarFromObject(p, this, handledType());
             // 17-May-2025, tatu: [databind#4656] need to check for `null`
             if (str != null) {
-                return _fromString(p, ctxt, str);
+                result = _fromString(p, ctxt, str);
+            } else {
+                return _handleUnexpectedToken(ctxt, p, "Expected array or string.");
             }
-            // fall through
         } else if (p.isExpectedStartArrayToken()) {
             JsonToken t = p.nextToken();
             if (t == JsonToken.END_ARRAY) {
@@ -125,15 +129,14 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
                 if (p.nextToken() != JsonToken.END_ARRAY) {
                     handleMissingEndArrayForSingle(p, ctxt);
                 }
-                return parsed;            
+                return parsed;
             }
             if (t == JsonToken.VALUE_NUMBER_INT) {
                 int hour = p.getIntValue();
-    
+
                 p.nextToken();
                 int minute = p.getIntValue();
-                LocalTime result;
-    
+
                 t = p.nextToken();
                 if (t == JsonToken.END_ARRAY) {
                     result = LocalTime.of(hour, minute);
@@ -154,17 +157,27 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
                         result = LocalTime.of(hour, minute, second, partialSecond);
                     }
                 }
-                return result;
+            } else {
+                ctxt.reportInputMismatch(handledType(),
+                        "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
+                        t);
+                return null; // Unreachable but satisfies compiler
             }
-            ctxt.reportInputMismatch(handledType(),
-                    "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
-                    t);
         } else if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {
-            return (LocalTime) p.getEmbeddedObject();
+            result = (LocalTime) p.getEmbeddedObject();
         } else if (p.hasToken(JsonToken.VALUE_NUMBER_INT)) {
             _throwNoNumericTimestampNeedTimeZone(p, ctxt);
+            return null; // Unreachable but satisfies compiler
+        } else {
+            return _handleUnexpectedToken(ctxt, p, "Expected array or string.");
         }
-        return _handleUnexpectedToken(ctxt, p, "Expected array or string.");
+
+        // Apply millisecond truncation if enabled
+        if (result != null && ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)) {
+            result = result.truncatedTo(ChronoUnit.MILLIS);
+        }
+
+        return result;
     }
 
     protected boolean shouldReadTimestampsAsNanoseconds(DeserializationContext context) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalTimeDeserializer.java
@@ -116,7 +116,7 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
             if (str != null) {
                 result = _fromString(p, ctxt, str);
             } else {
-                return _handleUnexpectedToken(ctxt, p, "Expected array or string.");
+                result = _handleUnexpectedToken(ctxt, p, "Expected array or string.");
             }
         } else if (p.isExpectedStartArrayToken()) {
             JsonToken t = p.nextToken();
@@ -129,6 +129,7 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
                 if (p.nextToken() != JsonToken.END_ARRAY) {
                     handleMissingEndArrayForSingle(p, ctxt);
                 }
+                // Already truncated if need be by `deserialize()`
                 return parsed;
             }
             if (t == JsonToken.VALUE_NUMBER_INT) {
@@ -158,10 +159,9 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
                     }
                 }
             } else {
-                ctxt.reportInputMismatch(handledType(),
+                result = ctxt.reportInputMismatch(handledType(),
                         "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
                         t);
-                return null; // Unreachable but satisfies compiler
             }
         } else if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {
             result = (LocalTime) p.getEmbeddedObject();
@@ -169,7 +169,7 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
             _throwNoNumericTimestampNeedTimeZone(p, ctxt);
             return null; // Unreachable but satisfies compiler
         } else {
-            return _handleUnexpectedToken(ctxt, p, "Expected array or string.");
+            result = _handleUnexpectedToken(ctxt, p, "Expected array or string.");
         }
 
         // Apply millisecond truncation if enabled

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/OffsetTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/OffsetTimeDeserializer.java
@@ -20,6 +20,7 @@ import java.time.DateTimeException;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -101,78 +102,91 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
     public OffsetTime deserialize(JsonParser p, DeserializationContext ctxt)
         throws JacksonException
    {
+        OffsetTime result;
+
         if (p.hasToken(JsonToken.VALUE_STRING)) {
-            return _fromString(p, ctxt, p.getString());
+            result = _fromString(p, ctxt, p.getString());
         }
         // 30-Sep-2020, tatu: New! "Scalar from Object" (mostly for XML)
-        if (p.isExpectedStartObjectToken()) {
+        else if (p.isExpectedStartObjectToken()) {
             final String str = ctxt.extractScalarFromObject(p, this, handledType());
             // 17-May-2025, tatu: [databind#4656] need to check for `null`
             if (str != null) {
-                return _fromString(p, ctxt, str);
+                result = _fromString(p, ctxt, str);
+            } else {
+                throw ctxt.wrongTokenException(p, handledType(), JsonToken.START_ARRAY,
+                        "Expected array or string");
             }
-            // fall through
         }
-        if (!p.isExpectedStartArrayToken()) {
+        else if (!p.isExpectedStartArrayToken()) {
             if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {
-                return (OffsetTime) p.getEmbeddedObject();
-            }
-            if (p.hasToken(JsonToken.VALUE_NUMBER_INT)) {
+                result = (OffsetTime) p.getEmbeddedObject();
+            } else if (p.hasToken(JsonToken.VALUE_NUMBER_INT)) {
                 _throwNoNumericTimestampNeedTimeZone(p, ctxt);
+                return null; // Unreachable but satisfies compiler
+            } else {
+                throw ctxt.wrongTokenException(p, handledType(), JsonToken.START_ARRAY,
+                        "Expected array or string");
             }
-            throw ctxt.wrongTokenException(p, handledType(), JsonToken.START_ARRAY,
-                    "Expected array or string");
-        }
-        JsonToken t = p.nextToken();
-        if (t != JsonToken.VALUE_NUMBER_INT) {
-            if (t == JsonToken.END_ARRAY) {
-                return null;
-            }
-            if ((t == JsonToken.VALUE_STRING || t == JsonToken.VALUE_EMBEDDED_OBJECT)
-                    && ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
-                final OffsetTime parsed = deserialize(p, ctxt);
-                if (p.nextToken() != JsonToken.END_ARRAY) {
-                    handleMissingEndArrayForSingle(p, ctxt);
-                }
-                return parsed;            
-            }
-            ctxt.reportInputMismatch(handledType(),
-                    "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
-                    t);
-        }
-        int hour = p.getIntValue();
-        int minute = p.nextIntValue(-1);
-        if (minute == -1) {
-            t = p.currentToken();
-            if (t == JsonToken.END_ARRAY) {
-                return null;
-            }
+        } else {
+            JsonToken t = p.nextToken();
             if (t != JsonToken.VALUE_NUMBER_INT) {
-                _reportWrongToken(ctxt, JsonToken.VALUE_NUMBER_INT, "minutes");
-            }
-            minute = p.getIntValue();
-        }
-        int partialSecond = 0;
-        int second = 0;
-        if (p.nextToken() == JsonToken.VALUE_NUMBER_INT) {
-            second = p.getIntValue();
-            if (p.nextToken() == JsonToken.VALUE_NUMBER_INT) {
-                partialSecond = p.getIntValue();
-                if (partialSecond < 1_000 && !shouldReadTimestampsAsNanoseconds(ctxt)) {
-                    partialSecond *= 1_000_000; // value is milliseconds, convert it to nanoseconds
+                if (t == JsonToken.END_ARRAY) {
+                    return null;
                 }
-                p.nextToken();
+                if ((t == JsonToken.VALUE_STRING || t == JsonToken.VALUE_EMBEDDED_OBJECT)
+                        && ctxt.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)) {
+                    final OffsetTime parsed = deserialize(p, ctxt);
+                    if (p.nextToken() != JsonToken.END_ARRAY) {
+                        handleMissingEndArrayForSingle(p, ctxt);
+                    }
+                    return parsed;
+                }
+                ctxt.reportInputMismatch(handledType(),
+                        "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
+                        t);
+            }
+            int hour = p.getIntValue();
+            int minute = p.nextIntValue(-1);
+            if (minute == -1) {
+                t = p.currentToken();
+                if (t == JsonToken.END_ARRAY) {
+                    return null;
+                }
+                if (t != JsonToken.VALUE_NUMBER_INT) {
+                    _reportWrongToken(ctxt, JsonToken.VALUE_NUMBER_INT, "minutes");
+                }
+                minute = p.getIntValue();
+            }
+            int partialSecond = 0;
+            int second = 0;
+            if (p.nextToken() == JsonToken.VALUE_NUMBER_INT) {
+                second = p.getIntValue();
+                if (p.nextToken() == JsonToken.VALUE_NUMBER_INT) {
+                    partialSecond = p.getIntValue();
+                    if (partialSecond < 1_000 && !shouldReadTimestampsAsNanoseconds(ctxt)) {
+                        partialSecond *= 1_000_000; // value is milliseconds, convert it to nanoseconds
+                    }
+                    p.nextToken();
+                }
+            }
+            if (p.currentToken() == JsonToken.VALUE_STRING) {
+                result = OffsetTime.of(hour, minute, second, partialSecond, ZoneOffset.of(p.getString()));
+                if (p.nextToken() != JsonToken.END_ARRAY) {
+                    _reportWrongToken(ctxt, JsonToken.END_ARRAY, "timezone");
+                }
+            } else {
+                throw ctxt.wrongTokenException(p, handledType(), JsonToken.VALUE_STRING,
+                        "Expected string for TimeZone after numeric values");
             }
         }
-        if (p.currentToken() == JsonToken.VALUE_STRING) {
-            OffsetTime result = OffsetTime.of(hour, minute, second, partialSecond, ZoneOffset.of(p.getString()));
-            if (p.nextToken() != JsonToken.END_ARRAY) {
-                _reportWrongToken(ctxt, JsonToken.END_ARRAY, "timezone");
-            }
-            return result;
+
+        // Apply millisecond truncation if enabled
+        if (result != null && ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)) {
+            result = result.truncatedTo(ChronoUnit.MILLIS);
         }
-        throw ctxt.wrongTokenException(p, handledType(), JsonToken.VALUE_STRING,
-                "Expected string for TimeZone after numeric values");
+
+        return result;
     }
 
     protected boolean shouldReadTimestampsAsNanoseconds(DeserializationContext context) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/OffsetTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/OffsetTimeDeserializer.java
@@ -53,9 +53,6 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
         _readTimestampsAsNanosOverride = null;
     }
 
-    /**
-     * Since 2.11
-     */
     protected OffsetTimeDeserializer(OffsetTimeDeserializer base, Boolean leniency) {
         super(base, leniency);
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
@@ -128,7 +125,7 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
                 throw ctxt.wrongTokenException(p, handledType(), JsonToken.START_ARRAY,
                         "Expected array or string");
             }
-        } else {
+        } else { // is START_ARRAY
             JsonToken t = p.nextToken();
             if (t != JsonToken.VALUE_NUMBER_INT) {
                 if (t == JsonToken.END_ARRAY) {
@@ -140,9 +137,10 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
                     if (p.nextToken() != JsonToken.END_ARRAY) {
                         handleMissingEndArrayForSingle(p, ctxt);
                     }
+                    // Possible truncation handled by `deserialize()` call above
                     return parsed;
                 }
-                ctxt.reportInputMismatch(handledType(),
+                result = ctxt.reportInputMismatch(handledType(),
                         "Unexpected token (%s) within Array, expected VALUE_NUMBER_INT",
                         t);
             }
@@ -153,10 +151,12 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
                 if (t == JsonToken.END_ARRAY) {
                     return null;
                 }
-                if (t != JsonToken.VALUE_NUMBER_INT) {
-                    _reportWrongToken(ctxt, JsonToken.VALUE_NUMBER_INT, "minutes");
+                if (t == JsonToken.VALUE_NUMBER_INT) {
+                    minute = p.getIntValue();
+                } else {
+                    result = _reportWrongToken(ctxt, JsonToken.VALUE_NUMBER_INT, "minutes");
+                    // unlikely to recover here?
                 }
-                minute = p.getIntValue();
             }
             int partialSecond = 0;
             int second = 0;

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/DurationSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/DurationSerializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.ser;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import tools.jackson.core.JacksonException;
@@ -116,6 +117,11 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
     public void serialize(Duration duration, JsonGenerator generator, SerializationContext ctxt)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            duration = duration.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         if (useTimestamp(ctxt)) {
             // 03-Aug-2022, tatu: As per [modules-java8#224] need to consider
             //     Pattern first, and only then nano-seconds/millis difference

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/DurationSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/DurationSerializer.java
@@ -55,11 +55,10 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
      * Only available when {@link SerializationFeature#WRITE_DURATIONS_AS_TIMESTAMPS} is enabled
      * and {@link SerializationFeature#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS} is not enabled
      * since the duration converters do not support fractions
-     * @since 2.12
      */
     private DurationUnitConverter _durationUnitConverter;
 
-    protected DurationSerializer() { // was private before 2.12
+    protected DurationSerializer() {
         super(Duration.class);
     }
 
@@ -88,7 +87,6 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
         return new DurationSerializer(this, converter);
     }
 
-    // @since 2.10
     @Override
     protected DateTimeFeature getTimestampsFeature() {
         return DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS;
@@ -101,14 +99,14 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
         JsonFormat.Value format = findFormatOverrides(ctxt, property, handledType());
         if (format != null && format.hasPattern()) {
             final String pattern = format.getPattern();
-            DurationUnitConverter p = DurationUnitConverter.from(pattern);
-            if (p == null) {
+            DurationUnitConverter conv = DurationUnitConverter.from(pattern);
+            if (conv == null) {
                 ctxt.reportBadDefinition(handledType(),
                         String.format(
                                 "Bad 'pattern' definition (\"%s\") for `Duration`: expected one of [%s]",
                                 pattern, DurationUnitConverter.descForAllowed()));
             }
-            ser = ser.withConverter(p);
+            ser = ser.withConverter(conv);
         }
         return ser;
     }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
@@ -136,11 +136,6 @@ public abstract class InstantSerializerBase<T extends Temporal>
 
     protected String formatValue(T value, SerializationContext ctxt)
     {
-        // Apply millisecond truncation if enabled
-        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
-            value = _truncateToMillis(value);
-        }
-
         DateTimeFormatter formatter = (_formatter == null) ? defaultFormat :_formatter;
         if (formatter != null) {
             if (formatter.getZone() == null) { // timezone set if annotated on property
@@ -160,12 +155,12 @@ public abstract class InstantSerializerBase<T extends Temporal>
     @SuppressWarnings("unchecked")
     protected T _truncateToMillis(T value) {
         // Handle concrete types that support truncation
-        if (value instanceof java.time.Instant) {
-            return (T) ((java.time.Instant) value).truncatedTo(ChronoUnit.MILLIS);
-        } else if (value instanceof java.time.OffsetDateTime) {
-            return (T) ((java.time.OffsetDateTime) value).truncatedTo(ChronoUnit.MILLIS);
-        } else if (value instanceof java.time.ZonedDateTime) {
-            return (T) ((java.time.ZonedDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+        if (value instanceof java.time.Instant inst) {
+            return (T) inst.truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.OffsetDateTime odt) {
+            return (T) odt.truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.ZonedDateTime zdt) {
+            return (T) zdt.truncatedTo(ChronoUnit.MILLIS);
         }
         // Return as-is if type doesn't support truncation
         return value;

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
@@ -17,6 +17,7 @@
 package tools.jackson.databind.ext.javatime.ser;
 
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
@@ -85,6 +86,11 @@ public abstract class InstantSerializerBase<T extends Temporal>
     public void serialize(T value, JsonGenerator generator, SerializationContext ctxt)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = _truncateToMillis(value);
+        }
+
         if (useTimestamp(ctxt)) {
             if (useNanoseconds(ctxt)) {
                 generator.writeNumber(DecimalUtils.toBigDecimal(
@@ -130,6 +136,11 @@ public abstract class InstantSerializerBase<T extends Temporal>
 
     protected String formatValue(T value, SerializationContext ctxt)
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = _truncateToMillis(value);
+        }
+
         DateTimeFormatter formatter = (_formatter == null) ? defaultFormat :_formatter;
         if (formatter != null) {
             if (formatter.getZone() == null) { // timezone set if annotated on property
@@ -144,5 +155,19 @@ public abstract class InstantSerializerBase<T extends Temporal>
         }
 
         return value.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected T _truncateToMillis(T value) {
+        // Handle concrete types that support truncation
+        if (value instanceof java.time.Instant) {
+            return (T) ((java.time.Instant) value).truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.OffsetDateTime) {
+            return (T) ((java.time.OffsetDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+        } else if (value instanceof java.time.ZonedDateTime) {
+            return (T) ((java.time.ZonedDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+        }
+        // Return as-is if type doesn't support truncation
+        return value;
     }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/JSR310FormattedSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/JSR310FormattedSerializerBase.java
@@ -61,8 +61,6 @@ abstract class JSR310FormattedSerializerBase<T>
     /**
      * Lazily constructed {@code JavaType} representing type
      * {@code List<Integer>}.
-     *
-     * @since 2.10
      */
     protected transient volatile JavaType _integerListType;
     
@@ -78,16 +76,6 @@ abstract class JSR310FormattedSerializerBase<T>
         _shape = null;
         _formatter = formatter;
     }
-
-    /*
-    
-    protected JSR310FormattedSerializerBase(JSR310FormattedSerializerBase<?> base,
-            DateTimeFormatter dtf,
-            Boolean useTimestamp, JsonFormat.Shape shape)
-    {
-        this(base, dtf, useTimestamp, null, shape);
-    }
-    */
 
     protected JSR310FormattedSerializerBase(JSR310FormattedSerializerBase<?> base,
             DateTimeFormatter dtf,
@@ -184,8 +172,6 @@ abstract class JSR310FormattedSerializerBase<T>
      *<p>
      * Note that this feature is just the baseline setting and may be overridden on per-type
      * or per-property basis.
-     *
-     * @since 2.10
      */
     protected DateTimeFeature getTimestampsFeature() {
         return DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS;
@@ -236,7 +222,9 @@ abstract class JSR310FormattedSerializerBase<T>
     }
 
     // modules-java8#189: to be overridden by other formatters using this as base class
-    protected DateTimeFormatter _useDateTimeFormatter(SerializationContext ctxt, JsonFormat.Value format) {
+    protected DateTimeFormatter _useDateTimeFormatter(SerializationContext ctxt,
+            JsonFormat.Value format)
+    {
         DateTimeFormatter dtf;
         final String pattern = format.getPattern();
         final Locale locale = format.hasLocale() ? format.getLocale() : ctxt.getLocale();

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.ser;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import tools.jackson.core.JacksonException;
@@ -26,6 +27,7 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonToken;
 import tools.jackson.core.type.WritableTypeId;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.jsontype.TypeSerializer;
 
 /**
@@ -64,6 +66,11 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
     public void serialize(LocalDateTime value, JsonGenerator g, SerializationContext ctxt)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = value.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         if (useTimestamp(ctxt)) {
             g.writeStartArray();
             _serializeAsArrayContents(value, g, ctxt);
@@ -82,6 +89,11 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
             TypeSerializer typeSer)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = value.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
                 typeSer.typeId(value, serializationShape(ctxt)));
         // need to write out to avoid double-writing array markers

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalTimeSerializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.ser;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -29,6 +30,7 @@ import tools.jackson.core.type.WritableTypeId;
 
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import tools.jackson.databind.jsonFormatVisitors.JsonValueFormat;
@@ -71,6 +73,11 @@ public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime
     public void serialize(LocalTime value, JsonGenerator g, SerializationContext ctxt)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = value.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         if (useTimestamp(ctxt)) {
             g.writeStartArray();
             _serializeAsArrayContents(value, g, ctxt);
@@ -89,6 +96,11 @@ public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime
             SerializationContext ctxt, TypeSerializer typeSer)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = value.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
                 typeSer.typeId(value, serializationShape(ctxt)));
         // need to write out to avoid double-writing array markers

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalTimeSerializer.java
@@ -35,11 +35,11 @@ import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import tools.jackson.databind.jsonFormatVisitors.JsonValueFormat;
 import tools.jackson.databind.jsontype.TypeSerializer;
+
 /**
  * Serializer for Java 8 temporal {@link LocalTime}s.
  *
  * @author Nick Williams
- * @since 2.2
  */
 public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime>
 {

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetTimeSerializer.java
@@ -19,6 +19,7 @@ package tools.jackson.databind.ext.javatime.ser;
 import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import tools.jackson.core.JacksonException;
@@ -26,6 +27,7 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonToken;
 import tools.jackson.core.type.WritableTypeId;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.jsontype.TypeSerializer;
 
 /**
@@ -61,6 +63,11 @@ public class OffsetTimeSerializer extends JSR310FormattedSerializerBase<OffsetTi
     public void serialize(OffsetTime time, JsonGenerator g, SerializationContext ctxt)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            time = time.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         if (useTimestamp(ctxt)) {
             g.writeStartArray();
             _serializeAsArrayContents(time, g, ctxt);
@@ -76,6 +83,11 @@ public class OffsetTimeSerializer extends JSR310FormattedSerializerBase<OffsetTi
             TypeSerializer typeSer)
         throws JacksonException
     {
+        // Apply millisecond truncation if enabled
+        if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+            value = value.truncatedTo(ChronoUnit.MILLIS);
+        }
+
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
                 typeSer.typeId(value, serializationShape(ctxt)));
         // need to write out to avoid double-writing array markers

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
@@ -2,6 +2,7 @@ package tools.jackson.databind.ext.javatime.ser;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -72,6 +73,10 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
             if ((_formatter != null) && (_shape == JsonFormat.Shape.STRING)) {
                 ; // use default handling
             } else if (shouldWriteWithZoneId(ctxt)) {
+                // Apply millisecond truncation if enabled
+                if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
+                    value = value.truncatedTo(ChronoUnit.MILLIS);
+                }
                 // write with zone
                 g.writeString(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(value));
                 return;

--- a/src/test/java/tools/jackson/databind/ext/javatime/TruncateToMillisecondsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/TruncateToMillisecondsTest.java
@@ -1,0 +1,308 @@
+package tools.jackson.databind.ext.javatime;
+
+import java.time.*;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.*;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link DateTimeFeature#TRUNCATE_TO_MSECS_ON_READ} and
+ * {@link DateTimeFeature#TRUNCATE_TO_MSECS_ON_WRITE} features.
+ */
+public class TruncateToMillisecondsTest extends DatabindTestUtil
+{
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    private final ObjectMapper MAPPER_TRUNCATE_WRITE = jsonMapperBuilder()
+        .enable(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)
+        .build();
+
+    private final ObjectMapper MAPPER_TRUNCATE_READ = jsonMapperBuilder()
+        .enable(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)
+        .build();
+
+    private final ObjectMapper MAPPER_TRUNCATE_BOTH = jsonMapperBuilder()
+        .enable(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)
+        .enable(DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ)
+        .build();
+
+    private final ObjectMapper MAPPER_WRITE_AS_TIMESTAMPS = jsonMapperBuilder()
+        .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .build();
+
+    private final ObjectMapper MAPPER_TRUNCATE_WRITE_AS_TIMESTAMPS = jsonMapperBuilder()
+        .enable(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)
+        .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .build();
+
+    // Serialization tests
+
+    @Test
+    public void testInstantSerializationTruncation() throws Exception {
+        Instant instant = Instant.parse("2023-01-15T10:30:45.123456789Z");
+
+        // Without truncation - preserves full nanoseconds
+        String json1 = MAPPER.writeValueAsString(instant);
+        assertTrue(json1.contains("123456789") || json1.contains("45.123456789"),
+            "Expected nanoseconds in: " + json1);
+
+        // With truncation - only milliseconds (zeros out extra nanoseconds)
+        String json2 = MAPPER_TRUNCATE_WRITE.writeValueAsString(instant);
+        assertTrue(json2.contains("123") && !json2.contains("456789"),
+            "Expected truncated value in: " + json2);
+    }
+
+    @Test
+    public void testLocalDateTimeSerializationTruncation() throws Exception {
+        LocalDateTime ldt = LocalDateTime.of(2023, 1, 15, 10, 30, 45, 123456789);
+
+        // Without truncation
+        String json1 = MAPPER.writeValueAsString(ldt);
+        assertTrue(json1.contains("123456789") || json1.contains("45.123456789"),
+            "Expected nanoseconds in: " + json1);
+
+        // With truncation
+        String json2 = MAPPER_TRUNCATE_WRITE.writeValueAsString(ldt);
+        assertFalse(json2.contains("456789"), "Expected truncated value in: " + json2);
+    }
+
+    @Test
+    public void testLocalTimeSerializationTruncation() throws Exception {
+        LocalTime time = LocalTime.of(10, 30, 45, 123456789);
+
+        // Without truncation
+        String json1 = MAPPER.writeValueAsString(time);
+        assertTrue(json1.contains("123456789") || json1.contains("45.123456789"),
+            "Expected nanoseconds in: " + json1);
+
+        // With truncation
+        String json2 = MAPPER_TRUNCATE_WRITE.writeValueAsString(time);
+        assertFalse(json2.contains("456789"), "Expected truncated value in: " + json2);
+    }
+
+    @Test
+    public void testDurationSerializationTruncation() throws Exception {
+        Duration duration = Duration.ofSeconds(123, 456789012);
+
+        // Without truncation
+        String json1 = MAPPER.writeValueAsString(duration);
+        assertTrue(json1.contains("456789012") || json1.contains(".456789012"),
+            "Expected nanoseconds in: " + json1);
+
+        // With truncation
+        String json2 = MAPPER_TRUNCATE_WRITE.writeValueAsString(duration);
+        assertTrue(json2.contains("456") || json2.contains(".456"),
+            "Expected milliseconds in: " + json2);
+        assertFalse(json2.contains("789012"), "Expected truncated value in: " + json2);
+    }
+
+    // Deserialization tests
+
+    @Test
+    public void testInstantDeserializationTruncation() throws Exception {
+        String json = "\"2023-01-15T10:30:45.123456789Z\"";
+
+        // Without truncation - preserves full nanoseconds
+        Instant instant1 = MAPPER.readValue(json, Instant.class);
+        assertEquals(123456789, instant1.getNano());
+
+        // With truncation - only milliseconds
+        Instant instant2 = MAPPER_TRUNCATE_READ.readValue(json, Instant.class);
+        assertEquals(123000000, instant2.getNano());
+    }
+
+    @Test
+    public void testLocalDateTimeDeserializationTruncation() throws Exception {
+        String json = "\"2023-01-15T10:30:45.123456789\"";
+
+        // Without truncation
+        LocalDateTime ldt1 = MAPPER.readValue(json, LocalDateTime.class);
+        assertEquals(123456789, ldt1.getNano());
+
+        // With truncation
+        LocalDateTime ldt2 = MAPPER_TRUNCATE_READ.readValue(json, LocalDateTime.class);
+        assertEquals(123000000, ldt2.getNano());
+    }
+
+    @Test
+    public void testLocalTimeDeserializationTruncation() throws Exception {
+        String json = "\"10:30:45.123456789\"";
+
+        // Without truncation
+        LocalTime time1 = MAPPER.readValue(json, LocalTime.class);
+        assertEquals(123456789, time1.getNano());
+
+        // With truncation
+        LocalTime time2 = MAPPER_TRUNCATE_READ.readValue(json, LocalTime.class);
+        assertEquals(123000000, time2.getNano());
+    }
+
+    @Test
+    public void testDurationDeserializationTruncation() throws Exception {
+        String json = "\"PT123.456789012S\"";
+
+        // Without truncation
+        Duration duration1 = MAPPER.readValue(json, Duration.class);
+        assertEquals(456789012, duration1.getNano());
+
+        // With truncation
+        Duration duration2 = MAPPER_TRUNCATE_READ.readValue(json, Duration.class);
+        assertEquals(456000000, duration2.getNano());
+    }
+
+    // Round-trip tests
+
+    @Test
+    public void testRoundTripWithBothFeaturesEnabled() throws Exception {
+        Instant original = Instant.parse("2023-01-15T10:30:45.123456789Z");
+
+        // Serialize with truncation
+        String json = MAPPER_TRUNCATE_BOTH.writeValueAsString(original);
+
+        // Deserialize with truncation
+        Instant result = MAPPER_TRUNCATE_BOTH.readValue(json, Instant.class);
+
+        // Result should have milliseconds only
+        assertEquals(123000000, result.getNano());
+        assertEquals(original.getEpochSecond(), result.getEpochSecond());
+    }
+
+    @Test
+    public void testRoundTripSerializeTruncateDeserializeWithout() throws Exception {
+        LocalDateTime original = LocalDateTime.of(2023, 1, 15, 10, 30, 45, 123456789);
+
+        // Serialize with truncation
+        String json = MAPPER_TRUNCATE_WRITE.writeValueAsString(original);
+
+        // Deserialize without truncation (value is already truncated)
+        LocalDateTime result = MAPPER.readValue(json, LocalDateTime.class);
+
+        // Result should still have milliseconds only (from serialization truncation)
+        assertEquals(123000000, result.getNano());
+    }
+
+    // Test with numeric timestamp format
+
+    @Test
+    public void testInstantNumericTimestampTruncation() throws Exception {
+        Instant instant = Instant.parse("2023-01-15T10:30:45.123456789Z");
+
+        // Serialize as numeric timestamp with truncation
+        String json = MAPPER_TRUNCATE_WRITE_AS_TIMESTAMPS.writeValueAsString(instant);
+
+        // The numeric value should not contain nanoseconds beyond milliseconds
+        Instant result = MAPPER.readValue(json, Instant.class);
+        assertTrue(result.getNano() % 1_000_000 == 0,
+            "Nanoseconds should be multiple of 1,000,000: " + result.getNano());
+    }
+
+    // Test values already at millisecond precision
+
+    @Test
+    public void testAlreadyTruncatedValueRemains() throws Exception {
+        // Value already at millisecond precision
+        Instant instant = Instant.parse("2023-01-15T10:30:45.123Z");
+        assertEquals(123000000, instant.getNano());
+
+        // Truncation should not change it
+        String json = MAPPER_TRUNCATE_WRITE.writeValueAsString(instant);
+        Instant result = MAPPER_TRUNCATE_READ.readValue(json, Instant.class);
+
+        assertEquals(123000000, result.getNano());
+        assertEquals(instant, result);
+    }
+
+    // Test edge cases
+
+    @Test
+    public void testZeroNanosecondsRemains() throws Exception {
+        Instant instant = Instant.parse("2023-01-15T10:30:45Z");
+        assertEquals(0, instant.getNano());
+
+        // Truncation should not change it
+        String json = MAPPER_TRUNCATE_WRITE.writeValueAsString(instant);
+        Instant result = MAPPER_TRUNCATE_READ.readValue(json, Instant.class);
+
+        assertEquals(0, result.getNano());
+        assertEquals(instant, result);
+    }
+
+    @Test
+    public void testNegativeDurationTruncation() throws Exception {
+        // Create a negative duration: -5 seconds
+        Duration duration = Duration.ofSeconds(-5);
+
+        // Serialize with truncation (should not change since it has no fractional part)
+        String json = MAPPER_TRUNCATE_WRITE.writeValueAsString(duration);
+
+        // Deserialize with truncation
+        Duration result = MAPPER_TRUNCATE_READ.readValue(json, Duration.class);
+
+        // Should preserve the negative duration
+        assertEquals(-5, result.getSeconds());
+        assertEquals(0, result.getNano());
+
+        // Test with negative duration that has fractional seconds
+        Duration duration2 = Duration.ofMillis(-5123).plusNanos(456789);
+        String json2 = MAPPER_TRUNCATE_WRITE.writeValueAsString(duration2);
+        Duration result2 = MAPPER_TRUNCATE_READ.readValue(json2, Duration.class);
+
+        // Should truncate to milliseconds
+        assertTrue(result2.toNanos() % 1_000_000 == 0,
+            "Expected millisecond precision for negative duration");
+    }
+
+    // Test independence from READ/WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS
+
+    @Test
+    public void testTruncationIndependentOfNanosecondFeature() throws Exception {
+        ObjectMapper mapperNanosOff = jsonMapperBuilder()
+            .disable(DateTimeFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+            .enable(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)
+            .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+        Instant instant = Instant.parse("2023-01-15T10:30:45.123456789Z");
+
+        // Even with nanoseconds disabled, truncation should still occur
+        String json = mapperNanosOff.writeValueAsString(instant);
+        Instant result = MAPPER.readValue(json, Instant.class);
+
+        // Result should have only millisecond precision
+        assertTrue(result.getNano() % 1_000_000 == 0,
+            "Expected millisecond precision: " + result.getNano());
+    }
+
+    // Test with OffsetDateTime and ZonedDateTime
+
+    @Test
+    public void testOffsetDateTimeTruncation() throws Exception {
+        OffsetDateTime odt = OffsetDateTime.parse("2023-01-15T10:30:45.123456789+01:00");
+
+        // Serialize with truncation
+        String json = MAPPER_TRUNCATE_WRITE.writeValueAsString(odt);
+
+        // Deserialize with truncation
+        OffsetDateTime result = MAPPER_TRUNCATE_READ.readValue(json, OffsetDateTime.class);
+
+        assertEquals(123000000, result.getNano());
+    }
+
+    @Test
+    public void testZonedDateTimeTruncation() throws Exception {
+        ZonedDateTime zdt = ZonedDateTime.parse("2023-01-15T10:30:45.123456789+01:00[Europe/Paris]");
+
+        // Serialize with truncation
+        String json = MAPPER_TRUNCATE_WRITE.writeValueAsString(zdt);
+
+        // Deserialize with truncation
+        ZonedDateTime result = MAPPER_TRUNCATE_READ.readValue(json, ZonedDateTime.class);
+
+        assertEquals(123000000, result.getNano());
+    }
+}


### PR DESCRIPTION
Add `DateTimeFeature.TRUNCATE_TO_MSECS_ON_READ`, `DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE`, support, wrt Java 8 date/time (`java.time`) types.

Claude Prompt:

    Try to implement https://github.com/FasterXML/jackson-databind/issues/5519 -- start with high-level plan
