### PR TITLE
Fix typo: MissingInjectableValueExcepion → MissingInjectableValueException

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -187,6 +187,8 @@ Lee Jiwon (@dlwldnjs1009)
  * Implemented #3284: Backward compatibility for timezone formats of UTC Date
    serialization
   [3.1.0]
+ * Implemented #5621: Fix typo: MissingInjectableValueExcepion → MissingInjectableValueException
+  [3.1.0]
 
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -157,6 +157,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #5616: `ObjectWriter` serializes `Optional`s with subtypes incompletely
  (reported by Brandon S)
  (implemented by @cowtowncoder, w/ Claude code)
+#5621: Fix typo: MissingInjectableValueExcepion → MissingInjectableValueException
+ (implemented by Lee Jiwon)
 
 3.0.4 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/DeserializationContext.java
+++ b/src/main/java/tools/jackson/databind/DeserializationContext.java
@@ -2153,7 +2153,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     public DatabindException missingInjectableValueException(String msg,
             Object valueId,
             BeanProperty forProperty, Object beanInstance) {
-        return MissingInjectableValueExcepion.from(_parser, msg,
+        return MissingInjectableValueException.from(_parser, msg,
                 valueId, forProperty, beanInstance);
     }
 

--- a/src/main/java/tools/jackson/databind/exc/MissingInjectableValueExcepion.java
+++ b/src/main/java/tools/jackson/databind/exc/MissingInjectableValueExcepion.java
@@ -1,0 +1,43 @@
+package tools.jackson.databind.exc;
+
+import tools.jackson.core.JsonParser;
+
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DatabindException;
+
+/**
+ * @deprecated Use {@link MissingInjectableValueException} instead.
+ */
+@Deprecated
+public class MissingInjectableValueExcepion
+    extends DatabindException
+{
+    private static final long serialVersionUID = 1L;
+
+    protected final Object _valueId;
+    protected final BeanProperty _forProperty;
+    protected final Object _beanInstance;
+
+    protected MissingInjectableValueExcepion(JsonParser p, String msg,
+            Object valueId, BeanProperty forProperty, Object beanInstance)
+    {
+        super(p, msg);
+        _valueId = valueId;
+        _forProperty = forProperty;
+        _beanInstance = beanInstance;
+    }
+
+    /**
+     * @deprecated Use {@link MissingInjectableValueException#from} instead.
+     */
+    @Deprecated
+    public static MissingInjectableValueExcepion from(JsonParser p, String msg,
+            Object valueId, BeanProperty forProperty, Object beanInstance)
+    {
+        return MissingInjectableValueException.from(p, msg, valueId, forProperty, beanInstance);
+    }
+
+    public Object getValueId() { return _valueId; }
+    public BeanProperty getForProperty() { return _forProperty; }
+    public Object getBeanInstance() { return _beanInstance; }
+}

--- a/src/main/java/tools/jackson/databind/exc/MissingInjectableValueException.java
+++ b/src/main/java/tools/jackson/databind/exc/MissingInjectableValueException.java
@@ -3,24 +3,17 @@ package tools.jackson.databind.exc;
 import tools.jackson.core.JsonParser;
 
 import tools.jackson.databind.BeanProperty;
-import tools.jackson.databind.DatabindException;
 
+@SuppressWarnings("deprecation") // extends deprecated MissingInjectableValueExcepion for backward compatibility
 public class MissingInjectableValueException
-    extends DatabindException
+    extends MissingInjectableValueExcepion
 {
     private static final long serialVersionUID = 1L;
-
-    protected final Object _valueId;
-    protected final BeanProperty _forProperty;
-    protected final Object _beanInstance;
 
     protected MissingInjectableValueException(JsonParser p, String msg,
             Object valueId, BeanProperty forProperty, Object beanInstance)
     {
-        super(p, msg);
-        _valueId = valueId;
-        _forProperty = forProperty;
-        _beanInstance = beanInstance;
+        super(p, msg, valueId, forProperty, beanInstance);
     }
 
     public static MissingInjectableValueException from(JsonParser p, String msg,
@@ -28,8 +21,4 @@ public class MissingInjectableValueException
     {
         return new MissingInjectableValueException(p, msg, valueId, forProperty, beanInstance);
     }
-
-    public Object getValueId() { return _valueId; }
-    public BeanProperty getForProperty() { return _forProperty; }
-    public Object getBeanInstance() { return _beanInstance; }
 }

--- a/src/main/java/tools/jackson/databind/exc/MissingInjectableValueException.java
+++ b/src/main/java/tools/jackson/databind/exc/MissingInjectableValueException.java
@@ -5,7 +5,7 @@ import tools.jackson.core.JsonParser;
 import tools.jackson.databind.BeanProperty;
 import tools.jackson.databind.DatabindException;
 
-public class MissingInjectableValueExcepion
+public class MissingInjectableValueException
     extends DatabindException
 {
     private static final long serialVersionUID = 1L;
@@ -14,7 +14,7 @@ public class MissingInjectableValueExcepion
     protected final BeanProperty _forProperty;
     protected final Object _beanInstance;
 
-    protected MissingInjectableValueExcepion(JsonParser p, String msg,
+    protected MissingInjectableValueException(JsonParser p, String msg,
             Object valueId, BeanProperty forProperty, Object beanInstance)
     {
         super(p, msg);
@@ -23,10 +23,10 @@ public class MissingInjectableValueExcepion
         _beanInstance = beanInstance;
     }
 
-    public static MissingInjectableValueExcepion from(JsonParser p, String msg,
+    public static MissingInjectableValueException from(JsonParser p, String msg,
             Object valueId, BeanProperty forProperty, Object beanInstance)
     {
-        return new MissingInjectableValueExcepion(p, msg, valueId, forProperty, beanInstance);
+        return new MissingInjectableValueException(p, msg, valueId, forProperty, beanInstance);
     }
 
     public Object getValueId() { return _valueId; }

--- a/src/test/java/tools/jackson/databind/deser/inject/JacksonInject1381Test.java
+++ b/src/test/java/tools/jackson/databind/deser/inject/JacksonInject1381Test.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.*;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.InjectableValues;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.exc.MissingInjectableValueExcepion;
+import tools.jackson.databind.exc.MissingInjectableValueException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -121,19 +121,19 @@ class JacksonInject1381Test extends DatabindTestUtil
     @Test
     @DisplayName("input NO, injectable NO, useInput DEFAULT|TRUE|FALSE => exception")
     void test1() {
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(empty, InputDefault.class));
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(empty, InputDefaultConstructor.class));
 
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(empty, InputTrue.class));
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(empty, InputTrueConstructor.class));
 
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(empty, InputFalse.class));
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(empty, InputFalseConstructor.class));
     }
 
