### PR TITLE
Fix issue where `_findSerializer()` was called with incorrect argument in `StdDelegatingSerializer::isEmpty()`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -11,6 +11,7 @@ Co-Authors (with only partial listings below):
 * Joo Hyuk Kim (@JooHyukKim)
 * PJ Fanning (@pjfanning)
 * Sim Yih Tsern (@yihtsern)
+* wrongwrong (@k163377)
 
 ----------------------------------------------------------------------------
 
@@ -112,3 +113,8 @@ Fouad Almalki (@Eng-Fouad)
  * Contributed fix for #5416: Annotations on an interface that's part of a JDK proxy are not honored
    with Jackson 3
   [3.0.3]
+
+wrongwrong (@k163377)
+ * Fixed #5685: Fix issue where `_findSerializer()` was called with incorrect argument in
+   `StdDelegatingSerializer::isEmpty()`
+  [3.0.5]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -9,6 +9,12 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 -
 
+3.0.5 (not yet released)
+
+#5685: Fix issue where `_findSerializer()` was called with incorrect argument in
+  `StdDelegatingSerializer::isEmpty()`
+ (fixed by @wrongwrong)
+
 3.0.4 (21-Jan-2026)
 
 #1288 (regression in 3.0.0) Type id not exposed for `JsonTypeInfo.As.EXTERNAL_PROPERTY`

--- a/src/main/java/tools/jackson/databind/ser/std/StdDelegatingSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/std/StdDelegatingSerializer.java
@@ -206,7 +206,7 @@ public class StdDelegatingSerializer
         }
         ValueSerializer<Object> ser = _delegateSerializer;
         if (ser == null) {
-            ser = _findSerializer(value, ctxt);
+            ser = _findSerializer(delegateValue, ctxt);
         }
         return ser.isEmpty(ctxt, delegateValue);
     }


### PR DESCRIPTION
This was discovered during the investigation of the following issue.
https://github.com/FasterXML/jackson-module-kotlin/issues/1065

---
I apologize for not being up to date on the recent maintenance policy.

First, I haven't been able to confirm whether fixes are needed for `2.x`.
I had assumed `2.x` didn't require fixes—is that correct?

Next, since this is a minor bug, I believe submitting it to the `3.0` branch is the correct approach—is that correct?
Separately, I'm also concerned that `2.x` appears not to have been merged into `3.0` (but has been merged into `3.x`).

Finally, how should tests be added for this issue?
Personally, I intended to add tests to `kotlin-module` after this PR is merged.
