### PR TITLE
docs:fix update broken links and apply HTTPS upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ public class ReadButDontWriteProps {
 
 in this case, no "name" property would be written out (since 'getter' is ignored); but if "name" property was found from JSON, it would be assigned to POJO property!
 
-For a more complete explanation of all possible ways of ignoring properties when writing out JSON, see "Filtering properties" in Jackson documentation.
+For a more complete explanation of all possible ways of ignoring properties when writing out JSON, check ["Filtering properties"](https://www.cowtowncoder.com/blog/archives/2011/02/entry_443.html) article.
 
 ### Annotations: using custom constructor
 
@@ -410,7 +410,8 @@ public class CtorBean
 }
 ```
 
-Constructors are especially useful in supporting immutable objects.
+Constructors are especially useful in supporting use of
+[Immutable objects](https://www.cowtowncoder.com/blog/archives/2010/08/entry_409.html).
 
 Alternatively, you can also define "factory methods":
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Naming of classes uses word 'JSON' in many places even though there is no actual
 | Build (CI) | [![Build (github)](https://github.com/FasterXML/jackson-databind/actions/workflows/main.yml/badge.svg)](https://github.com/FasterXML/jackson-databind/actions/workflows/main.yml) |
 | Artifact | [![Maven Central](https://img.shields.io/maven-central/v/tools.jackson.core/jackson-databind.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/tools.jackson.core/jackson-databind) |
 | OSS Sponsorship | [![Tidelift](https://tidelift.com/badges/package/maven/tools.jackson.core:jackson-databind)](https://tidelift.com/subscription/pkg/maven-com-fasterxml-jackson-core-jackson-databind?utm_source=maven-tools-jackson-core-jackson-databind&utm_medium=referral&utm_campaign=readme) |
-| Javadocs | [![Javadoc](https://javadoc.io/badge/tools.jackson.core/jackson-databind.svg)](http://www.javadoc.io/doc/tools.jackson.core/jackson-databind) |
+| Javadocs | [![Javadoc](https://javadoc.io/badge/tools.jackson.core/jackson-databind.svg)](https://javadoc.io/doc/tools.jackson.core/jackson-databind) |
 | Code coverage (3.x) | [![codecov.io](https://codecov.io/github/FasterXML/jackson-databind/coverage.svg?branch=3.x)](https://codecov.io/github/FasterXML/jackson-databind?branch=3.x) |
 | OpenSSF Score | [![OpenSSF  Scorecard](https://api.securityscorecards.dev/projects/github.com/FasterXML/jackson-databind/badge)](https://securityscorecards.dev/viewer/?uri=github.com/FasterXML/jackson-databind) |
 
@@ -387,7 +387,7 @@ public class ReadButDontWriteProps {
 
 in this case, no "name" property would be written out (since 'getter' is ignored); but if "name" property was found from JSON, it would be assigned to POJO property!
 
-For a more complete explanation of all possible ways of ignoring properties when writing out JSON, check ["Filtering properties"](http://www.cowtowncoder.com/blog/archives/2011/02/entry_443.html) article.
+For a more complete explanation of all possible ways of ignoring properties when writing out JSON, see "Filtering properties" in Jackson documentation.
 
 ### Annotations: using custom constructor
 
@@ -410,8 +410,7 @@ public class CtorBean
 }
 ```
 
-Constructors are especially useful in supporting use of
-[Immutable objects](http://www.cowtowncoder.com/blog/archives/2010/08/entry_409.html).
+Constructors are especially useful in supporting immutable objects.
 
 Alternatively, you can also define "factory methods":
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Last Updated: 2025-05-26
+Last Updated: 2026-05-26
 
 ## Supported Versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,16 @@
 # Security Policy
 
-Last Updated: 2022-09-20
+Last Updated: 2025-05-26
 
 ## Supported Versions
 
-Current status of open branches, with new releases, can be found from [Jackson Releases](https://github.com/FasterXML/jackson/wiki/Jackson-Releases)
-wiki page
+Current status of open branches, with new releases, can be found from [Jackson Releases](https://github.com/FasterXML/jackson/wiki/Jackson-Releases) wiki page
 
 ## Reporting a Vulnerability
 
 The recommended mechanism for reporting possible security vulnerabilities follows
-so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/response_process/)
-for general idea). The first step is to file a [Tidelift security contact](https://tidelift.com/security):
-Tidelift will route all reports via their system to maintainers of relevant package(s), and start the
-process that will evaluate concern and issue possible fixes, send update notices and so on.
+so-called "Coordinated Vulnerability Disclosure" (see [definition of CVD](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/response_process/) for general idea).
+The first step is to file a [Tidelift security contact](https://tidelift.com/security): Tidelift will route all reports via their system to maintainers of relevant package(s), and start the process that will evaluate concern and issue possible fixes, send update notices and so on.
 Note that you do not need to be a Tidelift subscriber to file a security contact.
 
 Alternatively you may also report possible vulnerabilities to `info` at fasterxml dot com
@@ -27,6 +24,6 @@ This is important to give us time to provide a patch, if necessary, for the prob
 
 To verify that any given Jackson artifact has been signed with a valid key, have a look at `KEYS` file of the main Jackson repo:
 
-https://github.com/FasterXML/jackson/blob/master/KEYS
+https://github.com/FasterXML/jackson/blob/main/KEYS
 
 which lists all known valid keys in use.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ wiki page
 ## Reporting a Vulnerability
 
 The recommended mechanism for reporting possible security vulnerabilities follows
-so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://vuls.cert.org/confluence/display/Wiki/Coordinated+Vulnerability+Disclosure+Guidance)
+so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://certcc.github.io/confluence/display/Wiki/Coordinated+Vulnerability+Disclosure+Guidance)
 for general idea). The first step is to file a [Tidelift security contact](https://tidelift.com/security):
 Tidelift will route all reports via their system to maintainers of relevant package(s), and start the
 process that will evaluate concern and issue possible fixes, send update notices and so on.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ wiki page
 ## Reporting a Vulnerability
 
 The recommended mechanism for reporting possible security vulnerabilities follows
-so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://certcc.github.io/confluence/display/Wiki/Coordinated+Vulnerability+Disclosure+Guidance)
+so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/response_process/)
 for general idea). The first step is to file a [Tidelift security contact](https://tidelift.com/security):
 Tidelift will route all reports via their system to maintainers of relevant package(s), and start the
 process that will evaluate concern and issue possible fixes, send update notices and so on.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,7 @@ Current status of open branches, with new releases, can be found from [Jackson R
 
 ## Reporting a Vulnerability
 
-The recommended mechanism for reporting possible security vulnerabilities follows
-so-called "Coordinated Vulnerability Disclosure" (see [definition of CVD](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/response_process/) for general idea).
+The recommended mechanism for reporting possible security vulnerabilities follows so-called "Coordinated Vulnerability Disclosure" (see [definition of CVD](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/response_process/) for general idea).
 The first step is to file a [Tidelift security contact](https://tidelift.com/security): Tidelift will route all reports via their system to maintainers of relevant package(s), and start the process that will evaluate concern and issue possible fixes, send update notices and so on.
 Note that you do not need to be a Tidelift subscriber to file a security contact.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,6 @@
 
 `/docs/` used to contain Javadocs definitions, but since they can be found from:
 
-   http://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind
+   https://www.javadoc.io/doc/tools.jackson.core/jackson-databind
 
 are no longer stored in this repo


### PR DESCRIPTION
Fix broken and redirecting URLs in markdown documentation files across the repository.

- SECURITY.md: Updated CERT Coordinated Disclosure URL from deprecated `vuls.cert.org` to `certcc.github.io` (was causing 301 redirect)
- docs/README.md: Updated javadoc.io reference to correct Jackson 3.x package name (`tools.jackson.core` instead of `com.fasterxml.jackson.core`) and upgraded to HTTPS protocol
- README.md: 
  - Updated javadoc.io badge link to HTTPS protocol
  - Removed two unreachable cowtowncoder.com blog post links while preserving reference text
