### PR TITLE
JsonNode changes to improve conversion vs coercion exception messages

### DIFF
--- a/src/main/java/tools/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/tools/jackson/databind/node/ArrayNode.java
@@ -68,7 +68,11 @@ public class ArrayNode
 
     @Override
     protected String _valueDesc() {
-        return "[...(" + _children.size() + " elements)]";
+        int size = _children.size();
+        if (size == 0) {
+            return "[ ]";
+        }
+        return "[...(" + size + " elements)]";
     }
     
     // note: co-variant to allow caller-side type safety

--- a/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
@@ -62,12 +62,14 @@ public abstract class BaseJsonNode
 
     @Override
     public Number numberValue() {
-        return _reportCoercionFail("numberValue()", Number.class, "value type not numeric");
+        return _reportConversionFail("numberValue()", Number.class,
+                "value type not numeric");
     }
 
     @Override
     public short shortValue() {
-        return _reportCoercionFail("shortValue()", Short.TYPE, "value type not numeric");
+        return _reportConversionFail("shortValue()", Short.TYPE,
+                "value type not numeric");
     }
 
     @Override
@@ -84,7 +86,7 @@ public abstract class BaseJsonNode
 
     @Override
     public short asShort() {
-        return _reportCoercionFail("asShort()", Short.TYPE, "value type not numeric");
+        return _reportCoercionFail("asShort()", Short.TYPE);
     }
 
     @Override
@@ -101,7 +103,8 @@ public abstract class BaseJsonNode
 
     @Override
     public int intValue() {
-        return _reportCoercionFail("intValue()", Integer.TYPE, "value type not numeric");
+        return _reportConversionFail("intValue()", Integer.TYPE,
+                "value type not numeric");
     }
 
     @Override
@@ -118,7 +121,7 @@ public abstract class BaseJsonNode
 
     @Override
     public int asInt() {
-        return _reportCoercionFail("asInt()", Integer.TYPE, "value type not numeric");
+        return _reportCoercionFail("asInt()", Integer.TYPE);
     }
 
     @Override
@@ -135,7 +138,8 @@ public abstract class BaseJsonNode
 
     @Override
     public long longValue() {
-        return _reportCoercionFail("longValue()", Long.TYPE, "value type not numeric");
+        return _reportConversionFail("longValue()", Long.TYPE,
+                "value type not numeric");
     }
 
     @Override
@@ -152,7 +156,7 @@ public abstract class BaseJsonNode
 
     @Override
     public long asLong() {
-        return _reportCoercionFail("asLong()", Long.TYPE, "value type not numeric");
+        return _reportCoercionFail("asLong()", Long.TYPE);
     }
 
     @Override
@@ -169,7 +173,8 @@ public abstract class BaseJsonNode
 
     @Override
     public BigInteger bigIntegerValue() {
-        return _reportCoercionFail("bigIntegerValue()", BigInteger.class, "value type not numeric");
+        return _reportConversionFail("bigIntegerValue()", BigInteger.class,
+                "value type not numeric");
     }
 
     @Override
@@ -186,7 +191,7 @@ public abstract class BaseJsonNode
 
     @Override
     public BigInteger asBigInteger() {
-        return _reportCoercionFail("asBigInteger()", BigInteger.class, "value type not numeric");
+        return _reportCoercionFail("asBigInteger()", BigInteger.class);
     }
 
     @Override
@@ -203,7 +208,8 @@ public abstract class BaseJsonNode
 
     @Override
     public float floatValue() {
-        return _reportCoercionFail("floatValue()", Float.TYPE, "value type not numeric");
+        return _reportConversionFail("floatValue()", Float.TYPE,
+                "value type not numeric");
     }
 
     @Override
@@ -220,7 +226,7 @@ public abstract class BaseJsonNode
 
     @Override
     public float asFloat() {
-        return _reportCoercionFail("asFloat()", Float.TYPE, "value type not numeric");
+        return _reportCoercionFail("asFloat()", Float.TYPE);
     }
 
     @Override
@@ -237,7 +243,8 @@ public abstract class BaseJsonNode
 
     @Override
     public double doubleValue() {
-        return _reportCoercionFail("doubleValue()", Double.TYPE, "value type not numeric");
+        return _reportConversionFail("doubleValue()", Double.TYPE,
+                "value type not numeric");
     }
 
     @Override
@@ -254,7 +261,7 @@ public abstract class BaseJsonNode
 
     @Override
     public double asDouble() {
-        return _reportCoercionFail("asDouble()", Double.TYPE, "value type not numeric");
+        return _reportCoercionFail("asDouble()", Double.TYPE);
     }
 
     @Override
@@ -271,7 +278,8 @@ public abstract class BaseJsonNode
 
     @Override
     public BigDecimal decimalValue() {
-        return _reportCoercionFail("decimalValue()", BigDecimal.class, "value type not numeric");
+        return _reportConversionFail("decimalValue()", BigDecimal.class,
+                "value type not numeric");
     }
 
     @Override
@@ -288,8 +296,7 @@ public abstract class BaseJsonNode
 
     @Override
     public BigDecimal asDecimal() {
-        return _reportCoercionFail("asDecimal()", BigDecimal.class,
-                "value type not coercible to `BigDecimal`");
+        return _reportCoercionFail("asDecimal()", BigDecimal.class);
     }
 
     @Override
