### PR TITLE
Proposed fix for issue 5923

### DIFF
--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -680,7 +680,7 @@ public class POJOPropertiesCollector
             //   creator was found (multi-arg @JsonCreator takes precedence over 0-arg one)
             if (zeroParamsConstructor != null && zeroParamsConstructor.isAnnotated()
                     && !creators.hasPropertiesBased()) {
-                creators.setPropertiesBased(_config, zeroParamsConstructor, "explicit");
+                creators.setExplicitPropertiesBased(_config, zeroParamsConstructor);
             }
         }
 
@@ -890,7 +890,7 @@ public class POJOPropertiesCollector
             if (isPropsBased) {
                 // Skipping done if we already got higher-precedence Creator
                 if (!skipPropsBased) {
-                    collector.setPropertiesBased(_config, ctor, "explicit");
+                    collector.setExplicitPropertiesBased(_config, ctor);
                 }
             } else {
                 collector.addExplicitDelegating(ctor);

--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -702,7 +702,7 @@ public class POJOPropertiesCollector
                 if (_isDelegatingConstructor(primaryCreator)) {
                     // 08-Oct-2024, tatu: [databind#4724] Only add if no explicit
                     //    candidates added
-                    if (!creators.hasDelegating()) {
+                    if (!creators.hasDelegating() && !creators.hasExplicitPropertiesBased()) {
                         // ... not technically explicit but simpler this way
                         creators.addExplicitDelegating(primaryCreator);
                     }

--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -708,7 +708,7 @@ public class POJOPropertiesCollector
                     }
                 } else { // primary creator is properties-based
                     if (!creators.hasPropertiesBased()) {
-                        creators.setPropertiesBased(_config, primaryCreator, "Primary");
+                        creators.setPropertiesBased(_config, primaryCreator, "primary");
                     }
                 }
             }

--- a/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
+++ b/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
@@ -32,7 +32,9 @@ public class PotentialCreators
     /**********************************************************************
      */
     
-    // mode -> "explicit", "implicit" etc
+    // {@code mode} is used only for diagnostic messages (e.g. "implicit",
+    // "Primary"); for creators from an explicit {@code @JsonCreator} annotation
+    // use {@link #setExplicitPropertiesBased} instead.
     public void setPropertiesBased(MapperConfig<?> config, PotentialCreator ctor, String mode)
     {
         _setPropertiesBased(config, ctor, mode, false);

--- a/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
+++ b/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
@@ -33,7 +33,7 @@ public class PotentialCreators
      */
     
     // {@code mode} is used only for diagnostic messages (e.g. "implicit",
-    // "Primary"); for creators from an explicit {@code @JsonCreator} annotation
+    // "primary"); for creators from an explicit {@code @JsonCreator} annotation
     // use {@link #setExplicitPropertiesBased} instead.
     public void setPropertiesBased(MapperConfig<?> config, PotentialCreator ctor, String mode)
     {

--- a/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
+++ b/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
@@ -10,6 +10,7 @@ public class PotentialCreators
      * Property-based Creator found, if any
      */
     public PotentialCreator propertiesBased;
+    private String propertiesBasedMode;
 
     private List<PotentialCreator> explicitDelegating;
 
@@ -33,6 +34,7 @@ public class PotentialCreators
                     mode, propertiesBased.creator(), ctor.creator()));
         }
         propertiesBased = ctor.introspectParamNames(config);
+        propertiesBasedMode = mode;
     }
 
     public void addExplicitDelegating(PotentialCreator ctor)
