### PR TITLE
Add new asXxxOr(defaultValue) that returns default value for NullNode instead of coercing

### DIFF
--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -616,6 +616,15 @@ public abstract class JsonNode
     public abstract String asString(String defaultValue);
 
     /**
+     * Similar to {@link #asString(String)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asString(String)}.
+     */
+    public String asStringOr(String defaultValue) {
+        return asString(defaultValue);
+    }
+
+    /**
      * Similar to {@link #asString()}, but instead of throwing an exception for
      * non-coercible values, will return {@code Optional.empty()}.
      */
@@ -706,6 +715,15 @@ public abstract class JsonNode
      * non-coercible values, will return specified default value.
      */
     public abstract boolean asBoolean(boolean defaultValue);
+
+    /**
+     * Similar to {@link #asBoolean(boolean)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asBoolean(boolean)}.
+     */
+    public boolean asBooleanOr(boolean defaultValue) {
+        return asBoolean(defaultValue);
+    }
 
     /**
      * Similar to {@link #asBoolean()}, but instead of throwing an exception for
@@ -804,6 +822,15 @@ public abstract class JsonNode
     public abstract short asShort(short defaultValue);
 
     /**
+     * Similar to {@link #asShort(short)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asShort(short)}.
+     */
+    public short asShortOr(short defaultValue) {
+        return asShort(defaultValue);
+    }
+
+    /**
      * Method similar to {@link #asShort()}, but that will return
      * ({@code Optional.empty()}) if this node cannot
      * be coerced to {@code short}.
@@ -890,6 +917,15 @@ public abstract class JsonNode
      *   {@code defaultValue} otherwise
      */
     public abstract int asInt(int defaultValue);
+
+    /**
+     * Similar to {@link #asInt(int)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asInt(int)}.
+     */
+    public int asIntOr(int defaultValue) {
+        return asInt(defaultValue);
+    }
 
     /**
      * Method similar to {@link #asInt()}, but that will return
@@ -981,6 +1017,15 @@ public abstract class JsonNode
     public abstract long asLong(long defaultValue);
 
     /**
+     * Similar to {@link #asLong(long)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asLong(long)}.
+     */
+    public long asLongOr(long defaultValue) {
+        return asLong(defaultValue);
+    }
+
+    /**
      * Method similar to {@link #asLong()}, but that will return
      * ({@code OptionalLong.empty()}) if this node cannot
      * be coerced to {@code long}.
@@ -1066,6 +1111,15 @@ public abstract class JsonNode
     public abstract BigInteger asBigInteger(BigInteger defaultValue);
 
     /**
+     * Similar to {@link #asBigInteger(BigInteger)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asBigInteger(BigInteger)}.
+     */
+    public BigInteger asBigIntegerOr(BigInteger defaultValue) {
+        return asBigInteger(defaultValue);
+    }
+
+    /**
      * Method similar to {@link #bigIntegerValue()}, but that will return empty
      * ({@code Optional.empty()}) if this node cannot
      * be converted to Java {@code BigInteger}.
@@ -1144,6 +1198,15 @@ public abstract class JsonNode
      * if possible to accurately represent; {@code defaultValue} otherwise
      */
     public abstract float asFloat(float defaultValue);
+
+    /**
+     * Similar to {@link #asFloat(float)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asFloat(float)}.
+     */
+    public float asFloatOr(float defaultValue) {
+        return asFloat(defaultValue);
+    }
 
     /**
      * Method similar to {@link #asFloat()}, but that will return
@@ -1227,6 +1290,15 @@ public abstract class JsonNode
     public abstract double asDouble(double defaultValue);
 
     /**
+     * Similar to {@link #asDouble(double)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asDouble(double)}.
+     */
+    public double asDoubleOr(double defaultValue) {
+        return asDouble(defaultValue);
+    }
+
+    /**
      * Method similar to {@link #asDouble()}, but that will return
      * ({@code OptionalDouble.empty()}) if this node cannot
      * be coerced to {@code double}.
@@ -1308,6 +1380,15 @@ public abstract class JsonNode
      * if possible to accurately represent; {@code defaultValue} otherwise
      */
     public abstract BigDecimal asDecimal(BigDecimal defaultValue);