@@ -312,13 +319,13 @@ public abstract class BaseJsonNode
 
     @Override
     public byte[] binaryValue() {
-        return _reportCoercionFail("binaryValue()", Boolean.TYPE,
+        return _reportConversionFail("binaryValue()", Boolean.TYPE,
                 "value type not binary (or convertible to binary via Base64-decoding)");
     }
 
     @Override
     public boolean booleanValue() {
-        return _reportCoercionFail("booleanValue()", Boolean.TYPE,
+        return _reportConversionFail("booleanValue()", Boolean.TYPE,
                 "value type not boolean");
     }
 
@@ -338,8 +345,7 @@ public abstract class BaseJsonNode
     public boolean asBoolean() {
         Boolean b = _asBoolean();
         if (b == null) {
-            return _reportCoercionFail("asBoolean()", Boolean.TYPE,
-                    "value type not coercible to `boolean`");
+            return _reportCoercionFail("asBoolean()", Boolean.TYPE);
         }
         return b;
     }
@@ -364,7 +370,7 @@ public abstract class BaseJsonNode
 
     @Override
     public String stringValue() {
-        return _reportCoercionFail("stringValue()", String.class,
+        return _reportConversionFail("stringValue()", String.class,
                 "value type not String");
     }
 
@@ -384,8 +390,7 @@ public abstract class BaseJsonNode
     public String asString() {
         String str = _asString();
         if (str == null) {
-            return _reportCoercionFail("asString()", String.class,
-                    "value type not coercible to `String`");
+            return _reportCoercionFail("asString()", String.class);
         }
         return str;
     }
@@ -649,7 +654,23 @@ public abstract class BaseJsonNode
     /**********************************************************************
      */
 
+    // @since 3.1
+    protected <T> T _reportCoercionFail(String method, Class<?> targetType)
+    {
+        return _reportCoercionFail(method, targetType, "value type not coercible");
+    }
+
+    // @since 3.0
     protected <T> T _reportCoercionFail(String method, Class<?> targetType,
+            String message)
+    {
+        throw JsonNodeException.from(this, "'%s' method `%s` cannot coerce value %s to %s: %s",
+                getClass().getSimpleName(), method,
+                _valueDesc(), ClassUtil.nameOf(targetType), message);
+    }
+
+    // @since 3.1
+    protected <T> T _reportConversionFail(String method, Class<?> targetType,
             String message)
     {
         throw JsonNodeException.from(this, "'%s' method `%s` cannot convert value %s to %s: %s",
@@ -662,8 +683,20 @@ public abstract class BaseJsonNode
             "value not in 16-bit `short` range");
     }
 
+    // @since 3.1
+    protected short _reportShortConversionRangeFail(String method) {
+        return _reportConversionFail(method, Short.TYPE,
+            "value not in 16-bit `short` range");
+    }
+
     protected int _reportIntCoercionRangeFail(String method) {
         return _reportCoercionFail(method, Integer.TYPE,
+            "value not in 32-bit `int` range");
+    }
+
+    // @since 3.1
+    protected int _reportIntConversionRangeFail(String method) {
+        return _reportConversionFail(method, Integer.TYPE,
             "value not in 32-bit `int` range");
     }
 
@@ -672,8 +705,20 @@ public abstract class BaseJsonNode
             "value not in 64-bit `long` range");
     }
 
+    // @since 3.1
+    protected long _reportLongConversionRangeFail(String method) {
+        return _reportConversionFail(method, Long.TYPE,
+            "value not in 64-bit `long` range");
+    }
+
     protected float _reportFloatCoercionRangeFail(String method) {
         return _reportCoercionFail(method, Float.TYPE,
+            "value not in 32-bit `float` range");
+    }
+
+    // @since 3.1
+    protected float _reportFloatConversionRangeFail(String method) {
+        return _reportConversionFail(method, Float.TYPE,
             "value not in 32-bit `float` range");
     }
 
@@ -682,8 +727,20 @@ public abstract class BaseJsonNode
             "value not in 64-bit `double` range");
     }
 
+    // @since 3.1
+    protected double _reportDoubleConversionRangeFail(String method) {
+        return _reportConversionFail(method, Double.TYPE,
+            "value not in 64-bit `double` range");
+    }
+
     protected short _reportShortCoercionFractionFail(String method) {
         return _reportCoercionFail(method, Short.TYPE,
+                "value has fractional part");
+    }
+
+    // @since 3.1
+    protected short _reportShortConversionFractionFail(String method) {
+        return _reportConversionFail(method, Short.TYPE,
                 "value has fractional part");
     }
 
@@ -692,8 +749,20 @@ public abstract class BaseJsonNode
                 "value has fractional part");
     }
 
+    // @since 3.1
+    protected int _reportIntConversionFractionFail(String method) {
+        return _reportConversionFail(method, Integer.TYPE,
+                "value has fractional part");
+    }
+
     protected long _reportLongCoercionFractionFail(String method) {
         return _reportCoercionFail(method, Long.TYPE,
+                "value has fractional part");
+    }
+
+    // @since 3.1
+    protected long _reportLongConversionFractionFail(String method) {
+        return _reportConversionFail(method, Long.TYPE,
                 "value has fractional part");
     }
 
@@ -702,8 +771,20 @@ public abstract class BaseJsonNode
                 "value has fractional part");
     }
 
+    // @since 3.1
+    protected BigInteger _reportBigIntegerConversionFractionFail(String method) {
+        return _reportConversionFail(method, BigInteger.class,
+                "value has fractional part");
+    }
+
     protected int _reportIntCoercionNaNFail(String method) {
         return _reportCoercionFail(method, Integer.TYPE,
+                "value non-Finite ('NaN')");
+    }
+
+    // @since 3.1
+    protected int _reportIntConversionNaNFail(String method) {
+        return _reportConversionFail(method, Integer.TYPE,
                 "value non-Finite ('NaN')");
     }
 