@@ -63,6 +65,9 @@ public class PotentialCreators
     
     public boolean hasPropertiesBased() {
         return (propertiesBased != null);
+    }
+    public boolean hasExplicitPropertiesBased() {
+        return hasPropertiesBased() && "explicit".equals(propertiesBasedMode);
     }
 
     public boolean hasPropertiesBasedOrDelegating() {

--- a/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
+++ b/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
@@ -10,7 +10,14 @@ public class PotentialCreators
      * Property-based Creator found, if any
      */
     public PotentialCreator propertiesBased;
-    private String propertiesBasedMode;
+
+    /**
+     * Whether {@link #propertiesBased} was registered via
+     * {@link #setExplicitPropertiesBased} (i.e. from an explicit
+     * {@code @JsonCreator}-style annotation), as opposed to an implicit
+     * or primary fallback.
+     */
+    private boolean propertiesBasedExplicit;
 
     private List<PotentialCreator> explicitDelegating;
 
@@ -28,13 +35,29 @@ public class PotentialCreators
     // mode -> "explicit", "implicit" etc
     public void setPropertiesBased(MapperConfig<?> config, PotentialCreator ctor, String mode)
     {
+        _setPropertiesBased(config, ctor, mode, false);
+    }
+
+    /**
+     * Variant of {@link #setPropertiesBased} for creators coming from explicit
+     * {@code @JsonCreator}-style annotations; records that the registered
+     * creator is {@code explicit} so later fallback logic can defer to it.
+     */
+    public void setExplicitPropertiesBased(MapperConfig<?> config, PotentialCreator ctor)
+    {
+        _setPropertiesBased(config, ctor, "explicit", true);
+    }
+
+    private void _setPropertiesBased(MapperConfig<?> config, PotentialCreator ctor,
+            String mode, boolean explicit)
+    {
         if (propertiesBased != null) {
             throw new IllegalArgumentException(String.format(
                     "Conflicting property-based creators: already had %s creator %s, encountered another: %s",
                     mode, propertiesBased.creator(), ctor.creator()));
         }
         propertiesBased = ctor.introspectParamNames(config);
-        propertiesBasedMode = mode;
+        propertiesBasedExplicit = explicit;
     }
 
     public void addExplicitDelegating(PotentialCreator ctor)
@@ -66,8 +89,9 @@ public class PotentialCreators
     public boolean hasPropertiesBased() {
         return (propertiesBased != null);
     }
+
     public boolean hasExplicitPropertiesBased() {
-        return hasPropertiesBased() && "explicit".equals(propertiesBasedMode);
+        return propertiesBasedExplicit;
     }
 
     public boolean hasPropertiesBasedOrDelegating() {

--- a/src/test/java/tools/jackson/databind/records/RecordJsonCreatorAndJsonValue5923Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordJsonCreatorAndJsonValue5923Test.java
@@ -44,4 +44,19 @@ public class RecordJsonCreatorAndJsonValue5923Test extends DatabindTestUtil
         Outer bw = MAPPER.readValue("{ \"renamed\": false }", Outer.class);
         assertEquals(false, bw.bools.innerValue);
     }
+
+    @Test
+    public void testSerializationViaJsonValue() throws Exception {
+        assertEquals("{\"renamed\":true}",
+                MAPPER.writeValueAsString(new Outer(new Inner(true))));
+        assertEquals("{\"renamed\":false}",
+                MAPPER.writeValueAsString(new Outer(new Inner(false))));
+    }
+
+    @Test
+    public void testRoundTrip() throws Exception {
+        Outer original = new Outer(new Inner(true));
+        Outer roundTripped = MAPPER.readValue(MAPPER.writeValueAsString(original), Outer.class);
+        assertEquals(original.bools.innerValue, roundTripped.bools.innerValue);
+    }
 }

--- a/src/test/java/tools/jackson/databind/records/RecordJsonCreatorAndJsonValue5923Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordJsonCreatorAndJsonValue5923Test.java
@@ -1,0 +1,35 @@
+package tools.jackson.databind.records;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import tools.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class RecordJsonCreatorAndJsonValue5923Test {
+
+    public record Inner(@JsonProperty(required = true, value = "innerValue") boolean innerValue) {}
+
+    public record Outer(Inner bools) {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public static Outer fromJson(@JsonProperty(required = true, value = "renamed") boolean booleanValue) {
+            return new Outer(new Inner(booleanValue));
+        }
+
+        @JsonValue
+        public Map<String, Boolean> toJson() {
+            return Map.of("renamed", bools.innerValue());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testDeserializationBug(boolean testVal) throws Exception {
+        var om = new ObjectMapper();
+        var bw = om.readValue(String.format("{ \"renamed\": %s }", testVal), Outer.class);
+        Assertions.assertEquals(testVal, bw.bools.innerValue, String.valueOf(bw));
+    }
+}

--- a/src/test/java/tools/jackson/databind/records/RecordJsonCreatorAndJsonValue5923Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordJsonCreatorAndJsonValue5923Test.java
@@ -1,16 +1,22 @@
 package tools.jackson.databind.records;
 
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import tools.jackson.databind.ObjectMapper;
-import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import tools.jackson.databind.testutil.DatabindTestUtil;
 
-public class RecordJsonCreatorAndJsonValue5923Test {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// [databind#5923] Record with @JsonCreator(mode=PROPERTIES) factory + @JsonValue
+//   fails to deserialize
+public class RecordJsonCreatorAndJsonValue5923Test extends DatabindTestUtil
+{
     public record Inner(@JsonProperty(required = true, value = "innerValue") boolean innerValue) {}
 
     public record Outer(Inner bools) {
@@ -25,11 +31,17 @@ public class RecordJsonCreatorAndJsonValue5923Test {
         }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = { true, false })
-    public void testDeserializationBug(boolean testVal) throws Exception {
-        var om = new ObjectMapper();
-        var bw = om.readValue(String.format("{ \"renamed\": %s }", testVal), Outer.class);
-        Assertions.assertEquals(testVal, bw.bools.innerValue, String.valueOf(bw));
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void testDeserializationTrue() throws Exception {
+        Outer bw = MAPPER.readValue("{ \"renamed\": true }", Outer.class);
+        assertEquals(true, bw.bools.innerValue);
+    }
+
+    @Test
+    public void testDeserializationFalse() throws Exception {
+        Outer bw = MAPPER.readValue("{ \"renamed\": false }", Outer.class);
+        assertEquals(false, bw.bools.innerValue);
     }
 }


### PR DESCRIPTION
This is a potential fix for https://github.com/FasterXML/jackson-databind/issues/5923

It extends the "explicit candidates" check in `POJOPropertiesCollector` to also include explicit property-based creators.

It identifies property-based creators by keeping track of the `mode` that is passed into `PotentialCreators` when the creator is added.  I'm not sure how reliable that is, though, since it seems like `mode` was only used for diagnostic purposes prior to this change.