### PR TITLE
Improve `InetSocketAddress` deserialization [CVE-2026-54514]

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1897,3 +1897,5 @@ Fawzi Essam (@iifawzi)
 Omkhar Arasaratnam (@omkhar)
  * Reported #5950: Improve `UUIDeserializer` error handling
   (2.18.8)
+ * Reported #: Improve `InetSocketAddress` deserialization
+  (2.18.8)

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1897,5 +1897,5 @@ Fawzi Essam (@iifawzi)
 Omkhar Arasaratnam (@omkhar)
  * Reported #5950: Improve `UUIDeserializer` error handling
   (2.18.8)
- * Reported #: Improve `InetSocketAddress` deserialization
+ * Reported #5951: Improve `InetSocketAddress` deserialization
   (2.18.8)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,8 @@ Project: jackson-databind
 
 #5950: Improve `UUIDeserializer` error handling
  (reported by Omkhar A)
+#: Improve `InetSocketAddress` deserialization
+ (reported by Omkhar A)
 
 2.18.7 (24-Apr-2026)
 2.18.6 (22-Feb-2026)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,7 +8,7 @@ Project: jackson-databind
 
 #5950: Improve `UUIDeserializer` error handling
  (reported by Omkhar A)
-#: Improve `InetSocketAddress` deserialization
+#5951: Improve `InetSocketAddress` deserialization
  (reported by Omkhar A)
 
 2.18.7 (24-Apr-2026)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
@@ -488,7 +488,8 @@ _coercedTypeDesc());
         }
 
         protected InetSocketAddress _inetSocketAddress(String host, int port) {
-            return new InetSocketAddress(host, port);
+            // 05-May-2026, tatu: [databind#5951] Prevent DNS lookup:
+            return InetSocketAddress.createUnresolved(host, port);
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
@@ -365,16 +365,16 @@ _coercedTypeDesc());
 
                     int j = value.indexOf(':', i);
                     int port = j > -1 ? Integer.parseInt(value.substring(j + 1)) : 0;
-                    return new InetSocketAddress(value.substring(0, i + 1), port);
+                    return _inetSocketAddress(value.substring(0, i + 1), port);
                 }
                 int ix = value.indexOf(':');
                 if (ix >= 0 && value.indexOf(':', ix + 1) < 0) {
                     // host:port
                     int port = Integer.parseInt(value.substring(ix+1));
-                    return new InetSocketAddress(value.substring(0, ix), port);
+                    return _inetSocketAddress(value.substring(0, ix), port);
                 }
                 // host or unbracketed IPv6, without port number
-                return new InetSocketAddress(value, 0);
+                return _inetSocketAddress(value, 0);
             }
             VersionUtil.throwInternal();
             return null;
@@ -485,6 +485,10 @@ _coercedTypeDesc());
                 // should we really just swallow the exception?
                 return new Locale(first, second, third);
             }
+        }
+
+        protected InetSocketAddress _inetSocketAddress(String host, int port) {
+            return new InetSocketAddress(host, port);
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/InetSocketAddressSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/InetSocketAddressSerializer.java
@@ -19,7 +19,8 @@ public class InetSocketAddressSerializer
     public InetSocketAddressSerializer() { super(InetSocketAddress.class); }
 
     @Override
-    public void serialize(InetSocketAddress value, JsonGenerator jgen, SerializerProvider provider) throws IOException
+    public void serialize(InetSocketAddress value, JsonGenerator g, SerializerProvider ctxt)
+        throws IOException
     {
         InetAddress addr = value.getAddress();
         String str = addr == null ? value.getHostName() : addr.toString().trim();
@@ -35,17 +36,18 @@ public class InetSocketAddressSerializer
             }
         }
 
-        jgen.writeString(str + ":" + value.getPort());
+        g.writeString(str + ":" + value.getPort());
     }
 
     @Override
     public void serializeWithType(InetSocketAddress value, JsonGenerator g,
-            SerializerProvider provider, TypeSerializer typeSer) throws IOException
+            SerializerProvider ctxt, TypeSerializer typeSer)
+        throws IOException
     {
         // Better ensure we don't use specific sub-classes...
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
                 typeSer.typeId(value, InetSocketAddress.class, JsonToken.VALUE_STRING));
-        serialize(value, g, provider);
+        serialize(value, g, ctxt);
         typeSer.writeTypeSuffix(g, typeIdDef);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -184,15 +184,15 @@ public class JDKStringLikeTypeDeserTest
     public void testInetSocketAddress() throws IOException
     {
         InetSocketAddress address = MAPPER.readValue(q("127.0.0.1"), InetSocketAddress.class);
-        assertEquals("127.0.0.1", address.getAddress().getHostAddress());
+        assertEquals("127.0.0.1", address.getHostName());
 
         InetSocketAddress ip6 = MAPPER.readValue(
                 q("2001:db8:85a3:8d3:1319:8a2e:370:7348"), InetSocketAddress.class);
-        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", ip6.getAddress().getHostAddress());
+        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", ip6.getHostName());
 
         InetSocketAddress ip6port = MAPPER.readValue(
                 q("[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"), InetSocketAddress.class);
-        assertEquals("2001:db8:85a3:8d3:1319:8a2e:370:7348", ip6port.getAddress().getHostAddress());
+        assertEquals("[2001:db8:85a3:8d3:1319:8a2e:370:7348]", ip6port.getHostName());
         assertEquals(443, ip6port.getPort());
 
         // should we try resolving host names? That requires connectivity...
@@ -205,7 +205,7 @@ public class JDKStringLikeTypeDeserTest
         assertEquals(HOST, address.getHostName());
         assertEquals(80, address.getPort());
 
-        // [databind#]: should NOT resolve address
+        // [databind#5951]: should NOT resolve address
         address = MAPPER.readValue(q("localhost:9999"), InetSocketAddress.class);
         assertTrue(address.isUnresolved(),
                 "`InetSocketAddress` resolved localhost during deserialization: "+ address);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -204,6 +204,11 @@ public class JDKStringLikeTypeDeserTest
         address = MAPPER.readValue(q(HOST_AND_PORT), InetSocketAddress.class);
         assertEquals(HOST, address.getHostName());
         assertEquals(80, address.getPort());
+
+        // [databind#]: should NOT resolve address
+        address = MAPPER.readValue(q("localhost:9999"), InetSocketAddress.class);
+        assertTrue(address.isUnresolved(),
+                "`InetSocketAddress` resolved localhost during deserialization: "+ address);
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
@@ -125,8 +125,12 @@ public class JDKTypeSerializationTest
     {
         assertEquals(q("127.0.0.1:8080"),
                 MAPPER.writeValueAsString(new InetSocketAddress("127.0.0.1", 8080)));
+        assertEquals(q("127.0.0.1:8080"),
+                MAPPER.writeValueAsString(InetSocketAddress.createUnresolved("127.0.0.1", 8080)));
         assertEquals(q("google.com:6667"),
                 MAPPER.writeValueAsString(new InetSocketAddress("google.com", 6667)));
+        assertEquals(q("google.com:6667"),
+                MAPPER.writeValueAsString(InetSocketAddress.createUnresolved("google.com", 6667)));
         assertEquals(q("[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"),
                 MAPPER.writeValueAsString(new InetSocketAddress("2001:db8:85a3:8d3:1319:8a2e:370:7348", 443)));
     }


### PR DESCRIPTION
Should create "unresolved" instances to avoid DNS lookup.
