### PR TITLE
Fix #5819: `JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES` not working with `ObjectMapper.valueToTree()`

### DIFF
--- a/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java
+++ b/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java
@@ -10,6 +10,7 @@ import tools.jackson.core.*;
 import tools.jackson.core.io.CharacterEscapes;
 import tools.jackson.core.util.JacksonFeatureSet;
 import tools.jackson.databind.*;
+import tools.jackson.databind.cfg.JsonNodeFeature;
 import tools.jackson.databind.util.RawValue;
 
 /**
@@ -46,6 +47,14 @@ public class TreeBuildingGenerator
      */
     protected final int _streamWriteFeatures;
 
+    /**
+     * Whether to strip trailing zeroes from {@link BigDecimal} values
+     * when building tree nodes.
+     *
+     * @since 3.1
+     */
+    protected final boolean _cfgStripTrailingBigDecimalZeroes;
+
     /*
     /**********************************************************************
     /* Output state
@@ -62,18 +71,21 @@ public class TreeBuildingGenerator
     /**********************************************************************
      */
 
-    TreeBuildingGenerator(ObjectWriteContext owCtxt, JsonNodeFactory nodeFactory)
+    TreeBuildingGenerator(ObjectWriteContext owCtxt, JsonNodeFactory nodeFactory,
+            boolean stripTrailingBigDecimalZeroes)
     {
         _objectWriteContext = owCtxt;
         _nodeFactory = nodeFactory;
         _streamWriteFeatures = DEFAULT_STREAM_WRITE_FEATURES;
+        _cfgStripTrailingBigDecimalZeroes = stripTrailingBigDecimalZeroes;
         _rootWriteContext = new RootContext(nodeFactory);
         _tokenWriteContext = _rootWriteContext;
     }
 
     public static TreeBuildingGenerator forSerialization(SerializationContext ctxt,
             JsonNodeFactory nodeFactory) {
-        return new TreeBuildingGenerator(ctxt, nodeFactory);
+        return new TreeBuildingGenerator(ctxt, nodeFactory,
+                (ctxt != null) && ctxt.isEnabled(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES));
     }
 
     public JsonNode treeBuilt() {
@@ -388,6 +400,10 @@ public class TreeBuildingGenerator
         if (v == null) {
             writeNull();
         } else {
+            // [databind#5819]: apply STRIP_TRAILING_BIGDECIMAL_ZEROES if enabled
+            if (_cfgStripTrailingBigDecimalZeroes) {
+                v = v.stripTrailingZeros();
+            }
             _tokenWriteContext.writeNumber(_nodeFactory.numberNode(v));
         }
         return this;

--- a/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java
+++ b/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java
@@ -51,7 +51,7 @@ public class TreeBuildingGenerator
      * Whether to strip trailing zeroes from {@link BigDecimal} values
      * when building tree nodes.
      *
-     * @since 3.1
+     * @since 3.1.1
      */
     protected final boolean _cfgStripTrailingBigDecimalZeroes;
 
@@ -72,7 +72,7 @@ public class TreeBuildingGenerator
      */
 
     /**
-     * @since 3.2
+     * @since 3.1.1
      */
     TreeBuildingGenerator(ObjectWriteContext owCtxt, JsonNodeFactory nodeFactory,
             boolean stripTrailingBigDecimalZeroes)
@@ -85,7 +85,7 @@ public class TreeBuildingGenerator
         _tokenWriteContext = _rootWriteContext;
     }
 
-    @Deprecated // since 3.2
+    @Deprecated // @since 3.1.1
     TreeBuildingGenerator(ObjectWriteContext owCtxt, JsonNodeFactory nodeFactory) {
         this(owCtxt, nodeFactory, false);
     }

--- a/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java
+++ b/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java
@@ -71,6 +71,9 @@ public class TreeBuildingGenerator
     /**********************************************************************
      */
 
+    /**
+     * @since 3.2
+     */
     TreeBuildingGenerator(ObjectWriteContext owCtxt, JsonNodeFactory nodeFactory,
             boolean stripTrailingBigDecimalZeroes)
     {
@@ -80,6 +83,11 @@ public class TreeBuildingGenerator
         _cfgStripTrailingBigDecimalZeroes = stripTrailingBigDecimalZeroes;
         _rootWriteContext = new RootContext(nodeFactory);
         _tokenWriteContext = _rootWriteContext;
+    }
+
+    @Deprecated // since 3.2
+    TreeBuildingGenerator(ObjectWriteContext owCtxt, JsonNodeFactory nodeFactory) {
+        this(owCtxt, nodeFactory, false);
     }
 
     public static TreeBuildingGenerator forSerialization(SerializationContext ctxt,

--- a/src/test/java/tools/jackson/databind/node/JsonNodeFactoryTest.java
+++ b/src/test/java/tools/jackson/databind/node/JsonNodeFactoryTest.java
@@ -102,4 +102,35 @@ public class JsonNodeFactoryTest extends NodeTestBase
        JsonNode n3 = normMapper.readTree(String.valueOf(NON_NORMALIZED));
        assertEquals(NORMALIZED, n3.decimalValue());
    }
+
+   // [databind#5819]: STRIP_TRAILING_BIGDECIMAL_ZEROES should also apply via valueToTree()
+   @Test
+   public void testBigDecimalNormalizationViaValueToTree() throws Exception
+   {
+       final BigDecimal BD_WITH_TRAILING = new BigDecimal("1.000");
+       final BigDecimal BD_NORMALIZED = BD_WITH_TRAILING.stripTrailingZeros();
+
+       // By default, no normalization
+       JsonNode n1 = MAPPER.valueToTree(BD_WITH_TRAILING);
+       assertEquals(BD_WITH_TRAILING, n1.decimalValue());
+
+       // With STRIP_TRAILING_BIGDECIMAL_ZEROES enabled, should normalize
+       ObjectMapper normMapper = JsonMapper.builder()
+               .enable(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
+               .build();
+       JsonNode n2 = normMapper.valueToTree(BD_WITH_TRAILING);
+       assertEquals(BD_NORMALIZED, n2.decimalValue());
+
+       // Also test within a POJO (the original reported use case)
+       ObjectNode tree = normMapper.valueToTree(
+               new java.util.LinkedHashMap<String, BigDecimal>() {{
+                   put("bd1", new BigDecimal("1.000"));
+                   put("bd2", new BigDecimal("2.00"));
+                   put("bd3", new BigDecimal("3000"));
+               }});
+       assertEquals(BD_NORMALIZED, tree.get("bd1").decimalValue());
+       assertEquals(new BigDecimal("2").stripTrailingZeros(), tree.get("bd2").decimalValue());
+       // 3000 -> 3E+3 after stripTrailingZeros
+       assertEquals(new BigDecimal("3000").stripTrailingZeros(), tree.get("bd3").decimalValue());
+   }
 }


### PR DESCRIPTION
Alternate fix proposal (to be backported in 3.1?)