### PR TITLE
Fix improper (De)Serialization given both @JsonTypeInfo and @JsonValue

### DIFF
--- a/src/main/java/tools/jackson/databind/jsontype/TypeResolverProvider.java
+++ b/src/main/java/tools/jackson/databind/jsontype/TypeResolverProvider.java
@@ -280,6 +280,7 @@ public class TypeResolverProvider
                     typeInfo = typeInfo.withInclusionType(JsonTypeInfo.As.PROPERTY);
                 }
 
+                // [databind:4983] baseType comes from the annotated class/interface, not the serialized type
                 detectedBaseType = ai.findPolymorphicBaseType(config, annotatedClass, typeInfo, baseType);
             } else {
             	// when method/field annotated, declared type MUST be intended base type

--- a/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
@@ -180,12 +180,25 @@ public class JsonValueSerializer
                  *   cases where "native" (aka "natural") type is being serialized,
                  *   using standard serializer
                  */
-                boolean forceTypeInformation = isNaturalTypeWithStdHandling(_valueType.getRawClass(), ser);
+                boolean forceTypeInformation;
+                if (_accessor == null) {
+                	forceTypeInformation = isNaturalTypeWithStdHandling(_valueType.getRawClass(), ser);
+                } else {
+                	// We came here due to a `@JsonValue`: the type of the accessed value is irrelevant as it is not the type of the original value
+                	forceTypeInformation = false;
+                }
                 return withResolved(property, vts, ser, forceTypeInformation);
             }
             // [databind#2822]: better hold on to "property", regardless
             if (property != _property) {
-                return withResolved(property, vts, ser, _forceTypeInformation);
+                boolean forceTypeInformation;
+                if (_accessor == null) {
+                	forceTypeInformation = this._forceTypeInformation;
+                } else {
+                	// We came here due to a `@JsonValue`: the type of the accessed value is irrelevant as it is not the type of the original value
+                	forceTypeInformation = false;
+                }
+                return withResolved(property, vts, ser, forceTypeInformation);
             }
         } else {
             // 05-Sep-2013, tatu: I _think_ this can be considered a primary property...

--- a/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
@@ -182,6 +182,7 @@ public class JsonValueSerializer
                  */
                 boolean forceTypeInformation;
                 if (_accessor == null) {
+                	// Why do we forceTypeInformation if the type is natural? Shouldn't it be the contrary?
                 	forceTypeInformation = isNaturalTypeWithStdHandling(_valueType.getRawClass(), ser);
                 } else {
                 	// We came here due to a `@JsonValue`: the type of the accessed value is irrelevant as it is not the type of the original value

--- a/src/test/java/tools/jackson/databind/jsontype/TestJsonTypeInfoJsonValue.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestJsonTypeInfoJsonValue.java
@@ -186,6 +186,21 @@ public class TestJsonTypeInfoJsonValue {
 		}
 	}
 
+
+	public static enum CustomOption_WithJsonValue implements SomeOption {
+		C, D;
+
+		@JsonValue
+		public String asString() {
+			return this.name();
+		}
+
+		@JsonCreator
+		public static CustomOption forValue(String value) {
+			return CustomOption.valueOf(value.toUpperCase(Locale.US));
+		}
+	}
+
 	public static enum OptionWithoutJsonTypeInfo {
 		E, F;
 
@@ -197,7 +212,7 @@ public class TestJsonTypeInfoJsonValue {
 	}
 
 	@Test
-	public void testEnum_Native_string() {
+	public void testEnum_Native() {
 		NativeOption matcher = NativeOption.A;
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -210,8 +225,21 @@ public class TestJsonTypeInfoJsonValue {
 	}
 
 	@Test
-	public void testEnum_Custom_string() {
+	public void testEnum_Custom() {
 		CustomOption matcher = CustomOption.C;
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(matcher);
+		Assertions.assertThat(asString).isEqualTo("[\"TestJsonTypeInfoJsonValue$CustomOption\",\"C\"]");
+
+		SomeOption fromString = objectMapper.readValue(asString, SomeOption.class);
+		Assertions.assertThat(fromString).isSameAs(matcher);
+	}
+
+	@Test
+	public void testEnum_Custom_jsonValue() {
+		CustomOption_WithJsonValue matcher = CustomOption_WithJsonValue.C;
 
 		ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/tools/jackson/databind/jsontype/TestJsonTypeInfoJsonValue.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestJsonTypeInfoJsonValue.java
@@ -1,0 +1,221 @@
+package tools.jackson.databind.jsontype;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import tools.jackson.databind.ObjectMapper;
+
+// Investigate around AsPropertyTypeSerializer
+// tools.jackson.databind.ser.jackson.JsonValueSerializer.serializeWithType(Object, JsonGenerator, SerializationContext, TypeSerializer)
+// tools.jackson.databind.ser.BasicSerializerFactory.findSerializerByAnnotations(SerializationContext, JavaType, Supplier)
+public class TestJsonTypeInfoJsonValue {
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+			include = JsonTypeInfo.As.PROPERTY,
+			property = "type",
+			defaultImpl = AroundString.class)
+	public interface AroundSomething {
+		Object getInner();
+	}
+
+	public static class AroundString implements AroundSomething {
+		@JsonValue
+		String inner;
+
+		@JsonCreator
+		public AroundString(String inner) {
+			this.inner = inner;
+		}
+
+		@Override
+		public Object getInner() {
+			return inner;
+		}
+
+		public void setInner(String inner) {
+			this.inner = inner;
+		}
+
+	}
+
+	public static class AroundObject implements AroundSomething {
+		@JsonValue
+		Object inner;
+
+		@JsonCreator
+		public AroundObject(Object inner) {
+			this.inner = inner;
+		}
+
+		@Override
+		public Object getInner() {
+			return inner;
+		}
+
+		public void setInner(String inner) {
+			this.inner = inner;
+		}
+
+	}
+
+	public static class AroundObject_NotJsonValue implements AroundSomething {
+		Object inner;
+
+		@Override
+		public Object getInner() {
+			return inner;
+		}
+
+		public void setInner(String inner) {
+			this.inner = inner;
+		}
+
+	}
+
+	public static class HasAround {
+		AroundSomething c;
+
+		public AroundSomething getC() {
+			return c;
+		}
+
+		public void setC(AroundSomething c) {
+			this.c = c;
+		}
+	}
+
+	@Test
+	public void aroundString() {
+		AroundString matcher = new AroundString("foo");
+
+		HasAround wrapper = new HasAround();
+		wrapper.setC(matcher);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(wrapper);
+		Assertions.assertThat(asString).isEqualTo("{\"c\":\"foo\"}");
+
+		HasAround fromString = objectMapper.readValue(asString, HasAround.class);
+		Assertions.assertThat(fromString.getC().getInner()).isEqualTo("foo");
+	}
+
+	@Test
+	public void aroundObject() {
+		AroundObject matcher = new AroundObject("foo");
+
+		HasAround wrapper = new HasAround();
+		wrapper.setC(matcher);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(wrapper);
+		Assertions.assertThat(asString).isEqualTo("{\"c\":\"foo\"}");
+
+		HasAround fromString = objectMapper.readValue(asString, HasAround.class);
+		Assertions.assertThat(fromString.getC().getInner()).isEqualTo("foo");
+	}
+
+	@Test
+	public void aroundObjectNotJsonValue() {
+		AroundObject_NotJsonValue matcher = new AroundObject_NotJsonValue();
+		matcher.setInner("foo");
+
+		HasAround wrapper = new HasAround();
+		wrapper.setC(matcher);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(wrapper);
+		Assertions.assertThat(asString)
+				.isEqualTo(
+						"{\"c\":{\"type\":\"TestJsonTypeInfoJsonValue$AroundObject_NotJsonValue\",\"inner\":\"foo\"}}");
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+			include = JsonTypeInfo.As.PROPERTY,
+			property = "type",
+			defaultImpl = NativeOption.class)
+	public interface SomeOption {
+	}
+
+	public static enum NativeOption implements SomeOption {
+		A, B;
+
+		@JsonValue
+		public String toString() {
+			return this.name();
+		}
+
+		@JsonCreator
+		public static NativeOption forValue(String value) {
+			return NativeOption.valueOf(value.toUpperCase(Locale.US));
+		}
+	}
+
+	public static enum CustomOption implements SomeOption {
+		C, D;
+
+		@JsonCreator
+		public static CustomOption forValue(String value) {
+			return CustomOption.valueOf(value.toUpperCase(Locale.US));
+		}
+	}
+
+	public static enum OptionWithoutJsonTypeInfo {
+		E, F;
+
+		@JsonCreator
+		public static OptionWithoutJsonTypeInfo forValue(String value) {
+			return OptionWithoutJsonTypeInfo.valueOf(value.toUpperCase(Locale.US));
+		}
+
+	}
+
+	@Test
+	public void testEnum_Native_string() {
+		NativeOption matcher = NativeOption.A;
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(matcher);
+		Assertions.assertThat(asString).isEqualTo("\"A\"");
+
+		SomeOption fromString = objectMapper.readValue(asString, SomeOption.class);
+		Assertions.assertThat(fromString).isSameAs(matcher);
+	}
+
+	@Test
+	public void testEnum_Custom_string() {
+		CustomOption matcher = CustomOption.C;
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(matcher);
+		Assertions.assertThat(asString).isEqualTo("[\"TestJsonTypeInfoJsonValue$CustomOption\",\"C\"]");
+
+		SomeOption fromString = objectMapper.readValue(asString, SomeOption.class);
+		Assertions.assertThat(fromString).isSameAs(matcher);
+	}
+
+	// To be removed, just to help debugging a standard scenario
+	@Test
+	public void testEnum_noJsonTypeInfo() {
+		OptionWithoutJsonTypeInfo matcher = OptionWithoutJsonTypeInfo.E;
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(matcher);
+		Assertions.assertThat(asString).isEqualTo("\"E\"");
+
+		OptionWithoutJsonTypeInfo fromString = objectMapper.readValue(asString, OptionWithoutJsonTypeInfo.class);
+		Assertions.assertThat(fromString).isSameAs(matcher);
+	}
+}

--- a/src/test/java/tools/jackson/databind/jsontype/TestJsonTypeInfoJsonValue.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestJsonTypeInfoJsonValue.java
@@ -17,7 +17,7 @@ import tools.jackson.databind.ObjectMapper;
 // tools.jackson.databind.ser.BasicSerializerFactory.findSerializerByAnnotations(SerializationContext, JavaType, Supplier)
 public class TestJsonTypeInfoJsonValue {
 
-	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+	@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS,
 			include = JsonTypeInfo.As.PROPERTY,
 			property = "type",
 			defaultImpl = AroundString.class)
@@ -80,14 +80,14 @@ public class TestJsonTypeInfoJsonValue {
 	}
 
 	public static class HasAround {
-		AroundSomething c;
+		AroundSomething wrapped;
 
-		public AroundSomething getC() {
-			return c;
+		public AroundSomething getWrapped() {
+			return wrapped;
 		}
 
-		public void setC(AroundSomething c) {
-			this.c = c;
+		public void setC(AroundSomething wrapped) {
+			this.wrapped = wrapped;
 		}
 	}
 
@@ -101,14 +101,14 @@ public class TestJsonTypeInfoJsonValue {
 		ObjectMapper objectMapper = new ObjectMapper();
 
 		String asString = objectMapper.writeValueAsString(wrapper);
-		Assertions.assertThat(asString).isEqualTo("{\"c\":\"foo\"}");
+		Assertions.assertThat(asString).isEqualTo("{\"wrapped\":\"foo\"}");
 
 		HasAround fromString = objectMapper.readValue(asString, HasAround.class);
-		Assertions.assertThat(fromString.getC().getInner()).isEqualTo("foo");
+		Assertions.assertThat(fromString.getWrapped().getInner()).isEqualTo("foo");
 	}
 
 	@Test
-	public void aroundObject() {
+	public void aroundObject_simpleType() {
 		AroundObject matcher = new AroundObject("foo");
 
 		HasAround wrapper = new HasAround();
@@ -117,10 +117,27 @@ public class TestJsonTypeInfoJsonValue {
 		ObjectMapper objectMapper = new ObjectMapper();
 
 		String asString = objectMapper.writeValueAsString(wrapper);
-		Assertions.assertThat(asString).isEqualTo("{\"c\":\"foo\"}");
+		Assertions.assertThat(asString).isEqualTo("{\"wrapped\":\"foo\"}");
 
 		HasAround fromString = objectMapper.readValue(asString, HasAround.class);
-		Assertions.assertThat(fromString.getC().getInner()).isEqualTo("foo");
+		Assertions.assertThat(fromString.getWrapped().getInner()).isEqualTo("foo");
+	}
+
+	@Test
+	public void aroundObject_complexType() {
+		AroundObject matcher = new AroundObject(Map.of("foo", "bar"));
+
+		HasAround wrapper = new HasAround();
+		wrapper.setC(matcher);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String asString = objectMapper.writeValueAsString(wrapper);
+		Assertions.assertThat(asString)
+				.isEqualTo("{\"wrapped\":{\"type\":\".TestJsonTypeInfoJsonValue$AroundObject\",\"foo\":\"bar\"}}");
+
+		HasAround fromString = objectMapper.readValue(asString, HasAround.class);
+		Assertions.assertThat(fromString.getWrapped().getInner()).isEqualTo(Map.of("foo", "bar"));
 	}
 
 	@Test
@@ -136,7 +153,7 @@ public class TestJsonTypeInfoJsonValue {
 		String asString = objectMapper.writeValueAsString(wrapper);
 		Assertions.assertThat(asString)
 				.isEqualTo(
-						"{\"c\":{\"type\":\"TestJsonTypeInfoJsonValue$AroundObject_NotJsonValue\",\"inner\":\"foo\"}}");
+						"{\"wrapped\":{\"type\":\".TestJsonTypeInfoJsonValue$AroundObject_NotJsonValue\",\"inner\":\"foo\"}}");
 	}
 
 	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,


### PR DESCRIPTION
This follow-up https://github.com/FasterXML/jackson-databind/issues/5035

I could open a dedicated issue, but I felt fine just opening a PR for now given I have code (UT and draft for fix).

This case refers to the interaction of `@JsonTypeInfo` and `@JsonValue`. 

- Expectation: Typically, in case of `@JsonValue`, I argue `@JsonTypeInfo` should not generally not trigger the type. 
- Observation: In current state of the library, it leads to wrapping the type and the `@JsonValue` field in an array.

Unit-tests demonstrates 2 cases which relates to the similar functional cases, but they seem to refer to different Jackson classes:
- A class with `@JsonValue` implements some interface with `@JsonTypeInfo`
- An `enum` (without `@JsonValue` but with similar semantic) implements some interface with `@JsonTypeInfo`

I reach good (in my perspective) behavior for the `@JsonValue` case by forcing `JsonValueSerializer.forceTypeInformation` when serializer has a `_accessor ` (which I interpret as a signal there is a `@JsonValue`) .

The `enum` is not benefitting from `@JsonValue` case as it seems there is no similar `forceTypeInformation` around enum.

Some stack relating to the enum case (I tried to find a spot to disable typeSerialization along this stack):

```
AsPropertyTypeSerializer.<init>(TypeIdResolver, BeanProperty, String) line: 24	
StdTypeResolverBuilder.buildTypeSerializer(SerializationContext, JavaType, Collection<NamedType>) line: 157	
TypeResolverProvider.findTypeSerializer(SerializationContext, JavaType, AnnotatedClass) line: 69	
SerializationContextExt$Impl(SerializationContext).findTypeSerializer(JavaType, AnnotatedClass) line: 842	
SerializationContextExt$Impl(SerializationContext).findTypeSerializer(JavaType) line: 830	
SerializationContextExt$Impl(SerializationContext).findTypedValueSerializer(Class<?>, boolean) line: 593	
SerializationContextExt$Impl(SerializationContextExt).serializeValue(JsonGenerator, Object) line: 297	
ObjectMapper._configAndWriteValue(SerializationContextExt, JsonGenerator, Object) line: 1901	
ObjectMapper.writeValueAsString(Object) line: 1845	
TestJsonTypeInfoJsonValue.testEnum_Custom_string() line: 201	
```