### PR TITLE
Fix #5734: Allow absent primitives for creators

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/jdk/NumberDeserializers.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/NumberDeserializers.java
@@ -159,6 +159,14 @@ public class NumberDeserializers
             return AccessPattern.CONSTANT;
         }
 
+        /**
+         * @return zero for primitives ({@code 0, 0.0, false} etc.) and {@code null} for wrappers
+         */
+        @Override
+        public final Object getAbsentValue(DeserializationContext ctxt) {
+            return _nullValue;
+        }
+
         @SuppressWarnings("unchecked")
         @Override
         public final T getNullValue(DeserializationContext ctxt) {

--- a/src/test/java/tools/jackson/databind/deser/creators/CreatorAbsentPrimitivesTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/CreatorAbsentPrimitivesTest.java
@@ -1,0 +1,41 @@
+package tools.jackson.databind.deser.creators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tools.jackson.databind.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES;
+import static tools.jackson.databind.testutil.DatabindTestUtil.jsonMapperBuilder;
+import static tools.jackson.databind.testutil.JacksonTestUtilBase.a2q;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import tools.jackson.databind.json.JsonMapper;
+
+// [databind#5734]
+class CreatorAbsentPrimitivesTest {
+
+    record PrimitiveRecord(int id, boolean enabled) {
+    }
+
+    @ParameterizedTest
+    @MethodSource("absentPrimitivesForRecordArguments")
+    void absentPrimitivesForRecordArguments(String json, PrimitiveRecord expected) {
+        JsonMapper mapper = jsonMapperBuilder()
+                .configure(FAIL_ON_NULL_FOR_PRIMITIVES, true) // Our values are not null, they are absent.
+                .build();
+
+        PrimitiveRecord actual = mapper.readValue(json, PrimitiveRecord.class);
+
+        assertEquals(expected, actual);
+    }
+
+    static Stream<Arguments> absentPrimitivesForRecordArguments() {
+        return Stream.of(
+                Arguments.of(a2q("{ }"), new PrimitiveRecord(0, false)),
+                Arguments.of(a2q("{'id': 42}"), new PrimitiveRecord(42, false)),
+                Arguments.of(a2q("{'enabled': true}"), new PrimitiveRecord(0, true))
+        );
+    }
+}

--- a/src/test/java/tools/jackson/databind/deser/creators/CreatorNullPrimitivesTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/CreatorNullPrimitivesTest.java
@@ -99,7 +99,7 @@ public class CreatorNullPrimitivesTest
     public void testCreatorNullPrimitive() throws Exception {
         final ObjectReader r = MAPPER.readerFor(JsonEntity.class)
             .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
-        String json = a2q("{'x': 2}");
+        String json = a2q("{'x': 2, 'y': null}");
         try {
             r.readValue(json);
             fail("Should not have succeeded");
@@ -114,7 +114,7 @@ public class CreatorNullPrimitivesTest
     public void testCreatorNullPrimitiveInNestedObject() throws Exception {
         final ObjectReader r = MAPPER.readerFor(NestedJsonEntity.class)
                 .with(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
-        String json = a2q("{ 'entity': {'x': 2}}");
+        String json = a2q("{ 'entity': {'x': 2, 'y': null}}");
         try {
             r.readValue(json);
             fail("Should not have succeeded");


### PR DESCRIPTION
Allows primitives to be absent in JSON when deserializing records or `@JsonCreator` classes.