### PR TITLE
Fix (minimal) for #1921: support limited merge for immutable POJOs

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -385,6 +385,10 @@ Balys Valentukevicius (@balysv)
    deserializing a collection of interfaces (immutables.io compatibility)
   [3.2.0]
 
+Patrik Mihalcin (@pmihalcin)
+ * Reported #1921: Reader for updating do not use `@JsonCreator` constructor
+  [3.2.0]
+
 Leonid Talalaev (@ltalal)
  * Reported #2100: Using `ObjectReader.withValueToUpdate()` with JsonPOJOBuilder
   no longer working

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -53,11 +53,14 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (reported by Balys V)
  (fix by @cowtowncoder, w/ Claude code)
 #1755: Get NPE on deserializing values with recursive `@JsonIgnoreProperties`
- (reported by @Romain-P)#
+ (reported by @Romain-P)
  (fix by @cowtowncoder, w/ Claude code)
 #1757: Regression in `JsonInclude.Include.NON_DEFAULT` set as global default
   serialization inclusion (add new `MapperFeature.USE_REAL_INCLUDE_NON_DEFAULT`)
  (reported by @yhack)
+ (fix by @cowtowncoder, w/ Claude code)
+#1921: Reader for updating do not use `@JsonCreator` constructor
+ (reported by Patrik M)
  (fix by @cowtowncoder, w/ Claude code)
 #2039: `@JsonUnwrapped` and `JsonTypeInfo.As.EXTERNAL_PROPERTY` in the
   same bean doesn't work

--- a/src/main/java/tools/jackson/databind/deser/CreatorProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/CreatorProperty.java
@@ -195,6 +195,17 @@ public class CreatorProperty
                 && _type.equals(fallbackSetter.getType());
     }
 
+    /**
+     * @return True if a non-creator mutator (setter or field) is available
+     *    for assigning this property's value into an existing instance;
+     *    false if this property can only be assigned via the creator.
+     *
+     * @since 3.2
+     */
+    public boolean hasFallbackSetter() {
+        return _fallbackSetter != null;
+    }
+
     @Override
     public void markAsIgnorable() {
         _ignorable = true;

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -256,15 +256,6 @@ public class BeanDeserializer
         if (_beanType.isRecordType() && _propertyBasedCreator != null) {
             return _deserializeRecordForUpdate(p, ctxt, bean);
         }
-        // [databind#1921]: Immutable POJO whose only assignment path is @JsonCreator:
-        // existing instance cannot be updated in-place (no setters/fields/any-setter),
-        // so construct a new instance via the creator. This discards existing values
-        // (true per-property merge requires getter introspection; out of scope here).
-        if (_propertyBasedCreator != null && !_hasUpdateableProperties()) {
-            // Delegate to 2-arg entry point so JSON-Object START token handling
-            // (advance past `{`) matches the fresh-deserialize path.
-            return deserialize(p, ctxt);
-        }
         if (_unwrappedPropertyHandler != null) {
             return deserializeWithUnwrapped(p, ctxt, bean);
         }
@@ -283,6 +274,15 @@ public class BeanDeserializer
             propName = p.currentName();
         } else {
             return bean;
+        }
+        // [databind#1921]: Immutable POJO whose only assignment path is @JsonCreator:
+        // existing instance cannot be updated in-place (no setters/fields/any-setter),
+        // so construct a new instance via the creator. This discards existing values
+        // (true per-property merge requires getter introspection; out of scope here).
+        // Positioned after the `propName == null` / non-object short-circuits so that
+        // empty-object and non-object updates continue to return `bean` unchanged.
+        if (_propertyBasedCreator != null && !_hasUpdateableProperties()) {
+            return deserializeFromObject(p, ctxt);
         }
         if (_needViewProcesing) {
             Class<?> view = ctxt.getActiveView();

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -256,6 +256,15 @@ public class BeanDeserializer
         if (_beanType.isRecordType() && _propertyBasedCreator != null) {
             return _deserializeRecordForUpdate(p, ctxt, bean);
         }
+        // [databind#1921]: Immutable POJO whose only assignment path is @JsonCreator:
+        // existing instance cannot be updated in-place (no setters/fields/any-setter),
+        // so construct a new instance via the creator. This discards existing values
+        // (true per-property merge requires getter introspection; out of scope here).
+        if (_propertyBasedCreator != null && !_hasUpdateableProperties()) {
+            // Delegate to 2-arg entry point so JSON-Object START token handling
+            // (advance past `{`) matches the fresh-deserialize path.
+            return deserialize(p, ctxt);
+        }
         if (_unwrappedPropertyHandler != null) {
             return deserializeWithUnwrapped(p, ctxt, bean);
         }

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -1316,6 +1316,30 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
         return _beanProperties.size();
     }
 