@@ -712,13 +793,31 @@ public abstract class BaseJsonNode
                 "value non-Finite ('NaN')");
     }
 
+    // @since 3.1
+    protected long _reportLongConversionNaNFail(String method) {
+        return _reportConversionFail(method, Long.TYPE,
+                "value non-Finite ('NaN')");
+    }
+
     protected BigInteger _reportBigIntegerCoercionNaNFail(String method) {
         return _reportCoercionFail(method, BigInteger.class,
                 "value non-Finite ('NaN')");
     }
     
+    // @since 3.1
+    protected BigInteger _reportBigIntegerConversonNaNFail(String method) {
+        return _reportConversionFail(method, BigInteger.class,
+                "value non-Finite ('NaN')");
+    }
+
     protected BigDecimal _reportBigDecimalCoercionNaNFail(String method) {
         return _reportCoercionFail(method, BigDecimal.class,
+                "value non-Finite ('NaN')");
+    }
+
+    // @since 3.1
+    protected BigDecimal _reportBigDecimalConversionNaNFail(String method) {
+        return _reportConversionFail(method, BigDecimal.class,
                 "value non-Finite ('NaN')");
     }
 

--- a/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
@@ -62,13 +62,13 @@ public abstract class BaseJsonNode
 
     @Override
     public Number numberValue() {
-        return _reportConversionFail("numberValue()", Number.class,
+        return _reportCoercionFail("numberValue()", Number.class,
                 "value type not numeric");
     }
 
     @Override
     public short shortValue() {
-        return _reportConversionFail("shortValue()", Short.TYPE,
+        return _reportCoercionFail("shortValue()", Short.TYPE,
                 "value type not numeric");
     }
 
@@ -103,7 +103,7 @@ public abstract class BaseJsonNode
 
     @Override
     public int intValue() {
-        return _reportConversionFail("intValue()", Integer.TYPE,
+        return _reportCoercionFail("intValue()", Integer.TYPE,
                 "value type not numeric");
     }
 
@@ -138,7 +138,7 @@ public abstract class BaseJsonNode
 
     @Override
     public long longValue() {
-        return _reportConversionFail("longValue()", Long.TYPE,
+        return _reportCoercionFail("longValue()", Long.TYPE,
                 "value type not numeric");
     }
 
@@ -173,7 +173,7 @@ public abstract class BaseJsonNode
 
     @Override
     public BigInteger bigIntegerValue() {
-        return _reportConversionFail("bigIntegerValue()", BigInteger.class,
+        return _reportCoercionFail("bigIntegerValue()", BigInteger.class,
                 "value type not numeric");
     }
 
@@ -208,7 +208,7 @@ public abstract class BaseJsonNode
 
     @Override
     public float floatValue() {
-        return _reportConversionFail("floatValue()", Float.TYPE,
+        return _reportCoercionFail("floatValue()", Float.TYPE,
                 "value type not numeric");
     }
 
@@ -243,7 +243,7 @@ public abstract class BaseJsonNode
 
     @Override
     public double doubleValue() {
-        return _reportConversionFail("doubleValue()", Double.TYPE,
+        return _reportCoercionFail("doubleValue()", Double.TYPE,
                 "value type not numeric");
     }
 
@@ -278,7 +278,7 @@ public abstract class BaseJsonNode
 
     @Override
     public BigDecimal decimalValue() {
-        return _reportConversionFail("decimalValue()", BigDecimal.class,
+        return _reportCoercionFail("decimalValue()", BigDecimal.class,
                 "value type not numeric");
     }
 

--- a/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
@@ -678,20 +678,10 @@ public abstract class BaseJsonNode
                 _valueDesc(), ClassUtil.nameOf(targetType), message);
     }
 
-    protected short _reportShortCoercionRangeFail(String method) {
-        return _reportCoercionFail(method, Short.TYPE,
-            "value not in 16-bit `short` range");
-    }
-
     // @since 3.1
     protected short _reportShortConversionRangeFail(String method) {
         return _reportConversionFail(method, Short.TYPE,
             "value not in 16-bit `short` range");
-    }
-
-    protected int _reportIntCoercionRangeFail(String method) {
-        return _reportCoercionFail(method, Integer.TYPE,
-            "value not in 32-bit `int` range");
     }
 
     // @since 3.1
@@ -700,20 +690,10 @@ public abstract class BaseJsonNode
             "value not in 32-bit `int` range");
     }
 
-    protected long _reportLongCoercionRangeFail(String method) {
-        return _reportCoercionFail(method, Long.TYPE,
-            "value not in 64-bit `long` range");
-    }
-
     // @since 3.1
     protected long _reportLongConversionRangeFail(String method) {
         return _reportConversionFail(method, Long.TYPE,
             "value not in 64-bit `long` range");
-    }
-
-    protected float _reportFloatCoercionRangeFail(String method) {
-        return _reportCoercionFail(method, Float.TYPE,
-            "value not in 32-bit `float` range");
     }
 
     // @since 3.1
@@ -722,30 +702,15 @@ public abstract class BaseJsonNode
             "value not in 32-bit `float` range");
     }
 
-    protected double _reportDoubleCoercionRangeFail(String method) {
-        return _reportCoercionFail(method, Double.TYPE,
-            "value not in 64-bit `double` range");
-    }
-
     // @since 3.1
     protected double _reportDoubleConversionRangeFail(String method) {
         return _reportConversionFail(method, Double.TYPE,
             "value not in 64-bit `double` range");
     }
 
-    protected short _reportShortCoercionFractionFail(String method) {
-        return _reportCoercionFail(method, Short.TYPE,
-                "value has fractional part");
-    }
-
     // @since 3.1
     protected short _reportShortConversionFractionFail(String method) {
         return _reportConversionFail(method, Short.TYPE,
-                "value has fractional part");
-    }
-
-    protected int _reportIntCoercionFractionFail(String method) {
-        return _reportCoercionFail(method, Integer.TYPE,
                 "value has fractional part");
     }
 
@@ -755,19 +720,9 @@ public abstract class BaseJsonNode
                 "value has fractional part");
     }
 
