### PR TITLE
Set utf-8 in export_to_json

### DIFF
--- a/filter_popular_issues.py
+++ b/filter_popular_issues.py
@@ -162,7 +162,7 @@ def export_to_json(issues: List[Dict], filename: str):
             'updated_at': issue['updated_at']
         })
 
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding="utf-8") as f:
         json.dump(simplified_issues, f, indent=2)
 
     print(f"\nExported {len(issues)} issues to {filename}")


### PR DESCRIPTION
The code around line 165 in filter_popular_issues.py looked like it might have an issue. it relies on the process default encoding. this patch makes the file open explicit about utf-8 so it behaves the same across environments.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.