### PR TITLE
Add missing `@JsonIdentityInfo` handling for implicit arrays with `DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1983,6 +1983,9 @@ Moritz Reyer (@MoritzR200)
  * Contributed #5537: Add missing `@JsonIdentityInfo` handling for implicit `Collection`s with
    `DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY`
   (2.20.2)
+ * Contributed #5541: Add missing `@JsonIdentityInfo` handling for implicit Arrays with
+   `DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY`
+  (2.21.0)
 
 Johnny Lim (@izeye)
  * Reported #5293: Fix minor typo in `PropertyBindingException.getMessageSuffix()`

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -34,6 +34,9 @@ Project: jackson-databind
  (implemented by @cowtowncoder, w/ Claude code)
 #5476: Support `@JsonSerializeAs` annotation
  (implemented by @cowtowncoder, w/ Claude code)
+#5541: Add missing `@JsonIdentityInfo` handling for implicit arrays with
+  `DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY`
+ (contributed by Moritz R)
 
 2.20.2 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -413,6 +413,7 @@ public class ObjectArrayDeserializer
             return ctxt.handleUnexpectedToken(_containerType, p);
         }
 
+        // 03-Jan-2026: [databind#5541] Support Object Id for implicit Object[]s too
         if (_elementDeserializer.getObjectIdReader() != null) {
             return _wrapSingleWithObjectId(p, ctxt);
         }
@@ -469,6 +470,8 @@ public class ObjectArrayDeserializer
         return result;
     }
 
+    // @since 2.21
+    // Copied from `_deserializeWithObjectId()`
     protected Object[] _wrapSingleWithObjectId(JsonParser p, DeserializationContext ctxt)
             throws IOException
     {
@@ -476,7 +479,6 @@ public class ObjectArrayDeserializer
         Object value;
         try {
             if (p.hasToken(JsonToken.VALUE_NULL)) {
-                // 03-Feb-2017, tatu: Should this be skipped or not?
                 if (_skipNullValues) {
                     return _emptyValue;
                 }
@@ -508,7 +510,6 @@ public class ObjectArrayDeserializer
 
             if (value == null) {
                 value = _nullProvider.getNullValue(ctxt);
-
                 if (value == null && _skipNullValues) {
                     return _emptyValue;
                 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/ObjectArrayDeserializer.java
@@ -284,9 +284,6 @@ public class ObjectArrayDeserializer
                     }
                     acc.add(value);
                 } catch (UnresolvedForwardReference reference) {
-                    if (acc == null) {
-                        throw reference;
-                    }
                     ArrayReferring referring = new ArrayReferring(reference, _elementClass, acc);
                     reference.getRoid().appendReferring(referring);
                 }
@@ -416,6 +413,10 @@ public class ObjectArrayDeserializer
             return ctxt.handleUnexpectedToken(_containerType, p);
         }
 
+        if (_elementDeserializer.getObjectIdReader() != null) {
+            return _wrapSingleWithObjectId(p, ctxt);
+        }
+
         Object value;
         if (p.hasToken(JsonToken.VALUE_NULL)) {
             // 03-Feb-2017, tatu: Should this be skipped or not?
@@ -466,6 +467,58 @@ public class ObjectArrayDeserializer
         }
         result[0] = value;
         return result;
+    }
+
+    protected Object[] _wrapSingleWithObjectId(JsonParser p, DeserializationContext ctxt)
+            throws IOException
+    {
+        final ObjectArrayReferringAccumulator acc = new ObjectArrayReferringAccumulator(_untyped, _elementClass);
+        Object value;
+        try {
+            if (p.hasToken(JsonToken.VALUE_NULL)) {
+                // 03-Feb-2017, tatu: Should this be skipped or not?
+                if (_skipNullValues) {
+                    return _emptyValue;
+                }
+                value = null;
+            } else {
+                if (p.hasToken(JsonToken.VALUE_STRING)) {
+                    String textValue = p.getText();
+                    // https://github.com/FasterXML/jackson-dataformat-xml/issues/513
+                    if (textValue.isEmpty()) {
+                        final CoercionAction act = ctxt.findCoercionAction(logicalType(), handledType(),
+                                CoercionInputShape.EmptyString);
+                        if (act != CoercionAction.Fail) {
+                            return (Object[]) _deserializeFromEmptyString(p, ctxt, act, handledType(),
+                                    "empty String (\"\")");
+                        }
+                    } else if (_isBlank(textValue)) {
+                        final CoercionAction act = ctxt.findCoercionFromBlankString(logicalType(), handledType(),
+                                CoercionAction.Fail);
+                        if (act != CoercionAction.Fail) {
+                            return (Object[]) _deserializeFromEmptyString(p, ctxt, act, handledType(),
+                                    "blank String (all whitespace)");
+                        }
+                    }
+                    // if coercion failed, we can still add it to a list
+                }
+
+                value = _deserializeNoNullChecks(p, ctxt);
+            }
+
+            if (value == null) {
+                value = _nullProvider.getNullValue(ctxt);
+
+                if (value == null && _skipNullValues) {
+                    return _emptyValue;
+                }
+            }
+            acc.add(value);
+        } catch (UnresolvedForwardReference reference) {
+            ArrayReferring referring = new ArrayReferring(reference, _elementClass, acc);
+            reference.getRoid().appendReferring(referring);
+        }
+        return acc.buildArray();
     }
 
     /**

--- a/src/test/java/com/fasterxml/jackson/databind/struct/SingleValueAsArrayTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/struct/SingleValueAsArrayTest.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -62,6 +64,30 @@ public class SingleValueAsArrayTest extends DatabindTestUtil
         }
     }
 
+    @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
+    static class IdentifiedType {
+        String entry;
+
+        @JsonCreator
+        IdentifiedType(@JsonProperty("entry") String entry)
+        {
+            this.entry = entry;
+        }
+    }
+
+    static class Bean1421D {
+        IdentifiedType[] array;
+        IdentifiedType value;
+
+        public void setValue(IdentifiedType value) {
+            this.value = value;
+        }
+
+        public void setArray(IdentifiedType[] array) {
+            this.array = array;
+        }
+    }
+
     /*
     /**********************************************************
     /* Unit tests
@@ -89,6 +115,17 @@ public class SingleValueAsArrayTest extends DatabindTestUtil
         List<String> expected = new ArrayList<>();
         expected.add("test2");
         assertEquals(expected, a.value);
+    }
+
+    @Test
+    public void testArrayWithObjectId() throws IOException
+    {
+        Bean1421D result = MAPPER.readValue("{\"array\":1,\"value\":{\"@id\":1,\"entry\":\"s\"}}", Bean1421D.class);
+        assertNotNull(result);
+        assertNotNull(result.value);
+        assertEquals(1, result.array.length);
+        assertNotNull(result.array[0]);
+        assertEquals("s", result.array[0].entry);
     }
 
     @Test


### PR DESCRIPTION
This fixes the same issue as https://github.com/FasterXML/jackson-databind/pull/5537 just for arrays in the `ObjectArrayDeserializer`.

I validated that this is still an issue in the branches 2.x and 3.x (the added test fails there without the fix).