### PR TITLE
Backport PR #5964 into 2.18 to fix #5962

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1910,4 +1910,7 @@ Omkhar Arasaratnam (@omkhar)
    should validate element type
   (2.18.8)
  * Reported #5988: `PolymorphicTypeValidator` needs to validate generic type parameters too
- (2.18.8)
+  (2.18.8)
+ * Contributed fix for #5962: Case-insensitive deserialization may use
+   wrong `@JsonIgnoreProperties`
+  (2.18.9)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,12 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.18.9 (not yet released)
+
+#5962: Case-insensitive deserialization may use wrong `@JsonIgnoreProperties`
+ [CVE-2026-54515]
+ (fixed by Omkhar A)
+
 2.18.8 (28-May-2026)
 
 #5950: Improve `UUIDDeserializer` error handling

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerBase.java
@@ -894,7 +894,10 @@ ClassUtil.nameOf(handledType()), ClassUtil.name(propName)));
             // 16-May-2016, tatu: How about per-property case-insensitivity?
             Boolean B = format.getFeature(JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
             if (B != null) {
-                BeanPropertyMap propsOrig = _beanProperties;
+                // [databind#5962]: must rebuild from the (possibly filtered) contextual
+                // BeanPropertyMap so that per-property @JsonIgnoreProperties exclusions
+                // applied by _handleByNameInclusion() above are preserved.
+                BeanPropertyMap propsOrig = contextual._beanProperties;
                 BeanPropertyMap props = propsOrig.withCaseInsensitivity(B.booleanValue());
                 if (props != propsOrig) {
                     contextual = contextual.withBeanProperties(props);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertiesCaseInsensitive5962Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertiesCaseInsensitive5962Test.java
@@ -1,0 +1,92 @@
+package com.fasterxml.jackson.databind.deser.filter;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * [databind#5962]: Case-insensitive BeanPropertyMap rebuild undoes per-property
+ * {@code @JsonIgnoreProperties}.
+ *
+ * {@code BeanDeserializerBase.createContextual()} calls {@code _handleByNameInclusion()}
+ * to filter properties according to per-property {@code @JsonIgnoreProperties}, producing
+ * a contextual deserializer with the restricted {@code BeanPropertyMap}. However, the
+ * subsequent case-insensitivity block read {@code _beanProperties} (the *original*
+ * unfiltered map from {@code this}) rather than {@code contextual._beanProperties} (the
+ * filtered map). {@code withCaseInsensitivity()} then rebuilt the map from the unfiltered
+ * source, and {@code contextual.withBeanProperties(props)} overwrote the filtered map with
+ * the unfiltered one — any properties removed by {@code _handleByNameInclusion} were
+ * restored.
+ *
+ * Patch: source the case-insensitive rebuild from {@code contextual._beanProperties}.
+ */
+public class IgnorePropertiesCaseInsensitive5962Test extends DatabindTestUtil
+{
+    static class AdminDto {
+        public String adminKey = "DEFAULT";
+        public String username;
+    }
+
+    // Container that ignores "adminKey" on the AdminDto field AND enables case-insensitive matching
+    static class Container {
+        @JsonIgnoreProperties("adminKey")
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+        public AdminDto admin;
+    }
+
+    // Baseline container: only @JsonIgnoreProperties, no case-insensitive format override
+    static class BaselineContainer {
+        @JsonIgnoreProperties("adminKey")
+        public AdminDto admin;
+    }
+
+    /**
+     * NEGATIVE CONTROL: without the @JsonFormat case-insensitive override, @JsonIgnoreProperties
+     * correctly suppresses adminKey on the nested AdminDto field.
+     */
+    @Test
+    public void test5962_negativeControl_withoutCaseInsensitivity() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder().build();
+        String json = "{\"admin\":{\"adminKey\":\"HACKED\",\"username\":\"alice\"}}";
+        BaselineContainer result = mapper.readValue(json, BaselineContainer.class);
+        // Without case-insensitive format, @JsonIgnoreProperties blocks adminKey
+        assertNotEquals("HACKED", result.admin.adminKey,
+                "@JsonIgnoreProperties alone (no case-insensitive format) should block adminKey");
+        assertEquals("alice", result.admin.username);
+    }
+
+    /**
+     * EXPLOIT PATH: the case-insensitive BeanPropertyMap rebuild (triggered by
+     * @JsonFormat ACCEPT_CASE_INSENSITIVE_PROPERTIES) restores the unfiltered original
+     * _beanProperties, undoing the @JsonIgnoreProperties("adminKey") exclusion.
+     * Case-insensitive matching then routes "adminKey" (or "ADMINKEY") to the setter.
+     *
+     * Security assertion: adminKey must NOT be settable via JSON when the enclosing
+     * container declares @JsonIgnoreProperties("adminKey") on the field.
+     */
+    @Test
+    public void test5962_caseInsensitiveRebuildRestoresIgnoredProperty() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder().build();
+
+        // Exact case — should be blocked by @JsonIgnoreProperties
+        String json = "{\"admin\":{\"adminKey\":\"HACKED\",\"username\":\"alice\"}}";
+        Container result = mapper.readValue(json, Container.class);
+        assertNotEquals("HACKED", result.admin.adminKey,
+                "[databind#5962]: case-insensitive BeanPropertyMap rebuild restored 'adminKey' " +
+                        "after it was removed by @JsonIgnoreProperties. The property was set to 'HACKED'.");
+        assertEquals("alice", result.admin.username);
+
+        // Mixed case — exploits the case-insensitive rebuild more directly
+        String jsonMixed = "{\"admin\":{\"AdminKey\":\"HACKED2\",\"username\":\"bob\"}}";
+        Container result2 = mapper.readValue(jsonMixed, Container.class);
+        assertNotEquals("HACKED2", result2.admin.adminKey,
+                "[databind#5962]: 'AdminKey' (mixed case) matched 'adminKey' via case-insensitive " +
+                        "lookup that was rebuilt from the unfiltered property map.");
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertiesCaseInsensitive5962Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/filter/IgnorePropertiesCaseInsensitive5962Test.java
@@ -72,7 +72,9 @@ public class IgnorePropertiesCaseInsensitive5962Test extends DatabindTestUtil
      */
     @Test
     public void test5962_caseInsensitiveRebuildRestoresIgnoredProperty() throws Exception {
-        ObjectMapper mapper = jsonMapperBuilder().build();
+        ObjectMapper mapper = jsonMapperBuilder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
 
         // Exact case — should be blocked by @JsonIgnoreProperties
         String json = "{\"admin\":{\"adminKey\":\"HACKED\",\"username\":\"alice\"}}";


### PR DESCRIPTION
backports test from 3.x branch.
#5964 #5962

One of the tests is broken:

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.014 s <<< FAILURE! -- in com.fasterxml.jackson.databind.deser.filter.IgnorePropertiesCaseInsensitive5962Test
[ERROR] com.fasterxml.jackson.databind.deser.filter.IgnorePropertiesCaseInsensitive5962Test.test5962_caseInsensitiveRebuildRestoresIgnoredProperty -- Time elapsed: 0.007 s <<< FAILURE!
org.opentest4j.AssertionFailedError: [databind#5962]: case-insensitive BeanPropertyMap rebuild restored 'adminKey' after it was removed by @JsonIgnoreProperties. The property was set to 'HACKED'. ==> expected: not equal but was: <HACKED>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertNotEquals.failEqual(AssertNotEquals.java:277)
	at org.junit.jupiter.api.AssertNotEquals.assertNotEquals(AssertNotEquals.java:263)
	at org.junit.jupiter.api.Assertions.assertNotEquals(Assertions.java:2832)
	at com.fasterxml.jackson.databind.deser.filter.IgnorePropertiesCaseInsensitive5962Test.test5962_caseInsensitiveRebuildRestoresIgnoredProperty(IgnorePropertiesCaseInsensitive5962Test.java:80)
```

I applied the fix from #5964 but it didn't fix the issue in the 2.18 code base.
The test fails in a different way with the 3.1 fix.
```
[ERROR] Errors: 
[ERROR]   IgnorePropertiesCaseInsensitive5962Test.test5962_caseInsensitiveRebuildRestoresIgnoredProperty:87 » UnrecognizedProperty Unrecognized field "AdminKey" (class com.fasterxml.jackson.databind.deser.filter.IgnorePropertiesCaseInsensitive5962Test$AdminDto), not marked as ignorable (one known property: "username"])
 at [Source: (String)"{"admin":{"AdminKey":"HACKED2","username":"bob"}}"; line: 1, column: 23] (through reference chain: com.fasterxml.jackson.databind.deser.filter.IgnorePropertiesCaseInsensitive5962Test$Container["admin"]->com.fasterxml.jackson.databind.deser.filter.IgnorePropertiesCaseInsensitive5962Test$AdminDto["AdminKey"])
```
