### PR TITLE
Fix #5734: add `DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -279,7 +279,7 @@ Matthew Luckam (@mluckam)
 
 Kyrylo Merzlikin (@kirmerzlikin)
  * Reported #5706: `TokenBuffer` serialization fails when buffer contains integer
-   encoded as Stri
+   encoded as String
   [3.1.0]
 
 Martin Uhlen (@MartinUhlen)

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -275,8 +275,14 @@ Brandon Schmitt (@BrandonSchmitt)
  
 Matthew Luckam (@mluckam)
  * Contributed #5630: Add `DelegatingSerializer`
+  [3.1.0]
 
 Kyrylo Merzlikin (@kirmerzlikin)
  * Reported #5706: `TokenBuffer` serialization fails when buffer contains integer
-   encoded as String
+   encoded as Stri
   [3.1.0]
+
+Martin Uhlen (@MartinUhlen)
+ * Requested #5734: Add `DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES` to
+   allow preventing absent-primitive failure
+  [3.2.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,6 +15,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
   `BeanDescription.getIgnoredPropertyNames()`
  (requested by Oliver D)
  (fix by @cowtowncoder, w/ Claude code)
+#5734: Add `DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES` to
+  allow preventing absent-primitive failure
+ (requested by Martin U)
+ (fix by @cowtowncoder, w/ Claude code)
 - Remove project-specific Android SDK compatibility level, use shared;
   no change level itself (stillAndroid SDK 34)
 

--- a/src/main/java/tools/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/tools/jackson/databind/DeserializationFeature.java
@@ -152,13 +152,30 @@ public enum DeserializationFeature implements ConfigFeature
     /**
      * Feature that determines whether encountering of JSON null
      * is an error when deserializing into Java primitive types
-     * (like 'int' or 'double'). If it is, a {@link DatabindException}
+     * (like {@code int} or {@code double}). If it is, a {@link DatabindException}
      * is thrown to indicate this; if not, default value is used
-     * (0 for 'int', 0.0 for double, same defaulting as what JVM uses).
+     * ({@code 0} for {@code int}, {@code 0.0} for {@code double}, same defaulting as JVM uses).
      *<p>
      * Feature is enabled by default as of Jackson 3.0 (in 2.x it was disabled).
      */
     FAIL_ON_NULL_FOR_PRIMITIVES(true),
+
+    /**
+     * Feature that determines whether absence of a JSON property
+     * is an error when deserializing into Java primitive types
+     * (like {@code int} or {@code double}). If it is, a {@link DatabindException}
+     * is thrown to indicate this; if not, default value is used
+     * ({@code 0} for {@code int}, {@code 0.0} for {@code double}, same defaulting as JVM uses).
+     *<p>
+     * Note that this is separate from {@link #FAIL_ON_NULL_FOR_PRIMITIVES}:
+     * that feature controls behavior for explicit JSON {@code null} values,
+     * while this one controls behavior when a JSON property is entirely absent.
+     *<p>
+     * Feature is disabled by default (added in Jackson 3.1).
+     *
+     * @since 3.1
+     */
+    FAIL_ON_ABSENT_FOR_PRIMITIVES(false),
 
     /**
      * Feature that determines what happens when type of a polymorphic

--- a/src/main/java/tools/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/tools/jackson/databind/DeserializationFeature.java
@@ -156,6 +156,9 @@ public enum DeserializationFeature implements ConfigFeature
      * is thrown to indicate this; if not, default value is used
      * ({@code 0} for {@code int}, {@code 0.0} for {@code double}, same defaulting as JVM uses).
      *<p>
+     * Note that this is separate from {@link #FAIL_ON_ABSENT_FOR_PRIMITIVES} added
+     * in 3.1.
+     *<p>
      * Feature is enabled by default as of Jackson 3.0 (in 2.x it was disabled).
      */
     FAIL_ON_NULL_FOR_PRIMITIVES(true),
@@ -190,7 +193,7 @@ public enum DeserializationFeature implements ConfigFeature
 
     /**
      * Feature that determines whether abstract types (abstract classes, interfaces)
-     * should be ignored when building the type fingerprints for polymorphic type
+     * should be ignored when building the type finger prints for polymorphic type
      * deduction using {@link com.fasterxml.jackson.annotation.JsonTypeInfo.Id#DEDUCTION}.
      * When enabled, non-concrete types are excluded from deduction since they cannot
      * be instantiated; when disabled, they participate in deduction which may cause

--- a/src/main/java/tools/jackson/databind/DeserializationFeature.java
+++ b/src/main/java/tools/jackson/databind/DeserializationFeature.java
@@ -174,7 +174,8 @@ public enum DeserializationFeature implements ConfigFeature
      * that feature controls behavior for explicit JSON {@code null} values,
      * while this one controls behavior when a JSON property is entirely absent.
      *<p>
-     * Feature is disabled by default (added in Jackson 3.1).
+     * Feature is disabled by default (added in Jackson 3.1); formerly
+     * value of {@link #FAIL_ON_NULL_FOR_PRIMITIVES} was used.
      *
      * @since 3.1
      */

--- a/src/main/java/tools/jackson/databind/deser/jdk/NumberDeserializers.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/NumberDeserializers.java
@@ -173,13 +173,12 @@ public class NumberDeserializers
         }
 
         // @since 3.1
