### PR TITLE
Add `MapperFeature.SORT_PROPERTIES_BY_INDEX` for #3064

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -2012,6 +2012,14 @@ Thomas Wöckinger (@thomaswoeckinger)
    negative timestamps (dates before 1970)
   [2.21.2]
 
+Christian Danner cdadac
+ * Reported #3064: `@JsonPropertyOrder(alphabetic=true)` is ignored in case indices
+   are defined for `@JsonProperty` -- add `MapperFeature.SORT_PROPERTIES_BY_INDEX`
+  [2.22.0]
+
 Lee Jiwon (@dlwldnjs1009)
+ * Contributed #3064: `@JsonPropertyOrder(alphabetic=true)` is ignored in case indices
+   are defined for `@JsonProperty` -- add `MapperFeature.SORT_PROPERTIES_BY_INDEX`
+  [2.22.0]
  * Contributed #3884: Add `ObjectNode.put(JsonPointer, JsonNode)` method
   [2.22.0]

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,6 +6,10 @@ Project: jackson-databind
 
 2.22.0 (not yet released)
 
+#3064: `@JsonPropertyOrder(alphabetic=true)` is ignored in case indices are
+  defined for `@JsonProperty` -- add `MapperFeature.SORT_PROPERTIES_BY_INDEX`
+ (reported by Christian D)
+ (contributed by Lee Jiwon)
 #3884: Add `ObjectNode.put(JsonPointer, JsonNode)` method
  (requested by @SaiKrishna369)
  (contributed by Lee Jiwon)

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -477,7 +477,7 @@ public enum MapperFeature implements ConfigFeature
      * {@link com.fasterxml.jackson.annotation.JsonPropertyOrder#value()} explicit
      * name-based ordering, which always takes precedence.
      *<p>
-     * Feature is enabled by default for backwards compatibility.
+     * Feature is enabled by default.
      *
      * @since 2.22
      */

--- a/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/MapperFeature.java
@@ -459,6 +459,30 @@ public enum MapperFeature implements ConfigFeature
      */
     SORT_CREATOR_PROPERTIES_BY_DECLARATION_ORDER(false),
 
+    /**
+     * Feature that determines whether explicit
+     * {@link com.fasterxml.jackson.annotation.JsonProperty#index()} values
+     * participate in POJO property ordering.
+     * When enabled (default), properties with an explicit index are sorted by
+     * that index and placed before non-indexed properties.
+     * When disabled, index values are ignored for ordering purposes and no longer
+     * take precedence over other applicable ordering rules (such as alphabetic
+     * ordering via {@link #SORT_PROPERTIES_ALPHABETICALLY} or
+     * {@link com.fasterxml.jackson.annotation.JsonPropertyOrder#alphabetic()}).
+     *<p>
+     * Note that this feature affects POJO property ordering logic used by
+     * shared property introspection paths.
+     *<p>
+     * Note that disabling this feature does NOT affect
+     * {@link com.fasterxml.jackson.annotation.JsonPropertyOrder#value()} explicit
+     * name-based ordering, which always takes precedence.
+     *<p>
+     * Feature is enabled by default for backwards compatibility.
+     *
+     * @since 2.22
+     */
+    SORT_PROPERTIES_BY_INDEX(true),
+
     /*
     /******************************************************
     /* Name-related features

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1765,10 +1765,15 @@ ctor.creator()));
                 ? _config.shouldSortPropertiesAlphabetically()
                 : alpha.booleanValue();
         final boolean indexed = _anyIndexed(props.values());
+        final boolean useIndexOrdering = indexed
+                && _config.isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX);
 
         String[] propertyOrder = intr.findSerializationPropertyOrder(_classDef);
 
         // no sorting? no need to shuffle, then
+        // NOTE: intentionally using `indexed` (not `useIndexOrdering`) here so that
+        // _putAnyGettersInTheEnd() and other post-processing steps are not skipped
+        // when SORT_PROPERTIES_BY_INDEX is disabled but indexed properties exist.
         if (!sortAlpha && !indexed && (_creatorProperties == null) && (propertyOrder == null)) {
             return;
         }
@@ -1808,7 +1813,7 @@ ctor.creator()));
         }
 
         // Second (starting with 2.11): index, if any:
-        if (indexed) {
+        if (useIndexOrdering) {
             Map<Integer,POJOPropertyBuilder> byIndex = new TreeMap<>();
             Iterator<Map.Entry<String,POJOPropertyBuilder>> it = all.entrySet().iterator();
             while (it.hasNext()) {

--- a/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ObjectMapperTest.java
@@ -660,4 +660,25 @@ public class ObjectMapperTest
             assertEquals(DEFAULT_TZ, w2.getConfig().getTimeZone());
         }
     }
+
+    // [databind#3064]
+    @Test
+    public void testConfigForIndexSorting() throws Exception {
+        // default: enabled
+        ObjectMapper m = newJsonMapper();
+        assertEquals(MapperFeature.SORT_PROPERTIES_BY_INDEX.enabledByDefault(),
+                m.isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX));
+        assertEquals(MapperFeature.SORT_PROPERTIES_BY_INDEX.enabledByDefault(),
+                m.getSerializationConfig().isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX));
+        assertEquals(MapperFeature.SORT_PROPERTIES_BY_INDEX.enabledByDefault(),
+                m.getDeserializationConfig().isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX));
+
+        // disabled
+        m = jsonMapperBuilder()
+                .disable(MapperFeature.SORT_PROPERTIES_BY_INDEX)
+                .build();
+        assertFalse(m.isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX));
+        assertFalse(m.getSerializationConfig().isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX));
+        assertFalse(m.getDeserializationConfig().isEnabled(MapperFeature.SORT_PROPERTIES_BY_INDEX));
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ser/SerializationOrderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/SerializationOrderTest.java
@@ -136,6 +136,26 @@ public class SerializationOrderTest
         public int getC() { return c; }
     }
 
+    // For [databind#3064]
+    @JsonPropertyOrder(alphabetic = true)
+    static class AlphaWithIndexBean {
+        @JsonProperty(index = 2)
+        public int c;
+        @JsonProperty(index = 0)
+        public int a;
+        public int b;
+    }
+
+    // For [databind#3064]: explicit name order + index
+    @JsonPropertyOrder({ "b", "a" })
+    static class ExplicitOrderWithIndexBean {
+        @JsonProperty(index = 2)
+        public int c;
+        @JsonProperty(index = 0)
+        public int a;
+        public int b;
+    }
+
     /*
     /*********************************************
     /* Unit tests
@@ -251,5 +271,45 @@ public class SerializationOrderTest
 
         assertEquals(a2q("{'a':2,'b':0,'c':1}"),
                 STRICT_ALPHA_MAPPER.writeValueAsString(new BeanForStrictOrdering(1, 2)));
+    }
+
+    // [databind#3064]: default behavior — class-level alphabetic + index → index wins
+    @Test
+    public void testAlphabeticWithIndexDefaultBehavior() throws Exception {
+        // AlphaWithIndexBean has @JsonPropertyOrder(alphabetic=true)
+        // but index is enabled by default, so indexed props (a:0, c:2) come first
+        assertEquals(a2q("{'a':0,'c':0,'b':0}"),
+                MAPPER.writeValueAsString(new AlphaWithIndexBean()));
+    }
+
+    // [databind#3064]: index disabled → class-level alphabetic annotation wins
+    @Test
+    public void testAlphabeticWithIndexDisabled() throws Exception {
+        final ObjectMapper mapper = jsonMapperBuilder()
+                .disable(MapperFeature.SORT_PROPERTIES_BY_INDEX)
+                .build();
+        assertEquals(a2q("{'a':0,'b':0,'c':0}"),
+                mapper.writeValueAsString(new AlphaWithIndexBean()));
+    }
+
+    // [databind#3064]: global alphabetic + index disabled → alphabetic wins
+    @Test
+    public void testGlobalAlphabeticWithIndexDisabled() throws Exception {
+        final ObjectMapper mapper = jsonMapperBuilder()
+                .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+                .disable(MapperFeature.SORT_PROPERTIES_BY_INDEX)
+                .build();
+        assertEquals(a2q("{'a':0,'b':0,'c':0}"),
+                mapper.writeValueAsString(new AlphaWithIndexBean()));
+    }
+
+    // [databind#3064]: explicit name order takes precedence even when index disabled
+    @Test
+    public void testExplicitNameOrderWinsWhenIndexDisabled() throws Exception {
+        final ObjectMapper mapper = jsonMapperBuilder()
+                .disable(MapperFeature.SORT_PROPERTIES_BY_INDEX)
+                .build();
+        assertEquals(a2q("{'b':0,'a':0,'c':0}"),
+                mapper.writeValueAsString(new ExplicitOrderWithIndexBean()));
     }
 }


### PR DESCRIPTION
Adds `MapperFeature.SORT_PROPERTIES_BY_INDEX` so that users can opt out of
`@JsonProperty(index)`-based property ordering at the mapper level.

This implements the mapper-level opt-out discussed in #3064.

Problem

There is currently no mapper-level way to disable index-based property sorting.
Users who rely on alphabetic or explicit name-based ordering via
`@JsonPropertyOrder` cannot suppress index ordering without removing `index`
values from annotations.

Changes

- Add `MapperFeature.SORT_PROPERTIES_BY_INDEX`, enabled by default for backwards compatibility
- Update `POJOPropertiesCollector._sortProperties()` to apply index-based sorting only when the feature is enabled
- Add `ObjectMapperTest.testConfigForIndexSorting()` to verify config propagation
- Add `SerializationOrderTest` coverage for:
  - default behavior
  - class-level alphabetic ordering when index sorting is disabled
  - global alphabetic ordering when index sorting is disabled
  - explicit name-order precedence when index sorting is disabled
