### PR TITLE
Change defaulting of `JsonNode.asXxx(defaultValue)`/`JsonNode.asXxxOpt()` for `NullNode`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -196,6 +196,11 @@ Jaeheon Kim (@jher235)
    doesn't work on custom Collection subclass
   [3.1.0]
 
+Filip Hrisafov (@filiphr)
+ * Contributed #5558: Change defaulting of `JsonNode.asXxx(defaultValue)`/`JsonNode.asXxxOpt()`
+   for `NullNode`
+  [3.1.0]
+
 Réda Housni Alaoui (@reda-alaoui)
  * Requested #5575: Allow configuring a default serialization and deserialization view (3.x)
   [3.1.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -122,8 +122,11 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #5542: `ObjectReader.readValue()` does not fail when
   `DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS` enabled
  (implemented by @cowtowncoder, w/ Claude code)
+#5558: Change defaulting of `JsonNode.asXxx(defaultValue)`/`JsonNode.asXxxOpt()`
+  for `NullNode`
+ (contributed by Filip H)
 #5570: Add `MapperFeature.WRAPPERS_DEFAULT_TO_NULL` to allow configuring
-  `JsonInclude.Include.NON_DEFAULT` default for primitive wrapper types to be `null`,
+ `JsonInclude.Include.NON_DEFAULT` default for primitive wrapper types to be `null`,
   not wrapped default of primitive
 #5575: Allow configuring a default serialization and deserialization view (3.x)
  (requested by Réda H-A)

--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -611,13 +611,13 @@ public abstract class JsonNode
 
     /**
      * Similar to {@link #asString()}, but instead of throwing an exception for
-     * non-coercible values, will return specified default value.
+     * non-coercible values or coercing {@code null}, will return the specified default value.
      */
     public abstract String asString(String defaultValue);
 
     /**
      * Similar to {@link #asString()}, but instead of throwing an exception for
-     * non-coercible values, will return {@code Optional.empty()}.
+     * non-coercible values or coercing {@code null}, will return {@code Optional.empty()}.
      */
     public abstract Optional<String> asStringOpt();
 
@@ -703,13 +703,13 @@ public abstract class JsonNode
 
     /**
      * Similar to {@link #asBoolean()}, but instead of throwing an exception for
-     * non-coercible values, will return specified default value.
+     * non-coercible values or coercing {@code null}, will return the specified default value.
      */
     public abstract boolean asBoolean(boolean defaultValue);
 
     /**
      * Similar to {@link #asBoolean()}, but instead of throwing an exception for
-     * non-coercible values, will return {@code Optional.empty()}.
+     * non-coercible values or coercing {@code null}, will return {@code Optional.empty()}.
      */
     public abstract Optional<Boolean> asBooleanOpt();
 
@@ -794,7 +794,7 @@ public abstract class JsonNode
 
     /**
      * Method similar to {@link #shortValue()}, but that will return specified
-     * {@code defaultValue} if this node cannot be converted to {@code short}.
+     * {@code defaultValue} if this node cannot be converted to {@code short} or if the value is {@code null}.
      *
      * @param defaultValue Value to return if this node cannot be converted to {@code short}
      *
@@ -806,7 +806,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asShort()}, but that will return
      * ({@code Optional.empty()}) if this node cannot
-     * be coerced to {@code short}.
+     * be coerced to {@code short} or if the value is {@code null}.
      *
      * @return {@code Optional<Short>} value this node represents,
      * if possible to accurately represent; {@code Optional.empty()} otherwise
@@ -882,7 +882,7 @@ public abstract class JsonNode
 
     /**
      * Method similar to {@link #intValue()}, but that will return specified
-     * {@code defaultValue} if this node cannot be converted to {@code int}.
+     * {@code defaultValue} if this node cannot be converted to {@code int} or if the value is {@code null}.
      *
      * @param defaultValue Value to return if this node cannot be converted to {@code int}
      *
@@ -894,7 +894,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asInt()}, but that will return
      * ({@code OptionalInt.empty()}) if this node cannot
-     * be coerced to {@code int}.
+     * be coerced to {@code int} or if the value is {@code null}.
      *
      * @return {@link OptionalInt} value this node represents,
      * if possible to accurately represent; {@code OptionalInt.empty()} otherwise
@@ -971,7 +971,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asLong()}, but that will return specified
      * {@code defaultValue} if this node cannot be coerced to {@code long}
-     * (instead of throwing an exception).
+     * (instead of throwing an exception) or if the value is {@code null}.
      *
      * @param defaultValue Value to return if this node cannot be coerced to {@code long}
      *
@@ -983,7 +983,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asLong()}, but that will return
      * ({@code OptionalLong.empty()}) if this node cannot
-     * be coerced to {@code long}.
+     * be coerced to {@code long} or if the value is {@code null}.
      *
      * @return {@link OptionalLong} value this node represents (or can be coerced to),
      *    {@code OptionalLong.empty()} otherwise
@@ -1056,7 +1056,7 @@ public abstract class JsonNode
 
     /**
      * Method similar to {@link #asBigInteger()}, but that will return specified
-     * {@code defaultValue} if this node cannot be converted to {@link BigInteger}.
+     * {@code defaultValue} if this node cannot be converted to {@link BigInteger} or if the value is {@code null}.
      *
      * @param defaultValue Value to return if this node cannot be converted to {@link BigInteger}
      *
@@ -1068,7 +1068,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #bigIntegerValue()}, but that will return empty
      * ({@code Optional.empty()}) if this node cannot
-     * be converted to Java {@code BigInteger}.
+     * be converted to Java {@code BigInteger} or if the value is {@code null}.
      *
      * @return {@link BigInteger} value this node represents, as {@code Optional<BigInteger>},
      * if possible to accurately represent; {@code Optional.empty()} otherwise.
@@ -1138,7 +1138,7 @@ public abstract class JsonNode
 
     /**
      * Method similar to {@link #asFloat()}, but that will return {@code defaultValue}
-     * if this node cannot be coerced to {@code float}.
+     * if this node cannot be coerced to {@code float} or if the value is {@code null}.
      *
      * @return {@code float} value this node represents,
      * if possible to accurately represent; {@code defaultValue} otherwise
@@ -1148,7 +1148,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asFloat()}, but that will return
      * ({@code Optional.empty()}) if this node cannot
-     * be coerced to {@code float}.
+     * be coerced to {@code float} or if the value is {@code null}.
      *
      * @return {@code Optional<Float>} value this node represents,
      * if possible to accurately represent; {@code Optional.empty()} otherwise
@@ -1219,7 +1219,7 @@ public abstract class JsonNode
 
     /**
      * Method similar to {@link #asDouble()}, but that will return {@code defaultValue}
-     * if this node cannot be coerced to {@code double}.
+     * if this node cannot be coerced to {@code double} or if the value is {@code null}.
      *
      * @return {@code double} value this node represents,
      * if possible to accurately represent; {@code defaultValue} otherwise
@@ -1229,7 +1229,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asDouble()}, but that will return
      * ({@code OptionalDouble.empty()}) if this node cannot
-     * be coerced to {@code double}.
+     * be coerced to {@code double} or if the value is {@code null}.
      *
      * @return {@link OptionalDouble} value this node represents,
      * if possible to accurately represent; {@code OptionalDouble.empty()} otherwise
@@ -1302,7 +1302,7 @@ public abstract class JsonNode
 
     /**
      * Method similar to {@link #asDecimal()}, but that will return {@code defaultValue}
-     * if this node cannot be coerced to Java {@code BigDecimal}.
+     * if this node cannot be coerced to Java {@code BigDecimal} or if the value is {@code null}.
      *
      * @return {@code BigDecimal} value this node represents,
      * if possible to accurately represent; {@code defaultValue} otherwise
@@ -1312,7 +1312,7 @@ public abstract class JsonNode
     /**
      * Method similar to {@link #asDecimal()}, but that will return empty
      * {@link Optional} ({@code Optional.empty()}) if this node cannot
-     * be coerced to {@code BigDecimal}.
+     * be coerced to {@code BigDecimal} or if the value is {@code null}.
      *
      * @return Java {@code BigDecimal} value this node represents, as {@code Optional<BigDecimal>},
      * if possible to accurately represent; {@code Optional.empty()} otherwise

--- a/src/main/java/tools/jackson/databind/node/NullNode.java
+++ b/src/main/java/tools/jackson/databind/node/NullNode.java
@@ -55,8 +55,28 @@ public class NullNode
     }
 
     @Override
+    public boolean asBoolean(boolean defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public Optional<Boolean> asBooleanOpt() {
+        return Optional.empty();
+    }
+
+    @Override
     protected String _asString() {
         return "";
+    }
+
+    @Override
+    public String asString(String defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public Optional<String> asStringOpt() {
+        return Optional.empty();
     }
 
     // Explicit overrides for all overloads for documentation purposes
@@ -85,16 +105,6 @@ public class NullNode
         return 0;
     }
 
-    @Override
-    public short asShort(short defaultValue) {
-        return 0;
-    }
-
-    @Override
-    public Optional<Short> asShortOpt() {
-        return Optional.of((short) 0);
-    }
-
     // `intValue()` (etc) fine as defaults (fail); but need to override `asInt()`
 
     @Override
@@ -102,44 +112,16 @@ public class NullNode
         return 0;
     }
 
-    @Override
-    public int asInt(int defaultValue) {
-        return 0;
-    }
-
-    @Override
-    public OptionalInt asIntOpt() {
-        return OptionalInt.of(0);
-    }
-
     // `longValue()` (etc) fine as defaults (fail); but need to override `asLong()`
 
     @Override
     public long asLong() { return 0L; }
-
-    @Override
-    public long asLong(long defaultValue) { return 0L; }
-
-    @Override
-    public OptionalLong asLongOpt() {
-        return OptionalLong.of(0L);
-    }
 
     // `bigIntegerValue()` (etc) fine as defaults (fail); but need to override `asBigInteger()`
 
     @Override
     public BigInteger asBigInteger() {
         return BigInteger.ZERO;
-    }
-
-    @Override
-    public BigInteger asBigInteger(BigInteger defaultValue) {
-        return asBigInteger();
-    }
-
-    @Override
-    public Optional<BigInteger> asBigIntegerOpt() {
-        return Optional.of(asBigInteger());
     }
 
     // `floatValue()` (etc) fine as defaults (fail); but need to override `asFloat()`
@@ -149,16 +131,6 @@ public class NullNode
         return 0.0f;
     }
 
-    @Override
-    public float asFloat(float defaultValue) {
-        return asFloat();
-    }
-
-    @Override
-    public Optional<Float> asFloatOpt() {
-        return Optional.of(asFloat());
-    }
-
     // `doubleValue()` (etc) fine as defaults (fail); but need to override `asDouble()`
 
     @Override
@@ -166,31 +138,11 @@ public class NullNode
         return 0.0d;
     }
 
-    @Override
-    public double asDouble(double defaultValue) {
-        return asDouble();
-    }
-
-    @Override
-    public OptionalDouble asDoubleOpt() {
-        return OptionalDouble.of(asDouble());
-    }
-    
     // `decimalValue()` (etc) fine as defaults (fail); but need to override `asDecimal()`
 
     @Override
     public BigDecimal asDecimal() {
         return BigDecimal.ZERO;
-    }
-
-    @Override
-    public BigDecimal asDecimal(BigDecimal defaultValue) {
-        return asDecimal();
-    }
-
-    @Override
-    public Optional<BigDecimal> asDecimalOpt() {
-        return Optional.of(asDecimal());
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/node/NullNode.java
+++ b/src/main/java/tools/jackson/databind/node/NullNode.java
@@ -3,9 +3,6 @@ package tools.jackson.databind.node;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
 
 import tools.jackson.core.*;
 import tools.jackson.databind.JsonNode;

--- a/src/main/java/tools/jackson/databind/node/POJONode.java
+++ b/src/main/java/tools/jackson/databind/node/POJONode.java
@@ -69,6 +69,32 @@ public class POJONode
     }
 
     @Override
+    public boolean asBoolean(boolean defaultValue) {
+        // First, `null` same as `NullNode`
+        if (_value == null) {
+            return defaultValue;
+        }
+        if (_value instanceof Boolean B) {
+            return B;
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public Optional<Boolean> asBooleanOpt() {
+        // First, `null` same as `NullNode`
+        if (_value == null) {
+            return Optional.empty();
+        }
+
+        if (_value instanceof Boolean B) {
+            return B ? OPT_TRUE : OPT_FALSE;
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
     protected String _asString() {
         if (_value instanceof String str) {
              return str;
@@ -76,6 +102,18 @@ public class POJONode
         // 21-Mar-2025, tatu: [databind#5034] Should we consider RawValue too?
         //    (for now, won't)
         return null;
+    }
+
+    @Override
+    public String asString(String defaultValue) {
+        // First, `null` same as `NullNode`
+        if (_value == null) {
+            return defaultValue;
+        }
+        if (_value instanceof String str) {
+            return str;
+        }
+        return defaultValue;
     }
 
     /**
@@ -126,7 +164,7 @@ public class POJONode
     public short asShort(short defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return 0;
+            return defaultValue;
         }
 
         // Next, check if the value is NOT a Number
@@ -146,7 +184,7 @@ public class POJONode
     public Optional<Short> asShortOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return Optional.of((short) 0);
+            return Optional.empty();
         }
 
         // Next, check if the value is NOT a Number
@@ -190,7 +228,7 @@ public class POJONode
     public int asInt(int defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return 0;
+            return defaultValue;
         }
 
         // Next, check if the value is NOT a Number
@@ -210,7 +248,7 @@ public class POJONode
     public OptionalInt asIntOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return OptionalInt.of(0);
+            return OptionalInt.empty();
         }
 
         // Next, check if the value is NOT a Number
@@ -254,7 +292,7 @@ public class POJONode
     public long asLong(long defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return 0L;
+            return defaultValue;
         }
 
         // Next, report coercion fail if the value is NOT a Number
@@ -274,7 +312,7 @@ public class POJONode
     public OptionalLong asLongOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return OptionalLong.of(0L);
+            return OptionalLong.empty();
         }
 
         // Next, report coercion fail if the value is NOT a Number
@@ -313,7 +351,7 @@ public class POJONode
     public BigInteger asBigInteger(BigInteger defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return BigInteger.ZERO;
+            return defaultValue;
         }
 
         // Next, check if the value is NOT a Number
@@ -329,7 +367,7 @@ public class POJONode
     public Optional<BigInteger> asBigIntegerOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return Optional.of(BigInteger.ZERO);
+            return Optional.empty();
         }
 
         // Next, check if the value is NOT a Number
@@ -369,7 +407,7 @@ public class POJONode
     public float asFloat(float defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return 0.0f;
+            return defaultValue;
         }
 
         // Next, check if the value is NOT a Number
@@ -389,7 +427,7 @@ public class POJONode
     public Optional<Float> asFloatOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return Optional.of(0.0f);
+            return Optional.empty();
         }
 
         // Next, check if the value is NOT a Number
@@ -433,7 +471,7 @@ public class POJONode
     public double asDouble(double defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return 0.0d;
+            return defaultValue;
         }
 
         // Next, check if the value is NOT a Number
@@ -453,7 +491,7 @@ public class POJONode
     public OptionalDouble asDoubleOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return OptionalDouble.of(0.0d);
+            return OptionalDouble.empty();
         }
 
         // Next, check if the value is NOT a Number
@@ -492,7 +530,7 @@ public class POJONode
     public BigDecimal asDecimal(BigDecimal defaultValue) {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return BigDecimal.ZERO;
+            return defaultValue;
         }
 
         // Next, check if the value is NOT a Number
@@ -508,7 +546,7 @@ public class POJONode
     public Optional<BigDecimal> asDecimalOpt() {
         // First, `null` same as `NullNode`
         if (_value == null) {
-            return Optional.of(BigDecimal.ZERO);
+            return Optional.empty();
         }
 
         // Next, check if the value is NOT a Number

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
@@ -188,7 +188,11 @@ public class JsonNodeBigIntegerValueTest
     public void asBigIntegerFromMiscOther()
     {
         // NullNode becomes 0, not fail
-        _assertAsBigInteger(BigInteger.ZERO, NODES.nullNode());
+        assertEquals(BigInteger.ZERO, NODES.nullNode().asBigInteger());
+
+        // and then defaulting
+        assertEquals(BigInteger.valueOf(9999999L), NODES.nullNode().asBigInteger(BigInteger.valueOf(9999999L)));
+        assertFalse(NODES.nullNode().asBigIntegerOpt().isPresent());
 
         // But MissingNode still fails
         _assertAsBigIntegerFailForNonNumber(NODES.missingNode());

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBooleanValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBooleanValueTest.java
@@ -136,7 +136,9 @@ public class JsonNodeBooleanValueTest
     public void asBooleanFromNonNumberMisc()
     {
         // Null ok
-        _assertFalseFromAsBoolean(NODES.nullNode());
+        assertEquals(false, NODES.nullNode().asBoolean());
+        assertEquals(true, NODES.nullNode().asBoolean(true));
+        assertFalse(NODES.nullNode().asBooleanOpt().isPresent());
         // And POJO node with Boolean:
         _assertFalseFromAsBoolean(NODES.pojoNode(Boolean.FALSE));
         _assertTrueFromAsBoolean(NODES.pojoNode(Boolean.TRUE));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
@@ -211,7 +211,11 @@ public class JsonNodeDecimalValueTest
     public void asDecimalFromMiscOther()
     {
         // "null" becomes "0.0"
-        _assertAsDecimal(BigDecimal.ZERO, NODES.nullNode());
+        assertEquals(BigDecimal.ZERO, NODES.nullNode().asDecimal());
+
+        // but also defaulting
+        assertEquals(BD_DEFAULT, NODES.nullNode().asDecimal(BD_DEFAULT));
+        assertFalse(NODES.nullNode().asDecimalOpt().isPresent());
 
         // but "missing" still fails
         _assertFailAsDecimalForNonNumber(NODES.missingNode());

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
@@ -233,7 +233,11 @@ public class JsonNodeDoubleValueTest
     public void asDoubleFromMiscOther()
     {
         // Null node converts to 0.0d; missing fails
-        _assertAsDouble((double) 0, NODES.nullNode());
+        assertEquals(0.0d, NODES.nullNode().asDouble());
+
+        // and defaults
+        assertEquals(-9999.5, NODES.nullNode().asDouble(-9999.5));
+        assertFalse(NODES.nullNode().asDoubleOpt().isPresent());
 
         _assertAsDoubleFailForNonNumber(NODES.missingNode());
     }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
@@ -235,7 +235,11 @@ public class JsonNodeFloatValueTest
     public void asFloatFromMiscOther()
     {
         // Null node converts to 0.0f; missing fails
-        _assertAsFloat((float) 0, NODES.nullNode());
+        assertEquals(0.0f, NODES.nullNode().asFloat());
+
+        // and defaults
+        assertEquals(-9999.5f, NODES.nullNode().asFloat(-9999.5f));
+        assertFalse(NODES.nullNode().asFloatOpt().isPresent());
         _assertAsFloatFailForNonNumber(NODES.missingNode());
     }
 

--- a/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
@@ -301,7 +301,11 @@ public class JsonNodeIntValueTest
     public void asIntFromMiscOther()
     {
         // NullNode -> 0 but "missing" still fails
-        _assertAsInt(0, NODES.nullNode());
+        assertEquals(0, NODES.nullNode().asInt());
+
+        // and defaulting
+        assertEquals(999_999, NODES.nullNode().asInt(999_999));
+        assertFalse(NODES.nullNode().asIntOpt().isPresent());
 
         _assertAsIntFailForNonNumber(NODES.missingNode());
     }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
@@ -296,7 +296,11 @@ public class JsonNodeLongValueTest
     public void asLongFromMiscOther()
     {
         // NullNode works, Missing fails
-        _assertAsLong(0L, NODES.nullNode());
+        assertEquals(0L, NODES.nullNode().asLong());
+
+        // But also fallbacks
+        assertEquals(999999L, NODES.nullNode().asLong(999999L));
+        assertFalse(NODES.nullNode().asLongOpt().isPresent());
 
         _assertAsLongFailForNonNumber(NODES.missingNode());
     }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
@@ -282,7 +282,11 @@ public class JsonNodeShortValueTest
     public void asIntFromMiscOther()
     {
         // NullNode -> 0 but "missing" still fails
-        _assertAsShort((short) 0, NODES.nullNode());
+        assertEquals((short) 0, NODES.nullNode().asShort());
+
+        // and defaulting
+        assertEquals((short) 99, NODES.nullNode().asShort((short) 99));
+        assertFalse(NODES.nullNode().asShortOpt().isPresent());
 
         _assertAsShortFailForNonNumber(NODES.missingNode());
     }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeStringValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeStringValueTest.java
@@ -123,7 +123,11 @@ public class JsonNodeStringValueTest
     @Test
     public void asStringFromNonNumberMisc()
     {
-        _assertAsStringSuccess("", NODES.nullNode());
+        assertEquals("", NODES.nullNode().asString());
+
+        // But also fallbacks
+        assertEquals("fallback", NODES.nullNode().asString("fallback"));
+        assertFalse(NODES.nullNode().asStringOpt().isPresent());
 
         _assertAsStringFailForNonString(NODES.missingNode());
     }

--- a/src/test/java/tools/jackson/databind/node/MissingNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/MissingNodeTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonToken;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.exc.JsonNodeException;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MissingNodeTest extends NodeTestBase
@@ -19,7 +21,9 @@ public class MissingNodeTest extends NodeTestBase
         assertTrue(n.isMissingNode());
         assertEquals(JsonToken.NOT_AVAILABLE, n.asToken());
         // exception in 3.0:
-        //assertEquals("", n.asString());
+        assertThatThrownBy(n::asString)
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'MissingNode' method `asString()` cannot convert value <missing> to `java.lang.String`: value type not coercible to `String`");
         assertEquals("default", n.asString("default"));
         assertStandardEquals(n);
         // 10-Dec-2018, tatu: With 2.10, should serialize same as via ObjectMapper/ObjectWriter

--- a/src/test/java/tools/jackson/databind/node/MissingNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/MissingNodeTest.java
@@ -23,7 +23,7 @@ public class MissingNodeTest extends NodeTestBase
         // exception in 3.0:
         assertThatThrownBy(n::asString)
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'MissingNode' method `asString()` cannot convert value <missing> to `java.lang.String`: value type not coercible to `String`");
+                .hasMessage("'MissingNode' method `asString()` cannot coerce value <missing> to `java.lang.String`: value type not coercible");
         assertEquals("default", n.asString("default"));
         assertStandardEquals(n);
         // 10-Dec-2018, tatu: With 2.10, should serialize same as via ObjectMapper/ObjectWriter

--- a/src/test/java/tools/jackson/databind/node/NodeTestBase.java
+++ b/src/test/java/tools/jackson/databind/node/NodeTestBase.java
@@ -18,9 +18,9 @@ abstract class NodeTestBase extends DatabindTestUtil
         assertFalse(n.canConvertToExactIntegral());
 
         // As of 3.0, coercion rules vary by specific type so can no longer test these
-        //assertEquals(-42, n.asInt(-42));
-        //assertEquals(12345678901L, n.asLong(12345678901L));
-        //assertEquals(-19.25, n.asDouble(-19.25));
+        assertEquals(-42, n.asInt(-42));
+        assertEquals(12345678901L, n.asLong(12345678901L));
+        assertEquals(-19.25, n.asDouble(-19.25));
     }
 
     // Test to check conversions, coercions

--- a/src/test/java/tools/jackson/databind/node/NullNodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/NullNodeTest.java
@@ -47,7 +47,7 @@ public class NullNodeTest extends NodeTestBase
         // fallback accessors
 
         assertEquals("", n.asString());
-        assertEquals("", n.asString("fallback"));
+        assertEquals("fallback", n.asString("fallback"));
 
         assertEquals(0, n.size());
         assertTrue(n.isEmpty());

--- a/src/test/java/tools/jackson/databind/node/POJONodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/POJONodeTest.java
@@ -87,8 +87,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(Boolean.FALSE).asBoolean()).isFalse();
         assertThatThrownBy(() -> new POJONode(new Data()).asBoolean())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asBoolean()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `boolean`: value type not coercible to `boolean`");
+                .hasMessage("'POJONode' method `asBoolean()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `boolean`: value type not coercible");
     }
 
     @Test
@@ -111,13 +111,13 @@ public class POJONodeTest extends NodeTestBase
     public void testAsString() {
         assertThatThrownBy(() -> new POJONode(null).asString())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asString()` cannot convert value"
-                        + " {POJO of type [null]} to `java.lang.String`: value type not coercible to `String`");
+                .hasMessage("'POJONode' method `asString()` cannot coerce value"
+                        + " {POJO of type [null]} to `java.lang.String`: value type not coercible");
         assertThat(new POJONode("test").asString()).isEqualTo("test");
         assertThatThrownBy(() -> new POJONode(new Data()).asString())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asString()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.lang.String`: value type not coercible to `String`");
+                .hasMessage("'POJONode' method `asString()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.lang.String`: value type not coercible");
     }
 
     @Test
@@ -146,8 +146,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asShort()).isEqualTo((short) 99);
         assertThatThrownBy(() -> new POJONode(new Data()).asShort())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asShort()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `short`: value type not numeric");
+                .hasMessage("'POJONode' method `asShort()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `short`: value type not coercible");
     }
 
     @Test
@@ -188,8 +188,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asInt()).isEqualTo(99);
         assertThatThrownBy(() -> new POJONode(new Data()).asInt())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asInt()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `int`: value type not numeric");
+                .hasMessage("'POJONode' method `asInt()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `int`: value type not coercible");
     }
 
     @Test
@@ -230,8 +230,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asLong()).isEqualTo(99L);
         assertThatThrownBy(() -> new POJONode(new Data()).asLong())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asLong()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `long`: value type not numeric");
+                .hasMessage("'POJONode' method `asLong()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `long`: value type not coercible");
     }
 
     @Test
@@ -272,8 +272,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
         assertThatThrownBy(() -> new POJONode(new Data()).asBigInteger())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asBigInteger()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.math.BigInteger`: value type not numeric");
+                .hasMessage("'POJONode' method `asBigInteger()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.math.BigInteger`: value type not coercible");
     }
 
     @Test
@@ -314,8 +314,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asFloat()).isEqualTo(99.99f);
         assertThatThrownBy(() -> new POJONode(new Data()).asFloat())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asFloat()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `float`: value type not numeric");
+                .hasMessage("'POJONode' method `asFloat()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `float`: value type not coercible");
     }
 
     @Test
@@ -356,8 +356,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDouble()).isEqualTo(99.99D);
         assertThatThrownBy(() -> new POJONode(new Data()).asDouble())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asDouble()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `double`: value type not numeric");
+                .hasMessage("'POJONode' method `asDouble()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `double`: value type not coercible");
     }
 
     @Test
@@ -398,8 +398,8 @@ public class POJONodeTest extends NodeTestBase
         assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDecimal()).isEqualTo(BigDecimal.valueOf(99.99));
         assertThatThrownBy(() -> new POJONode(new Data()).asDecimal())
                 .isInstanceOf(JsonNodeException.class)
-                .hasMessage("'POJONode' method `asDecimal()` cannot convert value"
-                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.math.BigDecimal`: value type not coercible to `BigDecimal`");
+                .hasMessage("'POJONode' method `asDecimal()` cannot coerce value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.math.BigDecimal`: value type not coercible");
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/node/POJONodeTest.java
+++ b/src/test/java/tools/jackson/databind/node/POJONodeTest.java
@@ -1,5 +1,7 @@
 package tools.jackson.databind.node;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -8,8 +10,11 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.*;
 import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.exc.JsonNodeException;
 import tools.jackson.databind.ser.std.StdSerializer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class POJONodeTest extends NodeTestBase
@@ -73,6 +78,354 @@ public class POJONodeTest extends NodeTestBase
         JsonNode result = MAPPER.readTree(json);
         String msg = result.path("test").asString();
         assertEquals(dt, LocalDateTime.parse(msg));
+    }
+
+    @Test
+    public void testAsBoolean() {
+        assertThat(new POJONode(null).asBoolean()).isFalse();
+        assertThat(new POJONode(Boolean.TRUE).asBoolean()).isTrue();
+        assertThat(new POJONode(Boolean.FALSE).asBoolean()).isFalse();
+        assertThatThrownBy(() -> new POJONode(new Data()).asBoolean())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asBoolean()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `boolean`: value type not coercible to `boolean`");
+    }
+
+    @Test
+    public void testAsBooleanDefaultValue() {
+        assertThat(new POJONode(null).asBoolean(true)).isTrue();
+        assertThat(new POJONode(Boolean.TRUE).asBoolean(false)).isTrue();
+        assertThat(new POJONode(Boolean.FALSE).asBoolean(true)).isFalse();
+        assertThat(new POJONode(new Data()).asBoolean(true)).isTrue();
+    }
+
+    @Test
+    public void testAsBooleanOpt() {
+        assertThat(new POJONode(null).asBooleanOpt()).isNotPresent();
+        assertThat(new POJONode(Boolean.TRUE).asBooleanOpt()).hasValue(Boolean.TRUE);
+        assertThat(new POJONode(Boolean.FALSE).asBooleanOpt()).hasValue(Boolean.FALSE);
+        assertThat(new POJONode(new Data()).asBooleanOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsString() {
+        assertThatThrownBy(() -> new POJONode(null).asString())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asString()` cannot convert value"
+                        + " {POJO of type [null]} to `java.lang.String`: value type not coercible to `String`");
+        assertThat(new POJONode("test").asString()).isEqualTo("test");
+        assertThatThrownBy(() -> new POJONode(new Data()).asString())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asString()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.lang.String`: value type not coercible to `String`");
+    }
+
+    @Test
+    public void testAsStringDefaultValue() {
+        assertThat(new POJONode(null).asString("fallback")).isEqualTo("fallback");
+        assertThat(new POJONode("test").asString("fallback")).isEqualTo("test");
+        assertThat(new POJONode(new Data()).asString("fallback")).isEqualTo("fallback");
+    }
+
+    @Test
+    public void testAsStringOpt() {
+        assertThat(new POJONode(null).asStringOpt()).isNotPresent();
+        assertThat(new POJONode("test").asStringOpt()).hasValue("test");
+        assertThat(new POJONode(new Data()).asStringOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsShort() {
+        assertThat(new POJONode(null).asShort()).isEqualTo((short) 0);
+        assertThat(new POJONode(99.99D).asShort()).isEqualTo((short) 99);
+        assertThat(new POJONode(99L).asShort()).isEqualTo((short) 99);
+        assertThat(new POJONode(99).asShort()).isEqualTo((short) 99);
+        assertThat(new POJONode((short) 99).asShort()).isEqualTo((short) 99);
+        assertThat(new POJONode((byte) 99).asShort()).isEqualTo((short) 99);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asShort()).isEqualTo((short) 99);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asShort()).isEqualTo((short) 99);
+        assertThatThrownBy(() -> new POJONode(new Data()).asShort())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asShort()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `short`: value type not numeric");
+    }
+
+    @Test
+    public void testAsShortDefaultValue() {
+        assertThat(new POJONode(null).asShort((short) 10)).isEqualTo((short) 10);
+        assertThat(new POJONode(99.99D).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode(99L).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode(99).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode((short) 99).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode((byte) 99).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asShort((short) 10)).isEqualTo((short) 99);
+        assertThat(new POJONode(new Data()).asShort((short) 10)).isEqualTo((short) 10);
+    }
+
+    @Test
+    public void testAsShortOpt() {
+        assertThat(new POJONode(null).asShortOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode(99L).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode(99).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode((short) 99).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode((byte) 99).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asShortOpt()).hasValue((short) 99);
+        assertThat(new POJONode(new Data()).asShortOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsInt() {
+        assertThat(new POJONode(null).asInt()).isEqualTo(0);
+        assertThat(new POJONode(99.99D).asInt()).isEqualTo(99);
+        assertThat(new POJONode(99L).asInt()).isEqualTo(99);
+        assertThat(new POJONode(99).asInt()).isEqualTo(99);
+        assertThat(new POJONode((short) 99).asInt()).isEqualTo(99);
+        assertThat(new POJONode((byte) 99).asInt()).isEqualTo(99);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asInt()).isEqualTo(99);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asInt()).isEqualTo(99);
+        assertThatThrownBy(() -> new POJONode(new Data()).asInt())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asInt()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `int`: value type not numeric");
+    }
+
+    @Test
+    public void testAsIntDefaultValue() {
+        assertThat(new POJONode(null).asInt(10)).isEqualTo(10);
+        assertThat(new POJONode(99.99D).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode(99L).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode(99).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode((short) 99).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode((byte) 99).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asInt(10)).isEqualTo(99);
+        assertThat(new POJONode(new Data()).asInt(10)).isEqualTo(10);
+    }
+
+    @Test
+    public void testAsIntOpt() {
+        assertThat(new POJONode(null).asIntOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asIntOpt()).hasValue(99);
+        assertThat(new POJONode(99L).asIntOpt()).hasValue(99);
+        assertThat(new POJONode(99).asIntOpt()).hasValue(99);
+        assertThat(new POJONode((short) 99).asIntOpt()).hasValue(99);
+        assertThat(new POJONode((byte) 99).asIntOpt()).hasValue(99);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asIntOpt()).hasValue(99);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asIntOpt()).hasValue(99);
+        assertThat(new POJONode(new Data()).asIntOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsLong() {
+        assertThat(new POJONode(null).asLong()).isEqualTo(0L);
+        assertThat(new POJONode(99.99D).asLong()).isEqualTo(99L);
+        assertThat(new POJONode(99L).asLong()).isEqualTo(99L);
+        assertThat(new POJONode(99).asLong()).isEqualTo(99L);
+        assertThat(new POJONode((short) 99).asLong()).isEqualTo(99L);
+        assertThat(new POJONode((byte) 99).asLong()).isEqualTo(99L);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asLong()).isEqualTo(99L);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asLong()).isEqualTo(99L);
+        assertThatThrownBy(() -> new POJONode(new Data()).asLong())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asLong()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `long`: value type not numeric");
+    }
+
+    @Test
+    public void testAsLongDefaultValue() {
+        assertThat(new POJONode(null).asLong(10)).isEqualTo(10L);
+        assertThat(new POJONode(99.99D).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode(99L).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode(99).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode((short) 99).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode((byte) 99).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asLong(10)).isEqualTo(99L);
+        assertThat(new POJONode(new Data()).asLong(10)).isEqualTo(10L);
+    }
+
+    @Test
+    public void testAsLongOpt() {
+        assertThat(new POJONode(null).asLongOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode(99L).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode(99).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode((short) 99).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode((byte) 99).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asLongOpt()).hasValue(99L);
+        assertThat(new POJONode(new Data()).asLongOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsBigInteger() {
+        assertThat(new POJONode(null).asBigInteger()).isEqualTo(BigInteger.ZERO);
+        assertThat(new POJONode(99.99D).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(99L).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(99).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode((short) 99).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode((byte) 99).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(BigInteger.valueOf(99)).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asBigInteger()).isEqualTo(BigInteger.valueOf(99));
+        assertThatThrownBy(() -> new POJONode(new Data()).asBigInteger())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asBigInteger()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.math.BigInteger`: value type not numeric");
+    }
+
+    @Test
+    public void testAsBigIntegerDefaultValue() {
+        assertThat(new POJONode(null).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.TEN);
+        assertThat(new POJONode(99.99D).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(99L).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(99).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode((short) 99).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode((byte) 99).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(BigInteger.valueOf(99)).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.valueOf(99));
+        assertThat(new POJONode(new Data()).asBigInteger(BigInteger.TEN)).isEqualTo(BigInteger.TEN);
+    }
+
+    @Test
+    public void testAsBigIntegerOpt() {
+        assertThat(new POJONode(null).asBigIntegerOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode(99L).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode(99).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode((short) 99).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode((byte) 99).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode(BigInteger.valueOf(99)).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asBigIntegerOpt()).hasValue(BigInteger.valueOf(99));
+        assertThat(new POJONode(new Data()).asBigIntegerOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsFloat() {
+        assertThat(new POJONode(null).asFloat()).isEqualTo(0.0f);
+        assertThat(new POJONode(99.99D).asFloat()).isEqualTo(99.99f);
+        assertThat(new POJONode(99L).asFloat()).isEqualTo(99f);
+        assertThat(new POJONode(99).asFloat()).isEqualTo(99f);
+        assertThat(new POJONode((short) 99).asFloat()).isEqualTo(99f);
+        assertThat(new POJONode((byte) 99).asFloat()).isEqualTo(99f);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asFloat()).isEqualTo(99f);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asFloat()).isEqualTo(99.99f);
+        assertThatThrownBy(() -> new POJONode(new Data()).asFloat())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asFloat()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `float`: value type not numeric");
+    }
+
+    @Test
+    public void testAsFloatDefaultValue() {
+        assertThat(new POJONode(null).asFloat(10.0f)).isEqualTo(10.0f);
+        assertThat(new POJONode(99.99D).asFloat(10.0f)).isEqualTo(99.99f);
+        assertThat(new POJONode(99L).asFloat(10.0f)).isEqualTo(99f);
+        assertThat(new POJONode(99).asFloat(10.0f)).isEqualTo(99f);
+        assertThat(new POJONode((short) 99).asFloat(10.0f)).isEqualTo(99f);
+        assertThat(new POJONode((byte) 99).asFloat(10.0f)).isEqualTo(99f);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asFloat(10.0f)).isEqualTo(99f);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asFloat(10.0f)).isEqualTo(99.99f);
+        assertThat(new POJONode(new Data()).asFloat(10.0f)).isEqualTo(10.0f);
+    }
+
+    @Test
+    public void testAsFloatOpt() {
+        assertThat(new POJONode(null).asFloatOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asFloatOpt()).hasValue(99.99f);
+        assertThat(new POJONode(99L).asFloatOpt()).hasValue(99f);
+        assertThat(new POJONode(99).asFloatOpt()).hasValue(99f);
+        assertThat(new POJONode((short) 99).asFloatOpt()).hasValue(99f);
+        assertThat(new POJONode((byte) 99).asFloatOpt()).hasValue(99f);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asFloatOpt()).hasValue(99f);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asFloatOpt()).hasValue(99.99f);
+        assertThat(new POJONode(new Data()).asFloatOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsDouble() {
+        assertThat(new POJONode(null).asDouble()).isEqualTo(0.0D);
+        assertThat(new POJONode(99.99D).asDouble()).isEqualTo(99.99D);
+        assertThat(new POJONode(99L).asDouble()).isEqualTo(99D);
+        assertThat(new POJONode(99).asDouble()).isEqualTo(99D);
+        assertThat(new POJONode((short) 99).asDouble()).isEqualTo(99D);
+        assertThat(new POJONode((byte) 99).asDouble()).isEqualTo(99D);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asDouble()).isEqualTo(99D);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDouble()).isEqualTo(99.99D);
+        assertThatThrownBy(() -> new POJONode(new Data()).asDouble())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asDouble()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `double`: value type not numeric");
+    }
+
+    @Test
+    public void testAsDoubleDefaultValue() {
+        assertThat(new POJONode(null).asDouble(10.42D)).isEqualTo(10.42D);
+        assertThat(new POJONode(99.99D).asDouble(10.42D)).isEqualTo(99.99D);
+        assertThat(new POJONode(99L).asDouble(10.42D)).isEqualTo(99D);
+        assertThat(new POJONode(99).asDouble(10.42D)).isEqualTo(99D);
+        assertThat(new POJONode((short) 99).asDouble(10.42D)).isEqualTo(99D);
+        assertThat(new POJONode((byte) 99).asDouble(10.42D)).isEqualTo(99D);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asDouble(10.42D)).isEqualTo(99D);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDouble(10.42D)).isEqualTo(99.99D);
+        assertThat(new POJONode(new Data()).asDouble(10.42D)).isEqualTo(10.42D);
+    }
+
+    @Test
+    public void testAsDoubleOpt() {
+        assertThat(new POJONode(null).asDoubleOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asDoubleOpt()).hasValue(99.99D);
+        assertThat(new POJONode(99L).asDoubleOpt()).hasValue(99D);
+        assertThat(new POJONode(99).asDoubleOpt()).hasValue(99D);
+        assertThat(new POJONode((short) 99).asDoubleOpt()).hasValue(99D);
+        assertThat(new POJONode((byte) 99).asDoubleOpt()).hasValue(99D);
+        assertThat(new POJONode(BigInteger.valueOf(99)).asDoubleOpt()).hasValue(99D);
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDoubleOpt()).hasValue(99.99D);
+        assertThat(new POJONode(new Data()).asDoubleOpt()).isNotPresent();
+    }
+
+    @Test
+    public void testAsDecimal() {
+        assertThat(new POJONode(null).asDecimal()).isEqualTo(BigDecimal.ZERO);
+        assertThat(new POJONode(99.99D).asDecimal()).isEqualTo(BigDecimal.valueOf(99.99));
+        assertThat(new POJONode(99L).asDecimal()).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode(99).asDecimal()).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode((short) 99).asDecimal()).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode((byte) 99).asDecimal()).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode(BigInteger.valueOf(99)).asDecimal()).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDecimal()).isEqualTo(BigDecimal.valueOf(99.99));
+        assertThatThrownBy(() -> new POJONode(new Data()).asDecimal())
+                .isInstanceOf(JsonNodeException.class)
+                .hasMessage("'POJONode' method `asDecimal()` cannot convert value"
+                        + " {POJO of type `tools.jackson.databind.node.POJONodeTest$Data`} to `java.math.BigDecimal`: value type not coercible to `BigDecimal`");
+    }
+
+    @Test
+    public void testAsDecimalDefaultValue() {
+        assertThat(new POJONode(null).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.TEN);
+        assertThat(new POJONode(99.99D).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99.99));
+        assertThat(new POJONode(99L).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode(99).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode((short) 99).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode((byte) 99).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode(BigInteger.valueOf(99)).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99));
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.valueOf(99.99));
+        assertThat(new POJONode(new Data()).asDecimal(BigDecimal.TEN)).isEqualTo(BigDecimal.TEN);
+    }
+
+    @Test
+    public void testAsDecimalOpt() {
+        assertThat(new POJONode(null).asDecimalOpt()).isNotPresent();
+        assertThat(new POJONode(99.99D).asDecimalOpt()).hasValue(BigDecimal.valueOf(99.99));
+        assertThat(new POJONode(99L).asDecimalOpt()).hasValue(BigDecimal.valueOf(99));
+        assertThat(new POJONode(99).asDecimalOpt()).hasValue(BigDecimal.valueOf(99));
+        assertThat(new POJONode((short) 99).asDecimalOpt()).hasValue(BigDecimal.valueOf(99));
+        assertThat(new POJONode((byte) 99).asDecimalOpt()).hasValue(BigDecimal.valueOf(99));
+        assertThat(new POJONode(BigInteger.valueOf(99)).asDecimalOpt()).hasValue(BigDecimal.valueOf(99));
+        assertThat(new POJONode(BigDecimal.valueOf(99.99)).asDecimalOpt()).hasValue(BigDecimal.valueOf(99.99));
+        assertThat(new POJONode(new Data()).asDecimalOpt()).isNotPresent();
     }
 
 }


### PR DESCRIPTION
Closes #5558

As discussed in #5417 and #5558 this PR changes the way `JsonNode.asXxx(defaultValue)` and `JsonNode.asXxxOpt()` works for `NullNode`.

Thew new behaviour is the following:

* Always use `defaultValue` when using `NullNode`
* Always return `Optional.empty()` when using `NullNode`

I also believe that the tests added to `POJONodeTest` would increase the test coverage a bit as per #5568