### PR TITLE
Apply per-property DYNAMIC typing override to `ObjectArraySerializer`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -239,6 +239,8 @@ Lee Jiwon (@dlwldnjs1009)
  * Implemented #3166: Ability to sort `Set`s before serialization (add
    `SerializationFeature.ORDER_SET_ELEMENTS`)
   [3.2.0]
+ * Fixed #5977: Apply per-property DYNAMIC typing override to `ObjectArraySerializer`
+  [3.2.0]
 
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -211,8 +211,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (reported by Omkhar A)
  (fix by @cowtowncoder, w/ Claude code)
 #5958: `@JsonView` ignored with `@JsonTypeInfo(include = As.EXTERNAL_PROPERTY)`
- (fixed by Omkhar A)
+ (fix by Omkhar A)
 #5960: Deprecate un-maintained `tools.jackson.databind.jsontype.impl.SubTypeValidator`
+#5977: Apply per-property DYNAMIC typing override to `ObjectArraySerializer`
+ (fix by Lee Jiwon)
 - Remove project-specific Android SDK compatibility level, use shared;
   no change level itself (stillAndroid SDK 34)
 

--- a/src/main/java/tools/jackson/databind/ser/jdk/ObjectArraySerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/ObjectArraySerializer.java
@@ -166,7 +166,8 @@ public class ObjectArraySerializer
             // 30-Sep-2012, tatu: One more thing -- if explicit content type is annotated,
             //   we can consider it a static case as well.
             if (_elementType != null) {
-                if (_staticTyping && !_elementType.isJavaLangObject()) {
+                if (_staticTyping && !_elementType.isJavaLangObject()
+                        && !_hasDynamicTypingOverride(ctxt, property)) {
                     ser = ctxt.findContentValueSerializer(_elementType, property);
                 }
             }

--- a/src/test/java/tools/jackson/databind/ser/StaticTyping1515Test.java
+++ b/src/test/java/tools/jackson/databind/ser/StaticTyping1515Test.java
@@ -12,7 +12,8 @@ import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class StaticTyping1515Test extends DatabindTestUtil {
+class StaticTyping1515Test extends DatabindTestUtil
+{
     static abstract class Base {
         public int a = 1;
     }
@@ -31,7 +32,7 @@ class StaticTyping1515Test extends DatabindTestUtil {
     }
 
     @JsonPropertyOrder({"value", "aValue", "dValue"})
-    static class Issue515Singles {
+    static class Issue1515Singles {
         public Base value = new Derived();
 
         @JsonSerialize(typing = JsonSerialize.Typing.DYNAMIC)
@@ -41,7 +42,7 @@ class StaticTyping1515Test extends DatabindTestUtil {
     }
 
     @JsonPropertyOrder({"map", "aMap", "dMap"})
-    static class Issue515Maps {
+    static class Issue1515Maps {
         public Map<String, Base> map = new LinkedHashMap<>();
 
         {
@@ -63,7 +64,7 @@ class StaticTyping1515Test extends DatabindTestUtil {
     }
 
     @JsonPropertyOrder({"list", "aList", "dList"})
-    static class Issue515Lists {
+    static class Issue1515Lists {
         public List<Base> list = new ArrayList<>();
 
         {
@@ -85,7 +86,7 @@ class StaticTyping1515Test extends DatabindTestUtil {
     }
 
     @JsonPropertyOrder({"array", "aArray", "dArray"})
-    static class Issue515Arrays {
+    static class Issue1515Arrays {
         public Base[] array = new Base[] { new Derived() };
 
         @JsonSerialize(typing = JsonSerialize.Typing.DYNAMIC)
@@ -100,25 +101,25 @@ class StaticTyping1515Test extends DatabindTestUtil {
 
     @Test
     void staticTypingForProperties() throws Exception {
-        String json = STAT_MAPPER.writeValueAsString(new Issue515Singles());
+        String json = STAT_MAPPER.writeValueAsString(new Issue1515Singles());
         assertEquals(a2q("{'value':{'a':1},'aValue':{'a':1,'b':2},'dValue':{'a':3,'b':4}}"), json);
     }
 
     @Test
     void staticTypingForMaps() throws Exception {
-        String json = STAT_MAPPER.writeValueAsString(new Issue515Maps());
+        String json = STAT_MAPPER.writeValueAsString(new Issue1515Maps());
         assertEquals(a2q("{'map':{'x':{'a':1}},'aMap':{'x':{'a':1,'b':2}},'dMap':{'x':{'a':3,'b':4}}}"), json);
     }
 
     @Test
     void staticTypingForLists() throws Exception {
-        String json = STAT_MAPPER.writeValueAsString(new Issue515Lists());
+        String json = STAT_MAPPER.writeValueAsString(new Issue1515Lists());
         assertEquals(a2q("{'list':[{'a':1}],'aList':[{'a':1,'b':2}],'dList':[{'a':3,'b':4}]}"), json);
     }
 
     @Test
     void staticTypingForObjectArrays() throws Exception {
-        String json = STAT_MAPPER.writeValueAsString(new Issue515Arrays());
+        String json = STAT_MAPPER.writeValueAsString(new Issue1515Arrays());
         assertEquals(a2q("{'array':[{'a':1}],'aArray':[{'a':1,'b':2}],'dArray':[{'a':3,'b':4}]}"), json);
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/StaticTyping1515Test.java
+++ b/src/test/java/tools/jackson/databind/ser/StaticTyping1515Test.java
@@ -84,6 +84,16 @@ class StaticTyping1515Test extends DatabindTestUtil {
         }
     }
 
+    @JsonPropertyOrder({"array", "aArray", "dArray"})
+    static class Issue515Arrays {
+        public Base[] array = new Base[] { new Derived() };
+
+        @JsonSerialize(typing = JsonSerialize.Typing.DYNAMIC)
+        public Base[] aArray = new Base[] { new Derived() };
+
+        public BaseDynamic[] dArray = new BaseDynamic[] { new DerivedDynamic() };
+    }
+
     private final ObjectMapper STAT_MAPPER = jsonMapperBuilder()
             .enable(MapperFeature.USE_STATIC_TYPING)
             .build();
@@ -104,5 +114,11 @@ class StaticTyping1515Test extends DatabindTestUtil {
     void staticTypingForLists() throws Exception {
         String json = STAT_MAPPER.writeValueAsString(new Issue515Lists());
         assertEquals(a2q("{'list':[{'a':1}],'aList':[{'a':1,'b':2}],'dList':[{'a':3,'b':4}]}"), json);
+    }
+
+    @Test
+    void staticTypingForObjectArrays() throws Exception {
+        String json = STAT_MAPPER.writeValueAsString(new Issue515Arrays());
+        assertEquals(a2q("{'array':[{'a':1}],'aArray':[{'a':1,'b':2}],'dArray':[{'a':3,'b':4}]}"), json);
     }
 }


### PR DESCRIPTION
Follow-up to #5661 (Fix #1515).

`ObjectArraySerializer.createContextual()` does not honor per-property `@JsonSerialize(typing=DYNAMIC)`. The `_hasDynamicTypingOverride` guard added to `AsArraySerializerBase`, `MapSerializer`, and `MapEntrySerializer` in #5661 is not present in `ObjectArraySerializer`. `ObjectArraySerializer` extends `ArraySerializerBase` directly (sibling to `AsArraySerializerBase`), so the fix did not propagate.

## Changes

- `ObjectArraySerializer.createContextual`: add `&& !_hasDynamicTypingOverride(ctxt, property)` to the same static-typing guard sibling serializers already use.

## Testing

`StaticTyping1515Test` — added `Issue515Arrays` fixture and `staticTypingForObjectArrays()`, mirroring the existing `Issue515Lists` / `Issue515Maps` cases. Covers both class-level `@JsonSerialize(typing=DYNAMIC)` (`BaseDynamic[]`) and field-level annotation (`@JsonSerialize(typing=DYNAMIC) public Base[] aArray`).

Before fix: `aArray` was serialized as `[{"a":1}]` (Base only, field-level DYNAMIC ignored).
After fix: `[{"a":1,"b":2}]` (Derived fields honored).