### PR TITLE
Convert String.format calls to formatted

### DIFF
--- a/src/main/java/tools/jackson/databind/DatabindContext.java
+++ b/src/main/java/tools/jackson/databind/DatabindContext.java
@@ -192,8 +192,7 @@ public abstract class DatabindContext
             } catch (ClassNotFoundException e) { // let caller handle this problem
                 return null;
             } catch (Exception e) {
-                throw invalidTypeIdException(baseType, subClassName, String.format(
-                        "problem: (%s) %s",
+                throw invalidTypeIdException(baseType, subClassName, "problem: (%s) %s".formatted(
                         e.getClass().getName(),
                         ClassUtil.exceptionMessage(e)));
             }
@@ -226,8 +225,7 @@ public abstract class DatabindContext
         } catch (ClassNotFoundException e) { // let caller handle this problem
             return null;
         } catch (Exception e) {
-            throw invalidTypeIdException(baseType, subClass, String.format(
-                    "problem: (%s) %s",
+            throw invalidTypeIdException(baseType, subClass, "problem: (%s) %s".formatted(
                     e.getClass().getName(),
                     ClassUtil.exceptionMessage(e)));
         }
@@ -549,7 +547,7 @@ public abstract class DatabindContext
 
     protected final String _format(String msg, Object... msgArgs) {
         if (msgArgs.length > 0) {
-            return String.format(msg, msgArgs);
+            return msg.formatted(msgArgs);
         }
         return msg;
     }

--- a/src/main/java/tools/jackson/databind/DeserializationContext.java
+++ b/src/main/java/tools/jackson/databind/DeserializationContext.java
@@ -1182,8 +1182,7 @@ public abstract class DeserializationContext
             DateFormat df = _getDateFormat();
             return df.parse(dateStr);
         } catch (ParseException e) {
-            throw new IllegalArgumentException(String.format(
-                    "Failed to parse Date value '%s': %s", dateStr,
+            throw new IllegalArgumentException("Failed to parse Date value '%s': %s".formatted(dateStr,
                     ClassUtil.exceptionMessage(e)));
         }
     }
@@ -1272,8 +1271,7 @@ public abstract class DeserializationContext
     {
         ValueDeserializer<Object> deser = findContextualValueDeserializer(type, prop);
         if (deser == null) {
-            return reportBadDefinition(type, String.format(
-                    "Could not find `ValueDeserializer` for type %s (via property %s)",
+            return reportBadDefinition(type, "Could not find `ValueDeserializer` for type %s (via property %s)".formatted(
                     ClassUtil.getTypeDescription(type), ClassUtil.nameOf(prop)));
         }
         return (T) _readValue(p, deser);
@@ -1412,8 +1410,7 @@ public abstract class DeserializationContext
                 if ((key == null) || keyClass.isInstance(key)) {
                     return key;
                 }
-                throw weirdStringException(keyValue, keyClass, String.format(
-                        "DeserializationProblemHandler.handleWeirdKey() for type %s returned value of type %s",
+                throw weirdStringException(keyValue, keyClass, "DeserializationProblemHandler.handleWeirdKey() for type %s returned value of type %s".formatted(
                         ClassUtil.getClassDescription(keyClass),
                         ClassUtil.getClassDescription(key)
                 ));
@@ -1456,8 +1453,7 @@ public abstract class DeserializationContext
                 if (_isCompatible(targetClass, instance)) {
                     return instance;
                 }
-                throw weirdStringException(value, targetClass, String.format(
-"`DeserializationProblemHandler.handleWeirdStringValue()` for type %s returned value of type %s",
+                throw weirdStringException(value, targetClass, "`DeserializationProblemHandler.handleWeirdStringValue()` for type %s returned value of type %s".formatted(
                         ClassUtil.getClassDescription(targetClass),
                         ClassUtil.getClassDescription(instance)
                 ));
@@ -1570,8 +1566,8 @@ public abstract class DeserializationContext
                 }
                 // In case our problem handler providing incompatible value,
                 throw new InvalidFormatException(_parser,
-String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for type %s returned value of type %s",
-                    ClassUtil.nameOf(targetClass), ClassUtil.getClassDescription(instance)),
+                        "`DeserializationProblemHandler.handleNullForPrimitives()` for type %s returned value of type %s".formatted(
+                                ClassUtil.nameOf(targetClass), ClassUtil.getClassDescription(instance)),
                     instance, targetClass
                         );
             }
@@ -1613,11 +1609,10 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
                 if (_isCompatible(instClass, instance)) {
                     return instance;
                 }
-                reportBadDefinition(constructType(instClass), String.format(
-"`DeserializationProblemHandler.handleMissingInstantiator()` for type %s returned value of type %s",
-                    ClassUtil.getClassDescription(instClass),
-                    ClassUtil.getClassDescription((instance)
-                )));
+                reportBadDefinition(constructType(instClass), "`DeserializationProblemHandler.handleMissingInstantiator()` for type %s returned value of type %s".formatted(
+                        ClassUtil.getClassDescription(instClass),
+                        ClassUtil.getClassDescription((instance)
+                        )));
             }
             h = h.next();
         }
@@ -1628,16 +1623,16 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
         // 24-Oct-2019, tatu: Further, as per [databind#2522], passing `null` ValueInstantiator
         //   should simply trigger definition problem
         if (valueInst == null ) {
-            msg = String.format("Cannot construct instance of %s: %s",
+            msg = "Cannot construct instance of %s: %s".formatted(
                     ClassUtil.nameOf(instClass), msg);
             return reportBadDefinition(instClass, msg);
         }
         if (!valueInst.canInstantiate()) {
-            msg = String.format("Cannot construct instance of %s (no Creators, like default constructor, exist): %s",
+            msg = "Cannot construct instance of %s (no Creators, like default constructor, exist): %s".formatted(
                     ClassUtil.nameOf(instClass), msg);
             return reportBadDefinition(instClass, msg);
         }
-        msg = String.format("Cannot construct instance of %s (although at least one Creator exists): %s",
+        msg = "Cannot construct instance of %s (although at least one Creator exists): %s".formatted(
                 ClassUtil.nameOf(instClass), msg);
         return reportInputMismatch(instClass, msg);
     }
@@ -1670,10 +1665,9 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
                 if (_isCompatible(instClass, instance)) {
                     return instance;
                 }
-                reportBadDefinition(constructType(instClass), String.format(
-"DeserializationProblemHandler.handleInstantiationProblem() for type %s returned value of type %s",
-                    ClassUtil.getClassDescription(instClass),
-                    ClassUtil.classNameOf(instance)
+                reportBadDefinition(constructType(instClass), "DeserializationProblemHandler.handleInstantiationProblem() for type %s returned value of type %s".formatted(
+                        ClassUtil.getClassDescription(instClass),
+                        ClassUtil.classNameOf(instance)
                 ));
             }
             h = h.next();
@@ -1747,8 +1741,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
                 if (_isCompatible(targetType.getRawClass(), instance)) {
                     return instance;
                 }
-                reportBadDefinition(targetType, String.format(
-                        "DeserializationProblemHandler.handleUnexpectedToken() for type %s returned value of type %s",
+                reportBadDefinition(targetType, "DeserializationProblemHandler.handleUnexpectedToken() for type %s returned value of type %s".formatted(
                         ClassUtil.getTypeDescription(targetType),
                         ClassUtil.classNameOf(instance)
                 ));
@@ -1758,10 +1751,10 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
         if (msg == null) {
             final String targetDesc = ClassUtil.getTypeDescription(targetType);
             if (t == null) {
-                msg = String.format("Unexpected end-of-input when trying read value of type %s",
+                msg = "Unexpected end-of-input when trying read value of type %s".formatted(
                         targetDesc);
             } else {
-                msg = String.format("Cannot deserialize value of type %s from %s (token `JsonToken.%s`)",
+                msg = "Cannot deserialize value of type %s from %s (token `JsonToken.%s`)".formatted(
                         targetDesc, _shapeForToken(t), t);
             }
         }
@@ -1861,7 +1854,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     {
         if (!isEnabled(MapperFeature.IGNORE_MERGE_FOR_UNMERGEABLE)) {
             JavaType type = constructType(deser.handledType());
-            String msg = String.format("Invalid configuration: values of type %s cannot be merged",
+            String msg = "Invalid configuration: values of type %s cannot be merged".formatted(
                     ClassUtil.getTypeDescription(type));
             throw InvalidDefinitionException.from(getParser(), msg, type);
         }
@@ -1935,7 +1928,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     public <T> T reportUnresolvedObjectId(ObjectIdReader oidReader, Object bean)
         throws DatabindException
     {
-        String msg = String.format("No Object Id found for an instance of %s, to assign to property '%s'",
+        String msg = "No Object Id found for an instance of %s, to assign to property '%s'".formatted(
                 ClassUtil.classNameOf(bean), oidReader.propertyName);
         return reportInputMismatch(oidReader.idProperty, msg);
     }
@@ -2073,7 +2066,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
             String msg, Object... msgArgs) throws DatabindException
     {
         String beanDesc = ClassUtil.nameOf(bean.getBeanClass());
-        msg = String.format("Invalid type definition for type %s: %s", beanDesc, _format(msg, msgArgs));
+        msg = "Invalid type definition for type %s: %s".formatted(beanDesc, _format(msg, msgArgs));
         throw InvalidDefinitionException.from(_parser, msg, bean, null);
     }
 
@@ -2096,7 +2089,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
         msg = _format(msg, msgArgs);
         String propName = ClassUtil.nameOf(prop);
         String beanDesc = ClassUtil.nameOf(bean.getBeanClass());
-        msg = String.format("Invalid definition for property %s (of type %s): %s",
+        msg = "Invalid definition for property %s (of type %s): %s".formatted(
                 propName, beanDesc, msg);
         throw InvalidDefinitionException.from(_parser, msg, bean, prop);
     }
@@ -2126,7 +2119,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     public DatabindException wrongTokenException(JsonParser p, JavaType targetType,
             JsonToken expToken, String extra)
     {
-        String msg = String.format("Unexpected token (`JsonToken.%s`), expected `JsonToken.%s`",
+        String msg = "Unexpected token (`JsonToken.%s`), expected `JsonToken.%s`".formatted(
                 p.currentToken(), expToken);
         msg = _colonConcat(msg, extra);
         return MismatchedInputException.from(p, targetType, msg);
@@ -2136,7 +2129,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
             JsonToken expToken, String extra)
     {
         JsonToken t = (p == null) ? null : p.currentToken();
-        String msg = String.format("Unexpected token (`JsonToken.%s`), expected `JsonToken.%s`", t, expToken);
+        String msg = "Unexpected token (`JsonToken.%s`), expected `JsonToken.%s`".formatted(t, expToken);
         msg = _colonConcat(msg, extra);
         return MismatchedInputException.from(p, targetType, msg);
     }
@@ -2152,7 +2145,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     public DatabindException weirdKeyException(Class<?> keyClass, String keyValue,
             String msg) {
         return InvalidFormatException.from(_parser,
-                String.format("Cannot deserialize Map key of type %s from String %s: %s",
+                "Cannot deserialize Map key of type %s from String %s: %s".formatted(
                         ClassUtil.nameOf(keyClass), _quotedString(keyValue), msg),
                 keyValue, keyClass);
     }
@@ -2171,7 +2164,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     public DatabindException weirdStringException(String value, Class<?> instClass,
             String msgBase)
     {
-        final String msg = String.format("Cannot deserialize value of type %s from String %s: %s",
+        final String msg = "Cannot deserialize value of type %s from String %s: %s".formatted(
                 ClassUtil.nameOf(instClass), _quotedString(value), msgBase);
         return InvalidFormatException.from(_parser, msg, value, instClass);
     }
@@ -2186,7 +2179,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     public DatabindException weirdNumberException(Number value, Class<?> instClass,
             String msg) {
         return InvalidFormatException.from(_parser,
-                String.format("Cannot deserialize value of type %s from number %s: %s",
+                "Cannot deserialize value of type %s from number %s: %s".formatted(
                         ClassUtil.nameOf(instClass), String.valueOf(value), msg),
                 value, instClass);
     }
@@ -2201,9 +2194,8 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
      */
     public DatabindException weirdNativeValueException(Object value, Class<?> instClass)
     {
-        return InvalidFormatException.from(_parser, String.format(
-"Cannot deserialize value of type %s from native value (`JsonToken.VALUE_EMBEDDED_OBJECT`) of type %s: incompatible types",
-            ClassUtil.nameOf(instClass), ClassUtil.classNameOf(value)),
+        return InvalidFormatException.from(_parser, "Cannot deserialize value of type %s from native value (`JsonToken.VALUE_EMBEDDED_OBJECT`) of type %s: incompatible types".formatted(
+                ClassUtil.nameOf(instClass), ClassUtil.classNameOf(value)),
                 value, instClass);
     }
 
@@ -2223,7 +2215,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
         } else if ((excMsg = ClassUtil.exceptionMessage(cause)) == null) {
             excMsg = ClassUtil.nameOf(cause.getClass());
         }
-        String msg = String.format("Cannot construct instance of %s, problem: %s",
+        String msg = "Cannot construct instance of %s, problem: %s".formatted(
                 ClassUtil.nameOf(instClass), excMsg);
         // [databind#2162]: use specific exception type as we don't know if it's
         // due to type definition, input, or neither
@@ -2243,7 +2235,7 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
         // [databind#2162]: use specific exception type as we don't know if it's
         // due to type definition, input, or neither
         return ValueInstantiationException.from(_parser,
-                String.format("Cannot construct instance of %s: %s",
+                "Cannot construct instance of %s: %s".formatted(
                         ClassUtil.nameOf(instClass), msg0),
                 constructType(instClass));
     }
@@ -2251,14 +2243,14 @@ String.format("`DeserializationProblemHandler.handleNullForPrimitives()` for typ
     @Override
     public DatabindException invalidTypeIdException(JavaType baseType, String typeId,
             String extraDesc) {
-        String msg = String.format("Could not resolve type id '%s' as a subtype of %s",
+        String msg = "Could not resolve type id '%s' as a subtype of %s".formatted(
                 typeId, ClassUtil.getTypeDescription(baseType));
         return InvalidTypeIdException.from(_parser, _colonConcat(msg, extraDesc), baseType, typeId);
     }
 
     public DatabindException missingTypeIdException(JavaType baseType,
             String extraDesc) {
-        String msg = String.format("Could not resolve subtype of %s",
+        String msg = "Could not resolve subtype of %s".formatted(
                 baseType);
         return InvalidTypeIdException.from(_parser, _colonConcat(msg, extraDesc), baseType, null);
     }

--- a/src/main/java/tools/jackson/databind/InjectableValues.java
+++ b/src/main/java/tools/jackson/databind/InjectableValues.java
@@ -60,9 +60,8 @@ public abstract class InjectableValues
         {
             if (!(valueId instanceof String)) {
                 throw ctxt.missingInjectableValueException(
-                        String.format(
-                        "Unsupported injectable value id type (%s), expecting String",
-                        ClassUtil.classNameOf(valueId)),
+                        "Unsupported injectable value id type (%s), expecting String".formatted(
+                                ClassUtil.classNameOf(valueId)),
                         valueId, forProperty, beanInstance);
             }
             return (String) valueId;
@@ -96,8 +95,8 @@ public abstract class InjectableValues
                 return null;
             }
             throw ctxt.missingInjectableValueException(
-                    String.format("No injectable value with id '%s' found (for property '%s')",
-                    key, forProperty.getName()),
+                    "No injectable value with id '%s' found (for property '%s')".formatted(
+                            key, forProperty.getName()),
                     key, forProperty, beanInstance);
         }
     }

--- a/src/main/java/tools/jackson/databind/JsonNode.java
+++ b/src/main/java/tools/jackson/databind/JsonNode.java
@@ -2275,10 +2275,10 @@ public abstract class JsonNode
      * methods).
      */
     protected <T> T _reportRequiredViolation(String msgTemplate, Object...args) {
-        throw JsonNodeException.from(this, String.format(msgTemplate, args));
+        throw JsonNodeException.from(this, msgTemplate.formatted(args));
     }
 
     protected <T> T _reportUnsupportedOperation(String msgTemplate, Object...args) {
-        throw JsonNodeException.from(this, String.format(msgTemplate, args));
+        throw JsonNodeException.from(this, msgTemplate.formatted(args));
     }
 }

--- a/src/main/java/tools/jackson/databind/ObjectReader.java
+++ b/src/main/java/tools/jackson/databind/ObjectReader.java
@@ -2112,7 +2112,7 @@ public class ObjectReader
 
     protected final void _assertNotNull(String paramName, Object src) {
         if (src == null){
-            throw new IllegalArgumentException(String.format("argument \"%s\" is null", paramName));
+            throw new IllegalArgumentException("argument \"%s\" is null".formatted(paramName));
         }
     }
 

--- a/src/main/java/tools/jackson/databind/SerializationContext.java
+++ b/src/main/java/tools/jackson/databind/SerializationContext.java
@@ -1361,7 +1361,7 @@ public abstract class SerializationContext
         if (bean != null) {
             beanDesc = ClassUtil.nameOf(bean.getBeanClass());
         }
-        msg = String.format("Invalid type definition for type %s: %s",
+        msg = "Invalid type definition for type %s: %s".formatted(
                 beanDesc, _format(msg, msgArgs));
         throw InvalidDefinitionException.from(getGenerator(), msg, bean, null);
     }
@@ -1384,7 +1384,7 @@ public abstract class SerializationContext
         if (bean != null) {
             beanDesc = ClassUtil.nameOf(bean.getBeanClass());
         }
-        message = String.format("Invalid definition for property %s (of type %s): %s",
+        message = "Invalid definition for property %s (of type %s): %s".formatted(
                 propName, beanDesc, message);
         throw InvalidDefinitionException.from(getGenerator(), message, bean, prop);
     }
@@ -1439,7 +1439,7 @@ public abstract class SerializationContext
     public DatabindException invalidTypeIdException(JavaType baseType, String typeId,
             String extraDesc)
     {
-        String msg = String.format("Could not resolve type id '%s' as a subtype of %s",
+        String msg = "Could not resolve type id '%s' as a subtype of %s".formatted(
                 typeId, ClassUtil.getTypeDescription(baseType));
         return InvalidTypeIdException.from(null, _colonConcat(msg, extraDesc), baseType, typeId);
     }
@@ -1455,8 +1455,7 @@ public abstract class SerializationContext
                 return;
             }
         }
-        reportBadDefinition(rootType, String.format(
-                "Incompatible types: declared root type (%s) vs %s",
+        reportBadDefinition(rootType, "Incompatible types: declared root type (%s) vs %s".formatted(
                 rootType, ClassUtil.classNameOf(value)));
     }
 

--- a/src/main/java/tools/jackson/databind/ValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ValueSerializer.java
@@ -265,8 +265,7 @@ public abstract class ValueSerializer<T>
         if (clz == null) {
             clz = value.getClass();
         }
-        ctxt.reportBadDefinition(clz, String.format(
-"Type id handling (method `serializeWithType()`) not implemented for type %s (by serializer of type %s)",
+        ctxt.reportBadDefinition(clz, "Type id handling (method `serializeWithType()`) not implemented for type %s (by serializer of type %s)".formatted(
                 ClassUtil.nameOf(clz), ClassUtil.nameOf(getClass())));
     }
 

--- a/src/main/java/tools/jackson/databind/cfg/ConfigOverrides.java
+++ b/src/main/java/tools/jackson/databind/cfg/ConfigOverrides.java
@@ -284,7 +284,7 @@ public class ConfigOverrides
             TreeMap<String, MutableConfigOverride> sorted = new TreeMap<>();
             _overrides.forEach((k, v) -> sorted.put(k.getName(), v));
             sorted.forEach((k, v) -> {
-                sb.append(String.format("'%s'->%s", k, v));
+                sb.append("'%s'->%s".formatted(k, v));
             });
             sb.append("}");
         }

--- a/src/main/java/tools/jackson/databind/deser/AbstractDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/AbstractDeserializer.java
@@ -123,9 +123,8 @@ public class AbstractDeserializer
                         PropertyName propName = objectIdInfo.getPropertyName();
                         idProp = (_properties == null) ? null : _properties.get(propName.getSimpleName());
                         if (idProp == null) {
-                            ctxt.reportBadDefinition(_baseType, String.format(
-"Invalid Object Id definition for %s: cannot find property with name %s",
-ClassUtil.nameOf(handledType()), ClassUtil.name(propName)));
+                            ctxt.reportBadDefinition(_baseType, "Invalid Object Id definition for %s: cannot find property with name %s".formatted(
+                                    ClassUtil.nameOf(handledType()), ClassUtil.name(propName)));
                         }
                         idType = idProp.getType(); // lgtm [java/dereferenced-value-may-be-null]
                         idGen = new PropertyBasedObjectIdGenerator(objectIdInfo.getScope());

--- a/src/main/java/tools/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BasicDeserializerFactory.java
@@ -1071,9 +1071,8 @@ public abstract class BasicDeserializerFactory
                     Class<?> returnType = factory.getRawReturnType();
                     // usually should be class, but may be just plain Enum<?> (for Enum.valueOf()?)
                     if (!returnType.isAssignableFrom(enumClass)) {
-                        ctxt.reportBadDefinition(type, String.format(
-"Invalid `@JsonCreator` annotated Enum factory method [%s]: needs to return compatible type",
-factory.toString()));
+                        ctxt.reportBadDefinition(type, "Invalid `@JsonCreator` annotated Enum factory method [%s]: needs to return compatible type".formatted(
+                                factory.toString()));
                     }
                     deser = EnumDeserializer.deserializerForCreator(
                         config, enumClass, factory, valueInstantiator, creatorProps,

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerBuilder.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerBuilder.java
@@ -428,9 +428,9 @@ public class BeanDeserializerBuilder
             // as per [databind#777], allow empty name
             if (!expBuildMethodName.isEmpty()) {
                 _context.reportBadDefinition(_beanDescRef.getType(),
-                        String.format("Builder class %s does not have build method (name: '%s')",
-                        ClassUtil.getTypeDescription(_beanDescRef.getType()),
-                        expBuildMethodName));
+                        "Builder class %s does not have build method (name: '%s')".formatted(
+                                ClassUtil.getTypeDescription(_beanDescRef.getType()),
+                                expBuildMethodName));
             }
         } else {
             // also: type of the method must be compatible
@@ -440,10 +440,10 @@ public class BeanDeserializerBuilder
                     && !rawBuildType.isAssignableFrom(rawValueType)
                     && !rawValueType.isAssignableFrom(rawBuildType)) {
                 _context.reportBadDefinition(_beanDescRef.getType(),
-                        String.format("Build method `%s` has wrong return type (%s), not compatible with POJO type (%s)",
-                        _buildMethod.getFullName(),
-                        ClassUtil.getClassDescription(rawBuildType),
-                        ClassUtil.getTypeDescription(valueType)));
+                        "Build method `%s` has wrong return type (%s), not compatible with POJO type (%s)".formatted(
+                                _buildMethod.getFullName(),
+                                ClassUtil.getClassDescription(rawBuildType),
+                                ClassUtil.getTypeDescription(valueType)));
             }
         }
         _fixAccess(_properties.values());

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -419,10 +419,9 @@ public class BeanDeserializerFactory
                 if (beanDescRef.getType().isAbstract()) {
                     return;
                 }
-                throw new IllegalArgumentException(String.format(
-"Invalid Object Id definition for %s: cannot find property with name %s",
-ClassUtil.getTypeDescription(beanDescRef.getType()),
-ClassUtil.name(propName)));
+                throw new IllegalArgumentException("Invalid Object Id definition for %s: cannot find property with name %s".formatted(
+                        ClassUtil.getTypeDescription(beanDescRef.getType()),
+                        ClassUtil.name(propName)));
             }
             idType = idProp.getType();
             gen = new PropertyBasedObjectIdGenerator(objectIdInfo.getScope());
@@ -905,8 +904,7 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                         prop, mutator, valueType,
                         ctxt.findRootValueDeserializer(valueType));
             } else {
-                return ctxt.reportBadDefinition(beanDescRef.getType(), String.format(
-                        "Unsupported type for any-setter: %s -- only support `Map`s, `JsonNode` and `ObjectNode` ",
+                return ctxt.reportBadDefinition(beanDescRef.getType(), "Unsupported type for any-setter: %s -- only support `Map`s, `JsonNode` and `ObjectNode` ".formatted(
                         ClassUtil.getTypeDescription(fieldType)));
             }
         } else if (isParameter) {
@@ -932,13 +930,11 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 return SettableAnyProperty.constructForJsonNodeParameter(ctxt, prop, mutator, valueType,
                         ctxt.findRootValueDeserializer(valueType), parameterIndex);
             } else {
-                return ctxt.reportBadDefinition(beanDescRef.getType(), String.format(
-                    "Unsupported type for any-setter: %s -- only support `Map`s, `JsonNode` and `ObjectNode` ",
-                    ClassUtil.getTypeDescription(paramType)));
+                return ctxt.reportBadDefinition(beanDescRef.getType(), "Unsupported type for any-setter: %s -- only support `Map`s, `JsonNode` and `ObjectNode` ".formatted(
+                        ClassUtil.getTypeDescription(paramType)));
             }
         } else {
-            return ctxt.reportBadDefinition(beanDescRef.getType(), String.format(
-                    "Unrecognized mutator type for any-setter: %s",
+            return ctxt.reportBadDefinition(beanDescRef.getType(), "Unrecognized mutator type for any-setter: %s".formatted(
                     ClassUtil.nameOf(mutator.getClass())));
         }
 

--- a/src/main/java/tools/jackson/databind/deser/CollectingProblemHandler.java
+++ b/src/main/java/tools/jackson/databind/deser/CollectingProblemHandler.java
@@ -191,10 +191,9 @@ public class CollectingProblemHandler extends DeserializationProblemHandler
             Object beanOrClass, String propertyName)
         throws JacksonException
     {
-        String message = String.format(
-            "Unknown property '%s' for type %s",
-            propertyName,
-            ClassUtil.getClassDescription(beanOrClass)
+        String message = "Unknown property '%s' for type %s".formatted(
+                propertyName,
+                ClassUtil.getClassDescription(beanOrClass)
         );
 
         // Store null as rawValue for unknown properties
@@ -212,11 +211,10 @@ public class CollectingProblemHandler extends DeserializationProblemHandler
             Class<?> rawKeyType, String keyValue, String failureMsg)
         throws JacksonException
     {
-        String message = String.format(
-            "Cannot deserialize Map key '%s' to %s: %s",
-            keyValue,
-            ClassUtil.getClassDescription(rawKeyType),
-            failureMsg
+        String message = "Cannot deserialize Map key '%s' to %s: %s".formatted(
+                keyValue,
+                ClassUtil.getClassDescription(rawKeyType),
+                failureMsg
         );
 
         if (recordProblem(ctxt, message,
@@ -236,11 +234,10 @@ public class CollectingProblemHandler extends DeserializationProblemHandler
             Class<?> targetType, String valueToConvert, String failureMsg)
         throws JacksonException
     {
-        String message = String.format(
-            "Cannot deserialize value '%s' to %s: %s",
-            valueToConvert,
-            ClassUtil.getClassDescription(targetType),
-            failureMsg
+        String message = "Cannot deserialize value '%s' to %s: %s".formatted(
+                valueToConvert,
+                ClassUtil.getClassDescription(targetType),
+                failureMsg
         );
 
         if (recordProblem(ctxt, message,
@@ -257,11 +254,10 @@ public class CollectingProblemHandler extends DeserializationProblemHandler
             Class<?> targetType, Number valueToConvert, String failureMsg)
         throws JacksonException
     {
-        String message = String.format(
-            "Cannot deserialize number %s to %s: %s",
-            valueToConvert,
-            ClassUtil.getClassDescription(targetType),
-            failureMsg
+        String message = "Cannot deserialize number %s to %s: %s".formatted(
+                valueToConvert,
+                ClassUtil.getClassDescription(targetType),
+                failureMsg
         );
 
         if (recordProblem(ctxt, message,
@@ -277,10 +273,9 @@ public class CollectingProblemHandler extends DeserializationProblemHandler
             Class<?> instClass, Object argument, Throwable t)
         throws JacksonException
     {
-        String message = String.format(
-            "Cannot instantiate %s: %s",
-            ClassUtil.getClassDescription(instClass),
-            t.getMessage()
+        String message = "Cannot instantiate %s: %s".formatted(
+                ClassUtil.getClassDescription(instClass),
+                t.getMessage()
         );
 
         if (recordProblem(ctxt, message,

--- a/src/main/java/tools/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/SettableAnyProperty.java
@@ -379,8 +379,7 @@ public abstract class SettableAnyProperty
             throws JacksonException
         {
             if (_valueInstantiator == null) {
-                throw DatabindException.from(ctxt, String.format(
-                        "Cannot create an instance of %s for use as \"any-setter\" '%s'",
+                throw DatabindException.from(ctxt, "Cannot create an instance of %s for use as \"any-setter\" '%s'".formatted(
                         ClassUtil.nameOf(_type.getRawClass()), _property.getName()));
             }
             Map<Object,Object> map = (Map<Object,Object>) _valueInstantiator.createUsingDefault(ctxt);
@@ -433,8 +432,7 @@ public abstract class SettableAnyProperty
                 objectNode = _nodeFactory.objectNode();
                 field.setValue(instance, objectNode);
             } else if (!(val0 instanceof ObjectNode)) {
-                throw DatabindException.from((DeserializationContext) null, String.format(
-                        "Value \"any-setter\" '%s' not `ObjectNode` but %s",
+                throw DatabindException.from((DeserializationContext) null, "Value \"any-setter\" '%s' not `ObjectNode` but %s".formatted(
                         getPropertyName(),
                         ClassUtil.nameOf(val0.getClass())));
             } else {

--- a/src/main/java/tools/jackson/databind/deser/SettableBeanProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/SettableBeanProperty.java
@@ -464,8 +464,7 @@ public abstract class SettableBeanProperty
      */
     public int getCreatorIndex() {
         // changed from 'return -1' in 2.7.9 / 2.8.7
-        throw new IllegalStateException(String.format(
-                "Internal error: no creator index for property '%s' (of type %s)",
+        throw new IllegalStateException("Internal error: no creator index for property '%s' (of type %s)".formatted(
                 this.getName(), getClass().getName()));
     }
 

--- a/src/main/java/tools/jackson/databind/deser/UnresolvedId.java
+++ b/src/main/java/tools/jackson/databind/deser/UnresolvedId.java
@@ -43,7 +43,7 @@ public class UnresolvedId {
 
     @Override
     public String toString() {
-        return String.format("Object id [%s] (for %s) at %s", _id,
+        return "Object id [%s] (for %s) at %s".formatted(_id,
                 ClassUtil.nameOf(_type), _location);
     }
 }

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayBuilderDeserializer.java
@@ -321,8 +321,7 @@ public class BeanAsArrayBuilderDeserializer
                          *   supported (since ordering of elements may not be guaranteed);
                          *   but make explicitly non-supported for now.
                          */
-                        return ctxt.reportBadDefinition(_beanType, String.format(
-"Cannot support implicit polymorphic deserialization for POJOs-as-Arrays style: nominal type %s, actual type %s",
+                        return ctxt.reportBadDefinition(_beanType, "Cannot support implicit polymorphic deserialization for POJOs-as-Arrays style: nominal type %s, actual type %s".formatted(
                                 ClassUtil.getTypeDescription(_beanType),
                                 builder.getClass().getName()));
                     }

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -657,9 +657,8 @@ public abstract class BeanDeserializerBase
         if (_valueInstantiator.canCreateUsingDelegate()) {
             JavaType delegateType = _valueInstantiator.getDelegateType(ctxt.getConfig());
             if (delegateType == null) {
-                ctxt.reportBadDefinition(_beanType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'",
-ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiator)));
+                ctxt.reportBadDefinition(_beanType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'".formatted(
+                        ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiator)));
             }
             _delegateDeserializer = _findDelegateDeserializer(ctxt, delegateType,
                     _valueInstantiator.getDelegateCreator());
@@ -669,9 +668,8 @@ ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiato
         if (_valueInstantiator.canCreateUsingArrayDelegate()) {
             JavaType delegateType = _valueInstantiator.getArrayDelegateType(ctxt.getConfig());
             if (delegateType == null) {
-                ctxt.reportBadDefinition(_beanType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'",
-ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiator)));
+                ctxt.reportBadDefinition(_beanType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'".formatted(
+                        ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiator)));
             }
             _arrayDelegateDeserializer = _findDelegateDeserializer(ctxt, delegateType,
                     _valueInstantiator.getArrayDelegateCreator());
@@ -916,9 +914,8 @@ ClassUtil.getTypeDescription(_beanType), ClassUtil.classNameOf(_valueInstantiato
                     PropertyName propName = objectIdInfo.getPropertyName();
                     idProp = findProperty(propName);
                     if (idProp == null) {
-                        return ctxt.reportBadDefinition(_beanType, String.format(
-"Invalid Object Id definition for %s: cannot find property with name %s",
-ClassUtil.nameOf(handledType()), ClassUtil.name(propName)));
+                        return ctxt.reportBadDefinition(_beanType, "Invalid Object Id definition for %s: cannot find property with name %s".formatted(
+                                ClassUtil.nameOf(handledType()), ClassUtil.name(propName)));
                     }
                     idType = idProp.getType();
                     idGen = new PropertyBasedObjectIdGenerator(objectIdInfo.getScope());
@@ -1089,9 +1086,8 @@ Working alternatives:
 ClassUtil.name(refName), ClassUtil.getTypeDescription(propType),
 ClassUtil.getTypeDescription(ct));
             } else {
-                msg = String.format(
-"Cannot handle managed/back reference %s: no back reference property found from type %s",
-ClassUtil.name(refName), ClassUtil.getTypeDescription(propType));
+                msg = "Cannot handle managed/back reference %s: no back reference property found from type %s".formatted(
+                        ClassUtil.name(refName), ClassUtil.getTypeDescription(propType));
             }
             return ctxt.reportBadDefinition(_beanType, msg);
         }
@@ -1100,9 +1096,8 @@ ClassUtil.name(refName), ClassUtil.getTypeDescription(propType));
         JavaType backRefType = backProp.getType();
         boolean isContainer = prop.getType().isContainerType();
         if (!backRefType.getRawClass().isAssignableFrom(referredType.getRawClass())) {
-            ctxt.reportBadDefinition(_beanType, String.format(
-"Cannot handle managed/back reference %s: back reference type (%s) not compatible with managed type (%s)",
-ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
+            ctxt.reportBadDefinition(_beanType, "Cannot handle managed/back reference %s: back reference type (%s) not compatible with managed type (%s)".formatted(
+                    ClassUtil.name(refName), ClassUtil.getTypeDescription(backRefType),
                     referredType.getRawClass().getName()));
         }
         return new ManagedReferenceProperty(prop, refName, backProp, isContainer);

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanPropertyMap.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanPropertyMap.java
@@ -445,11 +445,11 @@ public class BeanPropertyMap
             if (count++ > 0) {
                 sb.append(", ");
             }
-            sb.append(String.format("%s(%s)", prop.getName(), prop.getType()));
+            sb.append("%s(%s)".formatted(prop.getName(), prop.getType()));
         }
         sb.append(']');
         if (_aliasDefs != null) {
-            sb.append(String.format("(aliases: %s)", _aliasDefs.length));
+            sb.append("(aliases: %s)".formatted(_aliasDefs.length));
         }
         return sb.toString();
     }

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -991,8 +991,7 @@ public class BuilderBasedDeserializer
     {
         // !!! 04-Mar-2012, TODO: Need to fix -- will not work as is...
         JavaType t = _targetType;
-        return ctxt.reportBadDefinition(t, String.format(
-                "Deserialization (of %s) with Builder, External type id, @JsonCreator not yet implemented",
+        return ctxt.reportBadDefinition(t, "Deserialization (of %s) with Builder, External type id, @JsonCreator not yet implemented".formatted(
                 t));
     }
 

--- a/src/main/java/tools/jackson/databind/deser/bean/CreatorCollector.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/CreatorCollector.java
@@ -179,8 +179,7 @@ public class CreatorCollector
                     }
                     Integer old = names.put(name, Integer.valueOf(i));
                     if (old != null) {
-                        throw new IllegalArgumentException(String.format(
-                                "Duplicate creator property \"%s\" (index %s vs %d) for type %s ",
+                        throw new IllegalArgumentException("Duplicate creator property \"%s\" (index %s vs %d) for type %s ".formatted(
                                 name, old, i, ClassUtil.nameOf(_beanType.getRawClass())));
                     }
                 }
@@ -338,8 +337,7 @@ public class CreatorCollector
     // @since 2.12
     protected void _reportDuplicateCreator(int typeIndex, boolean explicit,
             AnnotatedWithParams oldOne, AnnotatedWithParams newOne) {
-        throw new IllegalArgumentException(String.format(
-                "Conflicting %s creators: already had %s creator %s, encountered another: %s",
+        throw new IllegalArgumentException("Conflicting %s creators: already had %s creator %s, encountered another: %s".formatted(
                 TYPE_DESCS[typeIndex],
                 explicit ? "explicitly marked"
                         : "implicitly discovered",

--- a/src/main/java/tools/jackson/databind/deser/impl/InnerClassProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/InnerClassProperty.java
@@ -78,9 +78,8 @@ public final class InnerClassProperty
             try {
                 value = _creator.newInstance(bean);
             } catch (Exception e) {
-                ClassUtil.unwrapAndThrowAsIAE(e, String.format(
-"Failed to instantiate class %s, problem: %s",
-_creator.getDeclaringClass().getName(), e.getMessage()));
+                ClassUtil.unwrapAndThrowAsIAE(e, "Failed to instantiate class %s, problem: %s".formatted(
+                        _creator.getDeclaringClass().getName(), e.getMessage()));
                 value = null;
             }
             _valueDeserializer.deserialize(p, ctxt, value);

--- a/src/main/java/tools/jackson/databind/deser/impl/SetterlessProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/SetterlessProperty.java
@@ -113,8 +113,7 @@ public final class SetterlessProperty
         }
         // For [databind#501] fix we need to implement this but:
         if (_valueTypeDeserializer != null) {
-            ctxt.reportBadDefinition(getType(), String.format(
-                    "Problem deserializing 'setterless' property (\"%s\"): no way to handle typed deser with setterless yet",
+            ctxt.reportBadDefinition(getType(), "Problem deserializing 'setterless' property (\"%s\"): no way to handle typed deser with setterless yet".formatted(
                     getName()));
 //            return _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
         }
@@ -130,8 +129,7 @@ public final class SetterlessProperty
         // that's not good in common case. However, theoretically the case where
         // we get JSON null might be compatible. If so, implementation could be changed.
         if (toModify == null) {
-            ctxt.reportBadDefinition(getType(), String.format(
-                    "Problem deserializing 'setterless' property '%s': get method returned null",
+            ctxt.reportBadDefinition(getType(), "Problem deserializing 'setterless' property '%s': get method returned null".formatted(
                     getName()));
         }
         _valueDeserializer.deserialize(p, ctxt, toModify);

--- a/src/main/java/tools/jackson/databind/deser/impl/ValueInjector.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/ValueInjector.java
@@ -54,7 +54,7 @@ public class ValueInjector
         if (value == null) {
             if (Boolean.FALSE.equals(_optional)) {
                 throw context.missingInjectableValueException(
-                        String.format("No injectable value with id '%s' found (for property '%s')",
+                        "No injectable value with id '%s' found (for property '%s')".formatted(
                                 _valueId, getName()),
                         _valueId, null, beanInstance);
             }

--- a/src/main/java/tools/jackson/databind/deser/jdk/CollectionDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/CollectionDeserializer.java
@@ -190,17 +190,15 @@ public class CollectionDeserializer
             if (_valueInstantiator.canCreateUsingDelegate()) {
                 JavaType delegateType = _valueInstantiator.getDelegateType(ctxt.getConfig());
                 if (delegateType == null) {
-                    ctxt.reportBadDefinition(_containerType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'",
-_containerType,
+                    ctxt.reportBadDefinition(_containerType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'".formatted(
+                            _containerType,
                             _valueInstantiator.getClass().getName()));
                 }
                 delegateDeser = findDeserializer(ctxt, delegateType, property);
             } else if (_valueInstantiator.canCreateUsingArrayDelegate()) {
                 JavaType delegateType = _valueInstantiator.getArrayDelegateType(ctxt.getConfig());
                 if (delegateType == null) {
-                    ctxt.reportBadDefinition(_containerType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'",
+                    ctxt.reportBadDefinition(_containerType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'".formatted(
                             _containerType,
                             _valueInstantiator.getClass().getName()));
                 }

--- a/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
@@ -113,8 +113,7 @@ public class EnumMapDeserializer
             if (_valueInstantiator.canCreateUsingDelegate()) {
                 JavaType delegateType = _valueInstantiator.getDelegateType(ctxt.getConfig());
                 if (delegateType == null) {
-                    ctxt.reportBadDefinition(_containerType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'",
+                    ctxt.reportBadDefinition(_containerType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'".formatted(
                             _containerType,
                             _valueInstantiator.getClass().getName()));
                 }
@@ -126,8 +125,7 @@ public class EnumMapDeserializer
             } else if (_valueInstantiator.canCreateUsingArrayDelegate()) {
                 JavaType delegateType = _valueInstantiator.getArrayDelegateType(ctxt.getConfig());
                 if (delegateType == null) {
-                    ctxt.reportBadDefinition(_containerType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'",
+                    ctxt.reportBadDefinition(_containerType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'".formatted(
                             _containerType,
                             _valueInstantiator.getClass().getName()));
                 }

--- a/src/main/java/tools/jackson/databind/deser/jdk/MapDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/MapDeserializer.java
@@ -297,10 +297,9 @@ public class MapDeserializer
         if (_valueInstantiator.canCreateUsingDelegate()) {
             JavaType delegateType = _valueInstantiator.getDelegateType(ctxt.getConfig());
             if (delegateType == null) {
-                ctxt.reportBadDefinition(_containerType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'",
-                _containerType,
-                _valueInstantiator.getClass().getName()));
+                ctxt.reportBadDefinition(_containerType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingDelegate()', but null for 'getDelegateType()'".formatted(
+                        _containerType,
+                        _valueInstantiator.getClass().getName()));
             }
             // Theoretically should be able to get CreatorProperty for delegate
             // parameter to pass; but things get tricky because DelegateCreator
@@ -309,10 +308,9 @@ public class MapDeserializer
         } else if (_valueInstantiator.canCreateUsingArrayDelegate()) {
             JavaType delegateType = _valueInstantiator.getArrayDelegateType(ctxt.getConfig());
             if (delegateType == null) {
-                ctxt.reportBadDefinition(_containerType, String.format(
-"Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'",
-                    _containerType,
-                    _valueInstantiator.getClass().getName()));
+                ctxt.reportBadDefinition(_containerType, "Invalid delegate-creator definition for %s: value instantiator (%s) returned true for 'canCreateUsingArrayDelegate()', but null for 'getArrayDelegateType()'".formatted(
+                        _containerType,
+                        _valueInstantiator.getClass().getName()));
             }
             _delegateDeserializer = findDeserializer(ctxt, delegateType, null);
         }

--- a/src/main/java/tools/jackson/databind/deser/jdk/ObjectArrayDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/ObjectArrayDeserializer.java
@@ -426,9 +426,8 @@ public class ObjectArrayDeserializer
             // in future
             if (value != null && !_elementClass.isInstance(value)) {
                 throw DatabindException.from(p,
-                        String.format(
-"Internal error: deserialized value of type %s not assignable to expected array element type %s",
-ClassUtil.classNameOf(value), ClassUtil.nameOf(_elementClass)));
+                        "Internal error: deserialized value of type %s not assignable to expected array element type %s".formatted(
+                                ClassUtil.classNameOf(value), ClassUtil.nameOf(_elementClass)));
             }
             result = (Object[]) Array.newInstance(_elementClass, 1);
         }

--- a/src/main/java/tools/jackson/databind/deser/jdk/UUIDDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/UUIDDeserializer.java
@@ -125,9 +125,8 @@ public class UUIDDeserializer extends FromStringDeserializer<UUID>
         //   however, control flow is gnarly here, so for now just throw
         char ch = Character.isISOControl(c) ? '?' : c;
         throw ctxt.weirdStringException(uuidStr, handledType(),
-                String.format(
-                "Non-hex character '%c' (value 0x%s), not valid for UUID String",
-                ch, Integer.toHexString(c)));
+                "Non-hex character '%c' (value 0x%s), not valid for UUID String".formatted(
+                        ch, Integer.toHexString(c)));
     }
 
     private UUID _fromBytes(byte[] bytes, DeserializationContext ctxt) {

--- a/src/main/java/tools/jackson/databind/deser/std/ContainerDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/std/ContainerDeserializerBase.java
@@ -84,8 +84,7 @@ public abstract class ContainerDeserializerBase<T>
     public SettableBeanProperty findBackReference(String refName) {
         ValueDeserializer<Object> valueDeser = getContentDeserializer();
         if (valueDeser == null) {
-            throw new IllegalArgumentException(String.format(
-                    "Cannot handle managed/back reference '%s': type: container deserializer of type %s returned null for 'getContentDeserializer()'",
+            throw new IllegalArgumentException("Cannot handle managed/back reference '%s': type: container deserializer of type %s returned null for 'getContentDeserializer()'".formatted(
                     refName, getClass().getName()));
         }
         return valueDeser.findBackReference(refName);
@@ -126,7 +125,7 @@ public abstract class ContainerDeserializerBase<T>
         if (vi == null || !vi.canCreateUsingDefault()) {
             JavaType type = getValueType();
             ctxt.reportBadDefinition(type,
-                    String.format("Cannot create empty instance of %s, no default Creator", type));
+                    "Cannot create empty instance of %s, no default Creator".formatted(type));
         }
         return vi.createUsingDefault(ctxt);
     }

--- a/src/main/java/tools/jackson/databind/deser/std/StdDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/std/StdDeserializer.java
@@ -1719,7 +1719,7 @@ inputDesc, _coercedTypeDesc(targetType));
         } else {
             return;
         }
-        String strDesc = str.isEmpty() ? "empty String (\"\")" : String.format("String \"%s\"", str);
+        String strDesc = str.isEmpty() ? "empty String (\"\")" : "String \"%s\"".formatted(str);
         _reportFailedNullCoerce(ctxt, enable, feat, strDesc);
     }
 
@@ -2029,7 +2029,7 @@ inputDesc, _coercedTypeDesc(targetType));
                     if (!vi.canCreateFromObjectWith()) {
                         final JavaType type = (prop == null) ? bd.getValueType() : prop.getType();
                         return ctxt.reportBadDefinition(type,
-                                String.format("Cannot create empty instance of %s, no default or Properties-based Creator", type));
+                                "Cannot create empty instance of %s, no default or Properties-based Creator".formatted(type));
                     }
                 }
             }
@@ -2123,10 +2123,9 @@ handledType().getName());
      */
     protected Object handleNestedArrayForSingle(JsonParser p, DeserializationContext ctxt) throws JacksonException
     {
-        String msg = String.format(
-"Cannot deserialize value of type %s out of %s token: nested Arrays not allowed with %s",
-            ClassUtil.nameOf(_valueClass), JsonToken.START_ARRAY,
-            "DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS");
+        String msg = "Cannot deserialize value of type %s out of %s token: nested Arrays not allowed with %s".formatted(
+                ClassUtil.nameOf(_valueClass), JsonToken.START_ARRAY,
+                "DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS");
 
         return ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p, msg);
     }

--- a/src/main/java/tools/jackson/databind/exc/CollectedProblem.java
+++ b/src/main/java/tools/jackson/databind/exc/CollectedProblem.java
@@ -103,7 +103,7 @@ public final class CollectedProblem {
 
     @Override
     public String toString() {
-        return String.format("CollectedProblem[path=%s, message=%s, targetType=%s]",
-            path, message, targetType);
+        return "CollectedProblem[path=%s, message=%s, targetType=%s]".formatted(
+                path, message, targetType);
     }
 }

--- a/src/main/java/tools/jackson/databind/exc/DeferredBindingException.java
+++ b/src/main/java/tools/jackson/databind/exc/DeferredBindingException.java
@@ -86,11 +86,10 @@ public class DeferredBindingException extends DatabindException {
         }
 
         String limitNote = limitReached ? " (limit reached; more errors may exist)" : "";
-        return String.format(
-            "%d deserialization problems%s (showing first 5):%n%s",
-            count,
-            limitNote,
-            formatProblems(problems)
+        return "%d deserialization problems%s (showing first 5):%n%s".formatted(
+                count,
+                limitNote,
+                formatProblems(problems)
         );
     }
 
@@ -99,11 +98,11 @@ public class DeferredBindingException extends DatabindException {
         int limit = Math.min(5, problems.size());
         for (int i = 0; i < limit; i++) {
             CollectedProblem p = problems.get(i);
-            sb.append(String.format("  [%d] at %s: %s%n",
-                i + 1, p.getPath(), p.getMessage()));
+            sb.append("  [%d] at %s: %s%n".formatted(
+                    i + 1, p.getPath(), p.getMessage()));
         }
         if (problems.size() > 5) {
-            sb.append(String.format("  ... and %d more", problems.size() - 5));
+            sb.append("  ... and %d more".formatted(problems.size() - 5));
         }
         return sb.toString();
     }

--- a/src/main/java/tools/jackson/databind/exc/IgnoredPropertyException.java
+++ b/src/main/java/tools/jackson/databind/exc/IgnoredPropertyException.java
@@ -43,7 +43,7 @@ public class IgnoredPropertyException
         } else { // also acts as null check:
             ref = fromObjectOrClass.getClass();
         }
-        String msg = String.format("Ignored field \"%s\" (class %s) encountered; mapper configured not to allow this",
+        String msg = "Ignored field \"%s\" (class %s) encountered; mapper configured not to allow this".formatted(
                 propertyName, ref.getName());
         IgnoredPropertyException e = new IgnoredPropertyException(p, msg,
                 p.currentLocation(), ref, propertyName, propertyIds);

--- a/src/main/java/tools/jackson/databind/exc/InvalidNullException.java
+++ b/src/main/java/tools/jackson/databind/exc/InvalidNullException.java
@@ -44,7 +44,7 @@ public class InvalidNullException
     public static InvalidNullException from(DeserializationContext ctxt,
             PropertyName name, JavaType type)
     {
-        String msg = String.format("Invalid `null` value encountered for property %s",
+        String msg = "Invalid `null` value encountered for property %s".formatted(
                 ClassUtil.quotedOr(name, "<UNKNOWN>"));
         InvalidNullException exc = new InvalidNullException(ctxt, msg, name);
         if (type != null) {

--- a/src/main/java/tools/jackson/databind/exc/JsonNodeException.java
+++ b/src/main/java/tools/jackson/databind/exc/JsonNodeException.java
@@ -22,7 +22,7 @@ public class JsonNodeException
     public static JsonNodeException from(JsonNode node,
             String message, Object... args) {
         return new JsonNodeException(node,
-                String.format(message, args));
+                message.formatted(args));
     }
 
     public JsonNode getNode() {

--- a/src/main/java/tools/jackson/databind/exc/UnrecognizedPropertyException.java
+++ b/src/main/java/tools/jackson/databind/exc/UnrecognizedPropertyException.java
@@ -45,7 +45,7 @@ public class UnrecognizedPropertyException
         }
         // 06-May-2020, tatu: 2.x said "Unrecognized field" but we call them "properties"
         //    everywhere else so...
-        String msg = String.format("Unrecognized property \"%s\" (class %s), not marked as ignorable",
+        String msg = "Unrecognized property \"%s\" (class %s), not marked as ignorable".formatted(
                 propertyName, ref.getName());
         UnrecognizedPropertyException e = new UnrecognizedPropertyException(p, msg,
                 p.currentLocation(), ref, propertyName, propertyIds);

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/DurationDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/DurationDeserializer.java
@@ -113,8 +113,7 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
                 unitConverter = DurationUnitConverter.from(pattern);
                 if (unitConverter == null) {
                     ctxt.reportBadDefinition(getValueType(ctxt),
-                            String.format(
-                                    "Bad 'pattern' definition (\"%s\") for `Duration`: expected one of [%s]",
+                            "Bad 'pattern' definition (\"%s\") for `Duration`: expected one of [%s]".formatted(
                                     pattern, DurationUnitConverter.descForAllowed()));
                 }
             }
@@ -144,7 +143,7 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
                     result = DecimalUtils.extractSecondsAndNanos(value, Duration::ofSeconds, false);
                 } catch (DateTimeException | ArithmeticException e) {
                     throw DateTimeParseException.from(parser,
-                            String.format("Failed to deserialize %s from decimal value %s: %s",
+                            "Failed to deserialize %s from decimal value %s: %s".formatted(
                                     handledType().getName(), value, e.getMessage()),
                             value.toString(), handledType(), e);
                 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
@@ -415,7 +415,7 @@ public class InstantDeserializer<T extends Temporal>
                     timestamp, this.getZone(context)));
         } catch (DateTimeException e) {
             throw DateTimeParseException.from(context.getParser(),
-                    String.format("Failed to deserialize %s from timestamp value %d: %s",
+                    "Failed to deserialize %s from timestamp value %d: %s".formatted(
                             handledType().getName(), timestamp, e.getMessage()),
                     String.valueOf(timestamp), handledType(), e);
         }
@@ -432,7 +432,7 @@ public class InstantDeserializer<T extends Temporal>
             return fromNanoseconds.apply(args);
         } catch (DateTimeException | ArithmeticException e) {
             throw DateTimeParseException.from(context.getParser(),
-                    String.format("Failed to deserialize %s from decimal value %s: %s",
+                    "Failed to deserialize %s from decimal value %s: %s".formatted(
                             handledType().getName(), value, e.getMessage()),
                     value.toString(), handledType(), e);
         }

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateDeserializer.java
@@ -120,9 +120,9 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                     return LocalDate.of(year, month, day);
                 } catch (DateTimeException e) {
                     throw DateTimeParseException.from(p,
-                            String.format("Failed to deserialize %s from array value [%d,%d,%d]: %s",
+                            "Failed to deserialize %s from array value [%d,%d,%d]: %s".formatted(
                                     handledType().getName(), year, month, day, e.getMessage()),
-                            String.format("[%d,%d,%d]", year, month, day),
+                            "[%d,%d,%d]".formatted(year, month, day),
                             handledType(), e);
                 }
             }
@@ -146,7 +146,7 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                     return LocalDate.ofEpochDay(epochDay);
                 } catch (DateTimeException e) {
                     throw DateTimeParseException.from(p,
-                            String.format("Failed to deserialize %s from epoch day value %d: %s",
+                            "Failed to deserialize %s from epoch day value %d: %s".formatted(
                                     handledType().getName(), epochDay, e.getMessage()),
                             String.valueOf(epochDay),
                             handledType(), e);

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalDateTimeDeserializer.java
@@ -157,9 +157,9 @@ public class LocalDateTimeDeserializer
                     }
                 } catch (DateTimeException | ArithmeticException e) {
                     throw DateTimeParseException.from(p,
-                            String.format("Failed to deserialize %s from array value [%d,%d,%d,%d,%d,...]: %s",
+                            "Failed to deserialize %s from array value [%d,%d,%d,%d,%d,...]: %s".formatted(
                                     handledType().getName(), year, month, day, hour, minute, e.getMessage()),
-                            String.format("[%d,%d,%d,%d,%d,...]", year, month, day, hour, minute),
+                            "[%d,%d,%d,%d,%d,...]".formatted(year, month, day, hour, minute),
                             handledType(), e);
                 }
             } else {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/LocalTimeDeserializer.java
@@ -162,9 +162,9 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
                     }
                 } catch (DateTimeException | ArithmeticException e) {
                     throw DateTimeParseException.from(p,
-                            String.format("Failed to deserialize %s from array value [%d,%d,...]: %s",
+                            "Failed to deserialize %s from array value [%d,%d,...]: %s".formatted(
                                     handledType().getName(), hour, minute, e.getMessage()),
-                            String.format("[%d,%d,...]", hour, minute),
+                            "[%d,%d,...]".formatted(hour, minute),
                             handledType(), e);
                 }
             } else {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDayDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDayDeserializer.java
@@ -105,9 +105,9 @@ public class MonthDayDeserializer extends JSR310DateTimeDeserializerBase<MonthDa
                 return MonthDay.of(month, day);
             } catch (DateTimeException e) {
                 throw DateTimeParseException.from(p,
-                        String.format("Failed to deserialize %s from array value [%d,%d]: %s",
+                        "Failed to deserialize %s from array value [%d,%d]: %s".formatted(
                                 handledType().getName(), month, day, e.getMessage()),
-                        String.format("[%d,%d]", month, day),
+                        "[%d,%d]".formatted(month, day),
                         handledType(), e);
             }
         } else if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/OffsetTimeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/OffsetTimeDeserializer.java
@@ -175,9 +175,9 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
                     result = OffsetTime.of(hour, minute, second, partialSecond, ZoneOffset.of(p.getString()));
                 } catch (DateTimeException e) {
                     throw DateTimeParseException.from(p,
-                            String.format("Failed to deserialize %s from array value [%d,%d,...]: %s",
+                            "Failed to deserialize %s from array value [%d,%d,...]: %s".formatted(
                                     handledType().getName(), hour, minute, e.getMessage()),
-                            String.format("[%d,%d,...]", hour, minute),
+                            "[%d,%d,...]".formatted(hour, minute),
                             handledType(), e);
                 }
                 if (p.nextToken() != JsonToken.END_ARRAY) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/YearDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/YearDeserializer.java
@@ -137,7 +137,7 @@ public class YearDeserializer extends JSR310DateTimeDeserializerBase<Year>
             return Year.of(value);
         } catch (DateTimeException e) {
             throw DateTimeParseException.from(ctxt.getParser(),
-                    String.format("Failed to deserialize %s from number %d: %s",
+                    "Failed to deserialize %s from number %d: %s".formatted(
                             Year.class.getName(), value, e.getMessage()),
                     String.valueOf(value), Year.class, e);
         }

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/YearMonthDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/YearMonthDeserializer.java
@@ -125,9 +125,9 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
                 return YearMonth.of(year, month);
             } catch (DateTimeException e) {
                 throw DateTimeParseException.from(p,
-                        String.format("Failed to deserialize %s from array value [%d,%d]: %s",
+                        "Failed to deserialize %s from array value [%d,%d]: %s".formatted(
                                 handledType().getName(), year, month, e.getMessage()),
-                        String.format("[%d,%d]", year, month),
+                        "[%d,%d]".formatted(year, month),
                         handledType(), e);
             }
         } else if (p.hasToken(JsonToken.VALUE_EMBEDDED_OBJECT)) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/DurationSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/DurationSerializer.java
@@ -102,8 +102,7 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
             DurationUnitConverter conv = DurationUnitConverter.from(pattern);
             if (conv == null) {
                 ctxt.reportBadDefinition(handledType(),
-                        String.format(
-                                "Bad 'pattern' definition (\"%s\") for `Duration`: expected one of [%s]",
+                        "Bad 'pattern' definition (\"%s\") for `Duration`: expected one of [%s]".formatted(
                                 pattern, DurationUnitConverter.descForAllowed()));
             }
             ser = ser.withConverter(conv);

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -162,7 +162,7 @@ public final class AnnotatedConstructor
     @Override
     public String toString() {
         final int argCount = _constructor.getParameterCount();
-        return String.format("[constructor for %s (%d arg%s), annotations: %s",
+        return "[constructor for %s (%d arg%s), annotations: %s".formatted(
                 ClassUtil.nameOf(_constructor.getDeclaringClass()), argCount,
                 (argCount == 1) ? "" : "s", _annotations);
     }

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedCreatorCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedCreatorCollector.java
@@ -324,9 +324,8 @@ final class AnnotatedCreatorCollector
                 }
             }
             if (resolvedAnnotations == null) {
-                throw new IllegalStateException(String.format(
-"Internal error: constructor for %s has mismatch: %d parameters; %d sets of annotations",
-ctor.getDeclaringClass().getName(), paramCount, paramAnns.length));
+                throw new IllegalStateException("Internal error: constructor for %s has mismatch: %d parameters; %d sets of annotations".formatted(
+                        ctor.getDeclaringClass().getName(), paramCount, paramAnns.length));
             }
         } else {
             resolvedAnnotations = collectAnnotations(paramAnns,

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedMethod.java
@@ -209,7 +209,7 @@ public final class AnnotatedMethod
             return methodName+"("+getRawParameterType(0).getName()+")";
         default:
         }
-        return String.format("%s(%d params)", super.getFullName(), getParameterCount());
+        return "%s(%d params)".formatted(super.getFullName(), getParameterCount());
     }
 
     public Class<?>[] getRawParameterTypes()

--- a/src/main/java/tools/jackson/databind/introspect/BasicBeanDescription.java
+++ b/src/main/java/tools/jackson/databind/introspect/BasicBeanDescription.java
@@ -288,9 +288,8 @@ public class BasicBeanDescription extends BeanDescription
                  */
                 Class<?> type = anyMethod.getRawParameterType(0);
                 if ((type != String.class) && (type != Object.class)) {
-                    throw new IllegalArgumentException(String.format(
-"Invalid 'any-setter' annotation on method '%s()': first argument not of type `String` or `Object`, but %s",
-anyMethod.getName(), ClassUtil.nameOf(type)));
+                    throw new IllegalArgumentException("Invalid 'any-setter' annotation on method '%s()': first argument not of type `String` or `Object`, but %s".formatted(
+                            anyMethod.getName(), ClassUtil.nameOf(type)));
                 }
                 return anyMethod;
             }
@@ -301,9 +300,8 @@ anyMethod.getName(), ClassUtil.nameOf(type)));
                 Class<?> type = anyField.getRawType();
                 if (!Map.class.isAssignableFrom(type)
                         && !JsonNode.class.isAssignableFrom(type)) {
-                    throw new IllegalArgumentException(String.format(
-"Invalid 'any-setter' annotation on field '%s': type is not instance of `java.util.Map` or `JsonNode`",
-anyField.getName()));
+                    throw new IllegalArgumentException("Invalid 'any-setter' annotation on field '%s': type is not instance of `java.util.Map` or `JsonNode`".formatted(
+                            anyField.getName()));
                 }
                 return anyField;
             }
@@ -443,8 +441,7 @@ anyField.getName()));
                 Class<?> type = anyGetter.getRawType();
                 if (!Map.class.isAssignableFrom(type)
                         && !JsonNode.class.isAssignableFrom(type)) {
-                    throw new IllegalArgumentException(String.format(
-                            "Invalid 'any-getter' annotation on method '%s()': return type is not instance of `java.util.Map` or `JsonNode`",
+                    throw new IllegalArgumentException("Invalid 'any-getter' annotation on method '%s()': return type is not instance of `java.util.Map` or `JsonNode`".formatted(
                             anyGetter.getName()));
                 }
                 return anyGetter;
@@ -456,8 +453,7 @@ anyField.getName()));
                 Class<?> type = anyField.getRawType();
                 if (!Map.class.isAssignableFrom(type)
                         && !JsonNode.class.isAssignableFrom(type)) {
-                    throw new IllegalArgumentException(String.format(
-                            "Invalid 'any-getter' annotation on field '%s': type is not instance of `java.util.Map` or `JsonNode`",
+                    throw new IllegalArgumentException("Invalid 'any-getter' annotation on field '%s': type is not instance of `java.util.Map` or `JsonNode`".formatted(
                             anyField.getName()));
                 }
                 return anyField;

--- a/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -936,12 +936,12 @@ public class JacksonAnnotationIntrospector
                         type = type.withStaticTyping();
                     } else {
                         throw _databindException(
-                                String.format("Cannot refine serialization type %s into %s; types not related",
+                                "Cannot refine serialization type %s into %s; types not related".formatted(
                                         type, serClass.getName()));
                     }
                 } catch (IllegalArgumentException iae) {
                     throw _databindException(iae,
-                            String.format("Failed to widen type %s with annotation (value %s), from '%s': %s",
+                            "Failed to widen type %s with annotation (value %s), from '%s': %s".formatted(
                                     type, serClass.getName(), a.getName(), iae.getMessage()));
                 }
             }
@@ -974,12 +974,12 @@ public class JacksonAnnotationIntrospector
                             keyType = keyType.withStaticTyping();
                         } else {
                             throw _databindException(
-                                    String.format("Cannot refine serialization key type %s into %s; types not related",
+                                    "Cannot refine serialization key type %s into %s; types not related".formatted(
                                             keyType, keyClass.getName()));
                         }
                     } catch (IllegalArgumentException iae) {
                         throw _databindException(iae,
-                                String.format("Failed to widen key type of %s with concrete-type annotation (value %s), from '%s': %s",
+                                "Failed to widen key type of %s with concrete-type annotation (value %s), from '%s': %s".formatted(
                                         type, keyClass.getName(), a.getName(), iae.getMessage()));
                     }
                 }
@@ -1013,12 +1013,12 @@ public class JacksonAnnotationIntrospector
                            contentType = contentType.withStaticTyping();
                        } else {
                            throw _databindException(
-                                   String.format("Cannot refine serialization content type %s into %s; types not related",
+                                   "Cannot refine serialization content type %s into %s; types not related".formatted(
                                            contentType, contentClass.getName()));
                        }
                    } catch (IllegalArgumentException iae) { // shouldn't really happen
                        throw _databindException(iae,
-                               String.format("Internal error: failed to refine value type of %s with concrete-type annotation (value %s), from '%s': %s",
+                               "Internal error: failed to refine value type of %s with concrete-type annotation (value %s), from '%s': %s".formatted(
                                        type, contentClass.getName(), a.getName(), iae.getMessage()));
                    }
                }
@@ -1303,7 +1303,7 @@ public class JacksonAnnotationIntrospector
                 type = tf.constructSpecializedType(type, valueClass);
             } catch (IllegalArgumentException iae) {
                 throw _databindException(iae,
-                        String.format("Failed to narrow type %s with annotation (value %s), from '%s': %s",
+                        "Failed to narrow type %s with annotation (value %s), from '%s': %s".formatted(
                                 type, valueClass.getName(), a.getName(), iae.getMessage()));
             }
         }
@@ -1324,7 +1324,7 @@ public class JacksonAnnotationIntrospector
                     type = ((MapLikeType) type).withKeyType(keyType);
                 } catch (IllegalArgumentException iae) {
                     throw _databindException(iae,
-                            String.format("Failed to narrow key type of %s with concrete-type annotation (value %s), from '%s': %s",
+                            "Failed to narrow key type of %s with concrete-type annotation (value %s), from '%s': %s".formatted(
                                     type, keyClass.getName(), a.getName(), iae.getMessage()));
                 }
             }
@@ -1344,7 +1344,7 @@ public class JacksonAnnotationIntrospector
                     type = type.withContentType(contentType);
                 } catch (IllegalArgumentException iae) {
                     throw _databindException(iae,
-                            String.format("Failed to narrow value type of %s with concrete-type annotation (value %s), from '%s': %s",
+                            "Failed to narrow value type of %s with concrete-type annotation (value %s), from '%s': %s".formatted(
                                     type, contentClass.getName(), a.getName(), iae.getMessage()));
                 }
             }

--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -2115,7 +2115,7 @@ ctor.creator()));
 
     protected void reportProblem(String msg, Object... args) {
         if (args.length > 0) {
-            msg = String.format(msg, args);
+            msg = msg.formatted(args);
         }
         throw new IllegalArgumentException("Problem with definition of "+_classDef+": "+msg);
     }

--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertyBuilder.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertyBuilder.java
@@ -590,8 +590,7 @@ public class POJOPropertyBuilder
         // Otherwise
         String desc = conflicts.stream().map(AnnotatedMethod::getFullName)
                 .collect(Collectors.joining(" vs "));
-        throw new IllegalArgumentException(String.format(
-                "Conflicting setter definitions for property \"%s\": %s",
+        throw new IllegalArgumentException("Conflicting setter definitions for property \"%s\": %s".formatted(
                 getName(), desc));
     }
 
@@ -1677,7 +1676,7 @@ public class POJOPropertyBuilder
 
         @Override
         public String toString() {
-            String msg = String.format("%s[visible=%b,ignore=%b,explicitName=%b]",
+            String msg = "%s[visible=%b,ignore=%b,explicitName=%b]".formatted(
                     value.toString(), isVisible, isMarkedIgnored, isNameExplicit);
             if (next != null) {
                 msg = msg + ", "+next.toString();

--- a/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
+++ b/src/main/java/tools/jackson/databind/introspect/PotentialCreators.java
@@ -54,8 +54,7 @@ public class PotentialCreators
             String mode, boolean explicit)
     {
         if (propertiesBased != null) {
-            throw new IllegalArgumentException(String.format(
-                    "Conflicting property-based creators: already had %s creator %s, encountered another: %s",
+            throw new IllegalArgumentException("Conflicting property-based creators: already had %s creator %s, encountered another: %s".formatted(
                     mode, propertiesBased.creator(), ctor.creator()));
         }
         propertiesBased = ctor.introspectParamNames(config);

--- a/src/main/java/tools/jackson/databind/introspect/VisibilityChecker.java
+++ b/src/main/java/tools/jackson/databind/introspect/VisibilityChecker.java
@@ -368,7 +368,7 @@ public class VisibilityChecker
 
     @Override
     public String toString() {
-        return String.format("[Visibility: field=%s,getter=%s,isGetter=%s,setter=%s,creator=%s,scalarConstructor=%s]",
+        return "[Visibility: field=%s,getter=%s,isGetter=%s,setter=%s,creator=%s,scalarConstructor=%s]".formatted(
                 _fieldMinLevel, _getterMinLevel, _isGetterMinLevel, _setterMinLevel,
                 _creatorMinLevel, _scalarConstructorMinLevel);
     }

--- a/src/main/java/tools/jackson/databind/jsontype/impl/AsDeductionTypeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/AsDeductionTypeDeserializer.java
@@ -105,7 +105,7 @@ public class AsDeductionTypeDeserializer extends AsPropertyTypeDeserializer
             // Validate uniqueness
             if (existingFingerprint != null) {
                 throw new IllegalStateException(
-                        String.format("Subtypes %s and %s have the same signature and cannot be uniquely deduced.", existingFingerprint, subtype.getType().getName())
+                        "Subtypes %s and %s have the same signature and cannot be uniquely deduced.".formatted(existingFingerprint, subtype.getType().getName())
                         );
             }
         }
@@ -163,7 +163,7 @@ public class AsDeductionTypeDeserializer extends AsPropertyTypeDeserializer
         }
 
         // We have zero or multiple candidates, deduction has failed
-        String msgToReportIfDefaultImplFailsToo = String.format("Cannot deduce unique subtype of %s (%d candidates match)", ClassUtil.getTypeDescription(_baseType), candidates.size());
+        String msgToReportIfDefaultImplFailsToo = "Cannot deduce unique subtype of %s (%d candidates match)".formatted(ClassUtil.getTypeDescription(_baseType), candidates.size());
         return _deserializeTypedUsingDefaultImpl(p, ctxt, tb, msgToReportIfDefaultImplFailsToo);
     }
 

--- a/src/main/java/tools/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/AsPropertyTypeDeserializer.java
@@ -32,8 +32,8 @@ public class AsPropertyTypeDeserializer extends AsArrayTypeDeserializer
     protected final boolean _strictTypeIdHandling;
 
     protected final String _msgForMissingId = (_property == null)
-            ? String.format("missing type id property '%s'", _typePropertyName)
-            : String.format("missing type id property '%s' (for POJO property '%s')", _typePropertyName, _property.getName());
+            ? "missing type id property '%s'".formatted(_typePropertyName)
+            : "missing type id property '%s' (for POJO property '%s')".formatted(_typePropertyName, _property.getName());
 
     public AsPropertyTypeDeserializer(JavaType bt, TypeIdResolver idRes,
             String typePropertyName, boolean typeIdVisible, JavaType defaultImpl,

--- a/src/main/java/tools/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/StdTypeResolverBuilder.java
@@ -409,9 +409,8 @@ public class StdTypeResolverBuilder
     protected PolymorphicTypeValidator reportInvalidBaseType(DatabindContext ctxt,
             JavaType baseType, PolymorphicTypeValidator ptv)
     {
-        return ctxt.reportBadDefinition(baseType, String.format(
-"Configured `PolymorphicTypeValidator` (of type %s) denied resolution of all subtypes of base type %s",
-                        ClassUtil.classNameOf(ptv), ClassUtil.classNameOf(baseType.getRawClass()))
+        return ctxt.reportBadDefinition(baseType, "Configured `PolymorphicTypeValidator` (of type %s) denied resolution of all subtypes of base type %s".formatted(
+                ClassUtil.classNameOf(ptv), ClassUtil.classNameOf(baseType.getRawClass()))
                 );
     }
 

--- a/src/main/java/tools/jackson/databind/jsontype/impl/TypeDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/jsontype/impl/TypeDeserializerBase.java
@@ -293,7 +293,7 @@ public abstract class TypeDeserializerBase
             extraDesc = "known type ids = " + extraDesc;
         }
         if (_property != null) {
-            extraDesc = String.format("%s (for POJO property '%s')", extraDesc,
+            extraDesc = "%s (for POJO property '%s')".formatted(extraDesc,
                     _property.getName());
         }
         return ctxt.handleUnknownTypeId(_baseType, typeId, _idResolver, extraDesc);

--- a/src/main/java/tools/jackson/databind/module/SimpleModule.java
+++ b/src/main/java/tools/jackson/databind/module/SimpleModule.java
@@ -569,8 +569,7 @@ public class SimpleModule
     protected void _checkNotNull(Object thingy, String type)
     {
         if (thingy == null) {
-            throw new IllegalArgumentException(String.format(
-                    "Cannot pass `null` as %s", type));
+            throw new IllegalArgumentException("Cannot pass `null` as %s".formatted(type));
         }
     }
 }

--- a/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
+++ b/src/main/java/tools/jackson/databind/node/BaseJsonNode.java
@@ -791,7 +791,7 @@ public abstract class BaseJsonNode
      * this node being of wrong type
      */
     protected <T> T _reportWrongNodeType(String msgTemplate, Object...args) {
-        throw JsonNodeException.from(this, String.format(msgTemplate, args));
+        throw JsonNodeException.from(this, msgTemplate.formatted(args));
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/node/InternalNodeSerializer.java
+++ b/src/main/java/tools/jackson/databind/node/InternalNodeSerializer.java
@@ -111,7 +111,7 @@ class InternalNodeSerializer
                         try {
                             value.serialize(g, _context);
                         } catch (JacksonException e) {
-                            g.writeString(String.format("[ERROR: (%s) %s]",
+                            g.writeString("[ERROR: (%s) %s]".formatted(
                                     e.getClass().getName(), e.getMessage()));
                         }
                     } else {

--- a/src/main/java/tools/jackson/databind/node/TreeTraversingParser.java
+++ b/src/main/java/tools/jackson/databind/node/TreeTraversingParser.java
@@ -300,8 +300,7 @@ public class TreeTraversingParser
         if (!node.canConvertToShort()) {
             String desc = _longIntegerDesc(node.asString());
             if (!node.canConvertToExactIntegral()) {
-                throw _constructInputCoercion(String.format(
-"Numeric value (%s) of `%s` has fractional part; cannot convert to `short`",
+                throw _constructInputCoercion("Numeric value (%s) of `%s` has fractional part; cannot convert to `short`".formatted(
                         desc, node.getClass().getSimpleName()),
                     node.asToken(), Integer.TYPE);
             }
@@ -317,11 +316,10 @@ public class TreeTraversingParser
         if (!node.canConvertToInt()) {
             // [databind#5309] Misleading exception message for DoubleNode to `int` value conversion
             if (!node.canConvertToExactIntegral()) {
-                throw _constructInputCoercion(String.format(
-"Numeric value (%s) of `%s` has fractional part; cannot convert to `int`",
-                            _longIntegerDesc(node.asString()),
-                            node.getClass().getSimpleName()
-                        ),
+                throw _constructInputCoercion("Numeric value (%s) of `%s` has fractional part; cannot convert to `int`".formatted(
+                        _longIntegerDesc(node.asString()),
+                        node.getClass().getSimpleName()
+                ),
                         node.asToken(), Integer.TYPE);
             }
             // otherwise assume range overflow
@@ -358,11 +356,10 @@ public class TreeTraversingParser
         if (!node.canConvertToLong()) {
             // [databind#5309] Misleading exception message for DoubleNode to `long` value conversion
             if (!node.canConvertToExactIntegral()) {
-                throw _constructInputCoercion(String.format(
-"Numeric value (%s) of `%s` has fractional part; cannot convert to `long`",
-                            _longIntegerDesc(node.asString()),
-                            node.getClass().getSimpleName()
-                        ),
+                throw _constructInputCoercion("Numeric value (%s) of `%s` has fractional part; cannot convert to `long`".formatted(
+                        _longIntegerDesc(node.asString()),
+                        node.getClass().getSimpleName()
+                ),
                         node.asToken(), Long.TYPE);
             }
             // otherwise assume range overflow

--- a/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
@@ -78,8 +78,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
             return;
         }
         if (!(value instanceof Map<?,?>)) {
-            ctxt.reportBadDefinition(_property.getType(), String.format(
-                    "Value returned by 'any-getter' %s() not java.util.Map but %s",
+            ctxt.reportBadDefinition(_property.getType(), "Value returned by 'any-getter' %s() not java.util.Map but %s".formatted(
                     _accessor.getName(), value.getClass().getName()));
         }
         // 23-Feb-2015, tatu: Nasty, but has to do (for now)
@@ -111,8 +110,8 @@ public class AnyGetterWriter extends BeanPropertyWriter
         }
         if (!(value instanceof Map<?,?>)) {
             ctxt.reportBadDefinition(_property.getType(),
-                    String.format("Value returned by 'any-getter' (%s()) not java.util.Map but %s",
-                    _accessor.getName(), value.getClass().getName()));
+                    "Value returned by 'any-getter' (%s()) not java.util.Map but %s".formatted(
+                            _accessor.getName(), value.getClass().getName()));
         }
         // 19-Oct-2014, tatu: Should we try to support @JsonInclude options here?
         if (_mapSerializer != null) {
@@ -136,8 +135,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
         if (value instanceof ObjectNode objectNode) {
             return objectNode;
         }
-        return ctxt.reportBadDefinition(_property.getType(), String.format(
-                "Value returned by 'any-getter' %s not `ObjectNode` but `%s`; only `ObjectNode`s can be used as `@JsonAnyGetter` values",
+        return ctxt.reportBadDefinition(_property.getType(), "Value returned by 'any-getter' %s not `ObjectNode` but `%s`; only `ObjectNode`s can be used as `@JsonAnyGetter` values".formatted(
                 _accessor.getName(), value.getClass().getName()));
     }
 

--- a/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
@@ -414,8 +414,7 @@ public class BeanPropertyWriter
     public void assignSerializer(ValueSerializer<Object> ser) {
         // may need to disable check in future?
         if ((_serializer != null) && (_serializer != ser)) {
-            throw new IllegalStateException(String.format(
-                    "Cannot override _serializer: had a %s, trying to set to %s",
+            throw new IllegalStateException("Cannot override _serializer: had a %s, trying to set to %s".formatted(
                     ClassUtil.classNameOf(_serializer), ClassUtil.classNameOf(ser)));
         }
         _serializer = ser;
@@ -427,8 +426,7 @@ public class BeanPropertyWriter
     public void assignNullSerializer(ValueSerializer<Object> nullSer) {
         // may need to disable check in future?
         if ((_nullSerializer != null) && (_nullSerializer != nullSer)) {
-            throw new IllegalStateException(String.format(
-                    "Cannot override _nullSerializer: had a %s, trying to set to %s",
+            throw new IllegalStateException("Cannot override _nullSerializer: had a %s, trying to set to %s".formatted(
                     ClassUtil.classNameOf(_nullSerializer), ClassUtil.classNameOf(nullSer)));
         }
         _nullSerializer = nullSer;

--- a/src/main/java/tools/jackson/databind/ser/BeanSerializerBuilder.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanSerializerBuilder.java
@@ -105,8 +105,7 @@ public class BeanSerializerBuilder
     public void setFilteredProperties(BeanPropertyWriter[] properties) {
         if (properties != null) {
             if (properties.length != _properties.size()) { // as per [databind#1612]
-                throw new IllegalArgumentException(String.format(
-                        "Trying to set %d filtered properties; must match length of non-filtered `properties` (%d)",
+                throw new IllegalArgumentException("Trying to set %d filtered properties; must match length of non-filtered `properties` (%d)".formatted(
                         properties.length, _properties.size()));
             }
         }
@@ -206,9 +205,8 @@ public class BeanSerializerBuilder
         // 27-Apr-2017, tatu: Verify that filtered-properties settings are compatible
         if (_filteredProperties != null) {
             if (_filteredProperties.length != _properties.size()) { // lgtm [java/dereferenced-value-may-be-null]
-                throw new IllegalStateException(String.format(
-"Mismatch between `properties` size (%d), `filteredProperties` (%s): should have as many (or `null` for latter)",
-_properties.size(), _filteredProperties.length));
+                throw new IllegalStateException("Mismatch between `properties` size (%d), `filteredProperties` (%s): should have as many (or `null` for latter)".formatted(
+                        _properties.size(), _filteredProperties.length));
             }
         }
         ValueSerializer<?> ser = UnrolledBeanSerializer.tryConstruct(

--- a/src/main/java/tools/jackson/databind/ser/BeanSerializerFactory.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanSerializerFactory.java
@@ -484,9 +484,8 @@ public class BeanSerializerFactory
 
             for (int i = 0, len = props.size() ;; ++i) {
                 if (i == len) {
-                    throw new IllegalArgumentException(String.format(
-"Invalid Object Id definition for %s: cannot find property with name %s",
-ClassUtil.getTypeDescription(beanDescRef.getType()), ClassUtil.name(propName)));
+                    throw new IllegalArgumentException("Invalid Object Id definition for %s: cannot find property with name %s".formatted(
+                            ClassUtil.getTypeDescription(beanDescRef.getType()), ClassUtil.name(propName)));
                 }
                 BeanPropertyWriter prop = props.get(i);
                 if (propName.equals(prop.getName())) {

--- a/src/main/java/tools/jackson/databind/ser/SerializationContextExt.java
+++ b/src/main/java/tools/jackson/databind/ser/SerializationContextExt.java
@@ -128,9 +128,8 @@ public class SerializationContextExt
         try {
             return filter.equals(null);
         } catch (Exception e) {
-            String msg = String.format(
-"Problem determining whether filter of type '%s' should filter out `null` values: (%s) %s",
-filter.getClass().getName(), e.getClass().getName(), ClassUtil.exceptionMessage(e));
+            String msg = "Problem determining whether filter of type '%s' should filter out `null` values: (%s) %s".formatted(
+                    filter.getClass().getName(), e.getClass().getName(), ClassUtil.exceptionMessage(e));
             reportBadDefinition(filter.getClass(), msg, e);
             return false; // never gets here
         }

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -314,10 +314,10 @@ public abstract class BeanSerializerBase
                     TypeSerializer typeSer = (TypeSerializer) type.getContentType().getTypeHandler();
                     if (typeSer != null) {
                         // for now, can do this only for standard containers...
-                        if (ser instanceof StdContainerSerializer<?>) {
+                        if (ser instanceof StdContainerSerializer<?> serializer) {
                             // ugly casts... but necessary
                             @SuppressWarnings("unchecked")
-                            ValueSerializer<Object> ser2 = (ValueSerializer<Object>)((StdContainerSerializer<?>) ser).withValueTypeSerializer(typeSer);
+                            ValueSerializer<Object> ser2 = (ValueSerializer<Object>)serializer.withValueTypeSerializer(typeSer);
                             ser = ser2;
                         }
                     }
@@ -542,8 +542,7 @@ public abstract class BeanSerializerBase
 
                     for (int i = 0, len = _props.length; ; ++i) {
                         if (i == len) {
-                            ctxt.reportBadDefinition(_beanType, String.format(
-                                    "Invalid Object Id definition for %s: cannot find property with name %s",
+                            ctxt.reportBadDefinition(_beanType, "Invalid Object Id definition for %s: cannot find property with name %s".formatted(
                                     ClassUtil.getTypeDescription(_beanType), ClassUtil.name(propName)));
                         }
                         BeanPropertyWriter prop = _props[i];

--- a/src/main/java/tools/jackson/databind/ser/impl/UnknownSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/impl/UnknownSerializer.java
@@ -46,12 +46,10 @@ public class UnknownSerializer
     {
         final Class<?> cl = value.getClass();
         if (NativeImageUtil.needsReflectionConfiguration(cl)) {
-            prov.reportBadDefinition(handledType(), String.format(
-                    "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS). This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized",
+            prov.reportBadDefinition(handledType(), "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS). This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized".formatted(
                     cl.getName()));
         } else {
-            prov.reportBadDefinition(handledType(), String.format(
-                    "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)",
+            prov.reportBadDefinition(handledType(), "No serializer found for class %s and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)".formatted(
                     cl.getName()));
         }
     }

--- a/src/main/java/tools/jackson/databind/ser/jdk/DateTimeSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/DateTimeSerializerBase.java
@@ -109,9 +109,8 @@ public abstract class DateTimeSerializerBase<T>
         //    mechanism for changing `DateFormat` instances (or even clone()ing)
         //    So: require it be `SimpleDateFormat`; can't config other types
         if (!(df0 instanceof SimpleDateFormat)) {
-            serializers.reportBadDefinition(handledType(), String.format(
-"Configured `DateFormat` (%s) not a `SimpleDateFormat`; cannot configure `Locale` or `TimeZone`",
-df0.getClass().getName()));
+            serializers.reportBadDefinition(handledType(), "Configured `DateFormat` (%s) not a `SimpleDateFormat`; cannot configure `Locale` or `TimeZone`".formatted(
+                    df0.getClass().getName()));
         }
         SimpleDateFormat df = (SimpleDateFormat) df0;
         if (hasLocale) {

--- a/src/main/java/tools/jackson/databind/ser/jdk/EnumSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/EnumSerializer.java
@@ -224,8 +224,7 @@ public class EnumSerializer
             return Boolean.TRUE;
         }
         // 07-Mar-2017, tatu: Also means `OBJECT` not available as property annotation...
-        throw new IllegalArgumentException(String.format(
-                "Unsupported serialization shape (%s) for Enum %s, not supported as %s annotation",
-                    shape, enumClass.getName(), (fromClass? "class" : "property")));
+        throw new IllegalArgumentException("Unsupported serialization shape (%s) for Enum %s, not supported as %s annotation".formatted(
+                shape, enumClass.getName(), (fromClass ? "class" : "property")));
     }
 }

--- a/src/main/java/tools/jackson/databind/ser/jdk/NumberSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/NumberSerializer.java
@@ -162,9 +162,8 @@ public class NumberSerializer
                 if (!_verifyBigDecimalRange(gen, bd)) {
                     // ... but wouldn't it be nice to trigger error via generator? Alas,
                     // no method to do that. So we'll do...
-                    final String errorMsg = String.format(
-"Attempt to write plain `java.math.BigDecimal` (see JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN) with illegal scale (%d): needs to be between [-%d, %d]",
-bd.scale(), MAX_BIG_DECIMAL_SCALE, MAX_BIG_DECIMAL_SCALE);
+                    final String errorMsg = "Attempt to write plain `java.math.BigDecimal` (see JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN) with illegal scale (%d): needs to be between [-%d, %d]".formatted(
+                            bd.scale(), MAX_BIG_DECIMAL_SCALE, MAX_BIG_DECIMAL_SCALE);
                     ctxt.reportMappingProblem(errorMsg);
                 }
                 text = bd.toPlainString();

--- a/src/main/java/tools/jackson/databind/ser/jdk/NumberToStringWithRadixSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/NumberToStringWithRadixSerializer.java
@@ -37,7 +37,7 @@ public class NumberToStringWithRadixSerializer extends ToStringSerializerBase {
             throws JacksonException
     {
         if (radix < Character.MIN_RADIX || radix > Character.MAX_RADIX) {
-            String errorMsg = String.format("To use a custom radix for string serialization, use radix within [%d, %d]", Character.MIN_RADIX, Character.MAX_RADIX);
+            String errorMsg = "To use a custom radix for string serialization, use radix within [%d, %d]".formatted(Character.MIN_RADIX, Character.MAX_RADIX);
             provider.reportBadDefinition(handledType(), errorMsg);
         }
 

--- a/src/main/java/tools/jackson/databind/type/MapLikeType.java
+++ b/src/main/java/tools/jackson/databind/type/MapLikeType.java
@@ -251,7 +251,7 @@ public class MapLikeType extends TypeBase {
 
     @Override
     public String toString() {
-        return String.format("[map-like type; class %s, %s -> %s]",
+        return "[map-like type; class %s, %s -> %s]".formatted(
                 _class.getName(), _keyType, _valueType);
     }
 

--- a/src/main/java/tools/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/tools/jackson/databind/type/TypeFactory.java
@@ -449,7 +449,7 @@ public class TypeFactory
                 break;
             }
             if (!rawBase.isAssignableFrom(subclass)) {
-                throw new IllegalArgumentException(String.format("Class %s not subtype of %s",
+                throw new IllegalArgumentException("Class %s not subtype of %s".formatted(
                         ClassUtil.nameOf(subclass), ClassUtil.getTypeDescription(baseType)
                 ));
             }
@@ -520,8 +520,7 @@ public class TypeFactory
         // Then find super-type
         JavaType baseWithPlaceholders = tmpSub.findSuperType(baseType.getRawClass());
         if (baseWithPlaceholders == null) { // should be found but...
-            throw new IllegalArgumentException(String.format(
-                    "Internal error: unable to locate supertype (%s) from resolved subtype %s", baseType.getRawClass().getName(),
+            throw new IllegalArgumentException("Internal error: unable to locate supertype (%s) from resolved subtype %s".formatted(baseType.getRawClass().getName(),
                     subclass.getName()));
         }
         // and traverse type hierarchies to both verify and to resolve placeholders
@@ -587,8 +586,8 @@ public class TypeFactory
                         continue;
                     }
                 }
-                return String.format("Type parameter #%d/%d differs; cannot specialize %s with %s",
-                        (i+1), expCount, exp.toCanonical(), act.toCanonical());
+                return "Type parameter #%d/%d differs; cannot specialize %s with %s".formatted(
+                        (i + 1), expCount, exp.toCanonical(), act.toCanonical());
             }
         }
         return null;
@@ -636,12 +635,10 @@ public class TypeFactory
         if (superType == null) {
             // Most likely, caller did not verify sub/super-type relationship
             if (!superClass.isAssignableFrom(rawBase)) {
-                throw new IllegalArgumentException(String.format(
-                        "Class %s not a super-type of %s", superClass.getName(), baseType));
+                throw new IllegalArgumentException("Class %s not a super-type of %s".formatted(superClass.getName(), baseType));
             }
             // 01-Nov-2015, tatu: Should never happen, but ch
-            throw new IllegalArgumentException(String.format(
-                    "Internal error: class %s not included as super-type for %s",
+            throw new IllegalArgumentException("Internal error: class %s not included as super-type for %s".formatted(
                     superClass.getName(), baseType));
         }
         return superType;
@@ -834,8 +831,7 @@ public class TypeFactory
             JavaType t = result.findSuperType(Collection.class);
             JavaType realET = t.getContentType();
             if (!realET.equals(elementType)) {
-                throw new IllegalArgumentException(String.format(
-                        "Non-generic Collection class %s did not resolve to something with element type %s but %s ",
+                throw new IllegalArgumentException("Non-generic Collection class %s did not resolve to something with element type %s but %s ".formatted(
                         ClassUtil.nameOf(collectionClass), elementType, realET));
             }
         }
@@ -902,14 +898,12 @@ public class TypeFactory
             JavaType t = result.findSuperType(Map.class);
             JavaType realKT = t.getKeyType();
             if (!realKT.equals(keyType)) {
-                throw new IllegalArgumentException(String.format(
-                        "Non-generic Map class %s did not resolve to something with key type %s but %s ",
+                throw new IllegalArgumentException("Non-generic Map class %s did not resolve to something with key type %s but %s ".formatted(
                         ClassUtil.nameOf(mapClass), keyType, realKT));
             }
             JavaType realVT = t.getContentType();
             if (!realVT.equals(valueType)) {
-                throw new IllegalArgumentException(String.format(
-                        "Non-generic Map class %s did not resolve to something with value type %s but %s ",
+                throw new IllegalArgumentException("Non-generic Map class %s did not resolve to something with value type %s but %s ".formatted(
                         ClassUtil.nameOf(mapClass), valueType, realVT));
             }
         }
@@ -1137,9 +1131,8 @@ public class TypeFactory
                 vt = typeParams.get(1);
                 break;
             default:
-                throw new IllegalArgumentException(String.format(
-"Strange Map type %s with %d type parameter%s (%s), cannot resolve",
-ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
+                throw new IllegalArgumentException("Strange Map type %s with %d type parameter%s (%s), cannot resolve".formatted(
+                        ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
             }
         }
         return MapType.construct(rawClass, bindings, superClass, superInterfaces, kt, vt);
@@ -1311,8 +1304,7 @@ ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
         for (TypeModifier mod : _modifiers) {
             JavaType t = mod.modifyType(resultType, srcType, b, this);
             if (t == null) {
-                throw new IllegalStateException(String.format(
-                        "TypeModifier %s (of type %s) return null for type %s",
+                throw new IllegalStateException("TypeModifier %s (of type %s) return null for type %s".formatted(
                         mod, mod.getClass().getName(), resultType));
             }
             resultType = t;

--- a/src/main/java/tools/jackson/databind/type/TypeParser.java
+++ b/src/main/java/tools/jackson/databind/type/TypeParser.java
@@ -37,8 +37,7 @@ public class TypeParser
     public JavaType parse(TypeFactory tf, String canonical) throws IllegalArgumentException
     {
         if (canonical.length() > MAX_TYPE_LENGTH) {
-            throw new IllegalArgumentException(String.format(
-                    "Failed to parse type %s: too long (%d characters), maximum length allowed: %d",
+            throw new IllegalArgumentException("Failed to parse type %s: too long (%d characters), maximum length allowed: %d".formatted(
                     _quoteTruncated(canonical),
                     canonical.length(),
                     MAX_TYPE_LENGTH));
@@ -107,7 +106,7 @@ public class TypeParser
 
     protected IllegalArgumentException _problem(MyTokenizer tokens, String msg)
     {
-        return new IllegalArgumentException(String.format("Failed to parse type %s (remaining: %s): %s",
+        return new IllegalArgumentException("Failed to parse type %s (remaining: %s): %s".formatted(
                 _quoteTruncated(tokens.getAllInput()),
                 _quoteTruncated(tokens.getRemainingInput()),
                 msg));
@@ -117,7 +116,7 @@ public class TypeParser
         if (str.length() <= 1000) {
             return "'"+str+"'";
         }
-        return String.format("'%s...'[truncated %d charaters]",
+        return "'%s...'[truncated %d charaters]".formatted(
                 str.substring(0, 1000), str.length() - 1000);
     }
 

--- a/src/main/java/tools/jackson/databind/util/BeanUtil.java
+++ b/src/main/java/tools/jackson/databind/util/BeanUtil.java
@@ -185,7 +185,7 @@ public class BeanUtil
         } else {
             return null;
         }
-        return String.format("%s type %s not supported by default: add Module \"%s\" to enable handling",
+        return "%s type %s not supported by default: add Module \"%s\" to enable handling".formatted(
                 typeName, ClassUtil.getTypeDescription(type), moduleName);
     }
     

--- a/src/main/java/tools/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/tools/jackson/databind/util/ClassUtil.java
@@ -260,9 +260,8 @@ public final class ClassUtil
             String method)
     {
         if (instance.getClass() != expType) {
-            throw new IllegalStateException(String.format(
-                    "Sub-class %s (of class %s) must override method '%s'",
-                instance.getClass().getName(), expType.getName(), method));
+            throw new IllegalStateException("Sub-class %s (of class %s) must override method '%s'".formatted(
+                    instance.getClass().getName(), expType.getName(), method));
         }
     }
 
@@ -873,8 +872,7 @@ public final class ClassUtil
             if ("InaccessibleObjectException".equals(e.getClass().getSimpleName())) {
                 return;
             }
-            throw new IllegalArgumentException(String.format(
-                    "Failed to call `setAccess()` on %s '%s' (of class %s) due to `%s`, problem: %s",
+            throw new IllegalArgumentException("Failed to call `setAccess()` on %s '%s' (of class %s) due to `%s`, problem: %s".formatted(
                     member.getClass().getSimpleName(), member.getName(),
                     nameOf(member.getDeclaringClass()),
                     e.getClass().getName(), e.getMessage()), e);
@@ -1118,9 +1116,8 @@ public final class ClassUtil
     private static Method[] _failGetClassMethods(Class<?> cls, Throwable rootCause)
             throws IllegalArgumentException
     {
-        throw new IllegalArgumentException(String.format(
-"Failed on call to `getDeclaredMethods()` on class `%s`, problem: (%s) %s",
-cls.getName(), rootCause.getClass().getName(), rootCause.getMessage()),
+        throw new IllegalArgumentException("Failed on call to `getDeclaredMethods()` on class `%s`, problem: (%s) %s".formatted(
+                cls.getName(), rootCause.getClass().getName(), rootCause.getMessage()),
                 rootCause);
     }
 
@@ -1242,8 +1239,7 @@ cls.getName(), rootCause.getClass().getName(), rootCause.getMessage()),
                 return f;
             }
             // If not found, indicate with exception
-            throw new IllegalStateException(String.format(
-"No field named '%s' in class '%s'", expectedName, fromClass.getName()));
+            throw new IllegalStateException("No field named '%s' in class '%s'".formatted(expectedName, fromClass.getName()));
         }
     }
 

--- a/src/main/java/tools/jackson/databind/util/RawValue.java
+++ b/src/main/java/tools/jackson/databind/util/RawValue.java
@@ -116,6 +116,6 @@ public class RawValue
 
     @Override
     public String toString() {
-        return String.format("[RawValue of type %s]", ClassUtil.classNameOf(_value));
+        return "[RawValue of type %s]".formatted(ClassUtil.classNameOf(_value));
     }
 }

--- a/src/main/java/tools/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/tools/jackson/databind/util/StdDateFormat.java
@@ -364,8 +364,8 @@ public class StdDateFormat
         }
         sb.append('"');
         throw new ParseException
-            (String.format("Cannot parse date \"%s\": not compatible with any of standard forms (%s)",
-                           dateStr, sb.toString()), pos.getErrorIndex());
+            ("Cannot parse date \"%s\": not compatible with any of standard forms (%s)".formatted(
+                dateStr, sb.toString()), pos.getErrorIndex());
     }
 
     // 24-Jun-2017, tatu: I don't think this ever gets called. So could... just not implement?
@@ -553,7 +553,7 @@ public class StdDateFormat
 
     @Override
     public String toString() {
-        return String.format("DateFormat %s: (timezone: %s, locale: %s, lenient: %s)",
+        return "DateFormat %s: (timezone: %s, locale: %s, lenient: %s)".formatted(
                 getClass().getName(), _timezone, _locale, _lenient);
     }
 
@@ -631,8 +631,7 @@ public class StdDateFormat
         try {
             ts = NumberInput.parseLong(longStr);
         } catch (NumberFormatException e) {
-            throw new ParseException(String.format(
-                    "Timestamp value %s out of 64-bit value range", longStr),
+            throw new ParseException("Timestamp value %s out of 64-bit value range".formatted(longStr),
                     pos.getErrorIndex());
         }
         return new Date(ts);
@@ -644,7 +643,7 @@ public class StdDateFormat
         try {
             return _parseAsISO8601(dateStr, pos);
         } catch (IllegalArgumentException e) {
-            throw new ParseException(String.format("Cannot parse date \"%s\", problem: %s",
+            throw new ParseException("Cannot parse date \"%s\", problem: %s".formatted(
                     dateStr, e.getMessage()),
                     pos.getErrorIndex());
         }
@@ -726,10 +725,9 @@ public class StdDateFormat
                     default: // [databind#1745] Allow longer fractions... for now, cap at nanoseconds tho
 
                         if (fractLen > 9) { // only allow up to nanos
-                            throw new ParseException(String.format(
-"Cannot parse date \"%s\": invalid fractional seconds '%s'; can use at most 9 digits",
-                                       dateStr, m.group(1).substring(1)
-                                       ), start);
+                            throw new ParseException("Cannot parse date \"%s\": invalid fractional seconds '%s'; can use at most 9 digits".formatted(
+                                    dateStr, m.group(1).substring(1)
+                            ), start);
                         }
                         // fall through
                     case 3:
@@ -750,8 +748,8 @@ public class StdDateFormat
         }
 
         throw new ParseException
-        (String.format("Cannot parse date \"%s\": while it seems to fit format '%s', parsing fails (leniency? %s)",
-                       dateStr, formatStr, _lenient),
+        ("Cannot parse date \"%s\": while it seems to fit format '%s', parsing fails (leniency? %s)".formatted(
+                dateStr, formatStr, _lenient),
                 // [databind#1742]: Might be able to give actual location, some day, but for now
                 //  we can't give anything more indicative
                 0);

--- a/src/main/java/tools/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/tools/jackson/databind/util/TokenBuffer.java
@@ -520,8 +520,7 @@ public class TokenBuffer
                     } else if (n instanceof String str) {
                         gen.writeNumber(str);
                     } else {
-                        throw new StreamWriteException(gen, String.format(
-                                "Unrecognized value type for VALUE_NUMBER_FLOAT: %s, cannot serialize",
+                        throw new StreamWriteException(gen, "Unrecognized value type for VALUE_NUMBER_FLOAT: %s, cannot serialize".formatted(
                                 n.getClass().getName()));
                     }
                 }

--- a/src/test/java/perf/ObjectReaderTestBase.java
+++ b/src/test/java/perf/ObjectReaderTestBase.java
@@ -34,8 +34,8 @@ abstract class ObjectReaderTestBase
         /*T2 back2 =*/ mapper2.readValue(byteInput2, inputClass2);
         System.out.println("Input successfully round-tripped for both styles...");
 
-        _desc1 = String.format("%s (%d bytes)", desc1, byteInput1.length);
-        _desc2 = String.format("%s (%d bytes)", desc2, byteInput2.length);
+        _desc1 = "%s (%d bytes)".formatted(desc1, byteInput1.length);
+        _desc2 = "%s (%d bytes)".formatted(desc2, byteInput2.length);
 
         doTest(mapper1, byteInput1, inputClass1, mapper2, byteInput2, inputClass2);
     }
@@ -50,8 +50,8 @@ abstract class ObjectReaderTestBase
         final String input2 = mapper2.writeValueAsString(inputValue2);
         // Let's try to guestimate suitable size... to get to N megs to process
         REPS = (int) ((double) (targetSizeMegs() * 1000 * 1000) / (double) input1.length());
-        _desc1 = String.format("%s (%d chars)", desc1, input1.length());
-        _desc2 = String.format("%s (%d chars)", desc2, input2.length());
+        _desc1 = "%s (%d chars)".formatted(desc1, input1.length());
+        _desc2 = "%s (%d chars)".formatted(desc2, input2.length());
 
         // sanity check:
         /*T1 back1 =*/ mapper1.readValue(input1, inputClass1);

--- a/src/test/java/tools/jackson/databind/deser/CollectingErrorsTest.java
+++ b/src/test/java/tools/jackson/databind/deser/CollectingErrorsTest.java
@@ -228,8 +228,8 @@ public class CollectingErrorsTest extends DatabindTestUtil
                     final int index = i;
                     executor.submit(() -> {
                         try {
-                            String json = String.format("{\"name\":\"User%d\",\"age\":\"invalid%d\"}",
-                                index, index);
+                            String json = "{\"name\":\"User%d\",\"age\":\"invalid%d\"}".formatted(
+                                    index, index);
                             reader.readValueCollectingProblems(json);
                             unexpectedErrors.add(new AssertionError("Should have thrown DeferredBindingException"));
                         } catch (DeferredBindingException e) {

--- a/src/test/java/tools/jackson/databind/deser/creators/CreatorImplicitNameTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/CreatorImplicitNameTest.java
@@ -29,7 +29,7 @@ public class CreatorImplicitNameTest
         @Override
         public String findImplicitPropertyName(MapperConfig<?> config, AnnotatedMember member) {
             if (member instanceof AnnotatedParameter ap) {
-                return String.format("ctor%d", ap.getIndex());
+                return "ctor%d".formatted(ap.getIndex());
             }
             return super.findImplicitPropertyName(config, member);
         }
@@ -73,7 +73,7 @@ public class CreatorImplicitNameTest
         public String getPassword() { return password; }
 
         public String asString() {
-            return String.format("[password='%s',value=%d]", password, value);
+            return "[password='%s',value=%d]".formatted(password, value);
         }
     }
 

--- a/src/test/java/tools/jackson/databind/deser/dos/DeepJsonNodeSerTest.java
+++ b/src/test/java/tools/jackson/databind/deser/dos/DeepJsonNodeSerTest.java
@@ -60,7 +60,7 @@ public class DeepJsonNodeSerTest
         jsonString.append("{");
 
         for (int i=0; i < nesting; i++) {
-          jsonString.append(String.format("\"abc%s\": {", i));
+          jsonString.append("\"abc%s\": {".formatted(i));
         }
 
         for (int i=0; i < nesting; i++) {

--- a/src/test/java/tools/jackson/databind/deser/enums/EnumSetDeserializationWithDefaultTyping4849Test.java
+++ b/src/test/java/tools/jackson/databind/deser/enums/EnumSetDeserializationWithDefaultTyping4849Test.java
@@ -71,7 +71,7 @@ public class EnumSetDeserializationWithDefaultTyping4849Test
         throws Exception
     {
         // Given : Hard-coded output from Jackson 2.15.4
-        String input = String.format("[\"java.util.EnumSet<%s>\",[\"%s\"]]",
+        String input = "[\"java.util.EnumSet<%s>\",[\"%s\"]]".formatted(
                 TestEnum4849.class.getName(),
                 TestEnum4849.TEST_ENUM_VALUE.name());
         // When

--- a/src/test/java/tools/jackson/databind/deser/jdk/Base64DecodingTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/Base64DecodingTest.java
@@ -59,7 +59,7 @@ public class Base64DecodingTest
         }
 
         // and then tree model
-        JsonNode tree = mapper.readTree(String.format("{\"foo\":\"%s\"}", value));
+        JsonNode tree = mapper.readTree("{\"foo\":\"%s\"}".formatted(value));
         JsonNode nodeValue = tree.get("foo");
         try {
             /*byte[] b =*/ nodeValue.binaryValue();

--- a/src/test/java/tools/jackson/databind/deser/jdk/DateDeserializationTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/DateDeserializationTest.java
@@ -499,7 +499,7 @@ public class DateDeserializationTest
 
         // note: representation may differ (wrt timezone etc), but underlying value must remain the same:
         if (l != result.getTimeInMillis()) {
-            fail(String.format("Expected timestamp %d, got %d, for '%s'",
+            fail("Expected timestamp %d, got %d, for '%s'".formatted(
                     l, result.getTimeInMillis(), dateStr));
         }
     }

--- a/src/test/java/tools/jackson/databind/deser/jdk/MapKeyDeserializationTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/MapKeyDeserializationTest.java
@@ -100,7 +100,7 @@ public class MapKeyDeserializationTest
         public int hashCode() { return Objects.hash(value); }
 
         @Override
-        public String toString() { return String.format("DummyDto{value=%s}", value); }
+        public String toString() { return "DummyDto{value=%s}".formatted(value); }
     }
 
     private static final TypeReference<Map<DummyDto2158, Integer>> MAP_TYPE_2158 =

--- a/src/test/java/tools/jackson/databind/deser/merge/CustomCollectionMerge4783Test.java
+++ b/src/test/java/tools/jackson/databind/deser/merge/CustomCollectionMerge4783Test.java
@@ -128,8 +128,7 @@ public class CustomCollectionMerge4783Test
             MAPPER.readValue("{\"values\":[\"x\"]}", NonMergeCustomStringList.class);
             fail("Should not pass");
         } catch (InvalidDefinitionException e) {
-            verifyException(e, String.format(
-                    "Cannot construct instance of `%s` (no Creators",
+            verifyException(e, "Cannot construct instance of `%s` (no Creators".formatted(
                     MyListCustom.class.getName()));
         }
     }
@@ -141,8 +140,7 @@ public class CustomCollectionMerge4783Test
             MAPPER.readValue("[]", MyAbstractStringList.class);
             fail("Should not pass");
         } catch (InvalidDefinitionException e) {
-            verifyException(e, String.format(
-                    "Cannot construct instance of `%s` (no Creators",
+            verifyException(e, "Cannot construct instance of `%s` (no Creators".formatted(
                     MyAbstractStringList.class.getName()));
         }
     }

--- a/src/test/java/tools/jackson/databind/exc/ThrowableDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/exc/ThrowableDeserializerTest.java
@@ -708,7 +708,7 @@ public class ThrowableDeserializerTest extends DatabindTestUtil
                 return;
             }
         }
-        fail(String.format("StackTraceElement #%d, property '%s' differs: expected %s, actual %s",
+        fail("StackTraceElement #%d, property '%s' differs: expected %s, actual %s".formatted(
                 ix, prop, exp, act));
     }
 }

--- a/src/test/java/tools/jackson/databind/ext/javatime/DateTimeTestBase.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/DateTimeTestBase.java
@@ -53,6 +53,6 @@ public class DateTimeTestBase
     }
 
     protected static String mapAsString(String key, String value) {
-        return String.format("{\"%s\":\"%s\"}", key, value);
+        return "{\"%s\":\"%s\"}".formatted(key, value);
     }
 }

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
@@ -567,7 +567,7 @@ public class InstantDeserTest extends DateTimeTestBase
         assertEquals(result, inst);
 
         // but then quoted as JSON String
-        result = READER.readValue(String.format("\"%s\"", json));
+        result = READER.readValue("\"%s\"".formatted(json));
         assertNotNull(result);
         assertEquals(result, inst);
     }

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
@@ -94,13 +94,13 @@ public class MonthDeserializerTest extends DateTimeTestBase
     static void assertError(Executable codeToRun, Class<? extends Throwable> expectedException, String expectedMessage) {
         try {
             codeToRun.execute();
-            fail(String.format("Expecting %s, but nothing was thrown!", expectedException.getName()));
+            fail("Expecting %s, but nothing was thrown!".formatted(expectedException.getName()));
         } catch (Throwable actualException) {
             if (!expectedException.isInstance(actualException)) {
-                fail(String.format("Expecting exception of type %s, but %s was thrown instead", expectedException.getName(), actualException.getClass().getName()));
+                fail("Expecting exception of type %s, but %s was thrown instead".formatted(expectedException.getName(), actualException.getClass().getName()));
             }
             if (actualException.getMessage() == null || !actualException.getMessage().contains(expectedMessage)) {
-                fail(String.format("Expecting exception with message containing: '%s', but the actual error message was:'%s'", expectedMessage, actualException.getMessage()));
+                fail("Expecting exception with message containing: '%s', but the actual error message was:'%s'".formatted(expectedMessage, actualException.getMessage()));
             }
         }
     }

--- a/src/test/java/tools/jackson/databind/ext/javatime/ser/WriteDatesAsTimestamps5142JavaTimeTests.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/ser/WriteDatesAsTimestamps5142JavaTimeTests.java
@@ -148,12 +148,12 @@ public class WriteDatesAsTimestamps5142JavaTimeTests
         assertEquals(
                 withString,
                 WITH_TIMESTAMP_MAPPER.writerFor(clazz).writeValueAsString(value),
-                String.format("withTimestampMapper : Expected %s, got %s", withString, value)
+                "withTimestampMapper : Expected %s, got %s".formatted(withString, value)
         );
         assertEquals(
                 withoutString,
                 WITHOUT_TIMESTAMP_MAPPER.writerFor(clazz).writeValueAsString(value),
-                String.format("withoutTimestampMapper : Expected %s, got %s", withoutString, value)
+                "withoutTimestampMapper : Expected %s, got %s".formatted(withoutString, value)
         );
     }
 

--- a/src/test/java/tools/jackson/databind/ext/javatime/ser/WriteZoneIdTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/ser/WriteZoneIdTest.java
@@ -73,7 +73,7 @@ public class WriteZoneIdTest extends DateTimeTestBase
         if (!json.contains("\"01-01-1970T")) {
             fail("Should contain time prefix, did not: "+json);
         }
-        String match = String.format("[%s]", ZONE_ID_STR);
+        String match = "[%s]".formatted(ZONE_ID_STR);
         if (!json.contains(match)) {
             fail("Should contain zone id "+match+", does not: "+json);
         }

--- a/src/test/java/tools/jackson/databind/format/EnumFormatShapeTest.java
+++ b/src/test/java/tools/jackson/databind/format/EnumFormatShapeTest.java
@@ -151,7 +151,7 @@ public class EnumFormatShapeTest
 
     @Test
     public void testEnumPropertyAsNumber() throws Exception {
-        assertEquals(String.format(a2q("{'color':%s}"), Color.GREEN.ordinal()),
+        assertEquals(a2q("{'color':%s}").formatted(Color.GREEN.ordinal()),
                 MAPPER.writeValueAsString(new ColorWrapper(Color.GREEN)));
     }
 

--- a/src/test/java/tools/jackson/databind/jsontype/TypeIdPropertyDup1410Test.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TypeIdPropertyDup1410Test.java
@@ -73,7 +73,7 @@ public class TypeIdPropertyDup1410Test extends DatabindTestUtil
 
         @Override
         public String toString() {
-            return String.format("(%s): %s", status, getMessage());
+            return "(%s): %s".formatted(status, getMessage());
         }
     }
 

--- a/src/test/java/tools/jackson/databind/jsontype/deduct/BasicPolymorphicDeductionTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/deduct/BasicPolymorphicDeductionTest.java
@@ -331,7 +331,7 @@ public class BasicPolymorphicDeductionTest extends DatabindTestUtil {
     @ParameterizedTest
     @ValueSource(strings = {"y", "Y", "yy", "ff", "X"})
     public void testAliasWithPolymorphicDeduction4327(String field) throws Exception {
-        String json = a2q(String.format("{'%s': 2 }", field));
+        String json = a2q("{'%s': 2 }".formatted(field));
         Deduction4327 value = MAPPER.readValue(json, Deduction4327.class);
         assertNotNull(value);
         assertEquals(2, ((DeductionBean4327_2) value).y);

--- a/src/test/java/tools/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/ext/ExternalTypeIdTest.java
@@ -564,8 +564,8 @@ public class ExternalTypeIdTest extends DatabindTestUtil
 
         assertEquals(w.typeEnum, w2.typeEnum);
         assertTrue(w.value.equals(w2.value),
-            String.format("Expected %s = %s; got back %s = %s",
-                w.value.getClass().getSimpleName(), w.value.toString(), w2.value.getClass().getSimpleName(), w2.value.toString()));
+                "Expected %s = %s; got back %s = %s".formatted(
+                        w.value.getClass().getSimpleName(), w.value.toString(), w2.value.getClass().getSimpleName(), w2.value.toString()));
     }
 
     @Test
@@ -584,7 +584,7 @@ public class ExternalTypeIdTest extends DatabindTestUtil
 
         assertEquals(w.typeEnum, w2.typeEnum);
         assertTrue(w.value.equals(w2.value),
-            String.format("Expected %s = %s; got back %s = %s",
+                "Expected %s = %s; got back %s = %s".formatted(
                         w.value.getClass().getSimpleName(), w.value.toString(), w2.value.getClass().getSimpleName(), w2.value.toString()));
     }
 

--- a/src/test/java/tools/jackson/databind/misc/ThreadSafety1759Test.java
+++ b/src/test/java/tools/jackson/databind/misc/ThreadSafety1759Test.java
@@ -35,7 +35,7 @@ public class ThreadSafety1759Test extends DatabindTestUtil
         // IMPORTANT! Use different timestamp for every thread
         List<Callable<Throwable>> calls = new ArrayList<Callable<Throwable>>();
         for (int thread = 1; thread <= numThreads; ++thread) {
-            final String json = q(String.format("2017-01-%02dT16:30:49Z", thread));
+            final String json = q("2017-01-%02dT16:30:49Z".formatted(thread));
             final long timestamp = mapper.readValue(json, Date.class).getTime();
 
             calls.add(createCallable(thread, mapper, json, timestamp, COUNT, counter));

--- a/src/test/java/tools/jackson/databind/misc/ThreadSafetyWithConverterMixin5813Test.java
+++ b/src/test/java/tools/jackson/databind/misc/ThreadSafetyWithConverterMixin5813Test.java
@@ -159,7 +159,7 @@ public class ThreadSafetyWithConverterMixin5813Test
         }
 
         assertTrue(errors.isEmpty(),
-                () -> String.format("test failed with %d error(s):\n%s",
+                () -> "test failed with %d error(s):\n%s".formatted(
                         errors.size(),
                         errors.stream()
                                 .map(Throwable::toString)

--- a/src/test/java/tools/jackson/databind/misc/ThreadSafetyWithPolymorphicSer5615Test.java
+++ b/src/test/java/tools/jackson/databind/misc/ThreadSafetyWithPolymorphicSer5615Test.java
@@ -146,7 +146,7 @@ public class ThreadSafetyWithPolymorphicSer5615Test
         }
 
         assertTrue(errors.isEmpty(),
-                () -> String.format("test failed with %d error(s):\n%s",
+                () -> "test failed with %d error(s):\n%s".formatted(
                         errors.size(),
                         errors.stream()
                                 .map(Throwable::toString)

--- a/src/test/java/tools/jackson/databind/objectid/ObjectId3838Test.java
+++ b/src/test/java/tools/jackson/databind/objectid/ObjectId3838Test.java
@@ -200,7 +200,7 @@ public class ObjectId3838Test extends DatabindTestUtil
             if (!"great".equals(result)) {
                 fail("Class '"+cls.getName()+", json "+jsonStr
                         +" : should get 'great', got "
-                        +((result == null) ? "null" : String.format("'%s'", result)));
+                        +((result == null) ? "null" : "'%s'".formatted(result)));
             }
         }
     }

--- a/src/test/java/tools/jackson/databind/records/RecordTypeInfo3342Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordTypeInfo3342Test.java
@@ -157,7 +157,7 @@ public class RecordTypeInfo3342Test extends DatabindTestUtil
     @ParameterizedTest
     @ValueSource(strings = {"Y", "yy", "ff", "X"})
     public void testAliasWithPolymorphicDeduction(String field) throws Exception {
-        String json = a2q(String.format("{'%s': 2 }", field));
+        String json = a2q("{'%s': 2 }".formatted(field));
         Deduction4327 value = MAPPER.readValue(json, Deduction4327.class);
         assertNotNull(value);
         assertEquals(2, ((DeductionBean2_4327) value).y());

--- a/src/test/java/tools/jackson/databind/ser/GenericTypeSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/GenericTypeSerializationTest.java
@@ -679,7 +679,7 @@ public class GenericTypeSerializationTest extends DatabindTestUtil
     public void testIndexedListExample() throws Exception
     {
         UUID uuid = UUID.randomUUID();
-        IndexedList<TestIndexed, String> value = MAPPER.readValue(String.format("[\"%s\"]", uuid.toString()),
+        IndexedList<TestIndexed, String> value = MAPPER.readValue("[\"%s\"]".formatted(uuid.toString()),
                 new TypeReference<IndexedList<TestIndexed, String>>() {});
         assertEquals(1, value.size());
         assertEquals(uuid, value.delegate.get(0).value);

--- a/src/test/java/tools/jackson/databind/ser/JsonValueSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/JsonValueSerializationTest.java
@@ -409,7 +409,7 @@ public class JsonValueSerializationTest
     {
         String value = "abc";
         String result = MAPPER.writeValueAsString(new ClassGetter<String>(value));
-        String expected = String.format("{\"nonRaw\":\"%s\",\"raw\":%s,\"value\":%s}", value, value, value);
+        String expected = "{\"nonRaw\":\"%s\",\"raw\":%s,\"value\":%s}".formatted(value, value, value);
         assertEquals(expected, result);
     }
 
@@ -418,7 +418,7 @@ public class JsonValueSerializationTest
     {
         int value = 123;
         String result = MAPPER.writeValueAsString(new ClassGetter<Integer>(value));
-        String expected = String.format("{\"nonRaw\":%d,\"raw\":%d,\"value\":%d}", value, value, value);
+        String expected = "{\"nonRaw\":%d,\"raw\":%d,\"value\":%d}".formatted(value, value, value);
         assertEquals(expected, result);
     }
 

--- a/src/test/java/tools/jackson/databind/ser/dos/CyclicDataSerTest.java
+++ b/src/test/java/tools/jackson/databind/ser/dos/CyclicDataSerTest.java
@@ -59,7 +59,7 @@ public class CyclicDataSerTest
             writeAndMap(MAPPER, list);
             fail("expected DatabindException");
         } catch (StreamConstraintsException e) {
-            String exceptionPrefix = String.format("Document nesting depth (%d) exceeds the maximum allowed",
+            String exceptionPrefix = "Document nesting depth (%d) exceeds the maximum allowed".formatted(
                     StreamWriteConstraints.DEFAULT_MAX_DEPTH + 1);
             assertTrue(e.getMessage().startsWith(exceptionPrefix),
                 "DatabindException message is as expected?");

--- a/src/test/java/tools/jackson/databind/ser/jdk/CollectionSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/CollectionSerializationTest.java
@@ -396,7 +396,7 @@ public class CollectionSerializationTest
                         DefaultTyping.NON_FINAL)
                 .build();
         json = mapper.writeValueAsString(w);
-        assertEquals(a2q(String.format("['%s',{'list':['%s',['a','b','c']]}]",
+        assertEquals(a2q("['%s',{'list':['%s',['a','b','c']]}]".formatted(
                 w.getClass().getName(), w.list.getClass().getName())), json);
     }
 

--- a/src/test/java/tools/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
@@ -262,7 +262,7 @@ public class JDKTypeSerializationTest
         String json = mapper.writeValueAsString(input);
         assertEquals(q(input.getHostAddress()), json);
 
-        assertEquals(String.format("{\"value\":\"%s\"}", input.getHostAddress()),
+        assertEquals("{\"value\":\"%s\"}".formatted(input.getHostAddress()),
                 mapper.writeValueAsString(new InetAddressBean(input)));
     }
 

--- a/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/JavaUtilDateSerializationTest.java
@@ -614,12 +614,12 @@ public class JavaUtilDateSerializationTest
         assertEquals(
                 withString,
                 WITH_TIMESTAMP_MAPPER.writerFor(clazz).writeValueAsString(value),
-                String.format("withTimestampMapper : Expected %s, got %s", withString, value)
+                "withTimestampMapper : Expected %s, got %s".formatted(withString, value)
         );
         assertEquals(
                 withoutString,
                 WITHOUT_TIMESTAMP_MAPPER.writerFor(clazz).writeValueAsString(value),
-                String.format("withoutTimestampMapper : Expected %s, got %s", withoutString, value)
+                "withoutTimestampMapper : Expected %s, got %s".formatted(withoutString, value)
         );
     }
 }

--- a/src/test/java/tools/jackson/databind/testutil/DatabindTestUtil.java
+++ b/src/test/java/tools/jackson/databind/testutil/DatabindTestUtil.java
@@ -293,7 +293,7 @@ public class DatabindTestUtil
 
         @Override
         public String toString() {
-            return String.format("[x=%d, y=%d]", x, y);
+            return "[x=%d, y=%d]".formatted(x, y);
         }
     }
 

--- a/src/test/java/tools/jackson/databind/testutil/failure/JacksonTestFailureExpectedInterceptor.java
+++ b/src/test/java/tools/jackson/databind/testutil/failure/JacksonTestFailureExpectedInterceptor.java
@@ -36,7 +36,7 @@ public class JacksonTestFailureExpectedInterceptor
         //List<Object> arguments = invocationContext.getArguments();
 
         // Create message
-        String message = String.format("Test method %s.%s() passed, but should have failed", targetClass, testMethod);
+        String message = "Test method %s.%s() passed, but should have failed".formatted(targetClass, testMethod);
 
         // throw exception
         throw new JacksonTestShouldFailException(message);

--- a/src/test/java/tools/jackson/databind/util/JSONPObjectTest.java
+++ b/src/test/java/tools/jackson/databind/util/JSONPObjectTest.java
@@ -19,7 +19,7 @@ public class JSONPObjectTest extends DatabindTestUtil
      */
     @Test
     public void testU2028Escaped() throws IOException {
-        String containsU2028 = String.format("This string contains %c char", '\u2028');
+        String containsU2028 = "This string contains %c char".formatted('\u2028');
         JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2028);
         String valueAsString = MAPPER.writeValueAsString(jsonpObject);
         assertFalse(valueAsString.contains("\u2028"));
@@ -27,7 +27,7 @@ public class JSONPObjectTest extends DatabindTestUtil
 
     @Test
     public void testU2029Escaped() throws IOException {
-        String containsU2029 = String.format("This string contains %c char", '\u2029');
+        String containsU2029 = "This string contains %c char".formatted('\u2029');
         JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2029);
         String valueAsString = MAPPER.writeValueAsString(jsonpObject);
         assertFalse(valueAsString.contains("\u2029"));
@@ -35,7 +35,7 @@ public class JSONPObjectTest extends DatabindTestUtil
 
     @Test
     public void testU2030NotEscaped() throws IOException {
-        String containsU2030 = String.format("This string contains %c char", '\u2030');
+        String containsU2030 = "This string contains %c char".formatted('\u2030');
         JSONPObject jsonpObject = new JSONPObject(CALLBACK, containsU2030);
         String valueAsString = MAPPER.writeValueAsString(jsonpObject);
         assertTrue(valueAsString.contains("\u2030"));

--- a/src/test/java/tools/jackson/databind/views/ViewsWithCreatorTest.java
+++ b/src/test/java/tools/jackson/databind/views/ViewsWithCreatorTest.java
@@ -41,7 +41,7 @@ public class ViewsWithCreatorTest extends DatabindTestUtil
 
         @Override
         public String toString() {
-            return String.format("%s-%s-%s", a, b, c);
+            return "%s-%s-%s".formatted(a, b, c);
         }
     }
 
@@ -69,7 +69,7 @@ public class ViewsWithCreatorTest extends DatabindTestUtil
 
         @Override
         public String toString() {
-            return String.format("%s-%s-%s", a, b, c);
+            return "%s-%s-%s".formatted(a, b, c);
         }
     }
 


### PR DESCRIPTION
This PR splits out the String.format() -> .formatted() modernization changes from #5992.

No behavior changes intended.

All 5965 tests pass (0 failures, 0 errors).