### PR TITLE
Fix #1037: @JsonIgnoreProperties does not stack

### DIFF
--- a/src/main/java/tools/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/databind/AnnotationIntrospector.java
@@ -241,6 +241,16 @@ public abstract class AnnotationIntrospector
         return false;
     }
 
+    /**
+     * Method called to merge two annotations of the same type when
+     * collecting class-level annotations from type hierarchy.
+     *
+     * @since 3.1
+     */
+    public Annotation tryMergeClassAnnotation(Annotation existing, Annotation newValue) {
+        return null;
+    }
+
     /*
     /**********************************************************************
     /* Annotations for Object Id handling

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedClassResolver.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedClassResolver.java
@@ -307,6 +307,13 @@ public class AnnotatedClassResolver
                     if (_intr.isAnnotationBundle(ann)) {
                         c = _addFromBundleIfNotPresent(c, ann);
                     }
+                } else {
+                    Class<? extends Annotation> type = ann.annotationType();
+                    Annotation existing = c.asAnnotations().get(type);
+                    Annotation merged = _intr.tryMergeClassAnnotation(existing, ann);
+                    if (merged != null && merged != existing) {
+                        c = c.addOrOverride(merged);
+                    }
                 }
             }
         }

--- a/src/main/java/tools/jackson/databind/introspect/AnnotationIntrospectorPair.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotationIntrospectorPair.java
@@ -85,6 +85,18 @@ public class AnnotationIntrospectorPair
         return _primary.isAnnotationBundle(ann) || _secondary.isAnnotationBundle(ann);
     }
 
+    @Override
+    public Annotation tryMergeClassAnnotation(Annotation existing, Annotation newValue) {
+        Annotation merged = _primary.tryMergeClassAnnotation(existing, newValue);
+        if (merged != null) {
+            return merged;
+        }
+
+        // [databind#1037]: only support Jackson annotations
+        // return _secondary.tryMergeClassAnnotation(existing, newValue);
+        return null;
+    }
+
     /*
     /**********************************************************************
     /* General class annotations

--- a/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -163,6 +163,19 @@ public class JacksonAnnotationIntrospector
         return b.booleanValue();
     }
 
+    /**
+     * @since 3.1
+     */
+    @Override
+    public Annotation tryMergeClassAnnotation(Annotation existing, Annotation newValue) {
+        // Only handle JsonIgnoreProperties for now
+        // TODO: It will be added...
+        if (existing instanceof JsonIgnoreProperties && newValue instanceof JsonIgnoreProperties) {
+            return _mergeJsonIgnoreProperties((JsonIgnoreProperties) existing, (JsonIgnoreProperties) newValue);
+        }
+        return null;
+    }
+
     /*
     /**********************************************************************
     /* General annotations
@@ -275,26 +288,10 @@ public class JacksonAnnotationIntrospector
     public JsonIgnoreProperties.Value findPropertyIgnoralByName(MapperConfig<?> config, Annotated a)
     {
         JsonIgnoreProperties v = _findAnnotation(a, JsonIgnoreProperties.class);
-        JsonIgnoreProperties.Value result = (v == null)
-                ? JsonIgnoreProperties.Value.empty()
-                : JsonIgnoreProperties.Value.from(v);
-
-        // [databind#1037]: Need to collect JsonIgnoreProperties from super-classes for class-level
-        if (v != null) {
-            Set<String> ignoreNames = new HashSet<>(result.getIgnored());
-            for (Class<?> parent = a.getRawType().getSuperclass();
-                 (parent != null) && (parent != Object.class);
-                 parent = parent.getSuperclass()) {
-                JsonIgnoreProperties parentAnnotation = parent.getAnnotation(JsonIgnoreProperties.class);
-                if (parentAnnotation != null) {
-                    Set<String> parentIgnoreNames = JsonIgnoreProperties.Value.from(parentAnnotation).getIgnored();
-                    ignoreNames.addAll(parentIgnoreNames);
-                }
-            }
-            result = result.withIgnored(ignoreNames);
+        if (v == null) {
+            return JsonIgnoreProperties.Value.empty();
         }
-
-        return result;
+        return JsonIgnoreProperties.Value.from(v);
     }
 
     @Override
@@ -1526,5 +1523,50 @@ public class JacksonAnnotationIntrospector
     private DatabindException _databindException(Throwable t, String msg) {
         // not optimal as we have no parser/generator/context to pass
         return DatabindException.from((JsonParser) null, msg, t);
+    }
+
+    /**
+     * Helper method to merge two {@link JsonIgnoreProperties} annotations.
+     * The existing annotation (from more specific class) takes precedence for
+     * boolean flags, while ignored property names are combined (union).
+     *
+     * @since 3.1
+     */
+    private JsonIgnoreProperties _mergeJsonIgnoreProperties(JsonIgnoreProperties existing, JsonIgnoreProperties newValue) {
+        // Use Value class which already has merge logic
+        JsonIgnoreProperties.Value existingValue = JsonIgnoreProperties.Value.from(existing);
+        JsonIgnoreProperties.Value mergedValue = JsonIgnoreProperties.Value.from(newValue).withMerge();
+
+        // Merge: existing takes precedence, but names are combined
+        final JsonIgnoreProperties.Value merged = existingValue.withOverrides(mergedValue);
+
+        // Create a synthetic annotation instance
+        return new JsonIgnoreProperties() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonIgnoreProperties.class;
+            }
+
+            @Override
+            public String[] value() {
+                Set<String> ignored = merged.getIgnored();
+                return ignored.toArray(new String[0]);
+            }
+
+            @Override
+            public boolean ignoreUnknown() {
+                return merged.getIgnoreUnknown();
+            }
+
+            @Override
+            public boolean allowGetters() {
+                return merged.getAllowGetters();
+            }
+
+            @Override
+            public boolean allowSetters() {
+                return merged.getAllowSetters();
+            }
+        };
     }
 }

