### PR TITLE
Fix #5870: support `@JsonDeserialize(contentConverter)` for `EnumMap`/`EnumSet` properties

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -214,7 +214,9 @@ Lee Jiwon (@dlwldnjs1009)
   [3.1.0]
  * Fixed #5867: Fix `Map.Entry` deserialization for property-level
    `Shape.NATURAL` override
-  [3.1.0]
+  [3.1.2]
+ * Fixed  #5870: `EnumMap` and `EnumSet` properties ignore `@JsonDeserialize(contentConverter)`
+  [3.1.2]
 
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ No changes since 3.1
 #5867: Fix `Map.Entry` deserialization for property-level
   `Shape.NATURAL` override
  (fixed by Lee Jiwon)
+#5870: `EnumMap` and `EnumSet` properties ignore `@JsonDeserialize(contentConverter)`
+ (fixed by Lee Jiwon)
 
 3.1.1 (27-Mar-2026)
 

--- a/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
@@ -153,6 +153,8 @@ public class EnumMapDeserializer
             keyDeser = ctxt.findKeyDeserializer(_containerType.getKeyType(), property);
         }
         ValueDeserializer<?> valueDeser = _valueDeserializer;
+        // [databind#5870]: May have a content converter
+        valueDeser = findConvertingContentDeserializer(ctxt, property, valueDeser);
         final JavaType vt = _containerType.getContentType();
         if (valueDeser == null) {
             valueDeser = ctxt.findContextualValueDeserializer(vt, property);

--- a/src/main/java/tools/jackson/databind/deser/jdk/EnumSetDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/EnumSetDeserializer.java
@@ -151,6 +151,8 @@ public class EnumSetDeserializer
         final Boolean unwrapSingle = findFormatFeature(ctxt, property, EnumSet.class,
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         ValueDeserializer<?> deser = _enumDeserializer;
+        // [databind#5870]: May have a content converter
+        deser = findConvertingContentDeserializer(ctxt, property, deser);
         if (deser == null) {
             deser = ctxt.findContextualValueDeserializer(_enumType, property);
         } else { // if directly assigned, probably not yet contextual, so:

--- a/src/test/java/tools/jackson/databind/convert/ConvertingDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/convert/ConvertingDeserializerTest.java
@@ -87,6 +87,25 @@ public class ConvertingDeserializerTest
         public Map<String,Point> values;
     }
 
+    // [databind#5870]
+    enum EnumKey { A, B }
+
+    static class PointWrapperEnumMap {
+        @JsonDeserialize(contentConverter=PointConverter.class)
+        public EnumMap<EnumKey, Point> values;
+    }
+
+    static class PointWrapperEnumSet {
+        @JsonDeserialize(contentConverter=EnumKeyConverter.class)
+        public EnumSet<EnumKey> values;
+    }
+
+    static class EnumKeyConverter extends StdConverter<String, EnumKey> {
+        @Override public EnumKey convert(String value) {
+            return EnumKey.valueOf(value.toUpperCase());
+        }
+    }
+
     static class PointWrapperReference {
         @JsonDeserialize(contentConverter=PointConverter.class)
         public AtomicReference<Point> ref;
@@ -223,6 +242,32 @@ public class ConvertingDeserializerTest
         assertNotNull(p);
         assertEquals(1, p.x);
         assertEquals(2, p.y);
+    }
+
+    // [databind#5870]
+    @Test
+    public void testPropertyAnnotationForEnumMaps() throws Exception
+    {
+        PointWrapperEnumMap map = MAPPER.readerFor(PointWrapperEnumMap.class)
+                .readValue(a2q("{'values':{'A':[1,2]}}"));
+        assertNotNull(map);
+        assertNotNull(map.values);
+        assertEquals(1, map.values.size());
+        Point p = map.values.get(EnumKey.A);
+        assertNotNull(p);
+        assertEquals(1, p.x);
+        assertEquals(2, p.y);
+    }
+
+    // [databind#5870]
+    @Test
+    public void testPropertyAnnotationForEnumSets() throws Exception
+    {
+        PointWrapperEnumSet set = MAPPER.readerFor(PointWrapperEnumSet.class)
+                .readValue(a2q("{'values':['a','b']}"));
+        assertNotNull(set);
+        assertNotNull(set.values);
+        assertEquals(EnumSet.of(EnumKey.A, EnumKey.B), set.values);
     }
 
     @Test


### PR DESCRIPTION
Fixes #5870.

`EnumMapDeserializer.createContextual()` and `EnumSetDeserializer.createContextual()` did not call `findConvertingContentDeserializer()`, so property-level `@JsonDeserialize(contentConverter = ...)` was not applied for `EnumMap` values or `EnumSet` elements.

This adds the missing call in each deserializer (matching the pattern already used by `MapDeserializer`, `CollectionDeserializer`, `ObjectArrayDeserializer`, etc.) and regression tests for both.

Same fix applies cleanly to `2.21` as well; happy to open a backport PR if helpful.

Tested with:
- `./mvnw test -pl . -Dtest=ConvertingDeserializerTest -q`