### PR TITLE
Add ObjectNode#put(JsonPointer, JsonNode) method #3884

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1994,3 +1994,7 @@ Johnny Lim (@izeye)
 Hélios Gilles (@RoiSoleil)
  * Contributed #5413: Add/support forward reference resolution for array values
   [2.21.0]
+
+Lee Jiwon (@dlwldnjs1009)
+ * Contributed #3884: Add `ObjectNode.put(JsonPointe, JsonNode)` method
+  [2.22.0]

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,12 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.22.0 (not yet released)
+
+#3884: Add `ObjectNode.put(JsonPointe, JsonNode)` method
+ (requested by @SaiKrishna369)
+ (contributed by Lee Jiwon)
+
 2.21.0 (18-Jan-2026)
 
 #1381: Add a way to specify "inject-only" with `@JacksonInject`

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -1154,27 +1154,29 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
      * {@link ObjectNode}s and {@link ArrayNode}s as necessary (following the
      * same logic as {@link #withObject(JsonPointer)}).
      *<p>
-     * NOTE: if the last segment of the pointer is an array index (like {@code /arr/0}),
-     * the parent Array must already have enough elements; this method will not
+     * This method has two important limitations: first, if the pointer is empty
+     * (referring to this node itself), an {@link UnsupportedOperationException}
+     * is thrown since replacing the context node is not possible. Second, if the
+     * last segment of the pointer is an array index (like {@code /arr/0}), the
+     * parent array must already contain enough elements; this method will not
      * expand arrays to create missing elements.
-     *<p>
-     * NOTE: if the pointer is empty (matches root), an {@link IllegalArgumentException}
-     * is thrown since replacing {@code this} is not possible.
      *
      * @param ptr {@link JsonPointer} identifying location to set the value at
      * @param value Value to set at the specified path
      *
      * @return This node (to allow chaining)
      *
-     * @throws IllegalArgumentException if {@code ptr} is empty (root path)
+     * @throws UnsupportedOperationException if {@code ptr} is empty (refers to
+     *         this node itself, which cannot be replaced)
      *
      * @since 2.22
      */
     public ObjectNode put(JsonPointer ptr, JsonNode value)
     {
         if (ptr.matches()) {
-            throw new IllegalArgumentException(
-                "Cannot use `put(JsonPointer, JsonNode)` with empty JSON Pointer (root)");
+            return _reportWrongNodeOperation(
+                "Cannot use `put(JsonPointer, JsonNode)` with empty JSON Pointer: "
+                + "root node cannot be replaced as it is the context node itself");
         }
         if (value == null) {
             value = nullNode();

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -1150,19 +1150,26 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
 
     /**
      * Method for setting value of a property at specified JSON Pointer location
-     * on this {@code ObjectNode}: this will create intermediate
-     * {@link ObjectNode}s and {@link ArrayNode}s as necessary (following the
-     * same logic as {@link #withObject(JsonPointer)}).
+     * on this {@code ObjectNode}. Intermediate {@link ObjectNode}s are created
+     * as necessary (following the same logic as {@link #withObject(JsonPointer)}).
      *<p>
-     * This method has two important limitations: first, if the pointer is empty
-     * (referring to this node itself), an {@link UnsupportedOperationException}
-     * is thrown since replacing the context node is not possible. Second, if the
-     * last segment of the pointer is an array index (like {@code /arr/0}), the
-     * parent array must already contain enough elements; this method will not
-     * expand arrays to create missing elements.
+     * <b>Array index handling:</b> If the last segment appears to be an array index
+     * (non-negative integer like {@code /arr/0}), the method checks if the parent
+     * node already exists and is an {@link ArrayNode}:
+     * <ul>
+     *   <li>If parent is an existing {@link ArrayNode}: sets value at that index
+     *       (the array must already contain enough elements; arrays are NOT expanded)</li>
+     *   <li>Otherwise: treats the numeric segment as a property name (e.g., property "0")</li>
+     * </ul>
+     *<p>
+     * <b>Limitations:</b>
+     * <ul>
+     *   <li>Empty pointer (referring to this node) throws {@link UnsupportedOperationException}</li>
+     *   <li>Arrays are NOT created or expanded automatically</li>
+     * </ul>
      *
      * @param ptr {@link JsonPointer} identifying location to set the value at
-     * @param value Value to set at the specified path
+     * @param value Value to set at the specified path; {@code null} becomes a {@link NullNode}
      *
      * @return This node (to allow chaining)
      *
@@ -1187,8 +1194,11 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
         if (lastSegment.mayMatchElement()) {
             int index = lastSegment.getMatchingIndex();
             if (index >= 0) {
-                withArray(parentPtr).set(index, value);
-                return this;
+                JsonNode parent = this.at(parentPtr);
+                if (parent.isArray()) {
+                    ((ArrayNode) parent).set(index, value);
+                    return this;
+                }
             }
         }
         String propName = lastSegment.getMatchingProperty();

--- a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java
@@ -1144,6 +1144,58 @@ child.getClass().getName(), propName, OverwriteMode.NULLS);
 
     /*
     /**********************************************************
+    /* Extended ObjectNode API, mutators, JsonPointer-based
+    /**********************************************************
+     */
+
+    /**
+     * Method for setting value of a property at specified JSON Pointer location
+     * on this {@code ObjectNode}: this will create intermediate
+     * {@link ObjectNode}s and {@link ArrayNode}s as necessary (following the
+     * same logic as {@link #withObject(JsonPointer)}).
+     *<p>
+     * NOTE: if the last segment of the pointer is an array index (like {@code /arr/0}),
+     * the parent Array must already have enough elements; this method will not
+     * expand arrays to create missing elements.
+     *<p>
+     * NOTE: if the pointer is empty (matches root), an {@link IllegalArgumentException}
+     * is thrown since replacing {@code this} is not possible.
+     *
+     * @param ptr {@link JsonPointer} identifying location to set the value at
+     * @param value Value to set at the specified path
+     *
+     * @return This node (to allow chaining)
+     *
+     * @throws IllegalArgumentException if {@code ptr} is empty (root path)
+     *
+     * @since 2.22
+     */
+    public ObjectNode put(JsonPointer ptr, JsonNode value)
+    {
+        if (ptr.matches()) {
+            throw new IllegalArgumentException(
+                "Cannot use `put(JsonPointer, JsonNode)` with empty JSON Pointer (root)");
+        }
+        if (value == null) {
+            value = nullNode();
+        }
+        JsonPointer parentPtr = ptr.head();
+        JsonPointer lastSegment = ptr.last();
+
+        if (lastSegment.mayMatchElement()) {
+            int index = lastSegment.getMatchingIndex();
+            if (index >= 0) {
+                withArray(parentPtr).set(index, value);
+                return this;
+            }
+        }
+        String propName = lastSegment.getMatchingProperty();
+        withObject(parentPtr).set(propName, value);
+        return this;
+    }
+
+    /*
+    /**********************************************************
     /* Standard methods
     /**********************************************************
      */

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -710,6 +710,34 @@ public class ObjectNodeTest
             () -> root.put(JsonPointer.compile(""), MAPPER.createObjectNode()));
     }
 
+    // [databind#3884]: put with array index in JsonPointer
+    @Test
+    public void testPutWithJsonPointerArrayIndex() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        // Pre-create array with element (array must already have enough elements)
+        root.withArray("/arr").add("placeholder");
+
+        JsonNode value = MAPPER.getNodeFactory().textNode("replaced");
+        root.put(JsonPointer.compile("/arr/0"), value);
+
+        assertEquals("replaced", root.at("/arr/0").asText());
+    }
+
+    @Test
+    public void testPutWithJsonPointerNestedArrayIndex() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        // Create nested structure: {"data": {"items": ["x", "y"]}}
+        root.withArray("/data/items").add("x").add("y");
+
+        root.put(JsonPointer.compile("/data/items/1"),
+            MAPPER.getNodeFactory().textNode("updated"));
+
+        assertEquals("updated", root.at("/data/items/1").asText());
+        assertEquals("x", root.at("/data/items/0").asText()); // unchanged
+    }
+
     private String _toString(JsonNode n) {
         return n.properties().stream()
                 .map(e -> e.getKey() + "/" + e.getValue())

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -706,7 +706,7 @@ public class ObjectNodeTest
     {
         ObjectNode root = MAPPER.createObjectNode();
 
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(UnsupportedOperationException.class,
             () -> root.put(JsonPointer.compile(""), MAPPER.createObjectNode()));
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -741,6 +741,47 @@ public class ObjectNodeTest
         assertEquals(2, root.at("/data/items").size());
     }
 
+    // [databind#3884]: numeric segment is treated as property name unless parent is ArrayNode
+    @Test
+    public void testPutWithNumericPropertyName() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        // "/0" on ObjectNode: treat "0" as property name
+        root.put(JsonPointer.compile("/0"), MAPPER.getNodeFactory().textNode("value"));
+
+        assertTrue(root.has("0"));
+        assertEquals("value", root.get("0").asText());
+    }
+
+    // [databind#3884]: numeric segment is treated as property name when parent path is missing
+    @Test
+    public void testPutArrayIndexWhenParentMissing() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        // "/arr/0" with missing parent: treat "0" as property name -> {"arr":{"0":"value"}}
+        root.put(JsonPointer.compile("/arr/0"), MAPPER.getNodeFactory().textNode("value"));
+
+        assertTrue(root.has("arr"));
+        assertTrue(root.get("arr").isObject());
+        assertEquals("value", root.at("/arr/0").asText());
+    }
+
+    // [databind#3884]: numeric segment is treated as property name when parent is ObjectNode
+    @Test
+    public void testPutNumericSegmentOnExistingObject() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.putObject("obj");
+
+        // "/obj/0" with ObjectNode parent: treat "0" as property name
+        root.put(JsonPointer.compile("/obj/0"), MAPPER.getNodeFactory().textNode("value"));
+
+        assertTrue(root.get("obj").isObject());
+        assertEquals("value", root.at("/obj/0").asText());
+    }
+
     private String _toString(JsonNode n) {
         return n.properties().stream()
                 .map(e -> e.getKey() + "/" + e.getValue())

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -722,6 +722,8 @@ public class ObjectNodeTest
         root.put(JsonPointer.compile("/arr/0"), value);
 
         assertEquals("replaced", root.at("/arr/0").asText());
+        assertEquals(1, root.at("/arr").size());
+        assertEquals("replaced", root.at("/arr").get(0).asText());
     }
 
     @Test