--- a/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -275,10 +275,26 @@ public class JacksonAnnotationIntrospector
     public JsonIgnoreProperties.Value findPropertyIgnoralByName(MapperConfig<?> config, Annotated a)
     {
         JsonIgnoreProperties v = _findAnnotation(a, JsonIgnoreProperties.class);
-        if (v == null) {
-            return JsonIgnoreProperties.Value.empty();
+        JsonIgnoreProperties.Value result = (v == null)
+                ? JsonIgnoreProperties.Value.empty()
+                : JsonIgnoreProperties.Value.from(v);
+
+        // [databind#1037]: Need to collect JsonIgnoreProperties from super-classes for class-level
+        if (v != null) {
+            Set<String> ignoreNames = new HashSet<>(result.getIgnored());
+            for (Class<?> parent = a.getRawType().getSuperclass();
+                 (parent != null) && (parent != Object.class);
+                 parent = parent.getSuperclass()) {
+                JsonIgnoreProperties parentAnnotation = parent.getAnnotation(JsonIgnoreProperties.class);
+                if (parentAnnotation != null) {
+                    Set<String> parentIgnoreNames = JsonIgnoreProperties.Value.from(parentAnnotation).getIgnored();
+                    ignoreNames.addAll(parentIgnoreNames);
+                }
+            }
+            result = result.withIgnored(ignoreNames);
         }
-        return JsonIgnoreProperties.Value.from(v);
+
+        return result;
     }
 
     @Override

--- a/src/test/java/tools/jackson/databind/deser/filter/JsonIgnorePropertiesInheritance1037Test.java
+++ b/src/test/java/tools/jackson/databind/deser/filter/JsonIgnorePropertiesInheritance1037Test.java
@@ -27,14 +27,15 @@ public class JsonIgnorePropertiesInheritance1037Test
         }
     }
 
+    ObjectMapper MAPPER = newJsonMapper();
+
     @Test
     public void testReadOnlyProp() throws Exception
     {
-        ObjectMapper m = newJsonMapper();
-        String json = m.writeValueAsString(new ReadOnlyBean1037());
+        String json = MAPPER.writeValueAsString(new ReadOnlyBean1037());
         assertTrue(json.contains("generated"));
         assertTrue(json.contains("computed"));
-        ReadOnlyBean1037 bean = m.readValue(json, ReadOnlyBean1037.class);
+        ReadOnlyBean1037 bean = MAPPER.readValue(json, ReadOnlyBean1037.class);
         assertNotNull(bean);
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/filter/JsonIgnorePropertiesInheritance1037Test.java
+++ b/src/test/java/tools/jackson/databind/deser/filter/JsonIgnorePropertiesInheritance1037Test.java
@@ -1,0 +1,40 @@
+package tools.jackson.databind.deser.filter;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// https://github.com/FasterXML/jackson-databind/issues/1037
+public class JsonIgnorePropertiesInheritance1037Test
+    extends DatabindTestUtil
+{
+    @JsonIgnoreProperties(value = {"generated"}, allowGetters = true)
+    static class BaseBean1037 {
+        public String getGenerated() {
+            return "http://bar.com";
+        }
+    }
+
+    @JsonIgnoreProperties(value = {"computed"}, allowGetters = true)
+    static class ReadOnlyBean1037 extends BaseBean1037 {
+        public int getComputed() {
+            return 32;
+        }
+    }
+
+    @Test
+    public void testReadOnlyProp() throws Exception
+    {
+        ObjectMapper m = newJsonMapper();
+        String json = m.writeValueAsString(new ReadOnlyBean1037());
+        assertTrue(json.contains("generated"));
+        assertTrue(json.contains("computed"));
+        ReadOnlyBean1037 bean = m.readValue(json, ReadOnlyBean1037.class);
+        assertNotNull(bean);
+    }
+}

--- a/src/test/java/tools/jackson/databind/deser/filter/JsonIgnorePropertiesInheritance1037Test.java
+++ b/src/test/java/tools/jackson/databind/deser/filter/JsonIgnorePropertiesInheritance1037Test.java
@@ -27,7 +27,7 @@ public class JsonIgnorePropertiesInheritance1037Test
         }
     }
 
-    ObjectMapper MAPPER = newJsonMapper();
+    private final ObjectMapper MAPPER = newJsonMapper();
 
     @Test
     public void testReadOnlyProp() throws Exception

--- a/src/test/java/tools/jackson/databind/tofix/JsonIgnorePropertiesInheritance1037Test.java
+++ b/src/test/java/tools/jackson/databind/tofix/JsonIgnorePropertiesInheritance1037Test.java
@@ -1,10 +1,12 @@
-package tools.jackson.databind.deser.filter;
+package tools.jackson.databind.tofix;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,7 +29,9 @@ public class JsonIgnorePropertiesInheritance1037Test
         }
     }
 
-    private final ObjectMapper MAPPER = newJsonMapper();
+    private final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
 
     @Test
     public void testReadOnlyProp() throws Exception


### PR DESCRIPTION
Issue: #1037

Previously, `@JsonIgnoreProperties` annotations didn't stack across inheritance hierarchies.
When both a parent class and child class had `@JsonIgnoreProperties` annotations, only the child's annotation was recognized, ignoring the parent's configuration entirely.

So, I fixed this by collecting ignored property names into ignoreNames and merging them using withIgnored().