### PR TITLE
Fix #1670: @JsonPropertyOrder partially ignored when @JsonUnwrapped is used.

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/BeanSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanSerializer.java
@@ -1,6 +1,7 @@
 package tools.jackson.databind.ser;
 
 import java.util.Set;
+import java.util.List;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
@@ -40,9 +41,9 @@ public class BeanSerializer
      * @param properties Property writers used for actual serialization
      */
     public BeanSerializer(JavaType type, BeanSerializerBuilder builder,
-            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties)
+            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties, List<Object> _orderedProps)
     {
-        super(type, builder, properties, filteredProperties);
+        super(type, builder, properties, filteredProperties, _orderedProps);
     }
 
     /**
@@ -85,7 +86,7 @@ public class BeanSerializer
      */
     public static BeanSerializer createDummy(JavaType forType, BeanSerializerBuilder builder)
     {
-        return new BeanSerializer(forType, builder, NO_PROPS, null);
+        return new BeanSerializer(forType, builder, NO_PROPS, null, null);
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/BeanSerializerBuilder.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanSerializerBuilder.java
@@ -46,6 +46,14 @@ public class BeanSerializerBuilder
     protected BeanPropertyWriter[] _filteredProperties;
 
     /**
+     * Ordered properties when {@link com.fasterxml.jackson.annotation.JsonPropertyOrder}
+     * specifies ordering for {@link com.fasterxml.jackson.annotation.JsonUnwrapped} inner properties.
+     *
+     * @since 3.1
+     */
+    protected List<Object> _orderedProps;
+
+    /**
      * Writer used for "any getter" properties, if any.
      */
     protected AnyGetterWriter _anyGetter;
@@ -87,6 +95,7 @@ public class BeanSerializerBuilder
         _config = src._config;
         _properties = src._properties;
         _filteredProperties = src._filteredProperties;
+        _orderedProps = src._orderedProps;
         _anyGetter = src._anyGetter;
         _filterId = src._filterId;
         _typeId = src._typeId;
@@ -213,12 +222,12 @@ _properties.size(), _filteredProperties.length));
         }
         ValueSerializer<?> ser = UnrolledBeanSerializer.tryConstruct(
                 _beanDescRef.getType(), this,
-                    properties, _filteredProperties);
+                    properties, _filteredProperties, _orderedProps);
         if (ser != null) {
             return ser;
         }
         return new BeanSerializer(_beanDescRef.getType(), this,
-                properties, _filteredProperties);
+                properties, _filteredProperties, _orderedProps);
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/ser/UnrolledBeanSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/UnrolledBeanSerializer.java
@@ -1,6 +1,7 @@
 package tools.jackson.databind.ser;
 
 import java.util.Set;
+import java.util.List;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
@@ -51,9 +52,9 @@ public class UnrolledBeanSerializer
      * @param properties Property writers used for actual serialization
      */
     public UnrolledBeanSerializer(JavaType type, BeanSerializerBuilder builder,
-            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties)
+            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties, List<Object> orderedProps)
     {
-        super(type, builder, properties, filteredProperties);
+        super(type, builder, properties, filteredProperties, orderedProps);
         _propCount = _props.length;
         _calcUnrolled();
     }
@@ -90,13 +91,13 @@ public class UnrolledBeanSerializer
      * created.
      */
     public static UnrolledBeanSerializer tryConstruct(JavaType type, BeanSerializerBuilder builder,
-            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties)
+            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties, List<Object> orderedProps)
     {
         if ((properties.length > MAX_PROPS)
                 || (builder.getFilterId() != null)) {
             return null;
         }
-        return new UnrolledBeanSerializer(type, builder, properties, filteredProperties);
+        return new UnrolledBeanSerializer(type, builder, properties, filteredProperties, orderedProps);
     }
 
     /*
@@ -168,6 +169,14 @@ public class UnrolledBeanSerializer
     {
         // NOTE! We have ensured that "JSON Filter" and "Object Id" cases
         // always use "vanilla" BeanSerializer, so no need to check here
+
+        // [databind#1670]: use ordered props for proper interleaving of unwrapped properties
+        if (!_orderedProps.isEmpty()) {
+            gen.writeStartObject(bean);
+            _serializePropertiesOrdered(bean, gen, provider, _orderedProps);
+            gen.writeEndObject();
+            return;
+        }
 
         BeanPropertyWriter[] fProps = _filteredProps;
         if ((fProps != null) && (provider.getActiveView() != null)) {

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -80,6 +80,14 @@ public abstract class BeanSerializerBase
      */
     final protected JsonFormat.Shape _serializationShape;
 
