### PR TITLE
Fix `AtomicLongDeserializer` value truncation on coerced values

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/jdk/AtomicLongDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/AtomicLongDeserializer.java
@@ -30,6 +30,6 @@ public class AtomicLongDeserializer extends StdScalarDeserializer<AtomicLong>
         // 12-Jun-2020, tatu: May look convoluted, but need to work correctly with
         //   CoercionConfig
         Long L = _parseLong(p, ctxt, AtomicLong.class);
-        return (L == null) ? null : new AtomicLong(L.intValue());
+        return (L == null) ? null : new AtomicLong(L.longValue());
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/jdk/JDKAtomicTypesDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/JDKAtomicTypesDeserTest.java
@@ -185,6 +185,23 @@ public class JDKAtomicTypesDeserTest
         assertEquals(12345678901L, value.get());
     }
 
+    // Coerced-from-String / coerced-from-Float paths went through
+    // `_parseLong` + `Long.intValue()`, silently truncating values above
+    // `Integer.MAX_VALUE`.
+    @Test
+    public void testAtomicLongFromStringAboveIntRange() throws Exception
+    {
+        AtomicLong value = MAPPER.readValue("\"9999999999\"", AtomicLong.class);
+        assertEquals(9999999999L, value.get());
+    }
+
+    @Test
+    public void testAtomicLongFromFloatAboveIntRange() throws Exception
+    {
+        AtomicLong value = MAPPER.readValue("12345678901.25", AtomicLong.class);
+        assertEquals(12345678901L, value.get());
+    }
+
     @Test
     public void testAtomicReference() throws Exception
     {


### PR DESCRIPTION
`AtomicLongDeserializer` converts through `Long.intValue()` on the `_parseLong(...)` path, which silently truncates coerced values above `Integer.MAX_VALUE`.

This changes that path to use `Long.longValue()` and adds regression
tests for String and floating-point inputs above `Integer.MAX_VALUE`.

Testing:
- `./mvnw -q -Dtest=tools.jackson.databind.deser.jdk.JDKAtomicTypesDeserTest test`