-    protected long _reportLongCoercionFractionFail(String method) {
-        return _reportCoercionFail(method, Long.TYPE,
-                "value has fractional part");
-    }
-
     // @since 3.1
     protected long _reportLongConversionFractionFail(String method) {
         return _reportConversionFail(method, Long.TYPE,
-                "value has fractional part");
-    }
-
-    protected BigInteger _reportBigIntegerCoercionFractionFail(String method) {
-        return _reportCoercionFail(method, BigInteger.class,
                 "value has fractional part");
     }
 
@@ -777,19 +732,9 @@ public abstract class BaseJsonNode
                 "value has fractional part");
     }
 
-    protected int _reportIntCoercionNaNFail(String method) {
-        return _reportCoercionFail(method, Integer.TYPE,
-                "value non-Finite ('NaN')");
-    }
-
     // @since 3.1
     protected int _reportIntConversionNaNFail(String method) {
         return _reportConversionFail(method, Integer.TYPE,
-                "value non-Finite ('NaN')");
-    }
-
-    protected long _reportLongCoercionNaNFail(String method) {
-        return _reportCoercionFail(method, Long.TYPE,
                 "value non-Finite ('NaN')");
     }
 
@@ -799,19 +744,9 @@ public abstract class BaseJsonNode
                 "value non-Finite ('NaN')");
     }
 
-    protected BigInteger _reportBigIntegerCoercionNaNFail(String method) {
-        return _reportCoercionFail(method, BigInteger.class,
-                "value non-Finite ('NaN')");
-    }
-    
     // @since 3.1
     protected BigInteger _reportBigIntegerConversionNaNFail(String method) {
         return _reportConversionFail(method, BigInteger.class,
-                "value non-Finite ('NaN')");
-    }
-
-    protected BigDecimal _reportBigDecimalCoercionNaNFail(String method) {
-        return _reportCoercionFail(method, BigDecimal.class,
                 "value non-Finite ('NaN')");
     }
 

--- a/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
@@ -805,7 +805,7 @@ public abstract class BaseJsonNode
     }
     
     // @since 3.1
-    protected BigInteger _reportBigIntegerConversonNaNFail(String method) {
+    protected BigInteger _reportBigIntegerConversionNaNFail(String method) {
         return _reportConversionFail(method, BigInteger.class,
                 "value non-Finite ('NaN')");
     }

--- a/src/main/java/tools/jackson/databind/node/BigIntegerNode.java
+++ b/src/main/java/tools/jackson/databind/node/BigIntegerNode.java
@@ -72,7 +72,7 @@ public class BigIntegerNode
         if (inShortRange()) {
             return _value.shortValue();
         }
-        return _reportShortCoercionRangeFail("shortValue()");
+        return _reportShortConversionRangeFail("shortValue()");
     }
 
     @Override
@@ -90,7 +90,7 @@ public class BigIntegerNode
         if (inShortRange()) {
             return _value.shortValue();
         }
-        return _reportShortCoercionRangeFail("asShort()");
+        return _reportShortConversionRangeFail("asShort()");
     }
 
     @Override
@@ -108,7 +108,7 @@ public class BigIntegerNode
         if (inIntRange()) {
             return _value.intValue();
         }
-        return _reportIntCoercionRangeFail("intValue()");
+        return _reportIntConversionRangeFail("intValue()");
     }
 
     @Override
@@ -126,7 +126,7 @@ public class BigIntegerNode
         if (inIntRange()) {
             return _value.intValue();
         }
-        return _reportIntCoercionRangeFail("asInt()");
+        return _reportIntConversionRangeFail("asInt()");
     }
 
     @Override
@@ -144,7 +144,7 @@ public class BigIntegerNode
         if (canConvertToLong()) {
             return _value.longValue();
         }
-        return _reportLongCoercionRangeFail("longValue()");
+        return _reportLongConversionRangeFail("longValue()");
     }
 
     @Override
@@ -162,7 +162,7 @@ public class BigIntegerNode
         if (canConvertToLong()) {
             return _value.longValue();
         }
-        return _reportLongCoercionRangeFail("asLong()");
+        return _reportLongConversionRangeFail("asLong()");
     }
 
     @Override
@@ -194,7 +194,7 @@ public class BigIntegerNode
         if (Float.isFinite(f)) {
             return f;
         }
-        return _reportFloatCoercionRangeFail("floatValue()");
+        return _reportFloatConversionRangeFail("floatValue()");
     }
 
     @Override
@@ -218,7 +218,7 @@ public class BigIntegerNode
         if (Float.isFinite(f)) {
             return f;
         }
-        return _reportFloatCoercionRangeFail("asFloat()");
+        return _reportFloatConversionRangeFail("asFloat()");
     }
 
     @Override
@@ -242,7 +242,7 @@ public class BigIntegerNode
         if (Double.isFinite(d)) {
             return d;
         }
