### PR TITLE
Fix #5785: wrong path in InvalidFormatException for nested fields and BuilderBasedDeserializer

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -381,10 +381,11 @@ public class BuilderBasedDeserializer
         for (int ix = p.currentNameMatch(_propertyNameMatcher); ; ix = p.nextNameMatch(_propertyNameMatcher)) {
             if (ix >= 0) { // normal case
                 p.nextToken();
+                String currentName = p.currentName();
                 try {
                     bean = _propertiesByIndex[ix].deserializeSetAndReturn(p, ctxt, bean);
                 } catch (Exception e) {
-                    throw wrapAndThrow(e, bean, p.currentName(), ctxt);
+                    throw wrapAndThrow(e, bean, currentName, ctxt);
                 }
                 continue;
             }

--- a/src/test/java/tools/jackson/databind/deser/builder/BuilderWithNestedFieldsTest.java
+++ b/src/test/java/tools/jackson/databind/deser/builder/BuilderWithNestedFieldsTest.java
@@ -1,0 +1,108 @@
+package tools.jackson.databind.deser.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException.Reference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.exc.InvalidFormatException;
+
+class BuilderWithNestedFieldsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @JsonDeserialize(
+            builder = Child.ChildBuilder.class
+    )
+    static final class Child {
+        private final Integer field;
+
+        Child(final Integer field) {
+            this.field = field;
+        }
+
+        public Integer getField() {
+            return this.field;
+        }
+
+        public static class ChildBuilder {
+            private Integer field;
+
+            public ChildBuilder() {
+                System.out.println("ChildBuilder");
+            }
+
+            public ChildBuilder withField(final Integer field) {
+                this.field = field;
+                return this;
+            }
+
+            public Child build() {
+                return new Child(this.field);
+            }
+        }
+    }
+
+    @JsonDeserialize(
+            builder = Parent.ParentBuilder.class
+    )
+    static final class Parent {
+        private final Child child;
+
+        Parent(final Child child) {
+            this.child = child;
+        }
+
+        public Child getChild() {
+            return this.child;
+        }
+
+        public static class ParentBuilder {
+            private Child child;
+
+            public ParentBuilder() {
+                System.out.println("ParentBuilder");
+            }
+
+            public ParentBuilder withChild(final Child child) {
+                this.child = child;
+                return this;
+            }
+
+            public Parent build() {
+                return new Parent(this.child);
+            }
+        }
+    }
+
+    @Test
+    void shouldHandleNestedFieldWhenJacksonized2() {
+        String json = """
+                {
+                    "child": {
+                        "field": "invalid"
+                    }
+                }
+                """;
+
+        InvalidFormatException invalidFormatException = assertThrowsExactly(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue(json, Parent.class));
+
+        String fieldPath = fieldName(invalidFormatException.getPath());
+
+       assertEquals("child.field", fieldPath);
+    }
+
+    private String fieldName(List<Reference> path) {
+        return path.stream()
+                .map(Reference::getPropertyName)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining("."));
+    }
+}

--- a/src/test/java/tools/jackson/databind/deser/builder/BuilderWithNestedFieldsTest.java
+++ b/src/test/java/tools/jackson/databind/deser/builder/BuilderWithNestedFieldsTest.java
@@ -33,10 +33,6 @@ class BuilderWithNestedFieldsTest {
         public static class ChildBuilder {
             private Integer field;
 
-            public ChildBuilder() {
-                System.out.println("ChildBuilder");
-            }
-
             public ChildBuilder withField(final Integer field) {
                 this.field = field;
                 return this;
@@ -65,10 +61,6 @@ class BuilderWithNestedFieldsTest {
         public static class ParentBuilder {
             private Child child;
 
-            public ParentBuilder() {
-                System.out.println("ParentBuilder");
-            }
-
             public ParentBuilder withChild(final Child child) {
                 this.child = child;
                 return this;
@@ -81,7 +73,7 @@ class BuilderWithNestedFieldsTest {
     }
 
     @Test
-    void shouldHandleNestedFieldWhenJacksonized2() {
+    void shouldBuildCorrectPathForNestedFields() {
         String json = """
                 {
                     "child": {


### PR DESCRIPTION
### Fix for #5785 

Currently the path contains the name of the child field twice because p.currentName already points to it when catching the exception for the parent.

The change preserves the currentName in a variable and ensures its not changed when descending into childs