### PR TITLE
Follow-up to #5369: apply content `@JsonInclude` in `StringCollectionSerializer.serializeWithType`

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/jdk/IndexedStringListSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/IndexedStringListSerializer.java
@@ -161,9 +161,4 @@ public final class IndexedStringListSerializer
            wrapAndThrow(ctxt, e, value, i);
        }
    }
-
-    protected boolean _needToCheckFiltering(SerializationContext ctxt) {
-        return ((_suppressableValue != null) || _suppressNulls)
-                && ctxt.isEnabled(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS);
-    }
 }

--- a/src/main/java/tools/jackson/databind/ser/jdk/StaticListSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/StaticListSerializerBase.java
@@ -226,6 +226,18 @@ public abstract class StaticListSerializerBase<T extends Collection<?>>
             SerializationContext ctxt, TypeSerializer typeSer) throws JacksonException;
 
     /**
+     * Helper method for checking whether content filtering (from {@code @JsonInclude})
+     * needs to be applied at all: only when a suppression mechanism is configured
+     * <i>and</i> {@link SerializationFeature#APPLY_JSON_INCLUDE_FOR_CONTAINERS} is enabled.
+     *
+     * @since 3.2.1
+     */
+    protected final boolean _needToCheckFiltering(SerializationContext ctxt) {
+        return ((_suppressableValue != null) || _suppressNulls)
+                && ctxt.isEnabled(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS);
+    }
+
+    /**
      * Common utility method for checking if an element should be filtered/suppressed
      * based on @JsonInclude settings. Returns {@code true} if element should be serialized,
      * {@code false} if it should be skipped.

--- a/src/main/java/tools/jackson/databind/ser/jdk/StringCollectionSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/StringCollectionSerializer.java
@@ -114,7 +114,13 @@ public class StringCollectionSerializer
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
                 typeSer.typeId(value, JsonToken.START_ARRAY));
         g.assignCurrentValue(value);
-        serializeContents(value, g, ctxt);
+        if (ctxt.isEnabled(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
+            && ((_suppressableValue != null) || _suppressNulls)
+        ) {
+            serializeFilteredContents(value, g, ctxt);
+        } else {
+            serializeContents(value, g, ctxt);
+        }
         typeSer.writeTypeSuffix(g, ctxt, typeIdDef);
     }
 

--- a/src/main/java/tools/jackson/databind/ser/jdk/StringCollectionSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/StringCollectionSerializer.java
@@ -85,9 +85,7 @@ public class StringCollectionSerializer
             if (((_unwrapSingle == null) &&
                     ctxt.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED))
                     || (_unwrapSingle == Boolean.TRUE)) {
-                if (ctxt.isEnabled(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
-                    && ((_suppressableValue != null) || _suppressNulls)
-                ) {
+                if (_needToCheckFiltering(ctxt)) {
                     serializeFilteredContents(value, g, ctxt);
                 } else {
                     serializeContents(value, g, ctxt);
@@ -96,9 +94,7 @@ public class StringCollectionSerializer
             }
         }
         g.writeStartArray(value, len);
-        if (ctxt.isEnabled(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
-            && ((_suppressableValue != null) || _suppressNulls)
-        ) {
+        if (_needToCheckFiltering(ctxt)) {
             serializeFilteredContents(value, g, ctxt);
         } else {
             serializeContents(value, g, ctxt);
@@ -114,9 +110,7 @@ public class StringCollectionSerializer
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
                 typeSer.typeId(value, JsonToken.START_ARRAY));
         g.assignCurrentValue(value);
-        if (ctxt.isEnabled(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
-            && ((_suppressableValue != null) || _suppressNulls)
-        ) {
+        if (_needToCheckFiltering(ctxt)) {
             serializeFilteredContents(value, g, ctxt);
         } else {
             serializeContents(value, g, ctxt);

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeCollectionTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeCollectionTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.testutil.DatabindTestUtil;
+import tools.jackson.databind.testutil.NoCheckSubTypeValidator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -308,11 +310,34 @@ public class JsonIncludeCollectionTest extends DatabindTestUtil
         }
     }
 
+    // [databind#5370]: content filtering must also apply on the typed (polymorphic)
+    // serialization path of `StringCollectionSerializer`, like the regular path and
+    // sibling `IndexedStringListSerializer` already do.
+    static class TypedStringCollectionNonEmpty {
+        @JsonInclude(content = JsonInclude.Include.NON_EMPTY)
+        public Collection<String> values;
+
+        TypedStringCollectionNonEmpty(Collection<String> v) { values = v; }
+    }
+
+    static class TypedStringCollectionNonNull {
+        @JsonInclude(content = JsonInclude.Include.NON_NULL)
+        public Collection<String> values;
+
+        TypedStringCollectionNonNull(Collection<String> v) { values = v; }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // [databind#5369]
     private final ObjectMapper MAPPER_CONTAINERS = jsonMapperBuilder()
             .enable(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
+            .build();
+
+    // [databind#5370]: default typing forces `serializeWithType` on the String collection
+    private final ObjectMapper MAPPER_CONTAINERS_TYPED = jsonMapperBuilder()
+            .enable(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
+            .activateDefaultTyping(NoCheckSubTypeValidator.instance, DefaultTyping.NON_FINAL)
             .build();
 
     /*
@@ -490,5 +515,26 @@ public class JsonIncludeCollectionTest extends DatabindTestUtil
 
         assertEquals(a2q("{'values':[{'k':'v'},['x']]}"),
                 MAPPER_CONTAINERS.writeValueAsString(pojo));
+    }
+
+    // [databind#5370]: NON_EMPTY content filtering applied on typed (polymorphic) path,
+    // not just the regular `serialize()` path
+    @Test
+    public void testTypedStringCollectionNonEmpty() throws Exception
+    {
+        Collection<String> set = new LinkedHashSet<>(Arrays.asList("1", "", "2"));
+        assertEquals(a2q("['tools.jackson.databind.ser.filter.JsonIncludeCollectionTest$TypedStringCollectionNonEmpty',"
+                        + "{'values':['java.util.LinkedHashSet',['1','2']]}]"),
+                MAPPER_CONTAINERS_TYPED.writeValueAsString(new TypedStringCollectionNonEmpty(set)));
+    }
+
+    // [databind#5370]: NON_NULL content filtering applied on typed (polymorphic) path
+    @Test
+    public void testTypedStringCollectionNonNull() throws Exception
+    {
+        Collection<String> set = new LinkedHashSet<>(Arrays.asList("1", null, "2"));
+        assertEquals(a2q("['tools.jackson.databind.ser.filter.JsonIncludeCollectionTest$TypedStringCollectionNonNull',"
+                        + "{'values':['java.util.LinkedHashSet',['1','2']]}]"),
+                MAPPER_CONTAINERS_TYPED.writeValueAsString(new TypedStringCollectionNonNull(set)));
     }
 }


### PR DESCRIPTION
Follow-up to #5369 (pr #5370).

`StringCollectionSerializer.serializeWithType` called `serializeContents` directly, so `@JsonInclude(content=...)` was ignored on the polymorphic path even with `APPLY_JSON_INCLUDE_FOR_CONTAINERS` enabled. The regular `serialize()` path and the sibling `IndexedStringListSerializer.serializeWithType` already gate on the feature; this brings `serializeWithType` in line.

Before fix, a `Collection<String>` with `@JsonInclude(content=NON_EMPTY)` serialized with type information kept empty elements (`["1","","2"]`); after, they are filtered (`["1","2"]`). Same for `NON_NULL` and null elements.

Testing: `JsonIncludeCollectionTest#testTypedStringCollectionNonEmpty` and `#testTypedStringCollectionNonNull` (fail before fix, pass after).
