### PR TITLE
Fix #5729: signed numeric timestamps should not be treated as ISO-8601

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -431,6 +431,9 @@ Jonas Konrad (yawkat@github)
    (2.14.1)
   * Contributed fix for #4848: Avoid type pollution in `StringCollectionDeserializer`
    (2.18.3)
+  * Fixed #5729: (regression due to #5429) ISO-8601 change prevents parsing
+    negative timestamps (dates before 1970)
+   (2.21.2)
 
 Jirka Kremser (Jiri-Kremser@github)
   * Suggested #924: SequenceWriter.writeAll() could accept Iterable
@@ -2003,3 +2006,8 @@ Kyrylo Merzlikin (@kirmerzlikin)
  * Reported #5706: `TokenBuffer` serialization fails when buffer contains integer
    encoded as String
   [2.21.1]
+
+Thomas Wöckinger (@thomaswoeckinger)
+ * Reported #5729: (regression due to #5429) ISO-8601 change prevents parsing
+   negative timestamps (dates before 1970)
+  [2.21.2]

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,13 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.21.2 (not yet released)
+
+#5729: (regression due to #5429) ISO-8601 change prevents parsing
+  negative timestamps (dates before 1970)
+ (reported by Thomas W)
+ (fixed by by Jonas K)
+
 2.21.1 (22-Feb-2026)
 
 #5184: `@JsonIgnore` on record method applied to record matching

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -614,6 +614,7 @@ public class StdDateFormat
             final char c = dateStr.charAt(0);
             // [databind#5429]: extended year may have +/- prefix
             if (c == '+' || c == '-') {
+                // [databind#5729] avoid stringified timestamps
                 if (_isAllDigits(dateStr, 1)) {
                     return false;
                 }
@@ -628,6 +629,7 @@ public class StdDateFormat
         return false;
     }
 
+    // @since 2.21.2 (for [databind#5729])
     private static boolean _isAllDigits(String str, int offset)
     {
         final int len = str.length();
@@ -636,6 +638,7 @@ public class StdDateFormat
                 return false;
             }
         }
+        // return false if no digits past leading sign
         return (offset < len);
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java
@@ -614,6 +614,9 @@ public class StdDateFormat
             final char c = dateStr.charAt(0);
             // [databind#5429]: extended year may have +/- prefix
             if (c == '+' || c == '-') {
+                if (_isAllDigits(dateStr, 1)) {
+                    return false;
+                }
                 return (dateStr.length() >= 11)
                     && Character.isDigit(dateStr.charAt(1));
             }
@@ -623,6 +626,17 @@ public class StdDateFormat
                 && Character.isDigit(dateStr.charAt(5));
         }
         return false;
+    }
+
+    private static boolean _isAllDigits(String str, int offset)
+    {
+        final int len = str.length();
+        for (int i = offset; i < len; ++i) {
+            if (!Character.isDigit(str.charAt(i))) {
+                return false;
+            }
+        }
+        return (offset < len);
     }
 
     private Date _parseDateFromLong(String longStr, ParsePosition pos) throws ParseException

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/DateDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/DateDeserializationTest.java
@@ -134,6 +134,24 @@ public class DateDeserializationTest
     }
 
     @Test
+    public void testSignedStringTimestampViaObjectMapper() throws Exception
+    {
+        long before = -1383043669935L;
+        String json = q(String.valueOf(before));
+
+        Date date = MAPPER.readValue(json, Date.class);
+        assertEquals(before, date.getTime());
+
+        Calendar calendar = MAPPER.readValue(json, Calendar.class);
+        assertEquals(before, calendar.getTimeInMillis());
+
+        assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(q("+1383043669935"), Date.class));
+        assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(q("+1383043669935"), Calendar.class));
+    }
+
+    @Test
     public void testDateUtilRFC1123() throws Exception
     {
         DateFormat fmt = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);

--- a/src/test/java/com/fasterxml/jackson/databind/util/StdDateFormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/StdDateFormatTest.java
@@ -13,6 +13,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class StdDateFormatTest extends DatabindTestUtil
 {
+    static class TestStdDateFormat extends StdDateFormat {
+        boolean testLooksLikeISO8601(String input) {
+            return looksLikeISO8601(input);
+        }
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     public void testFactories() {
@@ -146,5 +152,35 @@ public class StdDateFormatTest extends DatabindTestUtil
         } catch (java.text.ParseException e) {
             verifyException(e, "Cannot parse");
         }
+    }
+
+    @Test
+    public void testNegativeTimestampParsing() throws Exception
+    {
+        StdDateFormat f = StdDateFormat.instance.clone();
+        f.setLenient(false);
+
+        Date dt = f.parse("-1383043669935");
+        assertEquals(-1383043669935L, dt.getTime());
+    }
+
+    @Test
+    public void testShortNegativeTimestampParsing() throws Exception
+    {
+        StdDateFormat f = StdDateFormat.instance.clone();
+        f.setLenient(false);
+
+        assertEquals(-1L, f.parse("-1").getTime());
+        assertEquals(-1234567890L, f.parse("-1234567890").getTime());
+    }
+
+    @Test
+    public void testCompactNumericDateInputStillHandledAsTimestamp() throws Exception
+    {
+        TestStdDateFormat f = new TestStdDateFormat();
+        f.setLenient(false);
+
+        assertFalse(f.testLooksLikeISO8601("20250305"));
+        assertEquals(20250305L, f.parse("20250305").getTime());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes `StdDateFormat.looksLikeISO8601()` so signed digit-only inputs (for example `-1383043669935`) are treated as numeric timestamps instead of ISO-8601 candidates.
- Adds regression tests for negative signed timestamps, including short negative values, to verify pre-1970 timestamps continue to parse.
- Adds a guard test showing compact numeric input like `20250305` does not route through ISO-8601 detection and keeps timestamp behavior.

Fixes #5729