+    /**
+     * Ordered properties when {@link com.fasterxml.jackson.annotation.JsonPropertyOrder}
+     * specifies ordering for {@link com.fasterxml.jackson.annotation.JsonUnwrapped} inner properties.
+     *
+     * @since 3.1
+     */
+    final protected List<Object> _orderedProps;
+
     /*
     /**********************************************************************
     /* Life-cycle: constructors
@@ -94,12 +102,13 @@ public abstract class BeanSerializerBase
      * @param builder Builder for accessing other collected information
      */
     protected BeanSerializerBase(JavaType type, BeanSerializerBuilder builder,
-            BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties)
+                BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties, List<Object> orderedProps)
     {
         super(type);
         _beanType = type;
         _props = properties;
         _filteredProps = filteredProperties;
+        _orderedProps = (orderedProps == null) ? new ArrayList<>() : orderedProps;
         if (builder == null) { // mostly for testing
             // 20-Sep-2019, tatu: Actually not just that but also "dummy" serializer for
             //     case of no bean properties, too
@@ -137,6 +146,7 @@ public abstract class BeanSerializerBase
         _objectIdWriter = src._objectIdWriter;
         _propertyFilterId = src._propertyFilterId;
         _serializationShape = src._serializationShape;
+        _orderedProps = src._orderedProps;
     }
 
     protected BeanSerializerBase(BeanSerializerBase src,
@@ -157,6 +167,7 @@ public abstract class BeanSerializerBase
         _objectIdWriter = objectIdWriter;
         _propertyFilterId = filterId;
         _serializationShape = src._serializationShape;
+        _orderedProps = src._orderedProps;
     }
 
     protected BeanSerializerBase(BeanSerializerBase src, Set<String> toIgnore, Set<String> toInclude)
@@ -189,6 +200,7 @@ public abstract class BeanSerializerBase
         _objectIdWriter = src._objectIdWriter;
         _propertyFilterId = src._propertyFilterId;
         _serializationShape = src._serializationShape;
+        _orderedProps = src._orderedProps;
     }
 
     /**
@@ -270,6 +282,7 @@ public abstract class BeanSerializerBase
     @Override
     public void resolve(SerializationContext provider)
     {
+        boolean hasUnwrapping = false;
         int filteredCount = (_filteredProps == null) ? 0 : _filteredProps.length;
         for (int i = 0, len = _props.length; i < len; ++i) {
             BeanPropertyWriter prop = _props[i];
@@ -344,6 +357,93 @@ public abstract class BeanSerializerBase
             if (prop instanceof AnyGetterWriter anyGetterWriter) {
                 anyGetterWriter.resolve(provider);
             }
+            // [databind#1670]: check to have @JsonUnwrapped
+            if (prop.isUnwrapping()) {
+                hasUnwrapping = true;
+            }
+        }
+
+        // [databind#1670]: re-order properties if @JsonPropertyOrder specifies
+        // order that includes unwrapped property names
+        _reorderPropertiesWithUnwrapped(hasUnwrapping, provider);
+    }
+
+    /**
+     * Helper method to reorder properties when {@code @JsonPropertyOrder} includes
+     * names from {@code @JsonUnwrapped} properties.
+     *
+     * @since 3.1
+     */
+    protected void _reorderPropertiesWithUnwrapped(boolean hasUnwrapping, SerializationContext ctxt)
+    {
+        if (_props.length <= 1 || !hasUnwrapping) {
+            return;
+        }
+
+        final AnnotationIntrospector intr = ctxt.getAnnotationIntrospector();
+        if (intr == null) {
+            return;
+        }
+        final String[] propertyOrder = intr.findSerializationPropertyOrder(
+                ctxt.getConfig(), ctxt.introspectBeanDescription(_beanType).getClassInfo());
+        if (propertyOrder == null || propertyOrder.length == 0) {
+            return;
+        }
+        // let's start re-order
+        _reorderProperties(propertyOrder, ctxt);
+    }
+
+    /**
+     * Method for reordering properties based on {@link com.fasterxml.jackson.annotation.JsonPropertyOrder},
+     * expanding {@link com.fasterxml.jackson.annotation.JsonUnwrapped} into inner properties.
+     *
+     * @since 3.1
+     */
+    protected void _reorderProperties(String[] order, SerializationContext ctxt)
+    {
+        final List<String> orderList = Arrays.asList(order);
+
+        // value : BeanPropertyWriter or Object[] (if unwrapped property)
+        List<Map.Entry<Integer, Object>> entries = new ArrayList<>();
+
+        for (BeanPropertyWriter prop : _props) {
+            int propIdx = orderList.indexOf(prop.getName());
+            if (propIdx < 0) {
+                propIdx = _props.length;
+            }
+
+            if (!prop.isUnwrapping()) {
+                // normal(not unwrapping property)
+                entries.add(Map.entry(propIdx, prop));
+                continue;
+            }
+
+            // need to resolve serializer for unwrapped
+            if (!prop.hasSerializer()) {
+                ValueSerializer<Object> ser = ctxt.findPrimaryPropertySerializer(prop.getType(), prop);
+                if (ser != null) {
+                    prop.assignSerializer(ser);
+                }
+            }
+
+            ValueSerializer<Object> ser = prop.getSerializer();
+            if (ser instanceof BeanSerializerBase bser) {
+                for (PropertyWriter pw : (Iterable<PropertyWriter>) bser::properties) {
+                    if (pw instanceof BeanPropertyWriter inner) {
+                        int idx = orderList.indexOf(inner.getName());
+                        if (idx < 0) {
+                            idx = propIdx;
+                        }
+                        entries.add(Map.entry(idx, new Object[]{prop, inner}));
+                    }
+                }
+            }
+
+        }
+        // key asc
+        entries.sort(Comparator.comparingInt(Map.Entry::getKey));
+        for (Map.Entry<Integer, Object> e : entries) {
+            _orderedProps.add(e.getValue());
         }
     }
 
