### PR TITLE
`updateValue()` for Record ignores View, `@JsonIgnore`, `@JsonIgnoredProperties`

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -330,10 +330,15 @@ public class BeanDeserializer
             ? creator.startBuildingWithAnySetter(p, ctxt, _objectIdReader, _anySetter, false)
             : creator.startBuilding(p, ctxt, _objectIdReader, false);
 
-        // Step 1: Pre-populate buffer from existing Record values
+        // Step 1: Pre-populate buffer from existing Record values, including
+        // components marked ignorable so their original values are retained
+        // (JSON cannot overwrite them; see Step 2).
         final Class<?> recordClass = _beanType.getRawClass();
         final RecordComponent[] components = recordClass.getRecordComponents();
-        for (SettableBeanProperty creatorProp : creator.properties()) {
+        for (SettableBeanProperty creatorProp : creator.creatorPropertiesInOrder()) {
+            if (creatorProp == null) {
+                continue;
+            }
             final int creatorIndex = creatorProp.getCreatorIndex();
             if (creatorIndex >= 0 && creatorIndex < components.length) {
                 try {

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -361,10 +361,23 @@ public class BeanDeserializer
             return _buildRecordFromBuffer(ctxt, creator, buffer);
         }
 
+        final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
+
         do {
             p.nextToken(); // to point to value
             final SettableBeanProperty creatorProp = creator.findCreatorProperty(propName);
             if (creatorProp != null) {
+                // [databind#5966] Honor @JsonView visibility, injection-only on creator parameters
+                if (((activeView != null) && !creatorProp.visibleInView(activeView))
+                        || creatorProp.isInjectionOnly()) {
+                    p.skipChildren();
+                    continue;
+                }
+                // [databind#5966] Honor @JsonIgnoreProperties on creator parameters
+                if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
+                    handleIgnoredProperty(p, ctxt, handledType(), propName);
+                    continue;
+                }
                 // Override the pre-populated value
                 buffer.assignParameter(creatorProp,
                         _deserializeWithErrorWrapping(p, ctxt, creatorProp));

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -335,7 +335,7 @@ public class BeanDeserializer
         // (JSON cannot overwrite them; see Step 2).
         final Class<?> recordClass = _beanType.getRawClass();
         final RecordComponent[] components = recordClass.getRecordComponents();
-        for (SettableBeanProperty creatorProp : creator.creatorPropertiesInOrder()) {
+        for (SettableBeanProperty creatorProp : creator.allPropertiesInOrder()) {
             if (creatorProp == null) {
                 continue;
             }

--- a/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
@@ -248,6 +248,16 @@ public final class PropertyBasedCreator
         return _propertyLookup.values();
     }
 
+    /**
+     * Returns all creator properties in creator-index order, including ones
+     * marked ignorable (which {@link #properties()} excludes).
+     *
+     * @since 3.2
+     */
+    public SettableBeanProperty[] creatorPropertiesInOrder() {
+        return _propertiesInOrder;
+    }
+
     public SettableBeanProperty findCreatorProperty(String name) {
         return _propertyLookup.get(name);
     }

--- a/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
@@ -249,6 +249,8 @@ public final class PropertyBasedCreator
     /**
      * Returns all creator properties in creator-index order, including ones
      * marked ignorable (which {@link #properties()} excludes).
+     *<p>
+     * Returned array is shared internal state; callers must not mutate it.
      *
      * @since 3.2
      */

--- a/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
@@ -50,8 +50,6 @@ public final class PropertyBasedCreator
     /**
      * Indexes of properties with associated Injectable values, if any:
      * {@code null} if none.
-     *
-     * @since 2.21
      */
     protected final BitSet _injectablePropIndexes;
 
@@ -254,7 +252,7 @@ public final class PropertyBasedCreator
      *
      * @since 3.2
      */
-    public SettableBeanProperty[] creatorPropertiesInOrder() {
+    public SettableBeanProperty[] allPropertiesInOrder() {
         return _propertiesInOrder;
     }
 

--- a/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5965Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5965Test.java
@@ -1,0 +1,149 @@
+package tools.jackson.databind.records;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JDB-003: Record updateValue() bypasses @JsonIgnore and @JsonView checks.
+ *
+ * Commit 7ec2a83f added _deserializeRecordForUpdate() for Records. The new method
+ * parses JSON properties and assigns them to creator parameters without checking:
+ *   - @JsonIgnore / @JsonIgnoreProperties on record components
+ *   - @JsonView visibility on creator properties
+ *   - isInjectionOnly() (injection-only creator params)
+ *
+ * The main _deserializeUsingPropertyBased path at line 731 DOES check activeView and
+ * at line 744 checks IgnorePropertiesUtil.shouldIgnore(); the new Record path omits both.
+ *
+ * Proof: live_runtime_proof (JUnit 5).
+ */
+public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
+{
+    // --- View classes ---
+    static class PublicView {}
+    static class AdminView extends PublicView {}
+
+    // --- Record model --- (must be public for Jackson reflection)
+
+    public record SecretRecord(
+        String name,
+        @JsonIgnore String secret
+    ) {}
+
+    @JsonIgnoreProperties({"password"})
+    public record IgnoredPropsRecord(
+        String username,
+        String password
+    ) {}
+
+    public record ViewRecord(
+        @JsonView(PublicView.class) String publicField,
+        @JsonView(AdminView.class) String adminField
+    ) {}
+
+    // --- Tests ---
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    /**
+     * NEGATIVE CONTROL: normal (non-update) deserialization of a Record with
+     * @JsonIgnore must reject the ignored field. Must pass before and after patch.
+     */
+    @Test
+    public void testJsonIgnore_normalDeser_negativeControl() throws Exception {
+        // Normal readValue should honour @JsonIgnore
+        SecretRecord result = MAPPER.readValue("{\"name\":\"alice\",\"secret\":\"s3cr3t\"}", SecretRecord.class);
+        // The exact behaviour depends on jackson version; the key point is that
+        // updateValue is the vulnerable path. We verify updateValue separately.
+        // Normal deser may accept or reject; the security concern is updateValue.
+        assertNotNull(result.name());
+    }
+
+    /**
+     * EXPLOIT PATH: ObjectMapper.updateValue() for a Record with @JsonIgnore.
+     *
+     * Security assertion: @JsonIgnore must prevent the attacker-supplied JSON value
+     * from being assigned to the "secret" component.  Because PropertyBasedCreator
+     * excludes ignored components from its lookup table, findCreatorProperty("secret")
+     * returns null and the JSON value is already rejected (secret = null, not "HACKED").
+     *
+     * Separate data-integrity note: the pre-existing record value "original-secret"
+     * is also lost (becomes null) because _deserializeRecordForUpdate pre-populates
+     * only non-ignored components.  That is a separate functional deficiency tracked
+     * independently; it is NOT the injection-bypass risk asserted here.
+     */
+    @Test
+    public void testJdb003_updateValueBypassesJsonIgnore() throws Exception {
+        SecretRecord original = new SecretRecord("alice", "original-secret");
+        String maliciousJson = "{\"name\":\"alice\",\"secret\":\"HACKED\"}";
+
+        SecretRecord updated = MAPPER.updateValue(original, MAPPER.readTree(maliciousJson));
+
+        assertEquals("alice", updated.name());
+        // @JsonIgnore on "secret" must prevent the attacker JSON value from taking effect.
+        // (secret may be null due to the data-integrity issue above; it must NOT be "HACKED")
+        assertNotEquals("HACKED", updated.secret(),
+            "JDB-003 VULNERABLE: updateValue() bypassed @JsonIgnore on Record component. " +
+            "secret was overwritten to: " + updated.secret());
+    }
+
+    /**
+     * EXPLOIT PATH: ObjectMapper.updateValue() with @JsonIgnoreProperties on Record.
+     *
+     * Security assertion: @JsonIgnoreProperties must prevent the JSON value from being
+     * assigned.  Same note as above: the original "original-pw" value is lost (null)
+     * due to the data-integrity issue with pre-populate, but "HACKED" must not appear.
+     */
+    @Test
+    public void testJdb003_updateValueBypassesJsonIgnoreProperties() throws Exception {
+        IgnoredPropsRecord original = new IgnoredPropsRecord("alice", "original-pw");
+        String maliciousJson = "{\"username\":\"alice\",\"password\":\"HACKED\"}";
+
+        IgnoredPropsRecord updated = MAPPER.updateValue(original, MAPPER.readTree(maliciousJson));
+
+        assertEquals("alice", updated.username());
+        // @JsonIgnoreProperties({"password"}) must block the attacker value.
+        assertNotEquals("HACKED", updated.password(),
+            "JDB-003 VULNERABLE: updateValue() bypassed @JsonIgnoreProperties on Record. " +
+            "password was overwritten to: " + updated.password());
+    }
+
+    /**
+     * EXPLOIT PATH: ObjectMapper.updateValue() with @JsonView — admin-only field
+     * must not be updated when active view is PublicView.
+     *
+     * Jackson 3.x defaults DEFAULT_VIEW_INCLUSION=false, so each Record component
+     * that should be visible in PublicView must carry @JsonView(PublicView.class).
+     * With PublicView active:
+     *   - publicField (@JsonView(PublicView.class)) IS visible → updated from JSON
+     *   - adminField  (@JsonView(AdminView.class))  is NOT visible → kept from original
+     */
+    @Test
+    public void testJdb003_updateValueBypassesJsonView() throws Exception {
+        ViewRecord original = new ViewRecord("public-val", "admin-original");
+        String maliciousJson = "{\"publicField\":\"new-public\",\"adminField\":\"HACKED-ADMIN\"}";
+
+        ViewRecord updated = MAPPER
+            .readerWithView(PublicView.class)
+            .withValueToUpdate(original)
+            .readValue(maliciousJson);
+
+        // publicField has @JsonView(PublicView.class): visible in PublicView → updated
+        assertEquals("new-public", updated.publicField());
+        // adminField has @JsonView(AdminView.class); with PublicView active it must not be updated
+        assertNotEquals("HACKED-ADMIN", updated.adminField(),
+            "JDB-003 VULNERABLE: updateValue() bypassed @JsonView on Record component. " +
+            "adminField was overwritten to: " + updated.adminField());
+        // The original adminField value must be preserved (pre-populated in Step 1)
+        assertEquals("admin-original", updated.adminField(),
+            "JDB-003 VULNERABLE: adminField should remain 'admin-original' but was: " + updated.adminField());
+    }
+}

--- a/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5966Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5966Test.java
@@ -12,7 +12,7 @@ import tools.jackson.databind.testutil.DatabindTestUtil;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * JDB-003: Record updateValue() bypasses @JsonIgnore and @JsonView checks.
+ * [databind#5966]: Record updateValue() bypasses @JsonIgnore and @JsonView checks.
  *
  * Commit 7ec2a83f added _deserializeRecordForUpdate() for Records. The new method
  * parses JSON properties and assigns them to creator parameters without checking:
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * Proof: live_runtime_proof (JUnit 5).
  */
-public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
+public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
 {
     // --- View classes ---
     static class PublicView {}
@@ -81,7 +81,7 @@ public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
      * independently; it is NOT the injection-bypass risk asserted here.
      */
     @Test
-    public void testJdb003_updateValueBypassesJsonIgnore() throws Exception {
+    public void test5966_updateValueBypassesJsonIgnore() throws Exception {
         SecretRecord original = new SecretRecord("alice", "original-secret");
         String maliciousJson = "{\"name\":\"alice\",\"secret\":\"HACKED\"}";
 
@@ -91,7 +91,7 @@ public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
         // @JsonIgnore on "secret" must prevent the attacker JSON value from taking effect.
         // (secret may be null due to the data-integrity issue above; it must NOT be "HACKED")
         assertNotEquals("HACKED", updated.secret(),
-            "JDB-003 VULNERABLE: updateValue() bypassed @JsonIgnore on Record component. " +
+            "[databind#5966] VULNERABLE: updateValue() bypassed @JsonIgnore on Record component. " +
             "secret was overwritten to: " + updated.secret());
     }
 
@@ -103,7 +103,7 @@ public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
      * due to the data-integrity issue with pre-populate, but "HACKED" must not appear.
      */
     @Test
-    public void testJdb003_updateValueBypassesJsonIgnoreProperties() throws Exception {
+    public void test5966_updateValueBypassesJsonIgnoreProperties() throws Exception {
         IgnoredPropsRecord original = new IgnoredPropsRecord("alice", "original-pw");
         String maliciousJson = "{\"username\":\"alice\",\"password\":\"HACKED\"}";
 
@@ -112,7 +112,7 @@ public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
         assertEquals("alice", updated.username());
         // @JsonIgnoreProperties({"password"}) must block the attacker value.
         assertNotEquals("HACKED", updated.password(),
-            "JDB-003 VULNERABLE: updateValue() bypassed @JsonIgnoreProperties on Record. " +
+            "[databind#5966] VULNERABLE: updateValue() bypassed @JsonIgnoreProperties on Record. " +
             "password was overwritten to: " + updated.password());
     }
 
@@ -127,7 +127,7 @@ public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
      *   - adminField  (@JsonView(AdminView.class))  is NOT visible → kept from original
      */
     @Test
-    public void testJdb003_updateValueBypassesJsonView() throws Exception {
+    public void test5966_updateValueBypassesJsonView() throws Exception {
         ViewRecord original = new ViewRecord("public-val", "admin-original");
         String maliciousJson = "{\"publicField\":\"new-public\",\"adminField\":\"HACKED-ADMIN\"}";
 
@@ -140,10 +140,10 @@ public class RecordUpdateValueIgnoreView5965Test extends DatabindTestUtil
         assertEquals("new-public", updated.publicField());
         // adminField has @JsonView(AdminView.class); with PublicView active it must not be updated
         assertNotEquals("HACKED-ADMIN", updated.adminField(),
-            "JDB-003 VULNERABLE: updateValue() bypassed @JsonView on Record component. " +
+            "[databind#5966] VULNERABLE: updateValue() bypassed @JsonView on Record component. " +
             "adminField was overwritten to: " + updated.adminField());
         // The original adminField value must be preserved (pre-populated in Step 1)
         assertEquals("admin-original", updated.adminField(),
-            "JDB-003 VULNERABLE: adminField should remain 'admin-original' but was: " + updated.adminField());
+            "[databind#5966] VULNERABLE: adminField should remain 'admin-original' but was: " + updated.adminField());
     }
 }

--- a/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5966Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5966Test.java
@@ -2,10 +2,13 @@ package tools.jackson.databind.records;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.annotation.OptBoolean;
 
+import tools.jackson.databind.InjectableValues;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
@@ -13,17 +16,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * [databind#5966]: Record updateValue() bypasses @JsonIgnore and @JsonView checks.
- *
- * Commit 7ec2a83f added _deserializeRecordForUpdate() for Records. The new method
- * parses JSON properties and assigns them to creator parameters without checking:
- *   - @JsonIgnore / @JsonIgnoreProperties on record components
- *   - @JsonView visibility on creator properties
- *   - isInjectionOnly() (injection-only creator params)
- *
- * The main _deserializeUsingPropertyBased path at line 731 DOES check activeView and
- * at line 744 checks IgnorePropertiesUtil.shouldIgnore(); the new Record path omits both.
- *
- * Proof: live_runtime_proof (JUnit 5).
  */
 public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
 {
@@ -49,13 +41,18 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
         @JsonView(AdminView.class) String adminField
     ) {}
 
+    public record InjectRecord(
+        String name,
+        @JacksonInject(value = "injected-key", useInput = OptBoolean.FALSE) String injected
+    ) {}
+
     // --- Tests ---
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
     /**
-     * NEGATIVE CONTROL: normal (non-update) deserialization of a Record with
-     * @JsonIgnore must reject the ignored field. Must pass before and after patch.
+     * Normal (non-update) deserialization of a Record with
+     * @JsonIgnore must reject the ignored field.
      */
     @Test
     public void testJsonIgnore_normalDeser_negativeControl() throws Exception {
@@ -68,16 +65,7 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
     }
 
     /**
-     * EXPLOIT PATH: ObjectMapper.updateValue() for a Record with @JsonIgnore.
-     *
-     * Security assertion: @JsonIgnore must prevent the attacker-supplied JSON value
-     * from being assigned to the "secret" component.  Because PropertyBasedCreator
-     * excludes ignored components from its lookup table, findCreatorProperty("secret")
-     * returns null and the JSON value is rejected.
-     *
-     * Data-integrity assertion: the pre-existing record value "original-secret"
-     * must be retained — _deserializeRecordForUpdate pre-populates ALL creator
-     * components from the source record, including ignored ones.
+     * ObjectMapper.updateValue() for a Record with @JsonIgnore.
      */
     @Test
     public void test5966_updateValueBypassesJsonIgnore() throws Exception {
@@ -97,9 +85,7 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
     }
 
     /**
-     * EXPLOIT PATH: ObjectMapper.updateValue() with @JsonIgnoreProperties on Record.
-     *
-     * Security assertion: @JsonIgnoreProperties must prevent the JSON value from being
+     * Verify that @JsonIgnoreProperties prevents the JSON value from being
      * assigned. Data-integrity assertion: original "original-pw" must be retained.
      */
     @Test
@@ -120,14 +106,8 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
     }
 
     /**
-     * EXPLOIT PATH: ObjectMapper.updateValue() with @JsonView — admin-only field
+     * ObjectMapper.updateValue() with @JsonView — admin-only field
      * must not be updated when active view is PublicView.
-     *
-     * Jackson 3.x defaults DEFAULT_VIEW_INCLUSION=false, so each Record component
-     * that should be visible in PublicView must carry @JsonView(PublicView.class).
-     * With PublicView active:
-     *   - publicField (@JsonView(PublicView.class)) IS visible → updated from JSON
-     *   - adminField  (@JsonView(AdminView.class))  is NOT visible → kept from original
      */
     @Test
     public void test5966_updateValueBypassesJsonView() throws Exception {
@@ -143,10 +123,48 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
         assertEquals("new-public", updated.publicField());
         // adminField has @JsonView(AdminView.class); with PublicView active it must not be updated
         assertNotEquals("HACKED-ADMIN", updated.adminField(),
-            "[databind#5966] VULNERABLE: updateValue() bypassed @JsonView on Record component. " +
+            "[databind#5966] updateValue() bypassed @JsonView on Record component. " +
             "adminField was overwritten to: " + updated.adminField());
         // The original adminField value must be preserved (pre-populated in Step 1)
         assertEquals("admin-original", updated.adminField(),
-            "[databind#5966] VULNERABLE: adminField should remain 'admin-original' but was: " + updated.adminField());
+            "[databind#5966] adminField should remain 'admin-original' but was: " + updated.adminField());
+    }
+
+    /**
+     * ObjectMapper.updateValue() with @JacksonInject(useInput=FALSE) on a Record
+     * component: JSON value must be skipped, injected value must take effect.
+     */
+    @Test
+    public void test5966_updateValueRespectsInjectionOnly() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+            .injectableValues(new InjectableValues.Std().addValue("injected-key", "INJECTED"))
+            .build();
+        InjectRecord original = new InjectRecord("alice", "original-injected");
+        String maliciousJson = "{\"name\":\"alice\",\"injected\":\"HACKED\"}";
+
+        InjectRecord updated = mapper.updateValue(original, mapper.readTree(maliciousJson));
+
+        assertEquals("alice", updated.name());
+        assertNotEquals("HACKED", updated.injected(),
+            "[databind#5966] updateValue() bypassed isInjectionOnly() on Record component. " +
+            "injected was overwritten to: " + updated.injected());
+        assertEquals("INJECTED", updated.injected(),
+            "[databind#5966] injected component should hold the injected value but was: " + updated.injected());
+    }
+
+    /**
+     * Empty-JSON updateValue() of a Record with @JsonIgnore: pre-populate must
+     * retain the source record's value for ignored components when no JSON
+     * properties are provided to override.
+     */
+    @Test
+    public void test5966_updateValueEmptyJsonRetainsIgnored() throws Exception {
+        SecretRecord original = new SecretRecord("alice", "original-secret");
+
+        SecretRecord updated = MAPPER.updateValue(original, MAPPER.readTree("{}"));
+
+        assertEquals("alice", updated.name());
+        assertEquals("original-secret", updated.secret(),
+            "[databind#5966] empty-JSON update should retain original secret but was: " + updated.secret());
     }
 }

--- a/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5966Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUpdateValueIgnoreView5966Test.java
@@ -73,12 +73,11 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
      * Security assertion: @JsonIgnore must prevent the attacker-supplied JSON value
      * from being assigned to the "secret" component.  Because PropertyBasedCreator
      * excludes ignored components from its lookup table, findCreatorProperty("secret")
-     * returns null and the JSON value is already rejected (secret = null, not "HACKED").
+     * returns null and the JSON value is rejected.
      *
-     * Separate data-integrity note: the pre-existing record value "original-secret"
-     * is also lost (becomes null) because _deserializeRecordForUpdate pre-populates
-     * only non-ignored components.  That is a separate functional deficiency tracked
-     * independently; it is NOT the injection-bypass risk asserted here.
+     * Data-integrity assertion: the pre-existing record value "original-secret"
+     * must be retained — _deserializeRecordForUpdate pre-populates ALL creator
+     * components from the source record, including ignored ones.
      */
     @Test
     public void test5966_updateValueBypassesJsonIgnore() throws Exception {
@@ -89,18 +88,19 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
 
         assertEquals("alice", updated.name());
         // @JsonIgnore on "secret" must prevent the attacker JSON value from taking effect.
-        // (secret may be null due to the data-integrity issue above; it must NOT be "HACKED")
         assertNotEquals("HACKED", updated.secret(),
             "[databind#5966] VULNERABLE: updateValue() bypassed @JsonIgnore on Record component. " +
             "secret was overwritten to: " + updated.secret());
+        // Original value must be retained (not nulled out).
+        assertEquals("original-secret", updated.secret(),
+            "[databind#5966] secret should retain original value but was: " + updated.secret());
     }
 
     /**
      * EXPLOIT PATH: ObjectMapper.updateValue() with @JsonIgnoreProperties on Record.
      *
      * Security assertion: @JsonIgnoreProperties must prevent the JSON value from being
-     * assigned.  Same note as above: the original "original-pw" value is lost (null)
-     * due to the data-integrity issue with pre-populate, but "HACKED" must not appear.
+     * assigned. Data-integrity assertion: original "original-pw" must be retained.
      */
     @Test
     public void test5966_updateValueBypassesJsonIgnoreProperties() throws Exception {
@@ -114,6 +114,9 @@ public class RecordUpdateValueIgnoreView5966Test extends DatabindTestUtil
         assertNotEquals("HACKED", updated.password(),
             "[databind#5966] VULNERABLE: updateValue() bypassed @JsonIgnoreProperties on Record. " +
             "password was overwritten to: " + updated.password());
+        // Original value must be retained (not nulled out).
+        assertEquals("original-pw", updated.password(),
+            "[databind#5966] password should retain original value but was: " + updated.password());
     }
 
     /**


### PR DESCRIPTION
Changes to apply View, ignore/inclusion definitions for Records, same as with POJOs.
