### PR TITLE
Fix #5897: skip TokenBuffer allocation for unknown properties in records

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -252,10 +252,11 @@ John Hendrikx (@hjohn)
 
 Viktor Szathmáry (@phraktle)
  * Reported #5115: `@JsonUnwrapped` Record deserialization can't handle name collision
- (reported by Viktor S)
   [3.1.0]
  * Reported #5716: `@JsonUnwrapped` properties moved to end in 3.1.0
   [3.1.1]
+ * Fixed #5897: Excessive `TokenBuffer` allocations when deserializing records
+  [3.2.0]
 
 Lee Chan Won (@chanwonlee)
  * Implemented #5223: Java Records missing type information with `DefaultTyping.NON_FINAL`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -159,6 +159,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #5872: ObjectId resolution with Builder fails for interface types
   (`UnresolvedForwardReference`)
  (fix by @cowtowncoder, w/ Claude code)
+#5897: Excessive `TokenBuffer` allocations when deserializing records
+ (fix by @phraktle, w/ Claude code)
 - Remove project-specific Android SDK compatibility level, use shared;
   no change level itself (stillAndroid SDK 34)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -168,6 +168,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @cowtowncoder, w/ Claude code)
 #5897: Excessive `TokenBuffer` allocations when deserializing records
  (fix by @phraktle, w/ Claude code)
+#5911: Deserialization failed with `@JsonUnwrapped` and `@JsonAlias` on
+  a property of the unwrapped type
+ (reported by Lucas C)
+ (fix by @cowtowncoder, w/ Claude code)
 - Remove project-specific Android SDK compatibility level, use shared;
   no change level itself (stillAndroid SDK 34)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -167,7 +167,7 @@ Versions: 3.x (for earlier see VERSION-2.x)
   (`UnresolvedForwardReference`)
  (fix by @cowtowncoder, w/ Claude code)
 #5897: Excessive `TokenBuffer` allocations when deserializing records
- (fix by @phraktle, w/ Claude code)
+ (fix by Viktor S, w/ Claude code)
 #5911: Deserialization failed with `@JsonUnwrapped` and `@JsonAlias` on
   a property of the unwrapped type
  (reported by Lucas C)

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -704,6 +704,7 @@ public class BeanDeserializer
 
         TokenBuffer unknown = null;
         final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
+        final boolean skipUnknown = _shouldSkipUnknowns(ctxt);
         JsonToken t = p.currentToken();
         List<BeanReferring> referrings = null;
 
@@ -814,8 +815,9 @@ public class BeanDeserializer
             }
             // 29-Mar-2021, tatu: [databind#3082] May skip collection if we know
             //    they'd just get ignored (note: any-setter handled above; unwrapped
