### PR TITLE
Pass dynamic serializer for `Iterable` content filtering

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -220,6 +220,8 @@ Lee Jiwon (@dlwldnjs1009)
  * Fixed #5891: `EnumMapDeserializer._deserializeUsingProperties()` corrupts parser
    state after skipping unknown enum keys
   [3.1.2]
+ * Fixed #5925: Pass dynamic serializer for `Iterable` content filtering
+  [3.1.3]
 
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -18,6 +18,8 @@ No changes since 3.1
 #5918: Creator properties always come first in 3.x
  (reported by Marco B)
  (fix by @cowtowncoder)
+#5925: Pass dynamic serializer for `Iterable` content filtering
+ (fixed by Lee Jiwon)
 
 3.1.2 (11-Apr-2026)
 

--- a/src/main/java/tools/jackson/databind/ser/jdk/IterableSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/IterableSerializer.java
@@ -126,7 +126,7 @@ public class IterableSerializer
                 }
                 // [databind#5369] Support `@JsonInclude` in `Collection`
                 //                Let's do filtering before serialization
-                if (needsFiltering && !_shouldSerializeElement(ctxt, elem, _elementSerializer)) {
+                if (needsFiltering && !_shouldSerializeElement(ctxt, elem, serializer)) {
                     continue;
                 }
                 if (typeSer == null) {

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeCollectionTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeCollectionTest.java
@@ -286,6 +286,28 @@ public class JsonIncludeCollectionTest extends DatabindTestUtil
         public Iterable<Integer> values = new Iterable5369(1);
     }
 
+    // Wildcard-typed Iterable so that `_elementSerializer` stays null and
+    // per-element serializers are resolved dynamically at serialize time.
+    static class IterableOfObjects implements Iterable<Object>
+    {
+        private final List<Object> values;
+
+        IterableOfObjects(Object... items) { values = Arrays.asList(items); }
+
+        @Override
+        public Iterator<Object> iterator() { return values.iterator(); }
+    }
+
+    static class BeanWithIterableNonEmpty
+    {
+        @JsonInclude(content = JsonInclude.Include.NON_EMPTY)
+        public Iterable<Object> values;
+
+        BeanWithIterableNonEmpty(Object... items) {
+            values = new IterableOfObjects(items);
+        }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // [databind#5369]
@@ -452,5 +474,21 @@ public class JsonIncludeCollectionTest extends DatabindTestUtil
         pojo.values = new Iterable5369(1, null, 2, 3, 5369);
 
         assertEquals("{\"values\":[5369]}", MAPPER_CONTAINERS.writeValueAsString(pojo));
+    }
+
+    // Regression: when `_elementSerializer` is not resolved statically (wildcard/Object element type),
+    // per-element dynamic serializer must be passed to `_shouldSerializeElement` so that
+    // `serializer.isEmpty(ctxt, elem)` is consulted for NON_EMPTY content inclusion.
+    @Test
+    public void testIterableNonEmptyWithWildcardElementType() throws Exception
+    {
+        BeanWithIterableNonEmpty pojo = new BeanWithIterableNonEmpty(
+                Collections.emptyMap(),
+                Collections.singletonMap("k", "v"),
+                Collections.emptyList(),
+                Collections.singletonList("x"));
+
+        assertEquals(a2q("{'values':[{'k':'v'},['x']]}"),
+                MAPPER_CONTAINERS.writeValueAsString(pojo));
     }
 }


### PR DESCRIPTION
Follow-up to #5370 ([databind#5369]).

With `SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS` enabled,
`IterableSerializer.serializeContents()` passes `_elementSerializer` to
`_shouldSerializeElement()`. When the declared element type is `Object` or a
wildcard, that field is null, so `NON_EMPTY` content filtering does not consult
the dynamically resolved serializer and empty `Map`/`List` elements are written
instead of suppressed.

Sibling serializers (`CollectionSerializer`, `IndexedListSerializer`,
`IteratorSerializer`, `ObjectArraySerializer`) pass the per-element
`serializer` resolved at the top of the loop. Align `IterableSerializer` with
that behavior so `serializer.isEmpty(ctxt, elem)` is consulted.

Before fix:
{"values":[{},{"k":"v"},[],["x"]]}

After fix:
{"values":[{"k":"v"},["x"]]}

Regression test added:
`JsonIncludeCollectionTest#testIterableNonEmptyWithWildcardElementType`