-        @SuppressWarnings("unchecked")
         @Override
         public Object getAbsentValue(DeserializationContext ctxt) {
-            // [databind#5734]: Absent (missing) JSON fields for primitives should be
-            //   controlled separately from explicit nulls (FAIL_ON_NULL_FOR_PRIMITIVES)
+            // [databind#5734]: Absent (missing) JSON fields for primitives controlled
+            //   separately from explicit nulls (FAIL_ON_NULL_FOR_PRIMITIVES)
             if (_primitive && ctxt.isEnabled(DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES)) {
-                return (T) ctxt.handleNullForPrimitives(handledType(), ctxt.getParser(), this,
+                return ctxt.handleNullForPrimitives(handledType(), ctxt.getParser(), this,
 "Cannot map absent (missing) value to type %s (set `DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES` to 'false' to allow)",
                                 ClassUtil.nameOf(handledType()));
             }

--- a/src/main/java/tools/jackson/databind/deser/jdk/NumberDeserializers.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/NumberDeserializers.java
@@ -172,6 +172,20 @@ public class NumberDeserializers
             return _nullValue;
         }
 
+        // @since 3.1
+        @SuppressWarnings("unchecked")
+        @Override
+        public Object getAbsentValue(DeserializationContext ctxt) {
+            // [databind#5734]: Absent (missing) JSON fields for primitives should be
+            //   controlled separately from explicit nulls (FAIL_ON_NULL_FOR_PRIMITIVES)
+            if (_primitive && ctxt.isEnabled(DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES)) {
+                return (T) ctxt.handleNullForPrimitives(handledType(), ctxt.getParser(), this,
+"Cannot map absent (missing) value to type %s (set `DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES` to 'false' to allow)",
+                                ClassUtil.nameOf(handledType()));
+            }
+            return _nullValue;
+        }
+
         @Override
         public Object getEmptyValue(DeserializationContext ctxt) {
             return _emptyValue;

--- a/src/test/java/tools/jackson/databind/deser/creators/CreatorNullPrimitivesTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/CreatorNullPrimitivesTest.java
@@ -133,7 +133,7 @@ public class CreatorNullPrimitivesTest
     }
 
     // [databind#5734]: absent (missing) primitive creator properties should get
-    //   JVM defaults, not trigger FAIL_ON_NULL_FOR_PRIMITIVES
+    //   JVM defaults when FAIL_ON_ABSENT_FOR_PRIMITIVES is disabled
     @Test
     public void testCreatorAbsentPrimitiveShouldDefault() throws Exception {
         final ObjectReader r = MAPPER.readerFor(JsonEntity.class)
@@ -207,9 +207,11 @@ public class CreatorNullPrimitivesTest
     }
 
     // [databind#5734]: record with absent primitives should use JVM defaults
+    //   when FAIL_ON_ABSENT_FOR_PRIMITIVES is disabled
     @Test
     void testRecordAbsentPrimitivesShouldDefault() throws Exception {
-        // FAIL_ON_NULL_FOR_PRIMITIVES is enabled by default in 3.x
+        // FAIL_ON_NULL_FOR_PRIMITIVES is enabled by default in 3.x;
+        // FAIL_ON_ABSENT_FOR_PRIMITIVES is disabled by default
         String json = a2q("{'int2': 42, 'boolean1': true}");
         PrimitiveRecord result = MAPPER.readValue(json, PrimitiveRecord.class);
         assertEquals(0, result.int1());

--- a/src/test/java/tools/jackson/databind/deser/creators/CreatorNullPrimitivesTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/CreatorNullPrimitivesTest.java
@@ -86,6 +86,10 @@ public class CreatorNullPrimitivesTest
         }
     }
 
