### PR TITLE
Backport #5967: "Renamed `@JsonIgnore`d setters can deserialize via private fields" [CVE-2026-54516]

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1922,6 +1922,8 @@ Omkhar Arasaratnam (@omkhar)
   (2.18.8)
  * Reported #5951: Improve `InetSocketAddress` deserialization
   (2.18.8)
+ * Contributed fix for #5967: Renamed `@JsonIgnore`d setters can deserialize via private fields
+  (2.21.4)
 
 Liam Feid (@fxshlein)
  * Contributed #1467: Support `@JsonUnwrapped` with `@JsonCreator`

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -12,6 +12,8 @@ Project: jackson-databind
  (reported by Omkhar A)
 #5951: Improve `InetSocketAddress` deserialization
  (reported by Omkhar A)
+#5967: Renamed `@JsonIgnore`d setters can deserialize via private fields
+ (fixed by Omkhar A)
 
 2.21.3 (28-Apr-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -1586,6 +1586,11 @@ ctor.creator()));
                 if (isRecordType() || !prop.anyExplicitsWithoutIgnoral()) {
                     continue;
                 }
+                // [databind#5967]: Strip inferred non-visible field mutators to preserve @JsonIgnore
+                // semantics. The ignored name was collected because couldDeserialize()==false,
+                // meaning any retained fields are non-visible (kept only by INFER_PROPERTY_MUTATORS).
+                // Removing them ensures the renamed property remains read-only (serialization only).
+                prop.removeFields();
             }
 
             Collection<PropertyName> l = prop.findExplicitNames();