@@ -151,14 +151,14 @@ class JacksonInject1381Test extends DatabindTestUtil
     @Test
     @DisplayName("input YES, injectable NO, useInput DEFAULT|FALSE => exception")
     void test3() {
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(input, InputDefault.class));
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(input, InputDefaultConstructor.class));
 
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(input, InputFalse.class));
-        assertThrows(MissingInjectableValueExcepion.class,
+        assertThrows(MissingInjectableValueException.class,
                 () -> plainMapper.readValue(input, InputFalseConstructor.class));
     }
 

--- a/src/test/java/tools/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/tools/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.OptBoolean;
 
 import tools.jackson.databind.*;
+import tools.jackson.databind.exc.MissingInjectableValueExcepion;
 import tools.jackson.databind.exc.MissingInjectableValueException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
@@ -141,5 +142,14 @@ class JacksonInject3072Test extends DatabindTestUtil
 
         assertNull(dto.id);
         assertNull(dto.optionalField);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testBackwardCompatWithDeprecatedClassName() throws Exception {
+        MissingInjectableValueException ex = assertThrows(
+                MissingInjectableValueException.class,
+                () -> READER.readValue("{}"));
+        assertThat(ex).isInstanceOf(MissingInjectableValueExcepion.class);
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/inject/JacksonInject3072Test.java
+++ b/src/test/java/tools/jackson/databind/deser/inject/JacksonInject3072Test.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.OptBoolean;
 
 import tools.jackson.databind.*;
-import tools.jackson.databind.exc.MissingInjectableValueExcepion;
+import tools.jackson.databind.exc.MissingInjectableValueException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -58,8 +58,8 @@ class JacksonInject3072Test extends DatabindTestUtil
 
     @Test
     void testMandatoryFieldNotFound() {
-        MissingInjectableValueExcepion exception = assertThrows(
-                MissingInjectableValueExcepion.class, () -> READER.readValue("{}"));
+        MissingInjectableValueException exception = assertThrows(
+                MissingInjectableValueException.class, () -> READER.readValue("{}"));
 
         assertThat(exception.getMessage())
             .startsWith("No injectable value with id 'id' found (for property 'id')");
@@ -72,8 +72,8 @@ class JacksonInject3072Test extends DatabindTestUtil
         ObjectReader reader = READER.forType(DtoWithRequired.class)
             .without(DeserializationFeature.FAIL_ON_UNKNOWN_INJECT_VALUE);
 
-        MissingInjectableValueExcepion exception = assertThrows(
-                MissingInjectableValueExcepion.class, () -> reader.readValue("{}"));
+        MissingInjectableValueException exception = assertThrows(
+                MissingInjectableValueException.class, () -> reader.readValue("{}"));
 
         assertThat(exception.getMessage())
             .startsWith("No injectable value with id 'requiredValue' found (for property 'requiredField')");
@@ -83,7 +83,7 @@ class JacksonInject3072Test extends DatabindTestUtil
                 .addValue("id", "idValue"));
 
         exception = assertThrows(
-                MissingInjectableValueExcepion.class, () -> reader2.readValue("{}"));
+                MissingInjectableValueException.class, () -> reader2.readValue("{}"));
 
         assertThat(exception.getMessage())
              .startsWith("No injectable value with id 'requiredValue' found (for property 'requiredField')");
@@ -100,8 +100,8 @@ class JacksonInject3072Test extends DatabindTestUtil
         ObjectReader reader = READER
                 .with(new InjectableValues.Std());
 
-        MissingInjectableValueExcepion exception = assertThrows(
-                MissingInjectableValueExcepion.class, () -> reader.readValue("{}"));
+        MissingInjectableValueException exception = assertThrows(
+                MissingInjectableValueException.class, () -> reader.readValue("{}"));
 
         assertThat(exception.getMessage())
             .startsWith("No injectable value with id 'id' found (for property 'id')");


### PR DESCRIPTION
## Summary

Fix typo in exception class name:
`MissingInjectableValueExcepion` → `MissingInjectableValueException` (missing "t").

- Added correctly named exception as sub-type of existing one
- Deprecated existing exception
- Updated all in-repo references (prod + tests)

## Test plan
- [x] ./mvnw test -pl . -Dtest="JacksonInject*Test"