### PR TITLE
Fix `Map.Entry` deserialization for property-level `Shape.NATURAL` override

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/jdk/MapEntryDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/MapEntryDeserializer.java
@@ -405,7 +405,7 @@ public class MapEntryDeserializer
         {
             // May override back to standard too:
             if (Boolean.FALSE.equals(_shouldDeserializeAsPOJO(ctxt, property))) {
-                return constructAsPOJO(ctxt, _valueType)
+                return constructDefault(ctxt, _valueType)
                         ._createContextual2(ctxt, property);
             }
             return _createContextual2(ctxt, property);

--- a/src/test/java/tools/jackson/databind/format/MapEntryFormatTest.java
+++ b/src/test/java/tools/jackson/databind/format/MapEntryFormatTest.java
@@ -231,6 +231,22 @@ public class MapEntryFormatTest extends DatabindTestUtil
                 || mapper.writeValueAsString(input).equals(a2q("{'value':'bar','key':'foo'}")));
     }
 
+    // [databind#1419]: Property-level NATURAL should reverse global POJO override on deserialization
+    @Test
+    public void testDefaultPOJOOverrideWithPropertyNatural() throws Exception
+    {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .withConfigOverride(Map.Entry.class,
+                        o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.POJO)))
+                .build();
+        // BeanWithMapEntry.entry has @JsonFormat(shape=NATURAL),
+        // so despite global POJO default, this property should use natural format
+        String json = a2q("{'entry':{'foo':'bar'}}");
+        BeanWithMapEntry result = mapper.readValue(json, BeanWithMapEntry.class);
+        assertEquals("foo", result.entry.getKey());
+        assertEquals("bar", result.entry.getValue());
+    }
+
     /*
     /**********************************************************
     /* Test methods, as-POJO (Shape) [databind#1419]


### PR DESCRIPTION
This is a small follow-up to #1419 / #5397.

When `Map.Entry` is globally configured with `JsonFormat.Shape.POJO`, a property-level `@JsonFormat(shape = JsonFormat.Shape.NATURAL)` should switch deserialization back to the default/natural form. `POJOWrappedDeserializer.createContextual()` was still rebuilding the POJO-wrapped deserializer in that branch, so the property-level override was ignored during deserialization.

This changes that branch to use the default `Map.Entry` deserializer instead and adds a regression test for the `ConfigOverride(POJO) + property-level NATURAL` case.

Tested with:
- `./mvnw test -pl . -Dtest=MapEntryFormatTest -q`