### PR TITLE
Change the return type to a more concrete type

### DIFF
--- a/src/main/java/tools/jackson/databind/node/ArrayNode.java
+++ b/src/main/java/tools/jackson/databind/node/ArrayNode.java
@@ -297,7 +297,7 @@ public class ArrayNode
      * NOTE: this returns the live <code>List</code> and not a copy.
      */
     @Override
-    public Collection<JsonNode> values() {
+    public List<JsonNode> values() {
         return _children;
     }
     
@@ -309,7 +309,7 @@ public class ArrayNode
     /**
      * Alias of {@link #values()}.
      */
-    public Collection<JsonNode> elements() {
+    public List<JsonNode> elements() {
         return values();
     }
 


### PR DESCRIPTION
While `ArrayNode` always has an order, I feel that the current method definitions appear to not necessarily preserve that order.
Also, although it’s a minor difference, `List` is more convenient because it defines more specific operations.
Therefore, I’ve modified it to return a more concrete type.

Since `ArrayNode` is not a `final class`, I consider this to be a breaking change, so I am submitting this for version `3.2`.