### PR TITLE
Add DateTimeFeature.WRITE_UTC_AS_OFFSET for legacy zero-offset formatting (#3284)

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -183,6 +183,11 @@ Kenneth Jorgensen (@kennethjor)
   `@JsonDeserialize.builderPrefix` property
   [3.1.0]
 
+Lee Jiwon (@dlwldnjs1009)
+ * Implemented #3284: Backward compatibility for timezone formats of UTC Date
+   serialization
+  [3.1.0]
+
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore
    getter method auto-detection for Records

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -51,6 +51,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #2686: `@JsonBackReference` does not work with a builder
  (reported by @janrieke)
  (fix by @JacksonJang)
+#3284: Backward compatibility for timezone formats of UTC Date
+  serialization
+ (requested by @arungitan)
+ (implemented by Lee Jiwon)
 #3964: Deserialization issue: MismatchedInputException, Bean not
   yet resolved
  (reported by @detomarco)

--- a/src/main/java/tools/jackson/databind/SerializationContext.java
+++ b/src/main/java/tools/jackson/databind/SerializationContext.java
@@ -35,6 +35,7 @@ import tools.jackson.databind.ser.impl.UnknownSerializer;
 import tools.jackson.databind.ser.std.NullSerializer;
 import tools.jackson.databind.type.TypeFactory;
 import tools.jackson.databind.util.ClassUtil;
+import tools.jackson.databind.util.StdDateFormat;
 import tools.jackson.databind.util.TokenBuffer;
 
 /**
@@ -1451,8 +1452,15 @@ public abstract class SerializationContext
         // At this point, all timezone configuration should have occurred, with respect
         // to default dateformat configuration. But we still better clone
         // an instance as formatters are stateful, not thread-safe.
-        DateFormat df = _config.getDateFormat();
-        _dateFormat = df = (DateFormat) df.clone();
+        DateFormat df = (DateFormat) _config.getDateFormat().clone();
+
+        // [databind#3284]: Configure zero-offset format based on DateTimeFeature
+        if (df instanceof StdDateFormat sdf
+                && isEnabled(DateTimeFeature.WRITE_UTC_AS_OFFSET)) {
+            df = sdf.withZeroOffsetAsZ(false);
+        }
+
+        _dateFormat = df;
         // [databind#939]: 26-Sep-2015, tatu: With 2.6, formatter has been (pre)configured
         // with TimeZone, so we should NOT try overriding it unlike with earlier versions
         /*

--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -269,15 +269,21 @@ public enum DateTimeFeature implements DatatypeFeature
      * is serialized: as "Z" (disabled, default in 3.x) or as numeric offset
      * "+00:00" / "+0000" (enabled, for Jackson 2.x backward compatibility).
      *<p>
-     * NOTE: The name "UTC" is historical and kept for public API naming consistency.
-     * This feature applies to <b>ALL timezones where the actual offset is zero</b>
-     * at serialization time (e.g., "UTC", "GMT", "Europe/London" in winter),
-     * regardless of the timezone ID. The check is based on offset value
-     * ({@code offset == 0}), not timezone name.
+     * NOTE: the name "UTC" is historical; this feature applies to <b>all timezones
+     * where the actual offset is zero</b> at serialization time (e.g., "UTC", "GMT",
+     * "Europe/London" in winter), regardless of the timezone ID.
      *<p>
-     * Only affects serialization when using
+     * For "classic" JDK date types ({@link java.util.Date}, {@link java.util.Calendar})
+     * this feature controls zero-offset formatting when using
      * {@link tools.jackson.databind.util.StdDateFormat} (the default).
-     * Custom {@link java.text.DateFormat} instances are not modified by this feature.
+     * For Java 8 ({@code java.time.*}) and Joda date/time types, formatting is
+     * controlled by {@code DateTimeFormatter} configuration and this feature
+     * has no effect.
+     * Custom {@link java.text.DateFormat} instances are also not modified.
+     *<p>
+     * NOTE: when enabled, this feature overrides any {@code StdDateFormat}
+     * configuration set via
+     * {@link tools.jackson.databind.util.StdDateFormat#withZeroOffsetAsZ(boolean)}.
      *<p>
      * When enabled, the colon format ("+00:00" vs "+0000") is controlled by
      * {@link tools.jackson.databind.util.StdDateFormat#withColonInTimeZone(boolean)}.

--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -264,6 +264,30 @@ public enum DateTimeFeature implements DatatypeFeature
      */
     TRUNCATE_TO_MSECS_ON_WRITE(false),
 
+    /**
+     * Feature that controls how <b>zero timezone offset</b> ({@code offset == 0})
+     * is serialized: as "Z" (disabled, default in 3.x) or as numeric offset
+     * "+00:00" / "+0000" (enabled, for Jackson 2.x backward compatibility).
+     *<p>
+     * NOTE: The name "UTC" is historical and kept for public API naming consistency.
+     * This feature applies to <b>ALL timezones where the actual offset is zero</b>
+     * at serialization time (e.g., "UTC", "GMT", "Europe/London" in winter),
+     * regardless of the timezone ID. The check is based on offset value
+     * ({@code offset == 0}), not timezone name.
+     *<p>
+     * Only affects serialization when using
+     * {@link tools.jackson.databind.util.StdDateFormat} (the default).
+     * Custom {@link java.text.DateFormat} instances are not modified by this feature.
+     *<p>
+     * When enabled, the colon format ("+00:00" vs "+0000") is controlled by
+     * {@link tools.jackson.databind.util.StdDateFormat#withColonInTimeZone(boolean)}.
+     *<p>
+     * Feature is disabled by default to maintain Jackson 3.x standard behavior ("Z").
+     *
+     * @since 3.1
+     */
+    WRITE_UTC_AS_OFFSET(false),
+
     ;
 
     private final static int FEATURE_INDEX = DatatypeFeatures.FEATURE_INDEX_DATETIME;

--- a/src/main/java/tools/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/tools/jackson/databind/util/StdDateFormat.java
@@ -150,6 +150,18 @@ public class StdDateFormat
      */
     protected boolean _tzSerializedWithColon = true;
 
+    /**
+     * Whether zero timezone offset should be serialized as "Z" (true, default in 3.x)
+     * or as numeric offset "+00:00"/"+0000" (false, legacy 2.x behavior).
+     *<p>
+     * NOTE: Applies to ALL timezones with zero offset, not just UTC TimeZone ID.
+     *<p>
+     * Default is {@code true} in Jackson 3.0; was effectively {@code false} in 2.x.
+     *
+     * @since 3.1
+     */
+    protected boolean _writeZeroOffsetAsZ = true;
+
     /*
     /**********************************************************************
     /* Life cycle, accessing singleton "standard" formats
@@ -157,15 +169,26 @@ public class StdDateFormat
      */
 
     public StdDateFormat() {
-        _locale = DEFAULT_LOCALE;
+        // NOTE: _timezone intentionally left null (means "use default when needed")
+        // Default 3.x behavior: colon in offset ("+HH:mm") and "Z" for zero offset
+        this(null, DEFAULT_LOCALE, null, true, true);
     }
 
     protected StdDateFormat(TimeZone tz, Locale loc, Boolean lenient,
             boolean formatTzOffsetWithColon) {
+        this(tz, loc, lenient, formatTzOffsetWithColon, true);
+    }
+
+    /**
+     * @since 3.1
+     */
+    protected StdDateFormat(TimeZone tz, Locale loc, Boolean lenient,
+            boolean formatTzOffsetWithColon, boolean writeZeroOffsetAsZ) {
         _timezone = tz;
         _locale = loc;
         _lenient = lenient;
         _tzSerializedWithColon = formatTzOffsetWithColon;
+        _writeZeroOffsetAsZ = writeZeroOffsetAsZ;
     }
 
     public static TimeZone getDefaultTimeZone() {
@@ -183,7 +206,7 @@ public class StdDateFormat
         if ((tz == _timezone) || tz.equals(_timezone)) {
             return this;
         }
-        return new StdDateFormat(tz, _locale, _lenient, _tzSerializedWithColon);
+        return new StdDateFormat(tz, _locale, _lenient, _tzSerializedWithColon, _writeZeroOffsetAsZ);
     }
 
     /**
@@ -196,7 +219,7 @@ public class StdDateFormat
         if (loc.equals(_locale)) {
             return this;
         }
-        return new StdDateFormat(_timezone, loc, _lenient, _tzSerializedWithColon);
+        return new StdDateFormat(_timezone, loc, _lenient, _tzSerializedWithColon, _writeZeroOffsetAsZ);
     }
 
     /**
@@ -208,7 +231,7 @@ public class StdDateFormat
         if (_equals(b, _lenient)) {
             return this;
         }
-        return new StdDateFormat(_timezone, _locale, b, _tzSerializedWithColon);
+        return new StdDateFormat(_timezone, _locale, b, _tzSerializedWithColon, _writeZeroOffsetAsZ);
     }
 
     /**
@@ -226,14 +249,34 @@ public class StdDateFormat
         if (_tzSerializedWithColon == b) {
             return this;
         }
-        return new StdDateFormat(_timezone, _locale, _lenient, b);
-     }
+        return new StdDateFormat(_timezone, _locale, _lenient, b, _writeZeroOffsetAsZ);
+    }
+
+    /**
+     * "Mutant factory" method that returns an instance that controls whether
+     * zero timezone offset is serialized as "Z" ({@code true}) or as numeric
+     * offset "+00:00"/"+0000" ({@code false}).
+     *<p>
+     * NOTE: Applies to ALL timezones with zero offset, not just UTC TimeZone ID.
+     *<p>
+     * When writing numeric offset, the colon inclusion is controlled by
+     * {@link #withColonInTimeZone(boolean)}.
+     *
+     * @since 3.1
+     */
+    public StdDateFormat withZeroOffsetAsZ(boolean b) {
+        if (_writeZeroOffsetAsZ == b) {
+            return this;
+        }
+        return new StdDateFormat(_timezone, _locale, _lenient,
+                _tzSerializedWithColon, b);
+    }
 
     @Override
     public StdDateFormat clone() {
         // Although there isn't that much state to share, we do need to
         // orchestrate a bit, mostly since timezones may be changed
-        return new StdDateFormat(_timezone, _locale, _lenient, _tzSerializedWithColon);
+        return new StdDateFormat(_timezone, _locale, _lenient, _tzSerializedWithColon, _writeZeroOffsetAsZ);
     }
 
     /*
@@ -417,19 +460,37 @@ public class StdDateFormat
 
         int offset = tz.getOffset(cal.getTimeInMillis());
         if (offset != 0) {
-            int hours = Math.abs((offset / (60 * 1000)) / 60);
-            int minutes = Math.abs((offset / (60 * 1000)) % 60);
-            buffer.append(offset < 0 ? '-' : '+');
-            pad2(buffer, hours);
-            if( _tzSerializedWithColon ) {
-                buffer.append(':');
-            }
-            pad2(buffer, minutes);
+            _appendOffset(buffer, offset);
         } else {
-            // 06-Mar-2020, tatu: Jackson versions 2.x forced use of numeric offset even
-            //    for Zulu; for 3.0 `Z` is used.
-            buffer.append('Z');
+            // [databind#3284]: Allow legacy format via _writeZeroOffsetAsZ toggle
+            if (_writeZeroOffsetAsZ) {
+                // 06-Mar-2020, tatu: Jackson versions 2.x forced use of numeric offset even
+                //    for Zulu; for 3.0 `Z` is used.
+                buffer.append('Z');
+            } else {
+                _appendOffset(buffer, 0);
+            }
         }
+    }
+
+    /**
+     * Helper to append timezone offset in +HH:mm or +HHmm format.
+     * Reused for both zero and non-zero offsets.
+     *
+     * @param buffer destination buffer
+     * @param offsetMillis offset in milliseconds; truncated to whole minutes (as per original logic)
+     */
+    private void _appendOffset(StringBuffer buffer, int offsetMillis) {
+        // Simplified calculation: divide once, then extract hours/minutes
+        int totalMinutes = offsetMillis / (60 * 1000);
+        int hours = Math.abs(totalMinutes / 60);
+        int minutes = Math.abs(totalMinutes % 60);
+        buffer.append(offsetMillis < 0 ? '-' : '+');
+        pad2(buffer, hours);
+        if (_tzSerializedWithColon) {
+            buffer.append(':');
+        }
+        pad2(buffer, minutes);
     }
 
     protected void _formatBCEYear(StringBuffer buffer, int bceYearNoSign) {

--- a/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
@@ -402,6 +402,138 @@ public class JavaUtilDateSerializationTest
         assertEquals(a2q("{'date':'1970-01-01X01:00:00'}"), json);
     }
 
+    /**
+     * Test zero-offset as numeric format ([databind#3284])
+     */
+    @Test
+    public void testDateISO8601_zeroOffsetAsNumeric() throws IOException {
+        // 1) Default: zero offset should serialize as "Z"
+        {
+            ObjectMapper mapper = jsonMapperBuilder().build();
+            serialize(mapper, judate(1970, 1, 1, 0, 0, 0, 0, "UTC"),
+                    "1970-01-01T00:00:00.000Z");
+        }
+
+        // 2) Feature enabled: zero offset should serialize as "+00:00" (colon=true by default)
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            serialize(mapper, judate(1970, 1, 1, 0, 0, 0, 0, "UTC"),
+                    "1970-01-01T00:00:00.000+00:00");
+        }
+
+        // 3) Feature enabled + colon disabled: zero offset should serialize as "+0000"
+        {
+            StdDateFormat df = new StdDateFormat()
+                    .withColonInTimeZone(false)
+                    .withZeroOffsetAsZ(false);
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .defaultDateFormat(df)
+                    .build();
+            serialize(mapper, judate(1970, 1, 1, 0, 0, 0, 0, "UTC"),
+                    "1970-01-01T00:00:00.000+0000");
+        }
+
+        // 4) Regression: Non-zero offset should be unaffected
+        // Use epoch (0L) with GMT+2 formatter to verify offset is correctly written
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .defaultTimeZone(TimeZone.getTimeZone("GMT+2"))
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            // epoch=0 formatted in GMT+2 => 1970-01-01T02:00:00.000+02:00
+            serialize(mapper, new Date(0L), "1970-01-01T02:00:00.000+02:00");
+        }
+
+        // 5) Calendar also respects the feature (exact match, not contains)
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            cal.setTimeInMillis(0);
+            String json = mapper.writeValueAsString(cal);
+            assertEquals("\"1970-01-01T00:00:00.000+00:00\"", json);
+        }
+
+        // 6) Non-UTC timezone ID with zero offset (e.g., "GMT") also uses numeric format
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            serialize(mapper, judate(1970, 1, 1, 0, 0, 0, 0, "GMT"),
+                    "1970-01-01T00:00:00.000+00:00");
+        }
+
+        // 7) Map<Date, ?> key serialization also respects the feature (exact match)
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            Map<Date, String> map = new LinkedHashMap<>();
+            map.put(judate(1970, 1, 1, 0, 0, 0, 0, "UTC"), "epoch");
+            String json = mapper.writeValueAsString(map);
+            assertEquals("{\"1970-01-01T00:00:00.000+00:00\":\"epoch\"}", json);
+        }
+
+        // 8) Custom DateFormat is NOT affected by the feature (by design)
+        {
+            // Use fixed literal 'Z' suffix to ensure predictable output regardless of JDK
+            SimpleDateFormat customFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            customFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .defaultDateFormat(customFormat)
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            Date date = judate(1970, 1, 1, 0, 0, 0, 0, "UTC");
+            String json = mapper.writeValueAsString(date);
+            // Custom DateFormat controls output - feature has no effect
+            // Output is literal 'Z' (not offset) because custom format overrides StdDateFormat
+            assertEquals("\"1970-01-01T00:00:00.000Z\"", json);
+        }
+
+        // 9) Map key with WRITE_DATE_KEYS_AS_TIMESTAMPS=true is unaffected (uses timestamp, not format)
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .enable(DateTimeFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS)
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            Map<Date, String> map = new LinkedHashMap<>();
+            map.put(judate(1970, 1, 1, 0, 0, 0, 0, "UTC"), "epoch");
+            String json = mapper.writeValueAsString(map);
+            assertEquals("{\"0\":\"epoch\"}", json);
+        }
+
+        // 10) WRITE_DATES_AS_TIMESTAMPS ignores the feature (outputs numeric timestamp)
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            String json = mapper.writeValueAsString(new Date(0L));
+            assertEquals("0", json);
+        }
+
+        // 11) DST zone: Europe/London winter (offset=0) vs summer (offset=+01:00)
+        // Verifies feature applies based on actual offset, not timezone ID
+        {
+            ObjectMapper mapper = jsonMapperBuilder()
+                    .defaultTimeZone(TimeZone.getTimeZone("Europe/London"))
+                    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
+                    .build();
+            // Winter: 2024-01-15 00:00:00 UTC -> offset=0 -> should be +00:00
+            Date winterDate = new Date(1705276800000L); // 2024-01-15T00:00:00Z
+            String winterJson = mapper.writeValueAsString(winterDate);
+            assertTrue(winterJson.endsWith("+00:00\""), "Winter should end with +00:00: " + winterJson);
+
+            // Summer: 2024-07-15 00:00:00 UTC -> offset=+01:00 -> should be +01:00
+            Date summerDate = new Date(1721001600000L); // 2024-07-15T00:00:00Z
+            String summerJson = mapper.writeValueAsString(summerDate);
+            assertTrue(summerJson.endsWith("+01:00\""), "Summer should end with +01:00: " + summerJson);
+        }
+    }
+
     private static Date judate(int year, int month, int day, int hour, int minutes, int seconds, int millis, String tz) {
         Calendar cal = Calendar.getInstance();
         // 23-Nov-2018, tatu: Safer this way, even though negative appears to work too


### PR DESCRIPTION
## Summary

Implements #3284: add `DateTimeFeature.WRITE_UTC_AS_OFFSET` to allow serializing
**zero timezone offsets** as numeric offsets (`+00:00` / `+0000`) instead of the
Jackson 3.x default `Z`.

> Note: Despite the feature name, this applies to **all timezones with effective offset == 0**
> at serialization time (e.g. `UTC`, `GMT`, `Europe/London` in winter).

## Implementation

Following @cowtowncoder’s suggestion to expose this via `DateTimeFeature`:

- Add `DateTimeFeature.WRITE_UTC_AS_OFFSET` (disabled by default to preserve 3.x behavior)
- Extend `StdDateFormat` with `_writeZeroOffsetAsZ` + `withZeroOffsetAsZ(boolean)`
- Apply the setting in `SerializationContext` during date format setup (post-clone)
- Keep colon control via existing `StdDateFormat.withColonInTimeZone(boolean)` (`+00:00` vs `+0000`)

### Usage

```java
// Default 3.x behavior: "Z"
ObjectMapper m1 = JsonMapper.builder().build();
m1.writeValueAsString(new Date(0L));
// -> "1970-01-01T00:00:00.000Z"

// Feature enabled: "+00:00"
ObjectMapper m2 = JsonMapper.builder()
    .enable(DateTimeFeature.WRITE_UTC_AS_OFFSET)
    .build();
m2.writeValueAsString(new Date(0L));
// -> "1970-01-01T00:00:00.000+00:00"

// Feature enabled + colon disabled: "+0000"
StdDateFormat df = new StdDateFormat()
    .withColonInTimeZone(false)
    .withZeroOffsetAsZ(false);

ObjectMapper m3 = JsonMapper.builder()
    .defaultDateFormat(df)
    .build();
m3.writeValueAsString(new Date(0L));
// -> "1970-01-01T00:00:00.000+0000"
```

## Tests

Add coverage for:
- Default behavior (Z)
- Feature enabled (+00:00)
- Feature + colon disabled (+0000)
- Non-zero offset regression check
- Calendar serialization
- Non-UTC timezone ID with zero offset (e.g. GMT)
- Map<Date, ?> key serialization
- Custom DateFormat unaffected (by design)
- Map key timestamp mode unaffected (WRITE_DATE_KEYS_AS_TIMESTAMPS)
- WRITE_DATES_AS_TIMESTAMPS ignores the feature
- DST zone behavior (Europe/London winter vs summer)