### PR TITLE
Fix Javadoc: correct method signature in CollectionDeserializer

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/jdk/CollectionDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/CollectionDeserializer.java
@@ -663,7 +663,7 @@ _containerType,
 
     /**
      * Helper class to maintain processing order of value. The resolved
-     * object associated with {@code #id} parameter from {@link #handleResolvedForwardReference(Object, Object)} 
+     * object associated with {@code #id} parameter from {@link #handleResolvedForwardReference(DeserializationContext, Object, Object)} 
      * comes before the values in {@link #next}.
      */
     private final static class CollectionReferring extends Referring {


### PR DESCRIPTION
## Summary
- Fix incorrect `@link` reference in `CollectionReferring` Javadoc comment
- `handleResolvedForwardReference(Object, Object)` → `handleResolvedForwardReference(DeserializationContext, Object, Object)` to match actual method signature

## Test plan
- No behavioral change; Javadoc-only fix