-        return _reportDoubleCoercionRangeFail("doubleValue()");
+        return _reportDoubleConversionRangeFail("doubleValue()");
     }
 
     @Override
@@ -266,7 +266,7 @@ public class BigIntegerNode
         if (Double.isFinite(d)) {
             return d;
         }
-        return _reportDoubleCoercionRangeFail("asDouble()");
+        return _reportDoubleConversionRangeFail("asDouble()");
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/node/DecimalNode.java
+++ b/src/main/java/tools/jackson/databind/node/DecimalNode.java
@@ -77,7 +77,7 @@ public class DecimalNode
         if (Float.isFinite(f)) {
             return f;
         }
-        return _reportFloatCoercionRangeFail("floatValue()");
+        return _reportFloatConversionRangeFail("floatValue()");
     }
 
     @Override
@@ -104,7 +104,7 @@ public class DecimalNode
         if (Float.isFinite(f)) {
             return f;
         }
-        return _reportFloatCoercionRangeFail("asFloat()");
+        return _reportFloatConversionRangeFail("asFloat()");
     }
 
     @Override
@@ -131,7 +131,7 @@ public class DecimalNode
         if (Double.isFinite(d)) {
             return d;
         }
-        return _reportDoubleCoercionRangeFail("doubleValue()");
+        return _reportDoubleConversionRangeFail("doubleValue()");
     }
 
     @Override
@@ -158,7 +158,7 @@ public class DecimalNode
         if (Double.isFinite(d)) {
             return d;
         }
-        return _reportDoubleCoercionRangeFail("asDouble()");
+        return _reportDoubleConversionRangeFail("asDouble()");
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/node/DoubleNode.java
+++ b/src/main/java/tools/jackson/databind/node/DoubleNode.java
@@ -75,7 +75,7 @@ public class DoubleNode
         if (Float.isFinite(f)) {
             return f;
         }
-        return _reportFloatCoercionRangeFail("floatValue()");
+        return _reportFloatConversionRangeFail("floatValue()");
     }
 
     @Override
@@ -102,7 +102,7 @@ public class DoubleNode
         if (Float.isFinite(f)) {
             return f;
         }
-        return _reportFloatCoercionRangeFail("asFloat()");
+        return _reportFloatConversionRangeFail("asFloat()");
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/node/IntNode.java
+++ b/src/main/java/tools/jackson/databind/node/IntNode.java
@@ -87,7 +87,7 @@ public class IntNode
         if (inShortRange()) {
             return (short) _value;
         }
-        return _reportShortCoercionRangeFail("shortValue()");
+        return _reportShortConversionRangeFail("shortValue()");
     }
 
     @Override
@@ -105,7 +105,7 @@ public class IntNode
         if (inShortRange()) {
             return (short) _value;
         }
-        return _reportShortCoercionRangeFail("asShort()");
+        return _reportShortConversionRangeFail("asShort()");
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/node/LongNode.java
+++ b/src/main/java/tools/jackson/databind/node/LongNode.java
@@ -67,7 +67,7 @@ public class LongNode
         if (inShortRange()) {
             return (short) _value;
         }
-        return _reportShortCoercionRangeFail("shortValue()");
+        return _reportShortConversionRangeFail("shortValue()");
     }
 
     @Override
@@ -85,7 +85,7 @@ public class LongNode
         if (inShortRange()) {
             return (short) _value;
         }
-        return _reportShortCoercionRangeFail("asShort()");
+        return _reportShortConversionRangeFail("asShort()");
     }
 
     @Override
@@ -103,7 +103,7 @@ public class LongNode
         if (inIntRange()) {
             return (int) _value;
         }
-        return _reportIntCoercionRangeFail("intValue()");
+        return _reportIntConversionRangeFail("intValue()");
     }
 
     @Override
@@ -121,7 +121,7 @@ public class LongNode
         if (inIntRange()) {
             return (int) _value;
         }
-        return _reportIntCoercionRangeFail("asInt()");
+        return _reportIntConversionRangeFail("asInt()");
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/node/NumericFPNode.java
+++ b/src/main/java/tools/jackson/databind/node/NumericFPNode.java
@@ -91,9 +91,9 @@ public abstract class NumericFPNode extends NumericNode
     public short asShort() {
         if (!inShortRange()) {
             if (isNaN()) {
-                _reportIntCoercionNaNFail("asShort()");
+                _reportIntConversionNaNFail("asShort()");
             }
-            return _reportShortCoercionRangeFail("asShort()");
+            return _reportShortConversionRangeFail("asShort()");
         }
         return _asShortValueUnchecked();
     }
@@ -148,9 +148,9 @@ public abstract class NumericFPNode extends NumericNode
     public int asInt() {
         if (!inIntRange()) {
             if (isNaN()) {
-                _reportIntCoercionNaNFail("asInt()");
+                _reportIntConversionNaNFail("asInt()");
             }
-            return _reportIntCoercionRangeFail("asInt()");
+            return _reportIntConversionRangeFail("asInt()");
         }
         return _asIntValueUnchecked();
     }
@@ -205,9 +205,9 @@ public abstract class NumericFPNode extends NumericNode
     public final long asLong() {
         if (!inLongRange()) {
             if (isNaN()) {
-                _reportLongCoercionNaNFail("asLong()");
+                _reportLongConversionNaNFail("asLong()");
             }
-            return _reportLongCoercionRangeFail("asLong()");
+            return _reportLongConversionRangeFail("asLong()");
         }
         return _asLongValueUnchecked();
     }
