### PR TITLE
Fix [databind#5840]: @JsonCreator on 0-arg constructor conflicts with multi-arg @JsonCreator in 2.21

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -2016,3 +2016,8 @@ David Nelson (@eatdrinksleepcode)
  * Reported #5814: Enum deserialization does not respect
    `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` override
   [2.21.2]
+
+Alexey Tsvetkov (@AlexeyTsvetkov)
+ * Reported #5840: Jackson 2.21 throws Conflicting property-based creators if both
+   default (0-arg) and multi-arg constructor annotated
+  [2.21.3]

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,13 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.21.3 (not yet released)
+
+#5840: Jackson 2.21 throws Conflicting property-based creators if both
+  default (0-arg) and multi-arg constructor annotated
+ (reported by Alexey T)
+ (fix by @pjfanning)
+
 2.21.2 (20-Mar-2026)
 
 #5729: (regression due to #5429) ISO-8601 change prevents parsing

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -723,17 +723,19 @@ public class POJOPropertiesCollector
         // and use annotations to find explicitly chosen Creators
         if (_useAnnotations) { // can't have explicit ones without Annotation introspection
             // Start with Constructors as they have higher precedence
-
-            // 08-Sep-2025, tatu: [databind#5045] Need to ensure 0-param ("default")
-            //   constructor considered if annotated (disabled case handled above).
-            if (zeroParamsConstructor != null && zeroParamsConstructor.isAnnotated()) {
-                creators.setPropertiesBased(_config, zeroParamsConstructor, "explicit");
-            }
-
             _addExplicitlyAnnotatedCreators(creators, constructors, props, false);
             // followed by Factory methods (lower precedence)
             _addExplicitlyAnnotatedCreators(creators, factories, props,
                     creators.hasPropertiesBased());
+
+            // 08-Sep-2025, tatu: [databind#5045] Need to ensure 0-param ("default")
+            //   constructor considered if annotated (disabled case handled above).
+            // 27-Mar-2026, [databind#5840] But only if no other properties-based
+            //   creator was found (multi-arg @JsonCreator takes precedence over 0-arg one)
+            if (zeroParamsConstructor != null && zeroParamsConstructor.isAnnotated()
+                    && !creators.hasPropertiesBased()) {
+                creators.setPropertiesBased(_config, zeroParamsConstructor, "explicit");
+            }
         }
 
         // If no Explicitly annotated creators (or Primary one) found, look
@@ -742,6 +744,7 @@ public class POJOPropertiesCollector
             // only discover constructor Creators?
             _addCreatorsWithAnnotatedNames(creators, constructors, primaryCreator);
         }
+
 
         // But if no annotation-based Creators found, find/use Primary Creator
         // detected earlier, if any

--- a/src/test/java/com/fasterxml/jackson/databind/deser/creators/JsonCreatorDefaultAndPropertiesCtors5840Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/creators/JsonCreatorDefaultAndPropertiesCtors5840Test.java
@@ -1,0 +1,66 @@
+package com.fasterxml.jackson.databind.deser.creators;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+// For [databind#5840]: no-arg @JsonCreator and multi-arg @JsonCreator should co-exist
+public class JsonCreatorDefaultAndPropertiesCtors5840Test extends DatabindTestUtil
+{
+    // Class with both a no-arg @JsonCreator (default values) and a multi-arg @JsonCreator
+    static final class AllDefaultsBean
+    {
+        private final String name;
+        private final int count;
+
+        @JsonCreator
+        public AllDefaultsBean(
+                @JsonProperty("name") String name,
+                @JsonProperty("count") int count
+        ) {
+            this.name = name;
+            this.count = count;
+        }
+
+        @JsonCreator
+        public AllDefaultsBean() {
+            this("default-name", 42);
+        }
+
+        public String getName() { return name; }
+        public int getCount() { return count; }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // [databind#5840]: verify no exception is thrown and multi-arg creator is used
+    @Test
+    public void testDeserWithPropertiesCreator5840() throws Exception
+    {
+        AllDefaultsBean result = MAPPER.readValue(
+                "{\"name\":\"hello\", \"count\":7}", AllDefaultsBean.class);
+        assertNotNull(result);
+        assertEquals("hello", result.getName());
+        assertEquals(7, result.getCount());
+    }
+
+    // [databind#5840]: verify no exception is thrown with empty JSON (uses multi-arg creator
+    // with null/0 defaults, same behavior as pre-2.21)
+    @Test
+    public void testDeserWithEmptyJson5840() throws Exception
+    {
+        AllDefaultsBean result = MAPPER.readValue("{}", AllDefaultsBean.class);
+        assertNotNull(result);
+        // Multi-arg @JsonCreator is used with missing properties defaulting to null/0
+        assertNull(result.getName());
+        assertEquals(0, result.getCount());
+    }
+}


### PR DESCRIPTION
- [x] Understand issue #5840: `@JsonCreator` on 0-arg default constructor conflicts with `@JsonCreator` on multi-arg constructor in Jackson 2.21
- [x] Create test class `JsonCreatorDefaultAndPropertiesCtors5840Test` in `deser/creators/` directory
- [x] Add test cases validating deserialization with both JSON fields present and empty JSON `{}`
- [x] Fix `POJOPropertiesCollector._addCreators()`: process multi-arg annotated constructors first, only use 0-arg as properties-based if no multi-arg creator found
- [x] Fix test: correct expected values for `{}` case — multi-arg constructor is used with null/0 defaults (matching pre-2.21 behavior)