### PR TITLE
`UPPER_SNAKE_CASE` and `LOWER_CASE` naming strategies must use `Locale.ROOT` for case folding

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
+++ b/src/main/java/com/fasterxml/jackson/databind/EnumNamingStrategies.java
@@ -151,7 +151,7 @@ public class EnumNamingStrategies
             if (length == 0) {
                 return word;
             }
-            return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+            return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase(Locale.ROOT);
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/NamingStrategyImpls.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/NamingStrategyImpls.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.util;
 
+import java.util.Locale;
+
 /**
  * Container for standard naming strategy implementations, specifically
  * used by property naming strategies (see {@link com.fasterxml.jackson.databind.PropertyNamingStrategies})
@@ -80,7 +82,7 @@ public enum NamingStrategyImpls {
       if (output == null) {
         return null;
       }
-      return output.toUpperCase();
+      return output.toUpperCase(Locale.ROOT);
     }
   },
 
@@ -93,7 +95,7 @@ public enum NamingStrategyImpls {
       if (beanName == null || beanName.isEmpty()) {
         return beanName;
       }
-      return beanName.toLowerCase();
+      return beanName.toLowerCase(Locale.ROOT);
     }
   },
 

--- a/src/test/java/com/fasterxml/jackson/databind/introspect/NamingStrategyLocaleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/introspect/NamingStrategyLocaleTest.java
@@ -1,0 +1,53 @@
+package com.fasterxml.jackson.databind.introspect;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.util.NamingStrategyImpls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that {@link NamingStrategyImpls#UPPER_SNAKE_CASE} and
+ * {@link NamingStrategyImpls#LOWER_CASE} fold case using {@code Locale.ROOT}
+ * rather than the JVM default locale, matching the existing pattern in
+ * {@code EnumNamingStrategies}. Under Turkish / Azerbaijani locales the
+ * Latin letter {@code i} maps to {@code İ} (U+0130) rather than {@code I}
+ * (U+0049), which silently breaks property-name matching for identifiers
+ * containing {@code i} or {@code I}.
+ *
+ * @see <a href="https://github.com/FasterXML/jackson-databind/issues/953">#953</a>
+ * @see <a href="https://github.com/FasterXML/jackson-databind/issues/3238">#3238</a>
+ */
+public class NamingStrategyLocaleTest
+{
+    private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
+
+    private Locale previousDefault;
+
+    @BeforeEach
+    public void switchToTurkishLocale() {
+        previousDefault = Locale.getDefault();
+        Locale.setDefault(TURKISH);
+    }
+
+    @AfterEach
+    public void restoreLocale() {
+        Locale.setDefault(previousDefault);
+    }
+
+    @Test
+    public void testUpperSnakeCaseUsesRootLocale() {
+        assertEquals("IS_ADMIN",
+                NamingStrategyImpls.UPPER_SNAKE_CASE.translate("isAdmin"));
+    }
+
+    @Test
+    public void testLowerCaseUsesRootLocale() {
+        assertEquals("clientid",
+                NamingStrategyImpls.LOWER_CASE.translate("ClientID"));
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/util/NamingStrategyLocaleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/NamingStrategyLocaleTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
+import com.fasterxml.jackson.databind.EnumNamingStrategies;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,5 +65,29 @@ public class NamingStrategyLocaleTest extends DatabindTestUtil
         // ...so "ClientID" would wrongly become "client\u0131d" without Locale.ROOT:
         assertEquals("clientid",
                 NamingStrategyImpls.LOWER_CASE.translate("ClientID"));
+    }
+
+    // Enum naming strategies share the same hazard: EnumNamingStrategies.normalizeWord()
+    // lower-cases the tail of each word, which must also use Locale.ROOT. Note the "I" must
+    // be a non-leading letter ("ADMIN"), since a word's first letter is folded with the
+    // locale-independent Character.toUpperCase(char).
+
+    @Test
+    public void testEnumLowerCamelCaseUsesRootLocale() {
+        // Precondition: under the active (Turkish) locale, "I" folds to dotless "\u0131"
+        assertEquals("\u0131", "I".toLowerCase(),
+                "Test requires a default locale where \"I\".toLowerCase() yields U+0131");
+        // ...so "IS_ADMIN" would wrongly become "isAdm\u0131n" without Locale.ROOT:
+        assertEquals("isAdmin",
+                EnumNamingStrategies.LOWER_CAMEL_CASE.convertEnumToExternalName("IS_ADMIN"));
+    }
+
+    @Test
+    public void testEnumUpperCamelCaseUsesRootLocale() {
+        assertEquals("\u0131", "I".toLowerCase(),
+                "Test requires a default locale where \"I\".toLowerCase() yields U+0131");
+        // ...so "IS_ADMIN" would wrongly become "IsAdm\u0131n" without Locale.ROOT:
+        assertEquals("IsAdmin",
+                EnumNamingStrategies.UPPER_CAMEL_CASE.convertEnumToExternalName("IS_ADMIN"));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/util/NamingStrategyLocaleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/NamingStrategyLocaleTest.java
@@ -1,12 +1,14 @@
-package com.fasterxml.jackson.databind.introspect;
+package com.fasterxml.jackson.databind.util;
 
 import java.util.Locale;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
-import com.fasterxml.jackson.databind.util.NamingStrategyImpls;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -22,7 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @see <a href="https://github.com/FasterXML/jackson-databind/issues/953">#953</a>
  * @see <a href="https://github.com/FasterXML/jackson-databind/issues/3238">#3238</a>
  */
-public class NamingStrategyLocaleTest
+// Mutates the global default Locale, so must not run concurrently with any
+// other test: acquire JUnit's built-in lock on the shared LOCALE resource.
+@ResourceLock(Resources.LOCALE)
+public class NamingStrategyLocaleTest extends DatabindTestUtil
 {
     private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
 

--- a/src/test/java/com/fasterxml/jackson/databind/util/NamingStrategyLocaleTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/util/NamingStrategyLocaleTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * {@link NamingStrategyImpls#LOWER_CASE} fold case using {@code Locale.ROOT}
  * rather than the JVM default locale, matching the existing pattern in
  * {@code EnumNamingStrategies}. Under Turkish / Azerbaijani locales the
- * Latin letter {@code i} maps to {@code İ} (U+0130) rather than {@code I}
+ * Latin letter {@code i} maps to {@code \u0130} (U+0130) rather than {@code I}
  * (U+0049), which silently breaks property-name matching for identifiers
  * containing {@code i} or {@code I}.
  *
@@ -46,12 +46,22 @@ public class NamingStrategyLocaleTest extends DatabindTestUtil
 
     @Test
     public void testUpperSnakeCaseUsesRootLocale() {
+        // Precondition: under the active (Turkish) locale, default-locale folding
+        // turns "i" into dotted capital I (U+0130); otherwise this test is vacuous
+        assertEquals("\u0130", "i".toUpperCase(),
+                "Test requires a default locale where \"i\".toUpperCase() yields U+0130");
+        // ...so "isAdmin" would wrongly become "\u0130S_ADM\u0130N" without Locale.ROOT:
         assertEquals("IS_ADMIN",
                 NamingStrategyImpls.UPPER_SNAKE_CASE.translate("isAdmin"));
     }
 
     @Test
     public void testLowerCaseUsesRootLocale() {
+        // Precondition: under the active (Turkish) locale, default-locale folding
+        // turns "I" into dotless lowercase i (U+0131); otherwise this test is vacuous
+        assertEquals("\u0131", "I".toLowerCase(),
+                "Test requires a default locale where \"I\".toLowerCase() yields U+0131");
+        // ...so "ClientID" would wrongly become "client\u0131d" without Locale.ROOT:
         assertEquals("clientid",
                 NamingStrategyImpls.LOWER_CASE.translate("ClientID"));
     }


### PR DESCRIPTION
## Issue

(see #5993)

`NamingStrategyImpls.UPPER_SNAKE_CASE.translate()` (line 83) and `LOWER_CASE.translate()` (line 96) invoke `String.toUpperCase()` / `toLowerCase()` without a `Locale` argument, falling back to the JVM default locale.

Under Turkish (`tr_TR`) or Azerbaijani (`az_AZ`) locale, the Latin letter `i` maps to `İ` (U+0130) rather than `I` (U+0049). When a deserializer derives expected JSON keys from Java identifiers via these strategies, payloads from clients running under non-Turkish locale silently fail to bind to fields containing `i` / `I`.

## Reproduction

| Input → strategy             | English locale | Turkish locale |
|------------------------------|----------------|----------------|
| `isAdmin` (UPPER_SNAKE_CASE) | `IS_ADMIN`     | `İS_ADMİN`     |
| `ClientID` (LOWER_CASE)      | `clientid`     | `clientıd`     |

## Fix

Use `Locale.ROOT`, matching the existing pattern in `EnumNamingStrategies` (same package) which already case-folds with `Locale.ROOT`.

```java
return output.toUpperCase(Locale.ROOT);    // L83
return beanName.toLowerCase(Locale.ROOT);  // L96
```

## Test

`NamingStrategyLocaleTest` switches the default locale to `tr-TR` and asserts ASCII case mapping for `UPPER_SNAKE_CASE` and `LOWER_CASE`. Both tests fail before the fix and pass after. Full `mvn test` is green.

## Related

Fixes #5993

- #953 — original Turkish-locale issue, closed in 2.11.0
- #2563 — follow-up `PropertyNamingStrategy` case-conversion fix
- #3238 — `UPPER_SNAKE_CASE` addition (2021-08), where the anti-pattern was reintroduced
