### PR TITLE
Add docs and tests for #5608: `FunctionalScalarDeserializer` error handling

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/std/FunctionalScalarDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/std/FunctionalScalarDeserializer.java
@@ -22,6 +22,15 @@ import tools.jackson.databind.util.ExceptionUtil;
  * supports other JSON scalar types via {@code getValueAsString()} coercion.
  * Non-scalar JSON values (arrays, objects, embedded objects) are rejected.
  * <p>
+ * <b>Error handling:</b>
+ * <ul>
+ *   <li>{@link JacksonException} thrown by user code is propagated as-is.</li>
+ *   <li>Other exceptions are wrapped in
+ *       {@link tools.jackson.databind.exc.InvalidFormatException}.</li>
+ *   <li>If {@link tools.jackson.databind.DeserializationFeature#WRAP_EXCEPTIONS}
+ *       is disabled, {@link RuntimeException} is thrown as-is without wrapping.</li>
+ * </ul>
+ * <p>
  * Usage examples:
  * <pre>
  * // Simple case - method reference

--- a/src/test/java/tools/jackson/databind/deser/std/FunctionalScalarDeserializer4004Test.java
+++ b/src/test/java/tools/jackson/databind/deser/std/FunctionalScalarDeserializer4004Test.java
@@ -5,8 +5,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
+import tools.jackson.core.JsonParser;
 import tools.jackson.core.type.TypeReference;
 
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.CoercionAction;
@@ -512,6 +515,97 @@ public class FunctionalScalarDeserializer4004Test
         } catch (MismatchedInputException e) {
             verifyException(e, "not a valid textual representation");
             verifyException(e, "BiFunction custom error");
+        }
+    }
+
+    @Test
+    public void testFunctionThrowsJacksonExceptionPropagatedAsIs() throws Exception
+    {
+        SimpleModule module = new SimpleModule("test");
+        module.addDeserializer(Bar.class,
+                new FunctionalScalarDeserializer<>(Bar.class, s -> {
+                    throw DatabindException.from((JsonParser) null, "User JacksonException");
+                }));
+
+        ObjectMapper mapper = jsonMapperBuilder()
+                .addModule(module)
+                .build();
+
+        try {
+            mapper.readValue("\"test\"", Bar.class);
+            fail("Should throw exception");
+        } catch (DatabindException e) {
+            assertEquals("User JacksonException", e.getOriginalMessage());
+        }
+    }
+
+    @Test
+    public void testBiFunctionThrowsJacksonExceptionPropagatedAsIs() throws Exception
+    {
+        SimpleModule module = new SimpleModule("test");
+        module.addDeserializer(Bar.class,
+                new FunctionalScalarDeserializer<>(Bar.class, (p, ctx) -> {
+                    throw DatabindException.from(p, "User BiFunction JacksonException");
+                }));
+
+        ObjectMapper mapper = jsonMapperBuilder()
+                .addModule(module)
+                .build();
+
+        try {
+            mapper.readValue("\"test\"", Bar.class);
+            fail("Should throw exception");
+        } catch (DatabindException e) {
+            assertEquals("User BiFunction JacksonException", e.getOriginalMessage());
+        }
+    }
+
+    @Test
+    public void testWrapExceptionsEnabled() throws Exception
+    {
+        SimpleModule module = new SimpleModule("test");
+        module.addDeserializer(Bar.class,
+                new FunctionalScalarDeserializer<>(Bar.class, s -> {
+                    throw new RuntimeException("User error");
+                }));
+
+        ObjectMapper mapper = jsonMapperBuilder()
+                .addModule(module)
+                .enable(DeserializationFeature.WRAP_EXCEPTIONS)
+                .build();
+
+        try {
+            mapper.readValue("\"test\"", Bar.class);
+            fail("Should throw exception");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "not a valid textual representation");
+            verifyException(e, "User error");
+        } catch (Exception e) {
+            fail("Should wrap as MismatchedInputException, got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void testWrapExceptionsDisabled() throws Exception
+    {
+        SimpleModule module = new SimpleModule("test");
+        module.addDeserializer(Bar.class,
+                new FunctionalScalarDeserializer<>(Bar.class, s -> {
+                    throw new RuntimeException("User error");
+                }));
+
+        ObjectMapper mapper = jsonMapperBuilder()
+                .addModule(module)
+                .disable(DeserializationFeature.WRAP_EXCEPTIONS)
+                .build();
+
+        try {
+            mapper.readValue("\"test\"", Bar.class);
+            fail("Should throw exception");
+        } catch (MismatchedInputException e) {
+            fail("Should not wrap exception when WRAP_EXCEPTIONS is disabled");
+        } catch (RuntimeException e) {
+            verifyException(e, "User error");
         }
     }
 }


### PR DESCRIPTION
Follow-up for #5608

This PR adds documentation and tests for `FunctionalScalarDeserializer` error handling behavior.

Changes:
  - Document error handling rules in Javadoc (JacksonException propagation, WRAP_EXCEPTIONS support)
  - Add tests for JacksonException propagation (Function and BiFunction paths)
  - Add tests for WRAP_EXCEPTIONS enabled/disabled behavior