@@ -258,7 +258,7 @@ public abstract class NumericFPNode extends NumericNode
     @Override
     public final BigInteger asBigInteger() {
         if (isNaN()) {
-            _reportBigIntegerCoercionNaNFail("asBigInteger()");
+            _reportBigIntegerConversionNaNFail("asBigInteger()");
         }
         return _asBigIntegerValueUnchecked();
     }
@@ -308,7 +308,7 @@ public abstract class NumericFPNode extends NumericNode
     @Override
     public BigDecimal asDecimal() {
         if (isNaN()) {
-            _reportBigDecimalCoercionNaNFail("asDecimal()");
+            _reportBigDecimalConversionNaNFail("asDecimal()");
         }
         return _asDecimalValueUnchecked();
     }

--- a/src/main/java/tools/jackson/databind/node/NumericFPNode.java
+++ b/src/main/java/tools/jackson/databind/node/NumericFPNode.java
@@ -61,12 +61,12 @@ public abstract class NumericFPNode extends NumericNode
     public final short shortValue() {
         if (!inShortRange()) {
             if (isNaN()) {
-                _reportIntCoercionNaNFail("shortValue()");
+                _reportIntConversionNaNFail("shortValue()");
             }
-            return _reportShortCoercionRangeFail("shortValue()");
+            return _reportShortConversionRangeFail("shortValue()");
         }
         if (hasFractionalPart()) {
-            _reportShortCoercionFractionFail("shortValue()");
+            _reportShortConversionFractionFail("shortValue()");
         }
         return _asShortValueUnchecked();
     }
@@ -118,12 +118,12 @@ public abstract class NumericFPNode extends NumericNode
     public final int intValue() {
         if (!inIntRange()) {
             if (isNaN()) {
-                _reportIntCoercionNaNFail("intValue()");
+                _reportIntConversionNaNFail("intValue()");
             }
-            return _reportIntCoercionRangeFail("intValue()");
+            return _reportIntConversionRangeFail("intValue()");
         }
         if (hasFractionalPart()) {
-            _reportIntCoercionFractionFail("intValue()");
+            _reportIntConversionFractionFail("intValue()");
         }
         return _asIntValueUnchecked();
     }

--- a/src/main/java/tools/jackson/databind/node/NumericFPNode.java
+++ b/src/main/java/tools/jackson/databind/node/NumericFPNode.java
@@ -175,12 +175,12 @@ public abstract class NumericFPNode extends NumericNode
     public final long longValue() {
         if (!inLongRange()) {
             if (isNaN()) {
-                _reportLongCoercionNaNFail("longValue()");
+                _reportLongConversionNaNFail("longValue()");
             }
-            return _reportLongCoercionRangeFail("longValue()");
+            return _reportLongConversionRangeFail("longValue()");
         }
         if (hasFractionalPart()) {
-            _reportLongCoercionFractionFail("longValue()");
+            _reportLongConversionFractionFail("longValue()");
         }
         return _asLongValueUnchecked();
     }
@@ -231,10 +231,10 @@ public abstract class NumericFPNode extends NumericNode
     @Override
     public final BigInteger bigIntegerValue() {
         if (isNaN()) {
-            _reportBigIntegerCoercionNaNFail("bigIntegerValue()");
+            _reportBigIntegerConversionNaNFail("bigIntegerValue()");
         }
         if (hasFractionalPart()) {
-            _reportBigIntegerCoercionFractionFail("bigIntegerValue()");
+            _reportBigIntegerConversionFractionFail("bigIntegerValue()");
         }
         return _asBigIntegerValueUnchecked();
     }
@@ -284,7 +284,7 @@ public abstract class NumericFPNode extends NumericNode
     @Override
     public BigDecimal decimalValue() {
         if (isNaN()) {
-            _reportBigDecimalCoercionNaNFail("decimalValue()");
+            _reportBigDecimalConversionNaNFail("decimalValue()");
         }
         return _asDecimalValueUnchecked();
     }

--- a/src/main/java/tools/jackson/databind/node/POJONode.java
+++ b/src/main/java/tools/jackson/databind/node/POJONode.java
@@ -117,7 +117,7 @@ public class POJONode
         Long L = _extractAsLong();
         if (L == null || L < Short.MIN_VALUE || L > Short.MAX_VALUE) {
             // report range fail
-            _reportShortCoercionRangeFail("asShort()");
+            _reportShortConversionRangeFail("asShort()");
         }
         return L.shortValue();
     }
@@ -181,7 +181,7 @@ public class POJONode
         Long L = _extractAsLong();
         if (L == null || L < Integer.MIN_VALUE || L > Integer.MAX_VALUE) {
             // report range fail
-            _reportIntCoercionRangeFail("asInt()");
+            _reportIntConversionRangeFail("asInt()");
         }
         return L.intValue();
     }
@@ -245,7 +245,7 @@ public class POJONode
         Long L = _extractAsLong();
         if (L == null) {
             // report range fail
-            _reportLongCoercionRangeFail("asLong()");
+            _reportLongConversionRangeFail("asLong()");
         }
         return L;
     }
@@ -360,7 +360,7 @@ public class POJONode
         Float F = _extractAsFloat();
         if (F == null) {
             // report range fail
-            _reportFloatCoercionRangeFail("asFloat()");
+            _reportFloatConversionRangeFail("asFloat()");
         }
         return F;
     }
@@ -424,7 +424,7 @@ public class POJONode
         Double D = _extractAsDouble();
         if (D == null) {
             // report range fail
-            _reportDoubleCoercionRangeFail("asDouble()");
+            _reportDoubleConversionRangeFail("asDouble()");
         }
         return D;
     }

