### PR TITLE
Apply content converters for String collection values (`StringCollectionDeserializer`)

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -224,6 +224,8 @@ Lee Jiwon (@dlwldnjs1009)
   [3.1.3]
  * Fixed #5931: Fix `AtomicLongDeserializer` value truncation on coerced values
   [3.1.3]
+ * Fixed #6048: Apply content converters for String collection values (`StringCollectionDeserializer`)
+  [3.1.5]
 
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -14,6 +14,8 @@ No changes since 3.1
 #6040: Inconsistency in current token on invalid type coercion for `List<String>`
  (reported by João G)
  (fix by @cowtowncoder, w/ Claude code)
+#6048: Apply content converters for String collection values (`StringCollectionDeserializer`)
+ (fixed by Lee Jiwon)
 
 3.1.4 (29-May-2026)
 

--- a/src/main/java/tools/jackson/databind/deser/jdk/StringCollectionDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/StringCollectionDeserializer.java
@@ -149,13 +149,11 @@ public final class StringCollectionDeserializer
         }
         ValueDeserializer<?> valueDeser = _valueDeserializer;
         final JavaType valueType = _containerType.getContentType();
+        // [databind#125]: May have a content converter
+        valueDeser = findConvertingContentDeserializer(ctxt, property, valueDeser);
         if (valueDeser == null) {
-            // [databind#125]: May have a content converter
-            valueDeser = findConvertingContentDeserializer(ctxt, property, valueDeser);
-            if (valueDeser == null) {
             // And we may also need to get deserializer for String
-                valueDeser = ctxt.findContextualValueDeserializer(valueType, property);
-            }
+            valueDeser = ctxt.findContextualValueDeserializer(valueType, property);
         } else { // if directly assigned, probably not yet contextual, so:
             valueDeser = ctxt.handleSecondaryContextualization(valueDeser, property, valueType);
         }

--- a/src/test/java/tools/jackson/databind/convert/ConvertingDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/convert/ConvertingDeserializerTest.java
@@ -138,6 +138,8 @@ public class ConvertingDeserializerTest
         public String[] texts;
     }
 
+    // [databind#6048]
+
     static class UpperCasingStringDeserializer extends StdScalarDeserializer<String>
     {
         public UpperCasingStringDeserializer() {
@@ -148,6 +150,11 @@ public class ConvertingDeserializerTest
         public String deserialize(JsonParser p, DeserializationContext ctxt) {
             return p.getValueAsString().toUpperCase() + "!";
         }
+    }
+
+    static class LowerCaseTextList {
+        @JsonDeserialize(contentConverter=LowerCaser.class)
+        public List<String> texts;
     }
 
     static class LowerCaseTextListWithDeserializer {
@@ -229,6 +236,18 @@ public class ConvertingDeserializerTest
         assertEquals("abc", texts.texts[0]);
     }
 
+    // [databind#6048]
+    @Test
+    public void testPropertyAnnotationStringListLC() throws Exception
+    {
+        LowerCaseTextList texts = MAPPER.readerFor(LowerCaseTextList.class)
+                .readValue("{\"texts\":[\"ABC\"]}");
+        assertNotNull(texts);
+        assertNotNull(texts.texts);
+        assertEquals(Collections.singletonList("abc"), texts.texts);
+    }
+
+    // [databind#6048]
     @Test
     public void testPropertyAnnotationStringListWithDeserializerLC() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/convert/ConvertingDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/convert/ConvertingDeserializerTest.java
@@ -6,8 +6,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.deser.std.StdScalarDeserializer;
 import tools.jackson.databind.util.StdConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -135,6 +138,24 @@ public class ConvertingDeserializerTest
         public String[] texts;
     }
 
+    static class UpperCasingStringDeserializer extends StdScalarDeserializer<String>
+    {
+        public UpperCasingStringDeserializer() {
+            super(String.class);
+        }
+
+        @Override
+        public String deserialize(JsonParser p, DeserializationContext ctxt) {
+            return p.getValueAsString().toUpperCase() + "!";
+        }
+    }
+
+    static class LowerCaseTextListWithDeserializer {
+        @JsonDeserialize(contentUsing=UpperCasingStringDeserializer.class,
+                contentConverter=LowerCaser.class)
+        public List<String> texts;
+    }
+
     // for [databind#795]
 
     static class ToNumberConverter extends StdConverter<String,Number>
@@ -206,6 +227,16 @@ public class ConvertingDeserializerTest
         assertNotNull(texts.texts);
         assertEquals(1, texts.texts.length);
         assertEquals("abc", texts.texts[0]);
+    }
+
+    @Test
+    public void testPropertyAnnotationStringListWithDeserializerLC() throws Exception
+    {
+        LowerCaseTextListWithDeserializer texts = MAPPER.readerFor(LowerCaseTextListWithDeserializer.class)
+                .readValue("{\"texts\":[\"abc\"]}");
+        assertNotNull(texts);
+        assertNotNull(texts.texts);
+        assertEquals(Collections.singletonList("abc!"), texts.texts);
     }
 
     @Test


### PR DESCRIPTION
`StringCollectionDeserializer` skipped `@JsonDeserialize(contentConverter=...)`
when a `Collection<String>` property also specified `contentUsing`, because
the converter lookup only ran when no content deserializer had been resolved.

Changes:
- Move content-converter lookup before the resolved-deserializer branch.
- Add regression coverage for `contentUsing` + `contentConverter` on `List<String>`.

Testing:
- `./mvnw -Dtest=ConvertingDeserializerTest#testPropertyAnnotationStringListWithDeserializerLC test`
- `./mvnw -Dtest=ConvertingDeserializerTest test`