@@ -841,6 +941,37 @@ public abstract class BeanSerializerBase
         }
     }
 
+    /**
+     * Method for serializing properties when {@link com.fasterxml.jackson.annotation.JsonPropertyOrder}
+     * includes {@link com.fasterxml.jackson.annotation.JsonUnwrapped} inner properties.
+     *
+     * @since 3.1
+     */
+    protected void _serializePropertiesOrdered(Object bean, JsonGenerator gen,
+                                               SerializationContext provider, List<Object> props) throws JacksonException
+    {
+        try {
+            for (Object entry : props) {
+                if (entry instanceof BeanPropertyWriter prop) {
+                    prop.serializeAsProperty(bean, gen, provider);
+                } else if (entry instanceof Object[] arr) {
+                    // arr = {parentUnwrappedProp, innerProp}
+                    BeanPropertyWriter unwrappedProp = (BeanPropertyWriter) arr[0];
+                    BeanPropertyWriter innerProp = (BeanPropertyWriter) arr[1];
+                    Object unwrappedValue = unwrappedProp.get(bean);
+                    if (unwrappedValue != null) {
+                        innerProp.serializeAsProperty(unwrappedValue, gen, provider);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            wrapAndThrow(provider, e, bean, "[ordered]");
+        } catch (StackOverflowError e) {
+            throw DatabindException.from(gen, "Infinite recursion (StackOverflowError)", e)
+                    .prependPath(bean, "[ordered]");
+        }
+    }
+
     /*
     /**********************************************************************
     /* Field serialization methods, 2.x
@@ -897,8 +1028,10 @@ public abstract class BeanSerializerBase
     protected void _serializeProperties(Object bean, JsonGenerator g, SerializationContext provider)
         throws JacksonException
     {
-        // NOTE: only called from places where FilterId (JsonView) already checked.
-        if (_filteredProps != null && provider.getActiveView() != null) {
+        if (!_orderedProps.isEmpty()) {
+            _serializePropertiesOrdered(bean, g, provider, _orderedProps);
+        } else if (_filteredProps != null && provider.getActiveView() != null) {
+            // NOTE: only called from places where FilterId (JsonView) already checked.
             _serializePropertiesMaybeView(bean, g, provider, _filteredProps);
         } else {
             _serializePropertiesNoView(bean, g, provider, _props);

--- a/src/test/java/tools/jackson/databind/ser/JsonPropertyOrderWithUnwrapped1670Test.java
+++ b/src/test/java/tools/jackson/databind/ser/JsonPropertyOrderWithUnwrapped1670Test.java
@@ -1,0 +1,85 @@
+package tools.jackson.databind.ser;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.*;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tools.jackson.databind.testutil.JacksonTestUtilBase.a2q;
+
+// https://github.com/FasterXML/jackson-databind/issues/1670
+public class JsonPropertyOrderWithUnwrapped1670Test {
+
+    @JsonPropertyOrder({"value4", "value3", "value2", "value1"})
+    static class Issue1670 {
+        private int value1;
+        private int value2;
+        @JsonUnwrapped
+        private Issue1670Child b;
+
+        public Issue1670(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+            this.b = new Issue1670Child(3, 4);
+        }
+
+        public static class Issue1670Child {
+            private int value3;
+            private int value4;
+
+            public Issue1670Child(int value3, int value4) {
+                this.value3 = value3;
+                this.value4 = value4;
+            }
+        }
+    }
+
+    @JsonPropertyOrder({"value2", "value3", "value1", "value4"})
+    static class JsonPropertyOrderTest {
+        private int value1;
+        private int value2;
+        @JsonUnwrapped
+        private Issue1670Child b;
+
+        public JsonPropertyOrderTest(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+            this.b = new Issue1670Child(3, 4);
+        }
+
+        public static class Issue1670Child {
+            private int value3;
+            private int value4;
+
+            public Issue1670Child(int value3, int value4) {
+                this.value3 = value3;
+                this.value4 = value4;
+            }
+        }
+    }
+
+    @Test
+    public void testSerialize1670() throws Exception {
+        String json = a2q("{'value4':4,'value3':3,'value2':2,'value1':1}");
+        ObjectMapper mapper = JsonMapper.builder()
+                .changeDefaultVisibility(vc ->
+                        vc.withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+                .build();
+
+        assertEquals(json, mapper.writeValueAsString(new Issue1670(1, 2)));
+    }
+
+    @Test
+    public void testJsonPropertyOrderTest() throws Exception {
+        String json = a2q("{'value2':2,'value3':3,'value1':1,'value4':4}");
+        ObjectMapper mapper = JsonMapper.builder()
+                .changeDefaultVisibility(vc ->
+                        vc.withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+                .build();
+
+        assertEquals(json, mapper.writeValueAsString(new JsonPropertyOrderTest(1, 2)));
+    }
+}

--- a/src/test/java/tools/jackson/databind/ser/JsonPropertyOrderWithUnwrapped1670Test.java
+++ b/src/test/java/tools/jackson/databind/ser/JsonPropertyOrderWithUnwrapped1670Test.java
@@ -14,55 +14,52 @@ import static tools.jackson.databind.testutil.JacksonTestUtilBase.a2q;
 public class JsonPropertyOrderWithUnwrapped1670Test {
 
     @JsonPropertyOrder({"value4", "value3", "value2", "value1"})
-    static class Issue1670 {
+    static class Issue1670
+    {
         private int value1;
         private int value2;
         @JsonUnwrapped
         private Issue1670Child b;
 
-        public Issue1670(int value1, int value2) {
+        public Issue1670(int value1, int value2)
+        {
             this.value1 = value1;
             this.value2 = value2;
             this.b = new Issue1670Child(3, 4);
-        }
-
-        public static class Issue1670Child {
-            private int value3;
-            private int value4;
-
-            public Issue1670Child(int value3, int value4) {
-                this.value3 = value3;
-                this.value4 = value4;
-            }
         }
     }
 
     @JsonPropertyOrder({"value2", "value3", "value1", "value4"})
-    static class JsonPropertyOrderTest {
+    static class JsonPropertyOrderTest
+    {
         private int value1;
         private int value2;
         @JsonUnwrapped
         private Issue1670Child b;
 
-        public JsonPropertyOrderTest(int value1, int value2) {
+        public JsonPropertyOrderTest(int value1, int value2)
+        {
             this.value1 = value1;
             this.value2 = value2;
             this.b = new Issue1670Child(3, 4);
         }
+    }
 
-        public static class Issue1670Child {
-            private int value3;
-            private int value4;
+    static class Issue1670Child
+    {
+        private int value3;
+        private int value4;
 
-            public Issue1670Child(int value3, int value4) {
-                this.value3 = value3;
-                this.value4 = value4;
-            }
+        public Issue1670Child(int value3, int value4)
+        {
+            this.value3 = value3;
+            this.value4 = value4;
         }
     }
 
     @Test
-    public void testSerialize1670() throws Exception {
+    public void testSerialize1670() throws Exception
+    {
         String json = a2q("{'value4':4,'value3':3,'value2':2,'value1':1}");
         ObjectMapper mapper = JsonMapper.builder()
                 .changeDefaultVisibility(vc ->
@@ -73,7 +70,8 @@ public class JsonPropertyOrderWithUnwrapped1670Test {
     }
 
     @Test
-    public void testJsonPropertyOrderTest() throws Exception {
+    public void testJsonPropertyOrderTest() throws Exception
+    {
         String json = a2q("{'value2':2,'value3':3,'value1':1,'value4':4}");
         ObjectMapper mapper = JsonMapper.builder()
                 .changeDefaultVisibility(vc ->


### PR DESCRIPTION
Issue: #1670

Previously, `@JsonPropertyOrder` was partially ignored when `@JsonUnwrapped` was used.
`@JsonPropertyOrder` now correctly orders `@JsonUnwrapped` inner properties during serialization.