### PR TITLE
Fix #5891: property-based EnumMap parsing after skipped unknown enum keys

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -215,7 +215,10 @@ Lee Jiwon (@dlwldnjs1009)
  * Fixed #5867: Fix `Map.Entry` deserialization for property-level
    `Shape.NATURAL` override
   [3.1.2]
- * Fixed  #5870: `EnumMap` and `EnumSet` properties ignore `@JsonDeserialize(contentConverter)`
+ * Fixed #5870: `EnumMap` and `EnumSet` properties ignore `@JsonDeserialize(contentConverter)`
+  [3.1.2]
+ * Fixed #5891: `EnumMapDeserializer._deserializeUsingProperties()` corrupts parser
+   state after skipping unknown enum keys
   [3.1.2]
 
 Garret Wilson (@garretwilson)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -28,6 +28,9 @@ No changes since 3.1
   on another property
  (reported by Aleksandr G)
  (fix by @cowtowncoder, w/ Claude code)
+#5891: `EnumMapDeserializer._deserializeUsingProperties()` corrupts parser
+  state after skipping unknown enum keys
+ (fixed by Lee Jiwon)
 
 3.1.1 (27-Mar-2026)
 

--- a/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
@@ -373,7 +373,6 @@ public class EnumMapDeserializer
                 }
                 // 24-Mar-2012, tatu: Null won't work as a key anyway, so let's
                 //  just skip the entry then. But we must skip the value as well, if so.
-                p.nextToken();
                 p.skipChildren();
                 continue;
             }

--- a/src/test/java/tools/jackson/databind/deser/enums/EnumMapDeserializationTest.java
+++ b/src/test/java/tools/jackson/databind/deser/enums/EnumMapDeserializationTest.java
@@ -190,6 +190,33 @@ public class EnumMapDeserializationTest
         assertEquals(2, map.size());
     }
 
+    // [databind#5891]: extra p.nextToken() in _deserializeUsingProperties()
+    //   corrupts parser state when skipping unknown enum key
+    @Test
+    public void testUnknownKeyAsNullWithPropertyBasedCreator() throws Exception
+    {
+        ObjectReader r = MAPPER.readerFor(FromPropertiesEnumMap.class)
+                .with(EnumFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+
+        _verifyFromPropertiesEnumMap(r.readValue(a2q(
+                "{'NOPE':'skip','a':13,'RULES':'jackson','b':-731,'OK':'yes'}")));
+
+        // Unknown-key values are skipped before deserializing into EnumMap<String>.
+        _verifyFromPropertiesEnumMap(r.readValue(a2q(
+                "{'NOPE':{'nested':'value'},'a':13,'RULES':'jackson','b':-731,'OK':'yes'}")));
+        _verifyFromPropertiesEnumMap(r.readValue(a2q(
+                "{'NOPE':[1,2,3],'a':13,'RULES':'jackson','b':-731,'OK':'yes'}")));
+    }
+
+    private void _verifyFromPropertiesEnumMap(FromPropertiesEnumMap map)
+    {
+        assertEquals(13, map.a0);
+        assertEquals(-731, map.b0);
+        assertEquals("jackson", map.get(TestEnum.RULES));
+        assertEquals("yes", map.get(TestEnum.OK));
+        assertEquals(2, map.size());
+    }
+
     /*
     /**********************************************************
     /* Test methods: polymorphic


### PR DESCRIPTION
When `EnumMapDeserializer._deserializeUsingProperties()` handles an
unknown enum key with `READ_UNKNOWN_ENUM_VALUES_AS_NULL`, the parser is
already positioned on the value token by the loop-level `p.nextToken()`.

Calling `p.nextToken()` again before `skipChildren()` advances into the
value and leaves the parser misaligned for the remaining creator
properties and buffered `EnumMap` entries.

This removes the extra token advance so skipped unknown keys follow the
same parser progression as the regular `deserialize()` path.

Tests:
- verify skipped unknown keys with scalar values
- verify skipped unknown keys with object values
- verify skipped unknown keys with array values