+
+    /**
+     * Similar to {@link #asDecimal(BigDecimal)}, but instead of coercing {@code null}
+     * it returns the {@code defaultValue}.
+     * This is the drop-in replacement for the Jackson 2 {@link #asDecimal(BigDecimal)}.
+     */
+    public BigDecimal asDecimalOr(BigDecimal defaultValue) {
+        return asDecimal(defaultValue);
+    }
 
     /**
      * Method similar to {@link #asDecimal()}, but that will return empty

--- a/src/main/java/tools/jackson/databind/node/NullNode.java
+++ b/src/main/java/tools/jackson/databind/node/NullNode.java
@@ -55,8 +55,18 @@ public class NullNode
     }
 
     @Override
+    public boolean asBooleanOr(boolean defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     protected String _asString() {
         return "";
+    }
+
+    @Override
+    public String asStringOr(String defaultValue) {
+        return defaultValue;
     }
 
     // Explicit overrides for all overloads for documentation purposes
@@ -91,6 +101,11 @@ public class NullNode
     }
 
     @Override
+    public short asShortOr(short defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public Optional<Short> asShortOpt() {
         return Optional.of((short) 0);
     }
@@ -108,6 +123,11 @@ public class NullNode
     }
 
     @Override
+    public int asIntOr(int defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public OptionalInt asIntOpt() {
         return OptionalInt.of(0);
     }
@@ -119,6 +139,11 @@ public class NullNode
 
     @Override
     public long asLong(long defaultValue) { return 0L; }
+
+    @Override
+    public long asLongOr(long defaultValue) {
+        return defaultValue;
+    }
 
     @Override
     public OptionalLong asLongOpt() {
@@ -135,6 +160,11 @@ public class NullNode
     @Override
     public BigInteger asBigInteger(BigInteger defaultValue) {
         return asBigInteger();
+    }
+
+    @Override
+    public BigInteger asBigIntegerOr(BigInteger defaultValue) {
+        return defaultValue;
     }
 
     @Override
@@ -155,6 +185,11 @@ public class NullNode
     }
 
     @Override
+    public float asFloatOr(float defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public Optional<Float> asFloatOpt() {
         return Optional.of(asFloat());
     }
@@ -172,6 +207,11 @@ public class NullNode
     }
 
     @Override
+    public double asDoubleOr(double defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public OptionalDouble asDoubleOpt() {
         return OptionalDouble.of(asDouble());
     }
@@ -186,6 +226,11 @@ public class NullNode
     @Override
     public BigDecimal asDecimal(BigDecimal defaultValue) {
         return asDecimal();
+    }
+
+    @Override
+    public BigDecimal asDecimalOr(BigDecimal defaultValue) {
+        return defaultValue;
     }
 
     @Override

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
@@ -188,7 +188,13 @@ public class JsonNodeBigIntegerValueTest
     public void asBigIntegerFromMiscOther()
     {
         // NullNode becomes 0, not fail
-        _assertAsBigInteger(BigInteger.ZERO, NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals(BigInteger.ZERO, node.asBigInteger());
+
+        // and then defaulting
+        assertEquals(BigInteger.ZERO, node.asBigInteger(BigInteger.valueOf(9999999L)));
+        assertEquals(BigInteger.valueOf(9999999L), node.asBigIntegerOr(BigInteger.valueOf(9999999L)));
+        assertEquals(BigInteger.ZERO, node.asBigIntegerOpt().get());
 
         // But MissingNode still fails
         _assertAsBigIntegerFailForNonNumber(NODES.missingNode());
@@ -249,6 +255,7 @@ public class JsonNodeBigIntegerValueTest
 
         // and then defaulting
         assertEquals(expected, node.asBigInteger(BigInteger.valueOf(9999999L)));
+        assertEquals(expected, node.asBigIntegerOr(BigInteger.valueOf(9999999L)));
         assertEquals(expected, node.asBigIntegerOpt().get());
     }
 
@@ -265,6 +272,7 @@ public class JsonNodeBigIntegerValueTest
 
         // Verify default value handling
         assertEquals(BigInteger.ONE, node.asBigInteger(BigInteger.ONE));
+        assertEquals(BigInteger.ONE, node.asBigIntegerOr(BigInteger.ONE));
         assertFalse(node.asBigIntegerOpt().isPresent());
     }
 }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBooleanValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBooleanValueTest.java
@@ -136,7 +136,11 @@ public class JsonNodeBooleanValueTest
     public void asBooleanFromNonNumberMisc()
     {
         // Null ok
-        _assertFalseFromAsBoolean(NODES.nullNode());
+        NullNode n = NODES.nullNode();
+        assertEquals(false, n.asBoolean());
+        assertEquals(false, n.asBoolean(true));
+        assertEquals(true, n.asBooleanOr(true));
+        assertEquals(false, n.asBooleanOpt().get());
         // And POJO node with Boolean:
         _assertFalseFromAsBoolean(NODES.pojoNode(Boolean.FALSE));
         _assertTrueFromAsBoolean(NODES.pojoNode(Boolean.TRUE));
@@ -162,12 +166,14 @@ public class JsonNodeBooleanValueTest
     private void _assertFalseFromAsBoolean(JsonNode n) {
         assertEquals(false, n.asBoolean());
         assertEquals(false, n.asBoolean(true));
+        assertEquals(false, n.asBooleanOr(true));
         assertEquals(false, n.asBooleanOpt().get());
     }
 
     private void _assertTrueFromAsBoolean(JsonNode n) {
         assertEquals(true, n.asBoolean());
         assertEquals(true, n.asBoolean(false));
+        assertEquals(true, n.asBooleanOr(false));
         assertEquals(true, n.asBooleanOpt().get());
     }
     
@@ -195,7 +201,9 @@ public class JsonNodeBooleanValueTest
 
         // But also check defaulting
         assertFalse(node.asBoolean(false));
+        assertFalse(node.asBooleanOr(false));
         assertTrue(node.asBoolean(true));
+        assertTrue(node.asBooleanOr(true));
         assertFalse(node.asBooleanOpt().isPresent());
     }
 }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
@@ -211,7 +211,14 @@ public class JsonNodeDecimalValueTest
     public void asDecimalFromMiscOther()
     {
         // "null" becomes "0.0"
-        _assertAsDecimal(BigDecimal.ZERO, NODES.nullNode());
+        NullNode fromNode = NODES.nullNode();
+        // main accessor
+        assertEquals(BigDecimal.ZERO, fromNode.asDecimal());
+
+        // but also defaulting
+        assertEquals(BigDecimal.ZERO, fromNode.asDecimal(BD_DEFAULT));
+        assertEquals(BD_DEFAULT, fromNode.asDecimalOr(BD_DEFAULT));
+        assertEquals(BigDecimal.ZERO, fromNode.asDecimalOpt().get());
 
         // but "missing" still fails
         _assertFailAsDecimalForNonNumber(NODES.missingNode());
@@ -236,6 +243,7 @@ public class JsonNodeDecimalValueTest
 
         // but also defaulting
         assertEquals(expected, fromNode.asDecimal(BD_DEFAULT));
+        assertEquals(expected, fromNode.asDecimalOr(BD_DEFAULT));
         assertEquals(expected, fromNode.asDecimalOpt().get());
     }
 
@@ -282,6 +290,7 @@ public class JsonNodeDecimalValueTest
 
         // Verify default value handling
         assertEquals(BD_DEFAULT, node.asDecimal(BD_DEFAULT));
+        assertEquals(BD_DEFAULT, node.asDecimalOr(BD_DEFAULT));
         assertEquals(Optional.empty(), node.asDecimalOpt());
     }
 
@@ -296,6 +305,7 @@ public class JsonNodeDecimalValueTest
 
         // Verify default value handling
         assertEquals(BD_DEFAULT, node.asDecimal(BD_DEFAULT));
+        assertEquals(BD_DEFAULT, node.asDecimalOr(BD_DEFAULT));
         assertEquals(Optional.empty(), node.asDecimalOpt());
     }
     

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
@@ -233,7 +233,13 @@ public class JsonNodeDoubleValueTest
     public void asDoubleFromMiscOther()
     {
         // Null node converts to 0.0d; missing fails
-        _assertAsDouble((double) 0, NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals(0d, node.asDouble());
+
+        // and defaults
+        assertEquals(0d, node.asDouble(-9999.5));
+        assertEquals(-9999.5d, node.asDoubleOr(-9999.5));
+        assertEquals(0d, node.asDoubleOpt().getAsDouble());
 
         _assertAsDoubleFailForNonNumber(NODES.missingNode());
     }
@@ -277,6 +283,7 @@ public class JsonNodeDoubleValueTest
 
         // and defaults
         assertEquals(expected, node.asDouble(-9999.5));
+        assertEquals(expected, node.asDoubleOr(-9999.5));
         assertEquals(expected, node.asDoubleOpt().getAsDouble());
     }
 
@@ -290,6 +297,7 @@ public class JsonNodeDoubleValueTest
             .contains("value not in 64-bit `double` range");
 
         assertEquals(-2.25d, node.asDouble(-2.25d));
+        assertEquals(-2.25d, node.asDoubleOr(-2.25d));
         assertEquals(OptionalDouble.empty(), node.asDoubleOpt());
     }
 
@@ -307,6 +315,7 @@ public class JsonNodeDoubleValueTest
             .contains(extraMatch);
 
         assertEquals(1.5d, node.asDouble(1.5d));
+        assertEquals(1.5d, node.asDoubleOr(1.5d));
         assertEquals(OptionalDouble.empty(), node.asDoubleOpt());
     }
 

--- a/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
@@ -235,7 +235,13 @@ public class JsonNodeFloatValueTest
     public void asFloatFromMiscOther()
     {
         // Null node converts to 0.0f; missing fails
-        _assertAsFloat((float) 0, NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals((float) 0, node.asFloat());
+
+        // and defaults
+        assertEquals((float) 0, node.asFloat(-9999.5f));
+        assertEquals(-9999.5f, node.asFloatOr(-9999.5f));
+        assertEquals((float) 0, node.asFloatOpt().get());
         _assertAsFloatFailForNonNumber(NODES.missingNode());
     }
 
@@ -279,6 +285,7 @@ public class JsonNodeFloatValueTest
 
         // and defaults
         assertEquals(expected, node.asFloat(-9999.5f));
+        assertEquals(expected, node.asFloatOr(-9999.5f));
         assertEquals(expected, node.asFloatOpt().get());
     }
 
@@ -292,6 +299,7 @@ public class JsonNodeFloatValueTest
                 .contains("value not in 32-bit `float` range");
 
         assertEquals(-2.25f, node.asFloat(-2.25f));
+        assertEquals(-2.25f, node.asFloatOr(-2.25f));
         assertEquals(Optional.empty(), node.asFloatOpt());
     }
 
@@ -309,6 +317,7 @@ public class JsonNodeFloatValueTest
                 .contains(extraMatch);
 
         assertEquals(1.5f, node.asFloat(1.5f));
+        assertEquals(1.5f, node.asFloatOr(1.5f));
         assertEquals(Optional.empty(), node.asFloatOpt());
     }
 

--- a/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
@@ -301,7 +301,14 @@ public class JsonNodeIntValueTest
     public void asIntFromMiscOther()
     {
         // NullNode -> 0 but "missing" still fails
-        _assertAsInt(0, NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals(0, node.asInt());
+
+        // and defaulting
+
+        assertEquals(0, node.asInt(999_999));
+        assertEquals(999_999, node.asIntOr(999_999));
+        assertEquals(0, node.asIntOpt().getAsInt());
 
         _assertAsIntFailForNonNumber(NODES.missingNode());
     }
@@ -381,6 +388,7 @@ public class JsonNodeIntValueTest
         // and defaulting
 
         assertEquals(expected, node.asInt(999_999));
+        assertEquals(expected, node.asIntOr(999_999));
         assertEquals(expected, node.asIntOpt().getAsInt());
     }
 
@@ -395,6 +403,7 @@ public class JsonNodeIntValueTest
 
         // assert defaulting
         assertEquals(99, node.asInt(99));
+        assertEquals(99, node.asIntOr(99));
         assertEquals(OptionalInt.empty(), node.asIntOpt());
     }
 
@@ -413,6 +422,7 @@ public class JsonNodeIntValueTest
 
         // assert defaulting
         assertEquals(99, node.asInt(99));
+        assertEquals(99, node.asIntOr(99));
         assertEquals(OptionalInt.empty(), node.asIntOpt());
     }
 
@@ -427,6 +437,7 @@ public class JsonNodeIntValueTest
 
         // Verify default value handling
         assertEquals(1, node.asInt(1));
+        assertEquals(1, node.asIntOr(1));
         assertFalse(node.asIntOpt().isPresent());
     }
 

--- a/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
@@ -296,7 +296,13 @@ public class JsonNodeLongValueTest
     public void asLongFromMiscOther()
     {
         // NullNode works, Missing fails
-        _assertAsLong(0L, NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals(0L, node.asLong());
+
+        // But also fallbacks
+        assertEquals(0L, node.asLong(999999L));
+        assertEquals(999999L, node.asLongOr(999999L));
+        assertEquals(0L, node.asLongOpt().getAsLong());
 
         _assertAsLongFailForNonNumber(NODES.missingNode());
     }
@@ -376,6 +382,7 @@ public class JsonNodeLongValueTest
 
         // But also fallbacks
         assertEquals(expected, node.asLong(999999L));
+        assertEquals(expected, node.asLongOr(999999L));
         assertEquals(expected, node.asLongOpt().getAsLong());
     }
 
@@ -390,6 +397,7 @@ public class JsonNodeLongValueTest
 
         // Verify default value handling
         assertEquals(1L, node.asLong(1L));
+        assertEquals(1L, node.asLongOr(1L));
         assertFalse(node.asLongOpt().isPresent());
     }
 
@@ -408,6 +416,7 @@ public class JsonNodeLongValueTest
 
         // Verify default value handling
         assertEquals(1L, node.asLong(1L));
+        assertEquals(1L, node.asLongOr(1L));
         assertFalse(node.asLongOpt().isPresent());
     }
 
@@ -422,6 +431,7 @@ public class JsonNodeLongValueTest
 
         // Verify default value handling
         assertEquals(1L, node.asLong(1L));
+        assertEquals(1L, node.asLongOr(1L));
         assertFalse(node.asLongOpt().isPresent());
     }
     

--- a/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
@@ -282,7 +282,12 @@ public class JsonNodeShortValueTest
     public void asIntFromMiscOther()
     {
         // NullNode -> 0 but "missing" still fails
-        _assertAsShort((short) 0, NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals((short) 0, node.asShort());
+        // and defaulting
+        assertEquals((short) 0, node.asShort((short) 99));
+        assertEquals(99, node.asShortOr((short) 99));
+        assertEquals((short) 0, node.asShortOpt().get());
 
         _assertAsShortFailForNonNumber(NODES.missingNode());
     }
@@ -346,6 +351,7 @@ public class JsonNodeShortValueTest
 
         // and defaulting
         assertEquals(expected, node.asShort((short) 99));
+        assertEquals(expected, node.asShortOr((short) 99));
         assertEquals(expected, node.asShortOpt().get());
     }
 
@@ -360,6 +366,7 @@ public class JsonNodeShortValueTest
 
         // assert defaulting
         assertEquals(99, node.asShort((short) 99));
+        assertEquals(99, node.asShortOr((short) 99));
         assertFalse(node.asShortOpt().isPresent());
     }
 
@@ -378,6 +385,7 @@ public class JsonNodeShortValueTest
 
         // assert defaulting
         assertEquals(99, node.asShort((short) 99));
+        assertEquals(99, node.asShortOr((short) 99));
         assertFalse(node.asShortOpt().isPresent());
     }
 
@@ -392,6 +400,7 @@ public class JsonNodeShortValueTest
 
         // Verify default value handling
         assertEquals(99, node.asShort((short) 99));
+        assertEquals(99, node.asShortOr((short) 99));
         assertFalse(node.asShortOpt().isPresent());
     }
 

--- a/src/test/java/tools/jackson/databind/node/JsonNodeStringValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeStringValueTest.java
@@ -123,7 +123,13 @@ public class JsonNodeStringValueTest
     @Test
     public void asStringFromNonNumberMisc()
     {
-        _assertAsStringSuccess("", NODES.nullNode());
+        NullNode node = NODES.nullNode();
+        assertEquals("", node.asString());
+
+        // But also fallbacks
+        assertEquals("", node.asString("fallback"));
+        assertEquals("fallback", node.asStringOr("fallback"));
+        assertEquals("", node.asStringOpt().get());
 
         _assertAsStringFailForNonString(NODES.missingNode());
     }
@@ -148,6 +154,7 @@ public class JsonNodeStringValueTest
 
         // But also fallbacks
         assertEquals(expected, node.asString("fallback"));
+        assertEquals(expected, node.asStringOr("fallback"));
         assertEquals(expected, node.asStringOpt().get());
     }
 
@@ -161,6 +168,7 @@ public class JsonNodeStringValueTest
 
         // But also check defaulting
         assertEquals("foo", node.asString("foo"));
+        assertEquals("foo", node.asStringOr("foo"));
         assertFalse(node.asStringOpt().isPresent());
     }
 }

--- a/src/test/java/tools/jackson/databind/node/MissingNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/MissingNodeTest.java
@@ -21,6 +21,7 @@ public class MissingNodeTest extends NodeTestBase
         // exception in 3.0:
         //assertEquals("", n.asString());
         assertEquals("default", n.asString("default"));
+        assertEquals("default", n.asStringOr("default"));
         assertStandardEquals(n);
         // 10-Dec-2018, tatu: With 2.10, should serialize same as via ObjectMapper/ObjectWriter
         // 10-Dec-2019, tatu: Surprise! No, this is not how it worked in 2.9, nor does it make
@@ -30,9 +31,13 @@ public class MissingNodeTest extends NodeTestBase
         assertNodeNumbersForNonNumeric(n);
 
         assertTrue(n.asBoolean(true));
+        assertTrue(n.asBooleanOr(true));
         assertEquals(4, n.asInt(4));
+        assertEquals(4, n.asIntOr(4));
         assertEquals(5L, n.asLong(5));
+        assertEquals(5L, n.asLongOr(5));
         assertEquals(0.25, n.asDouble(0.25));
+        assertEquals(0.25, n.asDoubleOr(0.25));
     }
 
     /**

--- a/src/test/java/tools/jackson/databind/node/NodeTestBase.java
+++ b/src/test/java/tools/jackson/databind/node/NodeTestBase.java
@@ -28,10 +28,13 @@ abstract class NodeTestBase extends DatabindTestUtil
     {
         assertEquals(expInt, n.asInt());
         assertEquals(expInt, n.asInt(-42));
+        assertEquals(expInt, n.asIntOr(-42));
         assertEquals((long) expInt, n.asLong());
         assertEquals((long) expInt, n.asLong(19L));
+        assertEquals((long) expInt, n.asLongOr(19L));
         assertEquals(expDouble, n.asDouble());
         assertEquals(expDouble, n.asDouble(-19.25));
+        assertEquals(expDouble, n.asDoubleOr(-19.25));
 
         assertTrue(n.isEmpty());
     }

--- a/src/test/java/tools/jackson/databind/node/NullNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/NullNodeTest.java
@@ -48,6 +48,7 @@ public class NullNodeTest extends NodeTestBase
 
         assertEquals("", n.asString());
         assertEquals("", n.asString("fallback"));
+        assertEquals("fallback", n.asStringOr("fallback"));
 
         assertEquals(0, n.size());
         assertTrue(n.isEmpty());

--- a/src/test/java/tools/jackson/databind/node/NumberNodesTest.java
+++ b/src/test/java/tools/jackson/databind/node/NumberNodesTest.java
@@ -94,6 +94,7 @@ public class NumberNodesTest extends NodeTestBase
         assertEquals("1", n.asString());
         // 2.4
         assertEquals("1", n.asString("foo"));
+        assertEquals("1", n.asStringOr("foo"));
 
         assertNodeNumbers(n, 1, 1.0);
 

--- a/src/test/java/tools/jackson/databind/node/StringNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/StringNodeTest.java
@@ -36,9 +36,13 @@ public class StringNodeTest extends NodeTestBase
         assertEquals("", empty.asString());
 
         assertTrue(StringNode.valueOf("true").asBoolean(true));
+        assertTrue(StringNode.valueOf("true").asBooleanOr(true));
         assertTrue(StringNode.valueOf("true").asBoolean(false));
+        assertTrue(StringNode.valueOf("true").asBooleanOr(false));
         assertFalse(StringNode.valueOf("false").asBoolean(true));
+        assertFalse(StringNode.valueOf("false").asBooleanOr(true));
         assertFalse(StringNode.valueOf("false").asBoolean(false));
+        assertFalse(StringNode.valueOf("false").asBooleanOr(false));
 
         assertNonContainerStreamMethods(n);
     }


### PR DESCRIPTION
This adds a new `asXxxOr(defaultValue)` method which returns default value instead of coercing when using `NullNode` like we discussed in #5417