+    // [databind#5734]
+    record PrimitiveRecord(int int1, int int2, boolean boolean1, boolean boolean2) {
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -96,10 +100,11 @@ public class CreatorNullPrimitivesTest
 
     // [databind#2101]: ensure that the property is included in the path
     @Test
-    public void testCreatorNullPrimitive() throws Exception {
+    public void testCreatorExplicitNullPrimitive() throws Exception {
         final ObjectReader r = MAPPER.readerFor(JsonEntity.class)
             .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
-        String json = a2q("{'x': 2}");
+        // Explicit null should still fail
+        String json = a2q("{'x': 2, 'y': null}");
         try {
             r.readValue(json);
             fail("Should not have succeeded");
@@ -111,10 +116,11 @@ public class CreatorNullPrimitivesTest
     }
 
     @Test
-    public void testCreatorNullPrimitiveInNestedObject() throws Exception {
+    public void testCreatorExplicitNullPrimitiveInNestedObject() throws Exception {
         final ObjectReader r = MAPPER.readerFor(NestedJsonEntity.class)
                 .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
-        String json = a2q("{ 'entity': {'x': 2}}");
+        // Explicit null should still fail
+        String json = a2q("{ 'entity': {'x': 2, 'y': null}}");
         try {
             r.readValue(json);
             fail("Should not have succeeded");
@@ -124,6 +130,31 @@ public class CreatorNullPrimitivesTest
             assertEquals("y", e.getPath().get(1).getPropertyName());
             assertEquals("entity", e.getPath().get(0).getPropertyName());
         }
+    }
+
+    // [databind#5734]: absent (missing) primitive creator properties should get
+    //   JVM defaults, not trigger FAIL_ON_NULL_FOR_PRIMITIVES
+    @Test
+    public void testCreatorAbsentPrimitiveShouldDefault() throws Exception {
+        final ObjectReader r = MAPPER.readerFor(JsonEntity.class)
+            .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+        // Missing "y" should default to 0, not fail
+        String json = a2q("{'x': 2}");
+        JsonEntity result = r.readValue(json);
+        assertEquals(2, result.x);
+        assertEquals(0, result.y);
+    }
+
+    // [databind#5734]: absent (missing) primitive creator properties in nested objects
+    @Test
+    public void testCreatorAbsentPrimitiveInNestedObjectShouldDefault() throws Exception {
+        final ObjectReader r = MAPPER.readerFor(NestedJsonEntity.class)
+                .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+        // Missing "y" in nested entity should default to 0, not fail
+        String json = a2q("{ 'entity': {'x': 2}}");
+        NestedJsonEntity result = r.readValue(json);
+        assertEquals(2, result.entity.x);
+        assertEquals(0, result.entity.y);
     }
 
     // [databind#988]
@@ -173,5 +204,59 @@ public class CreatorNullPrimitivesTest
                 .build();
         TestClass2977 result = mapper.readValue(a2q("{'aa': 8}"), TestClass2977.class);
         assertEquals(8, result.a);
+    }
+
+    // [databind#5734]: record with absent primitives should use JVM defaults
+    @Test
+    void testRecordAbsentPrimitivesShouldDefault() throws Exception {
+        // FAIL_ON_NULL_FOR_PRIMITIVES is enabled by default in 3.x
+        String json = a2q("{'int2': 42, 'boolean1': true}");
+        PrimitiveRecord result = MAPPER.readValue(json, PrimitiveRecord.class);
+        assertEquals(0, result.int1());
+        assertEquals(42, result.int2());
+        assertEquals(true, result.boolean1());
+        assertEquals(false, result.boolean2());
+    }
+
+    // [databind#5734]: record with explicit null primitives should still fail
+    @Test
+    void testRecordExplicitNullPrimitiveShouldFail() throws Exception {
+        String json = a2q("{'int1': 111, 'int2': 222, 'boolean1': true, 'boolean2': null}");
+        try {
+            MAPPER.readValue(json, PrimitiveRecord.class);
+            fail("Should not have succeeded");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot map `null` into type `boolean`");
+        }
+    }
+
+    // [databind#5734]: FAIL_ON_ABSENT_FOR_PRIMITIVES should fail on missing primitives
+    @Test
+    void testFailOnAbsentForPrimitivesEnabled() throws Exception {
+        final ObjectReader r = MAPPER.readerFor(JsonEntity.class)
+            .with(DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES);
+        String json = a2q("{'x': 2}");
+        try {
+            r.readValue(json);
+            fail("Should not have succeeded");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot map absent");
+            assertEquals(1, e.getPath().size());
+            assertEquals("y", e.getPath().get(0).getPropertyName());
+        }
+    }
+
+    // [databind#5734]: FAIL_ON_ABSENT_FOR_PRIMITIVES with record
+    @Test
+    void testFailOnAbsentForPrimitivesWithRecord() throws Exception {
+        final ObjectReader r = MAPPER.readerFor(PrimitiveRecord.class)
+            .with(DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES);
+        String json = a2q("{'int2': 42, 'boolean1': true}");
+        try {
+            r.readValue(json);
+            fail("Should not have succeeded");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Cannot map absent");
+        }
     }
 }


### PR DESCRIPTION
Implements #5734: adds new `DeserializationFeature.FAIL_ON_ABSENT_FOR_PRIMITIVES` (default: false)