--- a/src/test/java/tools/jackson/databind/deser/jdk/Base64DecodingTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/Base64DecodingTest.java
@@ -53,7 +53,7 @@ public class Base64DecodingTest
             /*byte[] b =*/ nodeValue.binaryValue();
             fail("Should not pass");
         } catch (JsonNodeException e) {
-            verifyException(e, "method `binaryValue()` cannot convert value");
+            verifyException(e, "method `binaryValue()` cannot coerce value");
             verifyException(e, "Illegal character '!'");
         }
     }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
@@ -223,7 +223,7 @@ public class JsonNodeBigIntegerValueTest
                 () ->  node.bigIntegerValue(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBigIntegerValueTest.java
@@ -261,7 +261,7 @@ public class JsonNodeBigIntegerValueTest
                 () ->  node.asBigInteger(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value");
+            .contains("cannot coerce value");
 
         // Verify default value handling
         assertEquals(BigInteger.ONE, node.asBigInteger(BigInteger.ONE));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeBooleanValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeBooleanValueTest.java
@@ -190,8 +190,8 @@ public class JsonNodeBooleanValueTest
                 () ->  node.asBoolean(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
-            .contains("value type not coercible to `boolean`");
+            .contains("cannot coerce value")
+            .contains("value type not coercible");
 
         // But also check defaulting
         assertFalse(node.asBoolean(false));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
@@ -291,7 +291,7 @@ public class JsonNodeDecimalValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
         .contains("asDecimal()")
-            .contains("cannot coerce value")
+            .contains("cannot convert value")
             .contains("value non-Finite ('NaN')");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
@@ -245,7 +245,7 @@ public class JsonNodeDecimalValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("decimalValue()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDecimalValueTest.java
@@ -268,7 +268,7 @@ public class JsonNodeDecimalValueTest
     }
 
     private void _assertFailAsDecimalForNonNumber(JsonNode node) {
-        _assertFailAsDecimal(node, "value type not coercible to `BigDecimal`");
+        _assertFailAsDecimal(node, "value type not coercible");
     }
 
     private void _assertFailAsDecimal(JsonNode node, String extraFailMsg) {
@@ -277,7 +277,7 @@ public class JsonNodeDecimalValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asDecimal()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains(extraFailMsg);
 
         // Verify default value handling
@@ -291,7 +291,7 @@ public class JsonNodeDecimalValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
         .contains("asDecimal()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value non-Finite ('NaN')");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
@@ -265,7 +265,7 @@ public class JsonNodeDoubleValueTest
                 () ->  node.doubleValue(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         assertEquals(1.5d, node.doubleValue(1.5d));
@@ -286,7 +286,7 @@ public class JsonNodeDoubleValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asDouble()")
-            .contains("cannot coerce value")
+            .contains("cannot convert value")
             .contains("value not in 64-bit `double` range");
 
         assertEquals(-2.25d, node.asDouble(-2.25d));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeDoubleValueTest.java
@@ -286,7 +286,7 @@ public class JsonNodeDoubleValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asDouble()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value not in 64-bit `double` range");
 
         assertEquals(-2.25d, node.asDouble(-2.25d));
@@ -294,7 +294,7 @@ public class JsonNodeDoubleValueTest
     }
 
     private void _assertAsDoubleFailForNonNumber(JsonNode node) {
-        _assertAsDoubleFailForNonNumber(node, "value type not numeric");
+        _assertAsDoubleFailForNonNumber(node, "value type not coercible");
     }
 
     private void _assertAsDoubleFailForNonNumber(JsonNode node, String extraMatch) {
@@ -303,7 +303,7 @@ public class JsonNodeDoubleValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asDouble()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains(extraMatch);
 
         assertEquals(1.5d, node.asDouble(1.5d));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
@@ -288,7 +288,7 @@ public class JsonNodeFloatValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
                 .contains("asFloat()")
-                .contains("cannot convert value")
+                .contains("cannot coerce value")
                 .contains("value not in 32-bit `float` range");
 
         assertEquals(-2.25f, node.asFloat(-2.25f));
@@ -296,7 +296,7 @@ public class JsonNodeFloatValueTest
     }
 
     private void _assertAsFloatFailForNonNumber(JsonNode node) {
-        _assertAsFloatFailForNonNumber(node, "value type not numeric");
+        _assertAsFloatFailForNonNumber(node, "value type not coercible");
     }
 
     private void _assertAsFloatFailForNonNumber(JsonNode node, String extraMatch) {
@@ -305,7 +305,7 @@ public class JsonNodeFloatValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
                 .contains("asFloat()")
-                .contains("cannot convert value")
+                .contains("cannot coerce value")
                 .contains(extraMatch);
 
         assertEquals(1.5f, node.asFloat(1.5f));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
@@ -267,7 +267,7 @@ public class JsonNodeFloatValueTest
                 () ->  node.floatValue(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         assertEquals(-2.25f, node.floatValue(-2.25f));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeFloatValueTest.java
@@ -288,7 +288,7 @@ public class JsonNodeFloatValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
                 .contains("asFloat()")
-                .contains("cannot coerce value")
+                .contains("cannot convert value")
                 .contains("value not in 32-bit `float` range");
 
         assertEquals(-2.25f, node.asFloat(-2.25f));

--- a/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
@@ -351,7 +351,7 @@ public class JsonNodeIntValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("intValue()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         // assert defaulting

--- a/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
@@ -390,7 +390,7 @@ public class JsonNodeIntValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asInt()")
-            .contains("cannot coerce value")
+            .contains("cannot convert value")
             .contains("value not in 32-bit `int` range");
 
         // assert defaulting
@@ -422,7 +422,7 @@ public class JsonNodeIntValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
         .contains("asInt()")
-            .contains("cannot coerce value")
+            .contains("cannot convert value")
             .contains("value non-Finite");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeIntValueTest.java
@@ -390,7 +390,7 @@ public class JsonNodeIntValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asInt()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value not in 32-bit `int` range");
 
         // assert defaulting
@@ -399,7 +399,7 @@ public class JsonNodeIntValueTest
     }
 
     private void _assertAsIntFailForNonNumber(JsonNode node) {
-        _assertAsIntFailForNonNumber(node, "value type not numeric");
+        _assertAsIntFailForNonNumber(node, "value type not coercible");
     }
 
     private void _assertAsIntFailForNonNumber(JsonNode node, String extraFailMsg) {
@@ -408,7 +408,7 @@ public class JsonNodeIntValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asInt()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains(extraFailMsg);
 
         // assert defaulting
@@ -422,7 +422,7 @@ public class JsonNodeIntValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
         .contains("asInt()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value non-Finite");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
@@ -346,7 +346,7 @@ public class JsonNodeLongValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("longValue()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         // Verify default value handling
@@ -385,7 +385,7 @@ public class JsonNodeLongValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asLong()")
-            .contains("cannot coerce value")
+            .contains("cannot convert value")
             .contains("value not in 64-bit `long` range");
 
         // Verify default value handling
@@ -417,7 +417,7 @@ public class JsonNodeLongValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asLong()")
-            .contains("cannot coerce value")
+            .contains("cannot convert value")
             .contains("value non-Finite");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeLongValueTest.java
@@ -385,7 +385,7 @@ public class JsonNodeLongValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asLong()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value not in 64-bit `long` range");
 
         // Verify default value handling
@@ -394,7 +394,7 @@ public class JsonNodeLongValueTest
     }
 
     private void _assertAsLongFailForNonNumber(JsonNode node) {
-        _assertAsLongFailForNonNumber(node, "value type not numeric");
+        _assertAsLongFailForNonNumber(node, "value type not coercible");
     }
 
     private void _assertAsLongFailForNonNumber(JsonNode node, String extraMsg) {
@@ -403,7 +403,7 @@ public class JsonNodeLongValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asLong()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains(extraMsg);
 
         // Verify default value handling
@@ -417,7 +417,7 @@ public class JsonNodeLongValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
             .contains("asLong()")
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value non-Finite");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeNumberValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeNumberValueTest.java
@@ -69,7 +69,7 @@ public class JsonNodeNumberValueTest
                 () ->  node.intValue(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
     }
 }

--- a/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
@@ -364,7 +364,7 @@ public class JsonNodeShortValueTest
     }
 
     private void _assertAsShortFailForNonNumber(JsonNode node) {
-        _assertAsShortFailForNonNumber(node, "value type not numeric");
+        _assertAsShortFailForNonNumber(node, "value type not coercible");
     }
 
     private void _assertAsShortFailForNonNumber(JsonNode node, String extraFailMsg) {
@@ -373,7 +373,7 @@ public class JsonNodeShortValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
                 .contains("asShort()")
-                .contains("cannot convert value")
+                .contains("cannot coerce value")
                 .contains(extraFailMsg);
 
         // assert defaulting
@@ -387,7 +387,7 @@ public class JsonNodeShortValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
                 .contains("asShort()")
-                .contains("cannot convert value")
+                .contains("cannot coerce value")
                 .contains("value non-Finite");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeShortValueTest.java
@@ -331,7 +331,7 @@ public class JsonNodeShortValueTest
                 () ->  node.shortValue(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
+            .contains("cannot coerce value")
             .contains("value type not numeric");
 
         // assert defaulting
@@ -387,7 +387,7 @@ public class JsonNodeShortValueTest
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
                 .contains("asShort()")
-                .contains("cannot coerce value")
+                .contains("cannot convert value")
                 .contains("value non-Finite");
 
         // Verify default value handling

--- a/src/test/java/tools/jackson/databind/node/JsonNodeStringValueTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeStringValueTest.java
@@ -156,8 +156,8 @@ public class JsonNodeStringValueTest
                 () ->  node.asString(),
                 "For ("+node.getClass().getSimpleName()+") value: "+node);
         assertThat(e.getMessage())
-            .contains("cannot convert value")
-            .contains("value type not coercible to `String`");
+            .contains("cannot coerce value")
+            .contains("value type not coercible");
 
         // But also check defaulting
         assertEquals("foo", node.asString("foo"));

--- a/src/test/java/tools/jackson/databind/node/TreeTraversingParserTest.java
+++ b/src/test/java/tools/jackson/databind/node/TreeTraversingParserTest.java
@@ -241,7 +241,7 @@ public class TreeTraversingParserTest
         try {
             p.getBinaryValue();
         } catch (JsonNodeException e) {
-            verifyException(e, "method `binaryValue()` cannot convert value");
+            verifyException(e, "method `binaryValue()` cannot coerce value");
             verifyException(e, "Illegal character");
         }
         p.close();


### PR DESCRIPTION
Intent is/was that:

* Conversion refers to changes within similar types (mostly numbers), like `int` to `double` (or vice versa)
* Coercion refers to force type change like JSON String "true" to `Boolean.TRUE`.

so this PR tackles that aspect. Also attempts to streamline usage slightly.

Actual conversion/coercion rules are NOT to change in this PR.