-            //    properties also separately handled)
-            if (_ignoreAllUnknown) {
+            //    properties also separately handled). Covers `_ignoreAllUnknown` and
+            //    [databind#5897] (final type, no handlers, `FAIL_ON_UNKNOWN_PROPERTIES` off).
+            if (skipUnknown) {
                 // 22-Aug-2021, tatu: [databind#3252] must ensure we do skip the whole value
                 p.skipChildren();
                 continue;

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -1885,9 +1885,16 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
     }
 
     /**
-     * True when an unknown property may be skipped at the source rather than
-     * buffered: either {@link #_ignoreAllUnknown} is set, or (per [databind#5897])
-     * the bean type is final and unknowns would be silently discarded anyway.
+     * True when unknown properties can be skipped via {@code skipChildren()}
+     * instead of buffered into a {@link TokenBuffer}. The buffer is otherwise
+     * needed for polymorphic replay (tokens unknown to the base may be known
+     * to a resolved subtype) or {@link #handleUnknownProperties}. Returns
+     * true when {@link #_ignoreAllUnknown} is set, or (per [databind#5897])
+     * the bean type is {@code final} (no subtype possible), no
+     * {@link DeserializationProblemHandler}s are registered, and
+     * {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES} is disabled.
+     *
+     * @since 3.2
      */
     protected final boolean _shouldSkipUnknowns(DeserializationContext ctxt) {
         if (_ignoreAllUnknown) {

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -1885,6 +1885,20 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
     }
 
     /**
+     * True when an unknown property may be skipped at the source rather than
+     * buffered: either {@link #_ignoreAllUnknown} is set, or (per [databind#5897])
+     * the bean type is final and unknowns would be silently discarded anyway.
+     */
+    protected final boolean _shouldSkipUnknowns(DeserializationContext ctxt) {
+        if (_ignoreAllUnknown) {
+            return true;
+        }
+        return _beanType.isFinal()
+                && ctxt.getConfig().getProblemHandlers() == null
+                && !ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    /**
      * Helper method called for an unknown property, when using "vanilla"
      * processing.
      *

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -1893,10 +1893,13 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
      * the bean type is {@code final} (no subtype possible), no
      * {@link DeserializationProblemHandler}s are registered, and
      * {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES} is disabled.
+     *<p>
+     * May be overridden by subclasses (notably {@code BuilderBasedDeserializer})
+     * where the type relevant to polymorphic replay differs from {@code _beanType}.
      *
      * @since 3.2
      */
-    protected final boolean _shouldSkipUnknowns(DeserializationContext ctxt) {
+    protected boolean _shouldSkipUnknowns(DeserializationContext ctxt) {
         if (_ignoreAllUnknown) {
             return true;
         }

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -446,6 +446,7 @@ public class BuilderBasedDeserializer
 
         // 04-Jan-2010, tatu: May need to collect unknown properties for polymorphic cases
         TokenBuffer unknown = null;
+        final boolean skipUnknown = _shouldSkipUnknowns(ctxt);
 
         JsonToken t = p.currentToken();
         for (; t == JsonToken.PROPERTY_NAME; t = p.nextToken()) {
@@ -505,6 +506,10 @@ public class BuilderBasedDeserializer
             // "any" property?
             if (_anySetter != null) {
                 buffer.bufferAnyProperty(_anySetter, propName, _anySetter.deserialize(p, ctxt));
+                continue;
+            }
+            if (skipUnknown) {
+                p.skipChildren();
                 continue;
             }
             // Ok then, let's collect the whole field; name and value

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -200,6 +200,20 @@ public class BuilderBasedDeserializer
         return Boolean.FALSE;
     }
 
+    // [databind#5897]: for builder-based deser, polymorphism is determined by what
+    // `build()` returns vs the declared target type — the builder class itself may
+    // be final while still producing subtypes of a non-final target. Check
+    // `_targetType` (built value type) rather than `_beanType` (builder class).
+    @Override
+    protected boolean _shouldSkipUnknowns(DeserializationContext ctxt) {
+        if (_ignoreAllUnknown) {
+            return true;
+        }
+        return _targetType.isFinal()
+                && ctxt.getConfig().getProblemHandlers() == null
+                && !ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
     protected Object finishBuild(DeserializationContext ctxt, Object builder)
             throws JacksonException
     {
@@ -446,9 +460,9 @@ public class BuilderBasedDeserializer
 
         // 04-Jan-2010, tatu: May need to collect unknown properties for polymorphic cases
         TokenBuffer unknown = null;
-        final boolean skipUnknown = _shouldSkipUnknowns(ctxt);
 
         JsonToken t = p.currentToken();
+        final boolean skipUnknown = _shouldSkipUnknowns(ctxt);
         for (; t == JsonToken.PROPERTY_NAME; t = p.nextToken()) {
             String propName = p.currentName();
             p.nextToken(); // to point to value

--- a/src/test/java/tools/jackson/databind/records/RecordUnknownProps5897Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUnknownProps5897Test.java
@@ -1,0 +1,65 @@
+package tools.jackson.databind.records;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.deser.DeserializationProblemHandler;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// [databind#5897]: fast path that skips TokenBuffer allocation for unknown
+// properties must preserve observable behavior across the relevant toggles.
+public class RecordUnknownProps5897Test extends DatabindTestUtil
+{
+    record Point(int x, int y) { }
+
+    private static final String JSON_WITH_EXTRAS =
+            "{\"x\":1,\"extra\":{\"nested\":[1,2,3]},\"y\":2,\"trailing\":\"ignored\"}";
+
+    @Test
+    public void testSkipUnknowns_defaultConfig() throws Exception {
+        JsonMapper mapper = jsonMapperBuilder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        Point p = mapper.readValue(JSON_WITH_EXTRAS, Point.class);
+        assertEquals(1, p.x());
+        assertEquals(2, p.y());
+    }
+
+    @Test
+    public void testFailOnUnknown_stillThrows() throws Exception {
+        JsonMapper mapper = jsonMapperBuilder()
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        assertThrows(UnrecognizedPropertyException.class,
+                () -> mapper.readValue(JSON_WITH_EXTRAS, Point.class));
+    }
+
+    @Test
+    public void testProblemHandler_stillInvoked() throws Exception {
+        final java.util.List<String> seen = new java.util.ArrayList<>();
+        JsonMapper mapper = jsonMapperBuilder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .addHandler(new DeserializationProblemHandler() {
+                    @Override
+                    public boolean handleUnknownProperty(
+                            tools.jackson.databind.DeserializationContext ctxt,
+                            tools.jackson.core.JsonParser p,
+                            tools.jackson.databind.ValueDeserializer<?> deserializer,
+                            Object beanOrClass, String propertyName) {
+                        seen.add(propertyName);
+                        try { p.skipChildren(); } catch (Exception e) { throw new RuntimeException(e); }
+                        return true;
+                    }
+                })
+                .build();
+        Point p = mapper.readValue(JSON_WITH_EXTRAS, Point.class);
+        assertEquals(1, p.x());
+        assertEquals(2, p.y());
+        assertTrue(seen.contains("extra"), "handler saw: " + seen);
+        assertTrue(seen.contains("trailing"), "handler saw: " + seen);
+    }
+}

--- a/src/test/java/tools/jackson/databind/records/RecordUnknownProps5897Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUnknownProps5897Test.java
@@ -2,6 +2,11 @@ package tools.jackson.databind.records;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.deser.DeserializationProblemHandler;
 import tools.jackson.databind.exc.UnrecognizedPropertyException;
@@ -61,5 +66,41 @@ public class RecordUnknownProps5897Test extends DatabindTestUtil
         assertEquals(2, p.y());
         assertTrue(seen.contains("extra"), "handler saw: " + seen);
         assertTrue(seen.contains("trailing"), "handler saw: " + seen);
+    }
+
+    // Non-final base + property-based creator + polymorphism: tokens unknown to
+    // the base may be known to the resolved subtype, so the TokenBuffer must be
+    // preserved for replay. This is the scenario that the `_beanType.isFinal()`
+    // guard exists to protect — if the fast-path ever triggered for non-final
+    // types, sub-only properties would be silently dropped.
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+    @JsonSubTypes({ @JsonSubTypes.Type(value = Dog.class, name = "dog") })
+    static class Animal {
+        public final String name;
+        @JsonCreator
+        public Animal(@JsonProperty("name") String name) { this.name = name; }
+    }
+
+    static class Dog extends Animal {
+        public String breed;
+        @JsonCreator
+        public Dog(@JsonProperty("name") String name, @JsonProperty("breed") String breed) {
+            super(name);
+            this.breed = breed;
+        }
+    }
+
+    @Test
+    public void testNonFinalPolymorphic_subPropertyPreserved() throws Exception {
+        JsonMapper mapper = jsonMapperBuilder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        // "breed" appears before the type discriminator and is unknown to Animal;
+        // it must be buffered and replayed through Dog's deserializer.
+        String json = "{\"breed\":\"poodle\",\"name\":\"Rex\",\"kind\":\"dog\"}";
+        Animal a = mapper.readValue(json, Animal.class);
+        assertInstanceOf(Dog.class, a);
+        assertEquals("Rex", a.name);
+        assertEquals("poodle", ((Dog) a).breed);
     }
 }


### PR DESCRIPTION
Partial fix for #5897.

Skips allocating a `TokenBuffer` for unknown properties in `_deserializeUsingPropertyBased` when the declared bean type is final, `FAIL_ON_UNKNOWN_PROPERTIES` is disabled, and no `DeserializationProblemHandler` is registered. Applied to `BeanDeserializer` and `BuilderBasedDeserializer`.

Benchmark is in line with `@JsonIgnoreProperties(ignoreUnknown=true)`, ~25% improvement in allocation/runtime.