### PR TITLE
Extend #5969/#5971 fixes to Builders, external-type-id case in regular BeanDeserializer

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -320,6 +320,7 @@ public class BeanDeserializer
         PropertyValueBuffer buffer = (_anySetter != null)
             ? creator.startBuildingWithAnySetter(p, ctxt, _objectIdReader, _anySetter)
             : creator.startBuilding(p, ctxt, _objectIdReader);
+        final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
 
         // Step 1: Pre-populate buffer from existing Record values
         final Class<?> recordClass = _beanType.getRawClass();
@@ -356,6 +357,12 @@ public class BeanDeserializer
             p.nextToken(); // to point to value
             final SettableBeanProperty creatorProp = creator.findCreatorProperty(propName);
             if (creatorProp != null) {
+                // [databind#5971]: must honor active view here too -- leave the
+                // pre-populated existing value untouched if hidden by active view
+                if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 // Override the pre-populated value
                 buffer.assignParameter(creatorProp,
                         _deserializeWithErrorWrapping(p, ctxt, creatorProp));
@@ -1174,6 +1181,7 @@ public class BeanDeserializer
         tokens.writeStartObject();
 
         final boolean isRecord = _beanType.isRecordType();
+        final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
         boolean hasUnwrappedContent = false;
         JsonToken t = p.currentToken();
         for (; t == JsonToken.PROPERTY_NAME; t = p.nextToken()) {
@@ -1187,6 +1195,11 @@ public class BeanDeserializer
             }
 
             if (creatorProp != null) {
+                // [databind#5971]: must honor active view here too
+                if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 // [databind#1381]: if useInput=FALSE, skip deserialization from input
                 if (creatorProp.isInjectionOnly()) {
                     // Skip the input value, will be injected later in PropertyValueBuffer
@@ -1212,6 +1225,11 @@ public class BeanDeserializer
             int ix = _propNameMatcher.matchName(propName);
             if (ix >= 0) {
                 SettableBeanProperty prop = _propsByIndex[ix];
+                // [databind#5969]: must honor active view here too
+                if ((activeView != null) && !prop.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
                 continue;
             }
@@ -1376,6 +1394,7 @@ public class BeanDeserializer
         final ExternalTypeHandler ext = _externalTypeIdHandler.start();
         final PropertyBasedCreator creator = _propertyBasedCreator;
         PropertyValueBuffer buffer = creator.startBuilding(p, ctxt, _objectIdReader);
+        final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
 
         for (JsonToken t = p.currentToken(); t == JsonToken.PROPERTY_NAME; t = p.nextToken()) {
             String propName = p.currentName();
@@ -1387,6 +1406,11 @@ public class BeanDeserializer
                 continue;
             }
             if (creatorProp != null) {
+                // [databind#5971]: must honor active view here too
+                if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 // [databind#1381]: if useInput=FALSE, skip deserialization from input
                 if (creatorProp.isInjectionOnly()) {
                     // Skip the input value, will be injected later in PropertyValueBuffer
@@ -1410,6 +1434,11 @@ public class BeanDeserializer
             int ix = _propNameMatcher.matchName(propName);
             if (ix >= 0) {
                 SettableBeanProperty prop = _propsByIndex[ix];
+                // [databind#5969]: must honor active view here too
+                if ((activeView != null) && !prop.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 // [databind#3045]: may have property AND be used as external type id:
                 if (t.isScalarValue()) {
                     ext.handleTypePropertyValue(p, ctxt, propName, null);

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -441,6 +441,13 @@ public class BuilderBasedDeserializer
             int ix = _propertyNameMatcher.matchName(propName);
             if (ix >= 0) {
                 SettableBeanProperty prop = _propertiesByIndex[ix];
+                // [databind#5969]: must honor active view here too -- otherwise
+                // a view-restricted property seen before the creator completes can be
+                // populated via the buffering path below.
+                if ((activeView != null) && !prop.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 // !!! 21-Nov-2017, tatu: Regular deserializer handles references here...
                 buffer.bufferProperty(prop, prop.deserialize(p, ctxt));
                 continue;
@@ -753,6 +760,7 @@ public class BuilderBasedDeserializer
     {
         final PropertyBasedCreator creator = _propertyBasedCreator;
         PropertyValueBuffer buffer = creator.startBuilding(p, ctxt, _objectIdReader);
+        final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
 
         TokenBuffer tokens = ctxt.bufferForInputBuffering(p);
         tokens.writeStartObject();
@@ -769,6 +777,11 @@ public class BuilderBasedDeserializer
                 continue;
             }
             if (creatorProp != null) {
+                // [databind#5971]: must honor active view here too
+                if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 // [databind#1381]: if useInput=FALSE, skip deserialization from input
                 if (creatorProp.isInjectionOnly()) {
                     // Skip the input value, will be injected later in PropertyValueBuffer
@@ -796,6 +809,11 @@ public class BuilderBasedDeserializer
             int ix = _propertyNameMatcher.matchName(propName);
             if (ix >= 0) {
                 SettableBeanProperty prop = _propertiesByIndex[ix];
+                // [databind#5969]: must honor active view here too
+                if ((activeView != null) && !prop.visibleInView(activeView)) {
+                    p.skipChildren();
+                    continue;
+                }
                 buffer.bufferProperty(prop, prop.deserialize(p, ctxt));
                 continue;
             }

--- a/src/test/java/tools/jackson/databind/views/BuilderViewBypassTest.java
+++ b/src/test/java/tools/jackson/databind/views/BuilderViewBypassTest.java
@@ -1,0 +1,101 @@
+package tools.jackson.databind.views;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * [databind#5969]: @JsonView bypass for builder-based POJOs using a
+ * property-based creator.
+ *
+ * The active-view check was added to {@code BeanDeserializer} but the parallel
+ * branch in {@code BuilderBasedDeserializer._deserializeUsingPropertyBased()}
+ * was left unpatched. A regular (non-creator) property annotated
+ * {@code @JsonView(Admin)} could be populated under a non-Admin view when ordered
+ * between the creator's first and last parameters (forcing the regular-property
+ * buffering path).
+ */
+public class BuilderViewBypassTest extends DatabindTestUtil
+{
+    static class PublicView {}
+    static class AdminView extends PublicView {}
+
+    @JsonDeserialize(builder = User.Builder.class)
+    public static class User {
+        @JsonView(PublicView.class) public final String name;
+        @JsonView(PublicView.class) public final String city;
+        @JsonView(AdminView.class)  public final String password;
+
+        private User(String n, String c, String p) {
+            this.name = n; this.city = c; this.password = p;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private String name, city, password;
+
+            @JsonCreator
+            public Builder(@JsonProperty("name") @JsonView(PublicView.class) String n,
+                    @JsonProperty("city") @JsonView(PublicView.class) String c) {
+                this.name = n; this.city = c;
+            }
+            @JsonView(PublicView.class) public Builder name(String n)     { this.name = n; return this; }
+            @JsonView(PublicView.class) public Builder city(String c)     { this.city = c; return this; }
+            @JsonView(AdminView.class)  public Builder password(String p) { this.password = p; return this; }
+            public User build() { return new User(name, city, password); }
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // Negative control: AdminView populates all properties.
+    @Test
+    public void testAdminView_negativeControl() throws Exception {
+        User u = MAPPER.readerWithView(AdminView.class)
+                .forType(User.class)
+                .readValue("{\"name\":\"alice\",\"password\":\"secret\",\"city\":\"NY\"}");
+        assertEquals("alice", u.name);
+        assertEquals("NY", u.city);
+        assertEquals("secret", u.password);
+    }
+
+    // Formerly failing case: "password" ordered BETWEEN the two creator props,
+    // forcing the regular-property buffering branch. Under PublicView the
+    // @JsonView(AdminView) property must remain null.
+    @Test
+    public void testRegularPropertyHonorsViewInCreatorWindow() throws Exception {
+        User u = MAPPER.readerWithView(PublicView.class)
+                .forType(User.class)
+                .readValue("{\"name\":\"alice\",\"password\":\"BYPASS\",\"city\":\"NY\"}");
+
+        assertEquals("alice", u.name);
+        assertEquals("NY", u.city);
+        assertNull(u.password,
+                "[databind#5969] @JsonView(AdminView) builder property was populated " +
+                "in PublicView via the creator-window buffering path. password = " + u.password);
+    }
+
+    // Control: password ordered AFTER both creator props was already view-aware
+    // (deserialization shifts to deserializeWithView once the creator completes).
+    @Test
+    public void testRegularPropertyHonorsViewAfterCreator() throws Exception {
+        User u = MAPPER.readerWithView(PublicView.class)
+                .forType(User.class)
+                .readValue("{\"name\":\"alice\",\"city\":\"NY\",\"password\":\"BYPASS\"}");
+
+        assertEquals("alice", u.name);
+        assertEquals("NY", u.city);
+        assertNull(u.password,
+                "[databind#5969] @JsonView(AdminView) builder property was populated " +
+                "in PublicView. password = " + u.password);
+    }
+}

--- a/src/test/java/tools/jackson/databind/views/ExternalTypeIdViewBypassTest.java
+++ b/src/test/java/tools/jackson/databind/views/ExternalTypeIdViewBypassTest.java
@@ -1,0 +1,119 @@
+package tools.jackson.databind.views;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonView;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * [databind#5969] / [databind#5971] (external-type-id path): @JsonView bypass for
+ * regular (non-creator) and creator properties handled by
+ * {@code BeanDeserializer.deserializeUsingPropertyBasedWithExternalTypeId()}.
+ *
+ * Same gap as the plain and unwrapped property-based-creator paths: an external
+ * type id ({@code @JsonTypeInfo(include = EXTERNAL_PROPERTY)}) combined with a
+ * property-based {@code @JsonCreator} routes through a dedicated method whose
+ * creator-property ([databind#5971]) and regular-property ([databind#5969])
+ * branches did not check {@code visibleInView}.
+ */
+public class ExternalTypeIdViewBypassTest extends DatabindTestUtil
+{
+    static class PublicView {}
+    static class AdminView extends PublicView {}
+
+    public interface Value { }
+
+    @JsonTypeName("string")
+    public static class StringValue implements Value {
+        public String v;
+    }
+
+    public static class Envelope {
+        @JsonView(PublicView.class)
+        public final String name;
+
+        // Creator parameter, view-restricted -> creator-property branch ([databind#5971]).
+        @JsonView(AdminView.class)
+        public final String secret;
+
+        // Non-creator, view-restricted property -> regular-property branch ([databind#5969]).
+        @JsonView(AdminView.class)
+        public String password;
+
+        // External-type-id property forces the dedicated code path; "valueType"
+        // is the external type id property.
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "valueType")
+        @JsonSubTypes({ @JsonSubTypes.Type(StringValue.class) })
+        @JsonView(PublicView.class)
+        public final Value value;
+
+        @JsonCreator
+        public Envelope(@JsonProperty("name") @JsonView(PublicView.class) String name,
+                @JsonProperty("secret") @JsonView(AdminView.class) String secret,
+                @JsonProperty("value") @JsonView(PublicView.class) Value value) {
+            this.name = name;
+            this.secret = secret;
+            this.value = value;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    private static final String FULL_JSON =
+            "{\"name\":\"alice\",\"secret\":\"sssh\",\"password\":\"pw\","
+            + "\"valueType\":\"string\",\"value\":{\"v\":\"x\"}}";
+
+    // Negative control: AdminView populates the view-restricted properties.
+    // (Note: the nested external-type-id value content is not deep-checked here;
+    // its binding under property-based creators is an unrelated existing quirk.)
+    @Test
+    public void testAdminView_negativeControl() throws Exception {
+        Envelope result = MAPPER.readerWithView(AdminView.class)
+                .forType(Envelope.class)
+                .readValue(FULL_JSON);
+        assertEquals("alice", result.name);
+        assertEquals("sssh", result.secret);
+        assertEquals("pw", result.password);
+        assertTrue(result.value instanceof StringValue);
+    }
+
+    // Formerly failing: under PublicView the @JsonView(AdminView) regular property
+    // "password" must not be populated via the external-type-id path.
+    @Test
+    public void testRegularPropertyHonorsViewWithExternalTypeId() throws Exception {
+        Envelope result = MAPPER.readerWithView(PublicView.class)
+                .forType(Envelope.class)
+                .readValue(FULL_JSON);
+
+        assertEquals("alice", result.name);
+        assertTrue(result.value instanceof StringValue);
+        assertNull(result.password,
+                "[databind#5969] @JsonView(AdminView) property was populated in PublicView " +
+                "via the external-type-id path. password = " + result.password);
+    }
+
+    // Formerly failing: under PublicView the @JsonView(AdminView) creator parameter
+    // "secret" must not be populated via the external-type-id path.
+    @Test
+    public void testCreatorPropertyHonorsViewWithExternalTypeId() throws Exception {
+        Envelope result = MAPPER.readerWithView(PublicView.class)
+                .forType(Envelope.class)
+                .readValue(FULL_JSON);
+
+        assertEquals("alice", result.name);
+        assertTrue(result.value instanceof StringValue);
+        assertNull(result.secret,
+                "[databind#5971] @JsonView(AdminView) creator parameter was populated in PublicView " +
+                "via the external-type-id path. secret = " + result.secret);
+    }
+}

--- a/src/test/java/tools/jackson/databind/views/RecordUpdateViewBypassTest.java
+++ b/src/test/java/tools/jackson/databind/views/RecordUpdateViewBypassTest.java
@@ -1,0 +1,60 @@
+package tools.jackson.databind.views;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * [databind#5971] (record-update path): @JsonView bypass for creator properties
+ * handled by {@code BeanDeserializer._deserializeRecordForUpdate()} (new in 3.1).
+ *
+ * The record-for-update path pre-populates the creator buffer from the existing
+ * record and then overrides from JSON input; the creator-property branch did not
+ * check {@code visibleInView}, so a {@code @JsonView(Admin)} component could be
+ * overwritten from untrusted JSON while updating under a less-privileged view.
+ */
+public class RecordUpdateViewBypassTest extends DatabindTestUtil
+{
+    static class PublicView {}
+    static class AdminView extends PublicView {}
+
+    public record User(
+            @JsonView(PublicView.class) String name,
+            @JsonView(AdminView.class) String role) {
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // Negative control: AdminView allows overriding the restricted component.
+    @Test
+    public void testAdminView_negativeControl() throws Exception {
+        User existing = new User("alice", "user");
+        User result = MAPPER.readerWithView(AdminView.class)
+                .forType(User.class)
+                .withValueToUpdate(existing)
+                .readValue("{\"name\":\"alice2\",\"role\":\"admin\"}");
+        assertEquals("alice2", result.name());
+        assertEquals("admin", result.role());
+    }
+
+    // Formerly failing: under PublicView the @JsonView(AdminView) "role" component
+    // must retain its pre-populated value, not be overwritten from JSON.
+    @Test
+    public void testCreatorPropertyHonorsViewOnRecordUpdate() throws Exception {
+        User existing = new User("alice", "user");
+        User result = MAPPER.readerWithView(PublicView.class)
+                .forType(User.class)
+                .withValueToUpdate(existing)
+                .readValue("{\"name\":\"alice2\",\"role\":\"HACKED\"}");
+
+        assertEquals("alice2", result.name());
+        assertEquals("user", result.role(),
+                "[databind#5971] @JsonView(AdminView) record component was overwritten in PublicView " +
+                "via the record-update path. role = " + result.role());
+    }
+}

--- a/src/test/java/tools/jackson/databind/views/UnwrappedPojoViewBypassTest.java
+++ b/src/test/java/tools/jackson/databind/views/UnwrappedPojoViewBypassTest.java
@@ -1,0 +1,111 @@
+package tools.jackson.databind.views;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonView;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * [databind#5969] / [databind#5971] (BeanDeserializer unwrapped path): @JsonView
+ * bypass for regular (non-creator) and creator properties handled by
+ * {@code BeanDeserializer.deserializeUsingPropertyBasedWithUnwrapped()}.
+ *
+ * The property-based-creator-with-unwrapped path on the POJO (non-builder)
+ * deserializer computed no active view and so skipped the {@code visibleInView}
+ * check on both the creator-property ([databind#5971]) and the regular-property
+ * ([databind#5969]) buffering branches. A {@code @JsonView(Admin)} property could
+ * be populated under a non-Admin view when an {@code @JsonUnwrapped} member forces
+ * this code path.
+ */
+public class UnwrappedPojoViewBypassTest extends DatabindTestUtil
+{
+    static class PublicView {}
+    static class AdminView extends PublicView {}
+
+    public static class Address {
+        @JsonView(PublicView.class)
+        public String city;
+    }
+
+    public static class UserBean {
+        @JsonView(PublicView.class)
+        public final String name;
+
+        // Creator parameter, view-restricted -> exercises the creator-property
+        // branch under the unwrapped code path ([databind#5971]).
+        @JsonView(AdminView.class)
+        public final String secret;
+
+        // Non-creator, view-restricted property -> exercises the regular-property
+        // buffering branch under the unwrapped code path ([databind#5969]).
+        @JsonView(AdminView.class)
+        public String password;
+
+        @JsonView(PublicView.class)
+        @JsonUnwrapped
+        public Address address;
+
+        @JsonCreator
+        public UserBean(@JsonProperty("name") @JsonView(PublicView.class) String name,
+                @JsonProperty("secret") @JsonView(AdminView.class) String secret) {
+            this.name = name;
+            this.secret = secret;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // Negative control: AdminView populates everything.
+    @Test
+    public void testAdminView_negativeControl() throws Exception {
+        UserBean result = MAPPER.readerWithView(AdminView.class)
+                .forType(UserBean.class)
+                .readValue("{\"name\":\"alice\",\"secret\":\"sssh\",\"password\":\"secret\",\"city\":\"NY\"}");
+        assertEquals("alice", result.name);
+        assertEquals("sssh", result.secret);
+        assertEquals("secret", result.password);
+        assertNotNull(result.address);
+        assertEquals("NY", result.address.city);
+    }
+
+    // Formerly failing: under PublicView the @JsonView(AdminView) "password" must
+    // not be populated even though @JsonUnwrapped routes deserialization through
+    // deserializeUsingPropertyBasedWithUnwrapped().
+    @Test
+    public void testRegularPropertyHonorsViewInUnwrappedPath() throws Exception {
+        UserBean result = MAPPER.readerWithView(PublicView.class)
+                .forType(UserBean.class)
+                .readValue("{\"name\":\"alice\",\"password\":\"BYPASS\",\"city\":\"NY\"}");
+
+        assertEquals("alice", result.name);
+        assertNotNull(result.address);
+        assertEquals("NY", result.address.city);
+        assertNull(result.password,
+                "[databind#5969] @JsonView(AdminView) property was populated in PublicView " +
+                "via the unwrapped property-based-creator path. password = " + result.password);
+    }
+
+    // Formerly failing: under PublicView the @JsonView(AdminView) creator parameter
+    // "secret" must not be populated via the creator-property branch of the unwrapped
+    // path ([databind#5971]).
+    @Test
+    public void testCreatorPropertyHonorsViewInUnwrappedPath() throws Exception {
+        UserBean result = MAPPER.readerWithView(PublicView.class)
+                .forType(UserBean.class)
+                .readValue("{\"name\":\"alice\",\"secret\":\"BYPASS\",\"city\":\"NY\"}");
+
+        assertEquals("alice", result.name);
+        assertNotNull(result.address);
+        assertEquals("NY", result.address.city);
+        assertNull(result.secret,
+                "[databind#5971] @JsonView(AdminView) creator parameter was populated in PublicView " +
+                "via the unwrapped property-based-creator path. secret = " + result.secret);
+    }
+}


### PR DESCRIPTION
Extends #5969/#5971 fixes wrt View applying into:

* Builder-based POJOs
* External type id case
