### PR TITLE
Fix #6043: honor FAIL_ON_UNKNOWN_PROPERTIES for creator-based POJOs-as-Array

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -579,3 +579,13 @@ Yusuke Nojima (@ynojima)
  * Reported #6031: Getter annotated with `@JsonIgnore` prevents `@JsonAlias`
    from working on `@JsonCreator` parameter (regression in 3.2.0)
   [3.2.1]
+
+Théo Szanto (@indyteo)
+ * Reported #6043: `FAIL_ON_UNKNOWN_PROPERTIES` has no effect with `JsonFormat.Shape.ARRAY`
+   when using creator-based instantiation (such as `record`)
+  [3.2.1]
+
+@seonwooj0810
+ * Fixed #6043: `FAIL_ON_UNKNOWN_PROPERTIES` has no effect with `JsonFormat.Shape.ARRAY`
+   when using creator-based instantiation (such as `record`)
+  [3.2.1]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -21,6 +21,10 @@ No changes since 3.2
   on `@JsonCreator` parameter (regression in 3.2.0)
  (reported by @ynojima)
  (fix by @cowtowncoder, w/ Claude code)
+#6043: `FAIL_ON_UNKNOWN_PROPERTIES` has no effect with `JsonFormat.Shape.ARRAY` when
+  using creator-based instantiation (such as `record`)
+ (reported by Théo S)
+ (fix by @seonwooj0810)
 
 3.2.0 (08-Jun-2026)
 

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayDeserializer.java
@@ -390,6 +390,14 @@ public class BeanAsArrayDeserializer
         for (; p.nextToken() != JsonToken.END_ARRAY; ++i) {
             SettableBeanProperty prop = (i < propCount) ? props[i] : null;
             if (prop == null) { // we get null if there are extra elements; maybe otherwise too?
+                // [databind#6043]: extra JSON Array elements past property count must
+                // honor FAIL_ON_UNKNOWN_PROPERTIES, same as the non-creator path above
+                if (!_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
+                    ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
+                            "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                            propCount);
+                    // never gets here
+                }
                 p.skipChildren();
                 continue;
             }

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayDeserializer.java
@@ -391,8 +391,12 @@ public class BeanAsArrayDeserializer
             SettableBeanProperty prop = (i < propCount) ? props[i] : null;
             if (prop == null) { // we get null if there are extra elements; maybe otherwise too?
                 // [databind#6043]: extra JSON Array elements past property count must
-                // honor FAIL_ON_UNKNOWN_PROPERTIES, same as the non-creator path above
-                if (!_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
+                // honor FAIL_ON_UNKNOWN_PROPERTIES, same as the non-creator path above.
+                // Only genuinely-extra elements (past property count) count as "unknown":
+                // in-bounds null slots (e.g. from renamed/unwrapped properties) are skipped,
+                // matching the non-creator path's position-based check.
+                if (i >= propCount
+                        && !_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
                     ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
                             "Unexpected JSON values; expected at most %d properties (in JSON Array)",
                             propCount);

--- a/src/test/java/tools/jackson/databind/struct/POJOAsArrayTest.java
+++ b/src/test/java/tools/jackson/databind/struct/POJOAsArrayTest.java
@@ -256,6 +256,10 @@ public class POJOAsArrayTest extends DatabindTestUtil
         public int getY() { return y; }
     }
 
+    // [databind#6043]
+    @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+    record XYZParams(int x, int y, int z) { }
+
     @JsonFormat(shape=JsonFormat.Shape.ARRAY)
     @JsonPropertyOrder({"a","b","x","y"})
     static class CreatorAsArrayShuffled
@@ -967,5 +971,30 @@ public class POJOAsArrayTest extends DatabindTestUtil
         // note: +1 for both so
         assertEquals(v._x, 2);
         assertEquals(v._y, 3);
+    }
+
+    // [databind#6043]: creator-based (e.g. record) POJOs-as-Array must also honor
+    // FAIL_ON_UNKNOWN_PROPERTIES when the JSON Array has more elements than properties
+    @Test
+    public void testCreatorUnknownExtraProp() throws Exception
+    {
+        String json = "[1, 2, 3, 4]";
+        try {
+            MAPPER.readerFor(XYZParams.class)
+                    .with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                    .readValue(json);
+            fail("should not pass with extra element");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Unexpected JSON values");
+        }
+
+        // but actually fine if skip-unknown set
+        XYZParams v = MAPPER.readerFor(XYZParams.class)
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .readValue(json);
+        assertNotNull(v);
+        assertEquals(1, v.x());
+        assertEquals(2, v.y());
+        assertEquals(3, v.z());
     }
 }


### PR DESCRIPTION
Fixes #6043

## Root cause
For POJOs serialized as JSON Arrays (`@JsonFormat(shape = ARRAY)`), the creator-based deserialization path `BeanAsArrayDeserializer._deserializeUsingPropertyBased` loops over array elements and, once it runs past the property count, hits the `prop == null` branch where it simply `skipChildren()` and continues. Unlike the non-creator paths (`deserialize`/`_deserializeNonVanilla`), it never consults `FAIL_ON_UNKNOWN_PROPERTIES`. As a result, extra array elements are silently ignored for creator-based types such as `record`s, even when the feature is enabled.

## Change
Add the same `FAIL_ON_UNKNOWN_PROPERTIES` guard already used on the non-creator paths to the `prop == null` (extra-element) branch of the creator path, reporting `reportWrongTokenException` with the existing "Unexpected JSON values; expected at most N properties" message. Behavior is unchanged when the feature is disabled or `@JsonIgnoreProperties(ignoreUnknown = true)` applies.

## Test evidence
Added `POJOAsArrayTest.testCreatorUnknownExtraProp` using the issue's reproduction (a `record XYZParams(int x, int y, int z)` annotated `@JsonFormat(shape = ARRAY)` reading `[1, 2, 3, 4]`). It fails before the fix (no exception thrown — "should not pass with extra element") and passes after, and also asserts the value still deserializes correctly when the feature is disabled. Full `POJOAsArrayTest` (27 tests) passes.

Verification done: ran `./mvnw test -Dtest=POJOAsArrayTest` (27/27 pass with fix); reverted the source change and confirmed the new test fails (assertion "should not pass with extra element"), then restored.