### PR TITLE
Fix #5870: support @JsonDeserialize(contentConverter) for EnumMap/EnumSet properties [2.21 backport]

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -10,6 +10,8 @@ Project: jackson-databind
   default (0-arg) and multi-arg constructor annotated
  (reported by Alexey T)
  (fix by @pjfanning)
+#5870: `EnumMap` and `EnumSet` properties ignore `@JsonDeserialize(contentConverter)`
+ (fixed by Lee Jiwon)
 
 2.21.2 (20-Mar-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumMapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumMapDeserializer.java
@@ -176,6 +176,8 @@ public class EnumMapDeserializer
             keyDeser = ctxt.findKeyDeserializer(_containerType.getKeyType(), property);
         }
         JsonDeserializer<?> valueDeser = _valueDeserializer;
+        // [databind#5870]: May have a content converter
+        valueDeser = findConvertingContentDeserializer(ctxt, property, valueDeser);
         final JavaType vt = _containerType.getContentType();
         if (valueDeser == null) {
             valueDeser = ctxt.findContextualValueDeserializer(vt, property);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumSetDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumSetDeserializer.java
@@ -178,6 +178,8 @@ public class EnumSetDeserializer
         final Boolean unwrapSingle = findFormatFeature(ctxt, property, EnumSet.class,
                 JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         JsonDeserializer<?> deser = _enumDeserializer;
+        // [databind#5870]: May have a content converter
+        deser = findConvertingContentDeserializer(ctxt, property, deser);
         if (deser == null) {
             deser = ctxt.findContextualValueDeserializer(_enumType, property);
         } else { // if directly assigned, probably not yet contextual, so:

--- a/src/test/java/com/fasterxml/jackson/databind/convert/ConvertingDeserializerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/convert/ConvertingDeserializerTest.java
@@ -87,6 +87,25 @@ public class ConvertingDeserializerTest
         public Map<String,Point> values;
     }
 
+    // [databind#5870]
+    enum EnumKey { A, B }
+
+    static class PointWrapperEnumMap {
+        @JsonDeserialize(contentConverter=PointConverter.class)
+        public EnumMap<EnumKey, Point> values;
+    }
+
+    static class PointWrapperEnumSet {
+        @JsonDeserialize(contentConverter=EnumKeyConverter.class)
+        public EnumSet<EnumKey> values;
+    }
+
+    static class EnumKeyConverter extends StdConverter<String, EnumKey> {
+        @Override public EnumKey convert(String value) {
+            return EnumKey.valueOf(value.toUpperCase());
+        }
+    }
+
     static class PointWrapperReference {
         @JsonDeserialize(contentConverter=PointConverter.class)
         public AtomicReference<Point> ref;
@@ -217,6 +236,32 @@ public class ConvertingDeserializerTest
         assertNotNull(p);
         assertEquals(1, p.x);
         assertEquals(2, p.y);
+    }
+
+    // [databind#5870]
+    @Test
+    public void testPropertyAnnotationForEnumMaps() throws Exception
+    {
+        PointWrapperEnumMap map = MAPPER.readerFor(PointWrapperEnumMap.class)
+                .readValue(a2q("{'values':{'A':[1,2]}}"));
+        assertNotNull(map);
+        assertNotNull(map.values);
+        assertEquals(1, map.values.size());
+        Point p = map.values.get(EnumKey.A);
+        assertNotNull(p);
+        assertEquals(1, p.x);
+        assertEquals(2, p.y);
+    }
+
+    // [databind#5870]
+    @Test
+    public void testPropertyAnnotationForEnumSets() throws Exception
+    {
+        PointWrapperEnumSet set = MAPPER.readerFor(PointWrapperEnumSet.class)
+                .readValue(a2q("{'values':['a','b']}"));
+        assertNotNull(set);
+        assertNotNull(set.values);
+        assertEquals(EnumSet.of(EnumKey.A, EnumKey.B), set.values);
     }
 
     @Test


### PR DESCRIPTION
Backport of #5871 to `2.21`.

Same fix as merged in `3.1`: `EnumMapDeserializer.createContextual()` and `EnumSetDeserializer.createContextual()` did not call `findConvertingContentDeserializer()`, so property-level `@JsonDeserialize(contentConverter = ...)` was not applied for `EnumMap` values or `EnumSet` elements.

Adds the missing call in each deserializer and regression tests for both.

Tested with:
- `./mvnw clean test -pl .` (3784 tests, all pass)