--- a/src/test-jdk17/java/com/fasterxml/jackson/databind/records/RecordRenamedPropertyIgnoreFieldBypass5967Test.java
+++ b/src/test-jdk17/java/com/fasterxml/jackson/databind/records/RecordRenamedPropertyIgnoreFieldBypass5967Test.java
@@ -1,0 +1,32 @@
+package com.fasterxml.jackson.databind.records;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// [databind#5967] Records take a different path in
+// POJOPropertiesCollector#_renameProperties (always skipped by isRecordType()
+// when the property name is in _ignoredPropertyNames), so the field-stripping
+// fix added for non-records must not regress record renaming.
+public class RecordRenamedPropertyIgnoreFieldBypass5967Test extends DatabindTestUtil
+{
+    public record RenamedRecord(@JsonProperty("renamedProp") String prop) {}
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void recordWithRenamedPropertyRoundTrips() throws Exception
+    {
+        RenamedRecord original = new RenamedRecord("someValue");
+        String json = MAPPER.writeValueAsString(original);
+        assertEquals("{\"renamedProp\":\"someValue\"}", json);
+
+        RenamedRecord result = MAPPER.readValue(json, RenamedRecord.class);
+        assertEquals("someValue", result.prop());
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/JsonIgnoreSetterFieldBypass5398Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/JsonIgnoreSetterFieldBypass5398Test.java
@@ -1,0 +1,156 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.*;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests covering the [databind#5398] follow-up: when a property's setter is
+ * {@code @JsonIgnore}d (and the getter carries {@code @JsonProperty} that
+ * keeps the property non-ignored as a whole), the inferred field mutator
+ * retained via {@code MapperFeature.INFER_PROPERTY_MUTATORS} must NOT be
+ * used to bypass the ignored setter. The property should remain
+ * serialization-only (read-only).
+ */
+public class JsonIgnoreSetterFieldBypass5398Test extends DatabindTestUtil
+{
+    static class RenamedGetterIgnoredSetter {
+        private String prop;
+
+        @JsonProperty("renamedProp")
+        public String getProp() {
+            return prop;
+        }
+
+        @JsonIgnore
+        public void setProp(String prop) {
+            this.prop = prop;
+        }
+    }
+
+    static class StandardGetterIgnoredSetter {
+        private String prop;
+
+        @JsonProperty
+        public String getProp() {
+            return prop;
+        }
+
+        @JsonIgnore
+        public void setProp(String prop) {
+            this.prop = prop;
+        }
+    }
+
+    // Sibling shape: READ_ONLY access on getter rather than @JsonIgnore on setter.
+    static class ReadOnlyRenamedGetter {
+        private String prop;
+
+        @JsonProperty(value = "renamedProp", access = JsonProperty.Access.READ_ONLY)
+        public String getProp() {
+            return prop;
+        }
+
+        public void setProp(String prop) {
+            this.prop = prop;
+        }
+    }
+
+    // 2.x defaults FAIL_ON_UNKNOWN_PROPERTIES to true; disable so the "not written"
+    // outcome (rather than an exception) is what we assert on read paths.
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
+
+    @Test
+    public void renamedGetterStillSerializes() throws Exception
+    {
+        RenamedGetterIgnoredSetter bean = new RenamedGetterIgnoredSetter();
+        bean.setProp("someValue");
+        assertEquals("{\"renamedProp\":\"someValue\"}",
+                MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void standardGetterStillSerializes() throws Exception
+    {
+        StandardGetterIgnoredSetter bean = new StandardGetterIgnoredSetter();
+        bean.setProp("someValue");
+        assertEquals("{\"prop\":\"someValue\"}",
+                MAPPER.writeValueAsString(bean));
+    }
+
+    // The renamed property must be read-only: @JsonIgnore on the setter
+    // blocks the write, and the inferred field mutator must not bypass it.
+    @Test
+    public void renamedIgnoredSetterDoesNotBypassViaField() throws Exception
+    {
+        RenamedGetterIgnoredSetter result = MAPPER.readValue(
+                "{\"renamedProp\":\"someValue\"}",
+                RenamedGetterIgnoredSetter.class);
+        assertNotNull(result);
+        assertNull(result.getProp());
+    }
+
+    @Test
+    public void standardIgnoredSetterDoesNotBypassViaField() throws Exception
+    {
+        StandardGetterIgnoredSetter result = MAPPER.readValue(
+                "{\"prop\":\"someValue\"}",
+                StandardGetterIgnoredSetter.class);
+        assertNotNull(result);
+        assertNull(result.getProp());
+    }
+
+    // Control: feeding the implicit field name (rather than the renamed
+    // public name) also does not write the field.
+    @Test
+    public void implicitFieldNameDoesNotWriteWhenSetterIgnored() throws Exception
+    {
+        RenamedGetterIgnoredSetter result = MAPPER.readerFor(RenamedGetterIgnoredSetter.class)
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .readValue("{\"prop\":\"someValue\"}");
+        assertNotNull(result);
+        assertNull(result.getProp());
+    }
+
+    // Bypass must also stay closed when INFER_PROPERTY_MUTATORS is disabled,
+    // i.e. the fix is not just an artifact of inference being on.
+    @Test
+    public void inferMutatorsDisabledStillBlocksWrite() throws Exception
+    {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .disable(MapperFeature.INFER_PROPERTY_MUTATORS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        RenamedGetterIgnoredSetter result = mapper.readValue(
+                "{\"renamedProp\":\"someValue\"}",
+                RenamedGetterIgnoredSetter.class);
+        assertNotNull(result);
+        assertNull(result.getProp());
+    }
+
+    // Sibling: @JsonProperty(access = READ_ONLY) on the renamed getter must
+    // produce the same outcome — serialize under the new name, not write
+    // back via the inferred field mutator.
+    @Test
+    public void readOnlyRenamedGetterIsSerializeOnly() throws Exception
+    {
+        ReadOnlyRenamedGetter bean = new ReadOnlyRenamedGetter();
+        bean.setProp("someValue");
+        assertEquals("{\"renamedProp\":\"someValue\"}",
+                MAPPER.writeValueAsString(bean));
+
+        ReadOnlyRenamedGetter result = MAPPER.readValue(
+                "{\"renamedProp\":\"someValue\"}",
+                ReadOnlyRenamedGetter.class);
+        assertNotNull(result);
+        assertNull(result.getProp());
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/JsonPropertyRename5398Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/JsonPropertyRename5398Test.java
@@ -53,11 +53,14 @@ public class JsonPropertyRename5398Test extends DatabindTestUtil
         // Should serialize with renamed property
         assertEquals("{\"renamedProp\":\"someValue\"}", json);
 
-        // Should be able to deserialize back (setter is ignored, so field remains default)
-        TestRename5398 result = MAPPER.readValue(json, TestRename5398.class);
+        // @JsonIgnore on the setter prevents write access to the backing field
+        // ([databind#5967] fix: inferred non-visible field mutator stripped when setter is @JsonIgnore).
+        // Deserialization of "renamedProp" is blocked; field stays at its default (null).
+        TestRename5398 result = MAPPER.readerFor(TestRename5398.class)
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .readValue(json);
         assertNotNull(result);
-        // The setter is ignored but the property is still considered read-write
-		assertEquals("someValue", result.getProp());
+        assertNull(result.getProp());
     }
 
     @Test
@@ -68,13 +71,15 @@ public class JsonPropertyRename5398Test extends DatabindTestUtil
 
         String json = MAPPER.writeValueAsString(original);
 
-        // Should serialize with renamed property
+        // Should serialize under the implicit property name
         assertEquals("{\"prop\":\"someValue\"}", json);
 
-        // Should be able to deserialize back (setter is ignored, so field remains default)
-        TestStd5398 result = MAPPER.readValue(json, TestStd5398.class);
+        // @JsonIgnore on the setter prevents write access to the backing field.
+        // Field stays at its default (null) after deserialization.
+        TestStd5398 result = MAPPER.readerFor(TestStd5398.class)
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .readValue(json);
         assertNotNull(result);
-		// The setter is ignored but the property is still considered read-write
-		assertEquals("someValue", result.getProp());
+        assertNull(result.getProp());
     }
 }


### PR DESCRIPTION
Backport of #5967.