+    /**
+     * [databind#1921]: Check whether any property can assign a value into an
+     * existing instance — either via setter/field mutator, any-setter, or as
+     * a {@link CreatorProperty} that has a fallback setter. Returns false for
+     * fully-immutable types whose only assignment path is via {@code @JsonCreator}.
+     *
+     * @since 3.2
+     */
+    protected boolean _hasUpdateableProperties() {
+        if (_anySetter != null) {
+            return true;
+        }
+        for (SettableBeanProperty prop : _beanProperties) {
+            if (prop instanceof CreatorProperty) {
+                if (((CreatorProperty) prop).hasFallbackSetter()) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public Collection<Object> getKnownPropertyNames() {
         ArrayList<Object> names = new ArrayList<>();

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -177,6 +177,18 @@ public abstract class BeanDeserializerBase
     protected transient ConcurrentHashMap<ClassKey, ValueDeserializer<Object>> _subDeserializers;
 
     /**
+     * [databind#1921]: Lazily computed cache for {@link #_hasUpdateableProperties()}.
+     * {@code null} until the first call; safe under concurrent reads/writes since
+     * the computation is pure and the cached reference is an immutable Boolean
+     * (benign race at worst causes redundant computation).
+     * Intentionally not propagated by copy constructors — copies recompute lazily
+     * so the cache stays consistent with a potentially-different property set.
+     *
+     * @since 3.2
+     */
+    protected transient volatile Boolean _hasUpdateablePropertiesFlag;
+
+    /**
      * If one of properties has "unwrapped" value, we need separate
      * helper object
      */
@@ -1321,10 +1333,21 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
      * existing instance — either via setter/field mutator, any-setter, or as
      * a {@link CreatorProperty} that has a fallback setter. Returns false for
      * fully-immutable types whose only assignment path is via {@code @JsonCreator}.
+     * Result is cached lazily in {@link #_hasUpdateablePropertiesFlag}.
      *
      * @since 3.2
      */
     protected boolean _hasUpdateableProperties() {
+        Boolean cached = _hasUpdateablePropertiesFlag;
+        if (cached != null) {
+            return cached;
+        }
+        boolean result = _computeHasUpdateableProperties();
+        _hasUpdateablePropertiesFlag = result;
+        return result;
+    }
+
+    private boolean _computeHasUpdateableProperties() {
         if (_anySetter != null) {
             return true;
         }

--- a/src/test/java/tools/jackson/databind/deser/merge/MergeWithCreator1921Test.java
+++ b/src/test/java/tools/jackson/databind/deser/merge/MergeWithCreator1921Test.java
@@ -1,6 +1,6 @@
 package tools.jackson.databind.deser.merge;
 
-import java.util.Objects;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +10,7 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.exc.ValueInstantiationException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 // For [databind#1921]: when merge target type is fully immutable (all properties
 // assigned via @JsonCreator, no setters/fields/any-setter), update-mode falls
@@ -66,6 +66,49 @@ class MergeWithCreator1921Test extends DatabindTestUtil
         }
     }
 
+    // Mergeable wrapper (no-arg ctor + setter) whose payload is fully-immutable,
+    // used to exercise the fix at the inner-property level under a normal merge.
+    static class MergeWrapper {
+        @JsonMerge
+        private OptionalFields payload;
+        public OptionalFields getPayload() { return payload; }
+        public void setPayload(OptionalFields p) { payload = p; }
+    }
+
+    static class OptionalFields {
+        public final String a;
+        public final String b;
+        @JsonCreator
+        public OptionalFields(@JsonProperty("a") String a, @JsonProperty("b") String b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    // Mixed: @JsonCreator param AND a setter/field for the same property.
+    // The fallback setter means _hasUpdateableProperties() returns true,
+    // so the new fix branch must NOT apply; update-mode keeps the existing
+    // instance and assigns via the setter.
+    static class CreatorPlusSetter {
+        private String a;
+        @JsonCreator
+        public CreatorPlusSetter(@JsonProperty("a") String a) { this.a = a; }
+        public String getA() { return a; }
+        public void setA(String a) { this.a = a; }
+    }
+
+    // Creator-only + @JsonAnySetter. _anySetter != null flips
+    // _hasUpdateableProperties() to true, so the fix must NOT apply;
+    // any-setter can carry the update into the existing instance.
+    static class CreatorPlusAnySetter {
+        public final String a;
+        public final Map<String, Object> extras = new LinkedHashMap<>();
+        @JsonCreator
+        public CreatorPlusAnySetter(@JsonProperty("a") String a) { this.a = a; }
+        @JsonAnySetter
+        public void put(String key, Object value) { extras.put(key, value); }
+    }
+
     @Test
     void mergeWithCreator() throws Exception {
         final String JSON = "{ \"validity\": { \"validFrom\": \"2018-02-01\", \"validTo\": \"2018-01-31\" } }";
@@ -89,5 +132,72 @@ class MergeWithCreator1921Test extends DatabindTestUtil
             verifyException(e, "Cannot construct");
             verifyException(e, Validity.VALID_TO_CANT_BE_BEFORE_VALID_FROM);
         }
+    }
+
+    // Partial JSON on fully-immutable merge target: narrow fix discards the
+    // existing payload and rebuilds via creator, so fields absent from JSON
+    // become null rather than inheriting the prior value. A fuller fix
+    // (mirroring _deserializeRecordForUpdate for POJOs) would preserve them.
+    @Test
+    void partialMergeOfImmutableDiscardsExistingValues() throws Exception {
+        final ObjectMapper mapper = newJsonMapper();
+        MergeWrapper wrapper = new MergeWrapper();
+        OptionalFields oldPayload = new OptionalFields("old-a", "old-b");
+        wrapper.setPayload(oldPayload);
+
+        MergeWrapper result = mapper.readerForUpdating(wrapper)
+                .readValue("{\"payload\":{\"a\":\"new-a\"}}");
+
+        assertSame(wrapper, result);
+        assertNotSame(oldPayload, result.getPayload());
+        assertEquals("new-a", result.getPayload().a);
+        assertNull(result.getPayload().b);
+    }
+
+    // Empty JSON object on a fully-immutable merge target: post-fix this
+    // rebuilds with null creator args instead of the pre-fix no-op-return.
+    // If we later decide the no-op was preferable, reposition the new
+    // branch past the `propName == null` short-circuit and update this test.
+    @Test
+    void emptyJsonOnImmutableMergeTargetBuildsFreshInstance() throws Exception {
+        final ObjectMapper mapper = newJsonMapper();
+        MergeWrapper wrapper = new MergeWrapper();
+        OptionalFields oldPayload = new OptionalFields("kept-a", "kept-b");
+        wrapper.setPayload(oldPayload);
+
+        MergeWrapper result = mapper.readerForUpdating(wrapper)
+                .readValue("{\"payload\":{}}");
+
+        assertSame(wrapper, result);
+        assertNotSame(oldPayload, result.getPayload());
+        assertNull(result.getPayload().a);
+        assertNull(result.getPayload().b);
+    }
+
+    // Regression guard: when a creator property has a fallback setter, the
+    // new branch must NOT trigger; existing instance is updated in-place.
+    @Test
+    void creatorWithFallbackSetterUpdatesExistingInstance() throws Exception {
+        final ObjectMapper mapper = newJsonMapper();
+        CreatorPlusSetter existing = new CreatorPlusSetter("old");
+        CreatorPlusSetter result = mapper.readerForUpdating(existing)
+                .readValue("{\"a\":\"new\"}");
+
+        assertSame(existing, result);
+        assertEquals("new", result.getA());
+    }
+
+    // Regression guard: @JsonAnySetter alone is enough to consider the type
+    // updateable; existing instance is updated in-place via the any-setter.
+    @Test
+    void creatorWithAnySetterUpdatesExistingInstance() throws Exception {
+        final ObjectMapper mapper = newJsonMapper();
+        CreatorPlusAnySetter existing = new CreatorPlusAnySetter("kept");
+        CreatorPlusAnySetter result = mapper.readerForUpdating(existing)
+                .readValue("{\"x\":\"y\"}");
+
+        assertSame(existing, result);
+        assertEquals("kept", result.a);
+        assertEquals("y", result.extras.get("x"));
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/merge/MergeWithCreator1921Test.java
+++ b/src/test/java/tools/jackson/databind/deser/merge/MergeWithCreator1921Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.databind.tofix;
+package tools.jackson.databind.deser.merge;
 
 import java.util.Objects;
 
@@ -9,17 +9,13 @@ import com.fasterxml.jackson.annotation.*;
 import tools.jackson.databind.*;
 import tools.jackson.databind.exc.ValueInstantiationException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
-import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-// For [databind#1921]: Creator method not used when merging even if there is
-// no feasible alternative. Unclear whether this can even theoretically be
-// improved since combination of Creator + Setter(s)/field is legit; but use
-// of Creator always means that operation is not true merge.
-// But added test just in case future brings us a good idea of way forward.
-//
-// 22-Apr-2026, tatu: Issue close as "wont-fix"; should test be removed?
+// For [databind#1921]: when merge target type is fully immutable (all properties
+// assigned via @JsonCreator, no setters/fields/any-setter), update-mode falls
+// back to creator-based construction so that creator-enforced invariants fire —
+// instead of throwing InvalidDefinitionException for the missing fallback setter.
 class MergeWithCreator1921Test extends DatabindTestUtil
 {
     static class Account {
@@ -70,7 +66,6 @@ class MergeWithCreator1921Test extends DatabindTestUtil
         }
     }
 
-    @JacksonTestFailureExpected
     @Test
     void mergeWithCreator() throws Exception {
         final String JSON = "{ \"validity\": { \"validFrom\": \"2018-02-01\", \"validTo\": \"2018-01-31\" } }";

--- a/src/test/java/tools/jackson/databind/deser/merge/MergeWithCreator1921Test.java
+++ b/src/test/java/tools/jackson/databind/deser/merge/MergeWithCreator1921Test.java
@@ -154,12 +154,11 @@ class MergeWithCreator1921Test extends DatabindTestUtil
         assertNull(result.getPayload().b);
     }
 
-    // Empty JSON object on a fully-immutable merge target: post-fix this
-    // rebuilds with null creator args instead of the pre-fix no-op-return.
-    // If we later decide the no-op was preferable, reposition the new
-    // branch past the `propName == null` short-circuit and update this test.
+    // Empty JSON object on a fully-immutable merge target: the new branch is
+    // positioned after the 3-arg path's `propName == null` short-circuit, so
+    // empty `{}` still no-ops and the existing payload is preserved.
     @Test
-    void emptyJsonOnImmutableMergeTargetBuildsFreshInstance() throws Exception {
+    void emptyJsonOnImmutableMergeTargetPreservesExisting() throws Exception {
         final ObjectMapper mapper = newJsonMapper();
         MergeWrapper wrapper = new MergeWrapper();
         OptionalFields oldPayload = new OptionalFields("kept-a", "kept-b");
@@ -169,9 +168,9 @@ class MergeWithCreator1921Test extends DatabindTestUtil
                 .readValue("{\"payload\":{}}");
 
         assertSame(wrapper, result);
-        assertNotSame(oldPayload, result.getPayload());
-        assertNull(result.getPayload().a);
-        assertNull(result.getPayload().b);
+        assertSame(oldPayload, result.getPayload());
+        assertEquals("kept-a", result.getPayload().a);
+        assertEquals("kept-b", result.getPayload().b);
     }
 
     // Regression guard: when a creator property has a fallback setter, the


### PR DESCRIPTION
Addresses #1921 — previously closed as wont-fix because a general solution is fragile when a type mixes `@JsonCreator` parameters with regular setters.
This PR takes a narrow slice of that problem that *is* safe to solve.

## What this fixes

When the merge target is a **fully-immutable** POJO — every property assigned through `@JsonCreator`, no fallback setters, no `@JsonAnySetter` — `readerForUpdating(existing).readValue(json)` previously failed with:

```
InvalidDefinitionException: No fallback setter/field defined for creator property ...
```

With this change, update-mode falls back to creator-based fresh construction, so creator-enforced invariants fire during merge — which is the concrete behavior #1921 was asking for.

The approach mirrors the existing `_deserializeRecordForUpdate` branch in `BeanDeserializer.deserialize(p, ctxt, bean)` (added for #3079): Records already get this treatment, and fully-immutable POJOs are the natural generalization.

## What this explicitly does *not* do

- **No pre-population from the existing instance.** The new branch delegates to fresh creator construction, so fields absent from the incoming JSON become `null` rather than inheriting from the prior object. A fuller fix — mirroring `_deserializeRecordForUpdate`'s getter-based pre-population for POJOs — is a viable follow-up, but out of scope here. Called out in the code comment.
- **Mixed creator + setter case is untouched.** If any creator property has a fallback setter, or the type has any regular setter or `@JsonAnySetter`, current behavior is preserved. `_hasUpdateableProperties()` returns `true` in those cases and the new branch does not trigger. This is where cowtowncoder's original fragility concern lives; deliberately deferred.

## Key design decisions

- **Runtime dispatch, not resolve-time decision.** The check runs inside the 3-arg `deserialize` only when merge update is actually happening. At resolve time (`_resolveMergeAndNullSettings`) the nested deserializer isn't fully available, so this avoids the "fragile, has to be decided too early" problem from the earlier discussion.
- **Positioned after the empty-object / non-object short-circuits.** Placed immediately after `propName` is determined. `readerForUpdating(x).readValue("{}")` continues to return `x` unchanged; only real update input with property data triggers creator reconstruction. (This was caught in review — the first iteration short-circuited earlier and replaced `x` with defaults.)
- **Lazy-cached decision.** `_hasUpdateablePropertiesFlag` caches the result per deserializer instance. `transient volatile Boolean`; copy constructors intentionally don't propagate it so copies recompute against their own property set.

## Test coverage (`MergeWithCreator1921Test`, moved from `tofix/` to `deser/merge/`)

- `mergeWithCreator` — the original issue scenario: creator invariants fire during merge, not just fresh `readValue`.
- `partialMergeOfImmutableDiscardsExistingValues` — pins the "no pre-population" limitation so the scope is visible in tests, not just in a comment.
- `emptyJsonOnImmutableMergeTargetPreservesExisting` — pins the empty-JSON no-op semantics and guards against accidental repositioning.
- `creatorWithFallbackSetterUpdatesExistingInstance` — regression guard: mixed creator+setter case still updates in-place via the setter.
- `creatorWithAnySetterUpdatesExistingInstance` — regression guard: `@JsonAnySetter`-only case still updates in-place via the any-setter.

## Files

- `deser/CreatorProperty.java` — new `hasFallbackSetter()` accessor.
- `deser/bean/BeanDeserializerBase.java` — new `_hasUpdateableProperties()` with lazy cached flag.
- `deser/bean/BeanDeserializer.java` — new dispatch branch in the 3-arg `deserialize`.
- Test moved + expanded.