@@ -735,7 +737,8 @@ public class ObjectNodeTest
             MAPPER.getNodeFactory().textNode("updated"));
 
         assertEquals("updated", root.at("/data/items/1").asText());
-        assertEquals("x", root.at("/data/items/0").asText()); // unchanged
+        assertEquals("x", root.at("/data/items/0").asText());
+        assertEquals(2, root.at("/data/items").size());
     }
 
     private String _toString(JsonNode n) {

--- a/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/node/ObjectNodeTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -649,6 +650,64 @@ public class ObjectNodeTest
         try (JsonParser p = MAPPER.createParser(a2q(json))) {
             return (ObjectNode) MAPPER.reader().readTree(p);
         }
+    }
+
+    // [databind#3884]: put(JsonPointer, JsonNode)
+    @Test
+    public void testPutWithJsonPointer() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        JsonNode value = MAPPER.getNodeFactory().textNode("test");
+
+        ObjectNode result = root.put(JsonPointer.compile("/a/b/c"), value);
+
+        assertSame(root, result);
+        assertEquals("test", root.at("/a/b/c").asText());
+    }
+
+    @Test
+    public void testPutWithJsonPointerOverwrite() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("key", "old");
+
+        root.put(JsonPointer.compile("/key"),
+            MAPPER.getNodeFactory().textNode("new"));
+
+        assertEquals("new", root.get("key").asText());
+    }
+
+    @Test
+    public void testPutWithJsonPointerChaining() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+        JsonNodeFactory f = MAPPER.getNodeFactory();
+
+        root.put(JsonPointer.compile("/a"), f.textNode("A"))
+            .put(JsonPointer.compile("/b"), f.textNode("B"));
+
+        assertEquals("A", root.get("a").asText());
+        assertEquals("B", root.get("b").asText());
+    }
+
+    @Test
+    public void testPutWithJsonPointerNullValue() throws Exception
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        root.put(JsonPointer.compile("/nullVal"), null);
+
+        assertTrue(root.has("nullVal"));
+        assertTrue(root.get("nullVal").isNull());
+    }
+
+    @Test
+    public void testPutWithJsonPointerRootFails()
+    {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> root.put(JsonPointer.compile(""), MAPPER.createObjectNode()));
     }
 
     private String _toString(JsonNode n) {


### PR DESCRIPTION
## Summary

  Implements #3884: Add `ObjectNode#put(JsonPointer, JsonNode)` method that allows
   setting values at JSON Pointer paths, creating intermediate `ObjectNode`s and
  `ArrayNode`s as necessary.

  ## Implementation

  Following the approach suggested by @sigpwned and guidelines from @cowtowncoder:

  - Leverages existing `withObject(JsonPointer)` and `withArray(JsonPointer)`
  methods for path creation
  - Accepts only `JsonNode` value (no primitive overloads as requested)
  - Returns `ObjectNode` (covariant return type) for method chaining
  - Converts Java `null` to `NullNode`
  - Throws `IllegalArgumentException` for empty pointer (root path)

  ```java
  ObjectNode root = mapper.createObjectNode();
  root.put(JsonPointer.compile("/a/b/c"),
  mapper.getNodeFactory().textNode("value"));
  // Creates: {"a":{"b":{"c":"value"}}}

  Tests Added

  - testPutWithJsonPointer - basic path creation
  - testPutWithJsonPointerOverwrite - overwriting existing value
  - testPutWithJsonPointerChaining - method chaining
  - testPutWithJsonPointerNullValue - null converts to NullNode
  - testPutWithJsonPointerRootFails - empty pointer throws exception

  Notes

  - Targets 2.x branch (version 2.22)
  - Array index paths (e.g., /arr/0) require the parent array to already have
  enough elements