### PR TITLE
Honor `@JsonView` for external-type-id (`EXTERNAL_PROPERTY`) properties [GHSA-mhm7-754m-9p8w]

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -9,6 +9,9 @@ Project: jackson-databind
 #5962: Case-insensitive deserialization may use wrong `@JsonIgnoreProperties`
  [CVE-2026-54515]
  (fixed by Omkhar A)
+#6054: Honor `@JsonView` for external-type-id (`EXTERNAL_PROPERTY`)
+  properties [GHSA-mhm7-754m-9p8w]
+ (reported by @Sharlong-Wen)
 #6060: `@JsonView` by-passed for `@JsonUnwrapped` Field/Setter properties
 
 2.18.8 (28-May-2026)

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -275,58 +275,68 @@ public class ExternalTypeHandler
         final Class<?> activeView = ctxt.getActiveView();
         for (int i = 0; i < len; ++i) {
             final ExtTypedProperty extProp = _properties[i];
-            // 26-Jun-2026, tatu: Must honor `@JsonView` for external-type-id
-            //   properties too (see JsonViewExternalTypeIdBypassTest): leave value
-            //   for property not visible in active view unbound (null), so it does
-            //   not bypass view-based filtering.
-            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
-                continue;
-            }
-            String typeId = _typeIds[i];
-            if (typeId == null) {
-                // let's allow missing both type and property (may already have been set, too)
-                TokenBuffer tb = _tokens[i];
-                if ((tb == null)
-                        // 19-Feb-2021, tatu: Both missing value and explicit `null`
-                        //    should be accepted...
-                        || (tb.firstToken() == JsonToken.VALUE_NULL)
-                    ) {
-                    continue;
-                }
-                // but not just one
-                // 26-Oct-2012, tatu: As per [databind#94], must allow use of 'defaultImpl'
-                if (!extProp.hasDefaultType()) {
-                    ctxt.reportPropertyInputMismatch(_beanType, extProp.getProperty().getName(),
-                            "Missing external type id property '%s'",
-                            extProp.getTypePropertyName());
-                } else {
-                    typeId = extProp.getDefaultTypeId();
-                }
-            }
-
-            if (_tokens[i] != null) {
-                values[i] = _deserialize(p, ctxt, i, typeId);
-            } else {
-                if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)) {
-                    SettableBeanProperty prop = extProp.getProperty();
-                    ctxt.reportPropertyInputMismatch(_beanType, prop.getName(),
-                            "Missing property '%s' for external type id '%s'",
-                            prop.getName(), _properties[i].getTypePropertyName());
-                }
-                // 03-Aug-2022, tatu: [databind#3533] to handle absent value matching
-                //    present type id
-                values[i] = _deserializeMissingToken(p, ctxt, i, typeId);
-            }
-
             final SettableBeanProperty prop = extProp.getProperty();
+            String typeId = _typeIds[i];
+
+            // 26-Jun-2026, tatu: Must honor `@JsonView` for external-type-id
+            //   properties too (see JsonViewExternalTypeIdBypassTest): leave the
+            //   value of a property not visible in the active view unbound (null),
+            //   so it does not bypass view-based filtering. NOTE: the external type
+            //   id itself may be a separate, still-visible creator property, so that
+            //   is still assigned below ([databind#999]).
+            final boolean viewHidden = (activeView != null) && !prop.visibleInView(activeView);
+
+            if (!viewHidden) {
+                if (typeId == null) {
+                    // let's allow missing both type and property (may already have been set, too)
+                    TokenBuffer tb = _tokens[i];
+                    if ((tb == null)
+                            // 19-Feb-2021, tatu: Both missing value and explicit `null`
+                            //    should be accepted...
+                            || (tb.firstToken() == JsonToken.VALUE_NULL)
+                        ) {
+                        continue;
+                    }
+                    // but not just one
+                    // 26-Oct-2012, tatu: As per [databind#94], must allow use of 'defaultImpl'
+                    if (!extProp.hasDefaultType()) {
+                        ctxt.reportPropertyInputMismatch(_beanType, prop.getName(),
+                                "Missing external type id property '%s'",
+                                extProp.getTypePropertyName());
+                    } else {
+                        typeId = extProp.getDefaultTypeId();
+                    }
+                }
+
+                if (_tokens[i] != null) {
+                    values[i] = _deserialize(p, ctxt, i, typeId);
+                } else {
+                    if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)) {
+                        ctxt.reportPropertyInputMismatch(_beanType, prop.getName(),
+                                "Missing property '%s' for external type id '%s'",
+                                prop.getName(), extProp.getTypePropertyName());
+                    }
+                    // 03-Aug-2022, tatu: [databind#3533] to handle absent value matching
+                    //    present type id
+                    values[i] = _deserializeMissingToken(p, ctxt, i, typeId);
+                }
+            }
+
             // also: if it's creator prop, fill in
             if (prop.getCreatorIndex() >= 0) {
-                buffer.assignParameter(prop, values[i]);
+                // ...but skip binding the value itself if hidden by the active view
+                if (!viewHidden) {
+                    buffer.assignParameter(prop, values[i]);
+                }
 
                 // [databind#999] And maybe there's creator property for type id too?
+                //   Assign it even when the value is view-hidden, provided we have a
+                //   type id and the type-id property is itself visible in the view.
                 SettableBeanProperty typeProp = extProp.getTypeProperty();
                 // for now, should only be needed for creator properties, too
-                if ((typeProp != null) && (typeProp.getCreatorIndex() >= 0)) {
+                if ((typeProp != null) && (typeProp.getCreatorIndex() >= 0)
+                        && (typeId != null)
+                        && ((activeView == null) || typeProp.visibleInView(activeView))) {
                     // 31-May-2018, tatu: [databind#1328] if id is NOT plain `String`, need to
                     //    apply deserializer... fun fun.
                     final Object v;
@@ -400,6 +410,18 @@ public class ExternalTypeHandler
     protected final void _deserializeAndSet(JsonParser p, DeserializationContext ctxt,
             Object bean, int index, String typeId) throws IOException
     {
+        // 26-Jun-2026, tatu: Must honor `@JsonView` here too (see
+        //   JsonViewExternalTypeIdBypassTest): for default-constructor beans the value
+        //   may be bound eagerly via this method (when the type id precedes the value),
+        //   so a property not visible in the active view must be skipped here as well.
+        //   The value is read from the buffered token (`_tokens[index]`), and the main
+        //   parser has already advanced past it, so we simply discard it (do not set).
+        final Class<?> activeView = ctxt.getActiveView();
+        final SettableBeanProperty valueProp = _properties[index].getProperty();
+        if ((activeView != null) && !valueProp.visibleInView(activeView)) {
+            return;
+        }
+
         // 11-Nov-2020, tatu: Should never get `null` passed this far,
         if (typeId == null) {
             ctxt.reportInputMismatch(_beanType, "Internal error in external Type Id handling: `null` type id passed");

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -201,9 +201,17 @@ public class ExternalTypeHandler
     public Object complete(JsonParser p, DeserializationContext ctxt, Object bean)
         throws IOException
     {
+        final Class<?> activeView = ctxt.getActiveView();
         for (int i = 0, len = _properties.length; i < len; ++i) {
-            String typeId = _typeIds[i];
             final ExtTypedProperty extProp = _properties[i];
+            // 26-Jun-2026, tatu: Must honor `@JsonView` for external-type-id
+            //   properties too (see JsonViewExternalTypeIdBypassTest); otherwise
+            //   value for property not visible in active view would still get bound,
+            //   bypassing view-based filtering.
+            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
+                continue;
+            }
+            String typeId = _typeIds[i];
             if (typeId == null) {
                 TokenBuffer tokens = _tokens[i];
                 // let's allow missing both type and property (may already have been set, too)
@@ -264,9 +272,17 @@ public class ExternalTypeHandler
         // first things first: deserialize all data buffered:
         final int len = _properties.length;
         Object[] values = new Object[len];
+        final Class<?> activeView = ctxt.getActiveView();
         for (int i = 0; i < len; ++i) {
-            String typeId = _typeIds[i];
             final ExtTypedProperty extProp = _properties[i];
+            // 26-Jun-2026, tatu: Must honor `@JsonView` for external-type-id
+            //   properties too (see JsonViewExternalTypeIdBypassTest): leave value
+            //   for property not visible in active view unbound (null), so it does
+            //   not bypass view-based filtering.
+            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
+                continue;
+            }
+            String typeId = _typeIds[i];
             if (typeId == null) {
                 // let's allow missing both type and property (may already have been set, too)
                 TokenBuffer tb = _tokens[i];
@@ -329,7 +345,12 @@ public class ExternalTypeHandler
         Object bean = creator.build(ctxt, buffer);
         // third: assign non-creator properties
         for (int i = 0; i < len; ++i) {
-            SettableBeanProperty prop = _properties[i].getProperty();
+            final ExtTypedProperty extProp = _properties[i];
+            // 26-Jun-2026, tatu: also honor `@JsonView` here (see above)
+            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
+                continue;
+            }
+            SettableBeanProperty prop = extProp.getProperty();
             if (prop.getCreatorIndex() < 0) {
                 prop.set(bean, values[i]);
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -417,8 +417,7 @@ public class ExternalTypeHandler
         //   The value is read from the buffered token (`_tokens[index]`), and the main
         //   parser has already advanced past it, so we simply discard it (do not set).
         final Class<?> activeView = ctxt.getActiveView();
-        final SettableBeanProperty valueProp = _properties[index].getProperty();
-        if ((activeView != null) && !valueProp.visibleInView(activeView)) {
+        if ((activeView != null) && !_properties[index].getProperty().visibleInView(activeView)) {
             return;
         }
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -357,10 +357,10 @@ public class ExternalTypeHandler
         for (int i = 0; i < len; ++i) {
             final ExtTypedProperty extProp = _properties[i];
             // 26-Jun-2026, tatu: also honor `@JsonView` here (see above)
-            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
+            final SettableBeanProperty prop = extProp.getProperty();
+            if ((activeView != null) && !prop.visibleInView(activeView)) {
                 continue;
             }
-            SettableBeanProperty prop = extProp.getProperty();
             if (prop.getCreatorIndex() < 0) {
                 prop.set(bean, values[i]);
             }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/impl/ExternalTypeHandler.java
@@ -201,9 +201,17 @@ public class ExternalTypeHandler
     public Object complete(JsonParser p, DeserializationContext ctxt, Object bean)
         throws IOException
     {
+        final Class<?> activeView = ctxt.getActiveView();
         for (int i = 0, len = _properties.length; i < len; ++i) {
-            String typeId = _typeIds[i];
             final ExtTypedProperty extProp = _properties[i];
+            // 26-Jun-2026, tatu: Must honor `@JsonView` for external-type-id
+            //   properties too (see JsonViewExternalTypeIdBypassTest); otherwise
+            //   value for property not visible in active view would still get bound,
+            //   bypassing view-based filtering.
+            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
+                continue;
+            }
+            String typeId = _typeIds[i];
             if (typeId == null) {
                 TokenBuffer tokens = _tokens[i];
                 // let's allow missing both type and property (may already have been set, too)
@@ -264,53 +272,71 @@ public class ExternalTypeHandler
         // first things first: deserialize all data buffered:
         final int len = _properties.length;
         Object[] values = new Object[len];
+        final Class<?> activeView = ctxt.getActiveView();
         for (int i = 0; i < len; ++i) {
-            String typeId = _typeIds[i];
             final ExtTypedProperty extProp = _properties[i];
-            if (typeId == null) {
-                // let's allow missing both type and property (may already have been set, too)
-                TokenBuffer tb = _tokens[i];
-                if ((tb == null)
-                        // 19-Feb-2021, tatu: Both missing value and explicit `null`
-                        //    should be accepted...
-                        || (tb.firstToken() == JsonToken.VALUE_NULL)
-                    ) {
-                    continue;
-                }
-                // but not just one
-                // 26-Oct-2012, tatu: As per [databind#94], must allow use of 'defaultImpl'
-                if (!extProp.hasDefaultType()) {
-                    ctxt.reportPropertyInputMismatch(_beanType, extProp.getProperty().getName(),
-                            "Missing external type id property '%s'",
-                            extProp.getTypePropertyName());
-                } else {
-                    typeId = extProp.getDefaultTypeId();
-                }
-            }
-
-            if (_tokens[i] != null) {
-                values[i] = _deserialize(p, ctxt, i, typeId);
-            } else {
-                if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)) {
-                    SettableBeanProperty prop = extProp.getProperty();
-                    ctxt.reportPropertyInputMismatch(_beanType, prop.getName(),
-                            "Missing property '%s' for external type id '%s'",
-                            prop.getName(), _properties[i].getTypePropertyName());
-                }
-                // 03-Aug-2022, tatu: [databind#3533] to handle absent value matching
-                //    present type id
-                values[i] = _deserializeMissingToken(p, ctxt, i, typeId);
-            }
-
             final SettableBeanProperty prop = extProp.getProperty();
+            String typeId = _typeIds[i];
+
+            // 26-Jun-2026, tatu: Must honor `@JsonView` for external-type-id
+            //   properties too (see JsonViewExternalTypeIdBypassTest): leave the
+            //   value of a property not visible in the active view unbound (null),
+            //   so it does not bypass view-based filtering. NOTE: the external type
+            //   id itself may be a separate, still-visible creator property, so that
+            //   is still assigned below ([databind#999]).
+            final boolean viewHidden = (activeView != null) && !prop.visibleInView(activeView);
+
+            if (!viewHidden) {
+                if (typeId == null) {
+                    // let's allow missing both type and property (may already have been set, too)
+                    TokenBuffer tb = _tokens[i];
+                    if ((tb == null)
+                            // 19-Feb-2021, tatu: Both missing value and explicit `null`
+                            //    should be accepted...
+                            || (tb.firstToken() == JsonToken.VALUE_NULL)
+                        ) {
+                        continue;
+                    }
+                    // but not just one
+                    // 26-Oct-2012, tatu: As per [databind#94], must allow use of 'defaultImpl'
+                    if (!extProp.hasDefaultType()) {
+                        ctxt.reportPropertyInputMismatch(_beanType, prop.getName(),
+                                "Missing external type id property '%s'",
+                                extProp.getTypePropertyName());
+                    } else {
+                        typeId = extProp.getDefaultTypeId();
+                    }
+                }
+
+                if (_tokens[i] != null) {
+                    values[i] = _deserialize(p, ctxt, i, typeId);
+                } else {
+                    if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)) {
+                        ctxt.reportPropertyInputMismatch(_beanType, prop.getName(),
+                                "Missing property '%s' for external type id '%s'",
+                                prop.getName(), extProp.getTypePropertyName());
+                    }
+                    // 03-Aug-2022, tatu: [databind#3533] to handle absent value matching
+                    //    present type id
+                    values[i] = _deserializeMissingToken(p, ctxt, i, typeId);
+                }
+            }
+
             // also: if it's creator prop, fill in
             if (prop.getCreatorIndex() >= 0) {
-                buffer.assignParameter(prop, values[i]);
+                // ...but skip binding the value itself if hidden by the active view
+                if (!viewHidden) {
+                    buffer.assignParameter(prop, values[i]);
+                }
 
                 // [databind#999] And maybe there's creator property for type id too?
+                //   Assign it even when the value is view-hidden, provided we have a
+                //   type id and the type-id property is itself visible in the view.
                 SettableBeanProperty typeProp = extProp.getTypeProperty();
                 // for now, should only be needed for creator properties, too
-                if ((typeProp != null) && (typeProp.getCreatorIndex() >= 0)) {
+                if ((typeProp != null) && (typeProp.getCreatorIndex() >= 0)
+                        && (typeId != null)
+                        && ((activeView == null) || typeProp.visibleInView(activeView))) {
                     // 31-May-2018, tatu: [databind#1328] if id is NOT plain `String`, need to
                     //    apply deserializer... fun fun.
                     final Object v;
@@ -329,7 +355,12 @@ public class ExternalTypeHandler
         Object bean = creator.build(ctxt, buffer);
         // third: assign non-creator properties
         for (int i = 0; i < len; ++i) {
-            SettableBeanProperty prop = _properties[i].getProperty();
+            final ExtTypedProperty extProp = _properties[i];
+            // 26-Jun-2026, tatu: also honor `@JsonView` here (see above)
+            if ((activeView != null) && !extProp.getProperty().visibleInView(activeView)) {
+                continue;
+            }
+            SettableBeanProperty prop = extProp.getProperty();
             if (prop.getCreatorIndex() < 0) {
                 prop.set(bean, values[i]);
             }
@@ -379,6 +410,18 @@ public class ExternalTypeHandler
     protected final void _deserializeAndSet(JsonParser p, DeserializationContext ctxt,
             Object bean, int index, String typeId) throws IOException
     {
+        // 26-Jun-2026, tatu: Must honor `@JsonView` here too (see
+        //   JsonViewExternalTypeIdBypassTest): for default-constructor beans the value
+        //   may be bound eagerly via this method (when the type id precedes the value),
+        //   so a property not visible in the active view must be skipped here as well.
+        //   The value is read from the buffered token (`_tokens[index]`), and the main
+        //   parser has already advanced past it, so we simply discard it (do not set).
+        final Class<?> activeView = ctxt.getActiveView();
+        final SettableBeanProperty valueProp = _properties[index].getProperty();
+        if ((activeView != null) && !valueProp.visibleInView(activeView)) {
+            return;
+        }
+
         // 11-Nov-2020, tatu: Should never get `null` passed this far,
         if (typeId == null) {
             ctxt.reportInputMismatch(_beanType, "Internal error in external Type Id handling: `null` type id passed");

--- a/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
@@ -86,6 +86,51 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
         }
     }
 
+    // Case (3): like case (1), but the external type id "kind" is ITSELF a creator
+    // parameter ([databind#999]). The value "asset" is admin-only, but "kind" carries
+    // no view, so hiding the value must not also drop the (visible) type id property.
+    static class TypeIdCreatorContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind",
+                visible = true)
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
+        })
+        @JsonView(AdminView.class)
+        public Asset asset;
+
+        public String label;
+        public String kind;
+
+        @JsonCreator
+        public TypeIdCreatorContainer(
+                @JsonProperty("label") String label,
+                @JsonProperty("kind") String kind,
+                @JsonProperty("asset") @JsonView(AdminView.class) Asset asset) {
+            this.label = label;
+            this.kind = kind;
+            this.asset = asset;
+        }
+    }
+
+    // Case (4): admin-only external-type property on a default-constructor (no
+    // @JsonCreator) bean -- exercises the other ExternalTypeHandler.complete() path.
+    static class DefaultCtorContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind")
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
+        })
+        @JsonView(AdminView.class)
+        public Asset asset;
+
+        public String label;
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // Case (1): admin-only polymorphic property must NOT be bound when reading
@@ -142,5 +187,40 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
         assertEquals("foo", asset.name);
         // ...but the admin-only field must not leak under PublicView
         assertNull(asset.secret, "Admin-only 'secret' must not leak under PublicView");
+    }
+
+    // Case (3): hiding the admin-only value must NOT drop the (non-view) type id
+    // property when the type id is itself a creator parameter ([databind#999]).
+    @Test
+    void testViewGatedValueKeepsVisibleTypeIdCreatorProp() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        TypeIdCreatorContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(TypeIdCreatorContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        // Admin-only value is hidden...
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
+        // ...but the visible type id creator property must still be bound
+        assertEquals("admin", result.kind, "Visible type id 'kind' must still be bound");
+    }
+
+    // Case (4): admin-only external-type property on a default-constructor bean must
+    // also be skipped under PublicView (covers the other complete() overload).
+    @Test
+    void testViewGatedExternalTypePropertyDefaultCtor() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        DefaultCtorContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(DefaultCtorContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
@@ -1,28 +1,53 @@
 package com.fasterxml.jackson.databind.views;
 
 import com.fasterxml.jackson.annotation.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
-    public static class PublicView {}
-    public static class AdminView extends PublicView {}
+// Tests to verify that {@code @JsonView} is honored for polymorphic properties
+// that use an EXTERNAL_PROPERTY type id AND are bound via a property-based
+// (@JsonCreator) constructor. A {@code @JsonView} never changes the type id, so
+// these tests check the two distinct things a view CAN do:
+//
+//  (1) hide the whole polymorphic property -> property left null
+//  (2) hide a field of the resolved subtype -> subtype built, field left null
+public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
+{
+    static class PublicView { }
+    static class AdminView extends PublicView { }
 
-    public static abstract class Asset { public String name; }
-    public static class PublicAsset extends Asset {}
-    public static class AdminAsset extends Asset { public String secret; }
+    static abstract class Asset {
+        public String name;
+    }
 
-    public static class Container {
+    static class PublicAsset extends Asset { }
+
+    static class AdminAsset extends Asset {
+        public String secret;
+    }
+
+    // Subtype used by case (2): here the admin-only marker is on the field, not
+    // on the owning property.
+    static class FieldGatedAdminAsset extends Asset {
+        @JsonView(AdminView.class)
+        public String secret;
+    }
+
+    // Case (1): the entire polymorphic property is admin-only.
+    static class PropertyGatedContainer {
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
                 include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
                 property = "kind")
         @JsonSubTypes({
                 @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
-                @JsonSubTypes.Type(value = AdminAsset.class,  name = "admin")
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
         })
         @JsonView(AdminView.class)
         public Asset asset;
@@ -30,7 +55,7 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
         public String label;
 
         @JsonCreator
-        public Container(
+        public PropertyGatedContainer(
                 @JsonProperty("label") String label,
                 @JsonProperty("asset") @JsonView(AdminView.class) Asset asset) {
             this.label = label;
@@ -38,23 +63,84 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
         }
     }
 
-    public static class Wrapper {
-        @JsonView(PublicView.class)
-        public Container data;
+    // Case (2): the property is always visible, but the resolved subtype has an
+    // admin-only field.
+    static class FieldGatedContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind")
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = FieldGatedAdminAsset.class, name = "admin")
+        })
+        public Asset asset;
+
+        public String label;
+
+        @JsonCreator
+        public FieldGatedContainer(
+                @JsonProperty("label") String label,
+                @JsonProperty("asset") Asset asset) {
+            this.label = label;
+            this.asset = asset;
+        }
     }
 
-    @Test
-    void testJsonViewExternalTypeIdBypass() throws Exception {
-        // Admin-only "asset" should be blocked when reading with PublicView
-        String json = a2q("{'data':{'label':'hello','kind':'admin',"
-                + "'asset':{'name':'foo','secret':'LEAKED'}}}");
+    private final ObjectMapper MAPPER = newJsonMapper();
 
-        ObjectMapper om = sharedMapper();
-        Wrapper r = om.readerWithView(PublicView.class)
-                .forType(Wrapper.class)
+    // Case (1): admin-only polymorphic property must NOT be bound when reading
+    // with the less-privileged PublicView. A view never rewrites the type id, so
+    // the only correct outcome is that "asset" is skipped entirely (left null).
+    @Test
+    void testViewGatedExternalTypeProperty() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        PropertyGatedContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(PropertyGatedContainer.class)
                 .readValue(json);
 
-        PublicAsset asset = assertInstanceOf(PublicAsset.class, r.data.asset);
+        assertEquals("hello", result.label);
+        // Admin-only property hidden from PublicView -> not bound at all
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
+    }
+
+    // Sanity check: with the AdminView active, the same property IS bound, and
+    // resolves to AdminAsset (the type id is "admin").
+    @Test
+    void testViewGatedExternalTypePropertyVisibleForAdmin() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'shh'}}");
+
+        PropertyGatedContainer result = MAPPER.readerWithView(AdminView.class)
+                .forType(PropertyGatedContainer.class)
+                .readValue(json);
+
+        AdminAsset asset = assertInstanceOf(AdminAsset.class, result.asset);
         assertEquals("foo", asset.name);
+        assertEquals("shh", asset.secret);
+    }
+
+    // Case (2): the property itself is always visible, so the type id "admin"
+    // correctly produces the admin subtype -- but its admin-only "secret" field
+    // must be left out when reading with PublicView.
+    @Test
+    void testViewGatedFieldOfExternalTypeSubtype() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        FieldGatedContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(FieldGatedContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        // View does not change the type id: still the admin subtype...
+        FieldGatedAdminAsset asset = assertInstanceOf(FieldGatedAdminAsset.class, result.asset);
+        assertEquals("foo", asset.name);
+        // ...but the admin-only field must not leak under PublicView
+        assertNull(asset.secret, "Admin-only 'secret' must not leak under PublicView");
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
@@ -1,0 +1,60 @@
+package com.fasterxml.jackson.databind.views;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
+    public static class PublicView {}
+    public static class AdminView extends PublicView {}
+
+    public static abstract class Asset { public String name; }
+    public static class PublicAsset extends Asset {}
+    public static class AdminAsset extends Asset { public String secret; }
+
+    public static class Container {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind")
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = AdminAsset.class,  name = "admin")
+        })
+        @JsonView(AdminView.class)
+        public Asset asset;
+
+        public String label;
+
+        @JsonCreator
+        public Container(
+                @JsonProperty("label") String label,
+                @JsonProperty("asset") @JsonView(AdminView.class) Asset asset) {
+            this.label = label;
+            this.asset = asset;
+        }
+    }
+
+    public static class Wrapper {
+        @JsonView(PublicView.class)
+        public Container data;
+    }
+
+    @Test
+    void testJsonViewExternalTypeIdBypass() throws Exception {
+        // Admin-only "asset" should be blocked when reading with PublicView
+        String json = a2q("{'data':{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}}");
+
+        ObjectMapper om = sharedMapper();
+        Wrapper r = om.readerWithView(PublicView.class)
+                .forType(Wrapper.class)
+                .readValue(json);
+
+        PublicAsset asset = assertInstanceOf(PublicAsset.class, r.data.asset);
+        assertEquals("foo", asset.name);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
@@ -3,6 +3,8 @@ package com.fasterxml.jackson.databind.views;
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
 import org.junit.jupiter.api.Test;
@@ -12,12 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 // Tests to verify that {@code @JsonView} is honored for polymorphic properties
-// that use an EXTERNAL_PROPERTY type id AND are bound via a property-based
-// (@JsonCreator) constructor. A {@code @JsonView} never changes the type id, so
-// these tests check the two distinct things a view CAN do:
+// that use an EXTERNAL_PROPERTY type id. A {@code @JsonView} never changes the
+// type id, so these tests check the two distinct things a view CAN do -- (a) hide
+// the whole polymorphic property (left null), or (b) hide a field of the resolved
+// subtype (subtype built, field left null) -- across the different ways such a
+// property gets bound:
 //
-//  (1) hide the whole polymorphic property -> property left null
-//  (2) hide a field of the resolved subtype -> subtype built, field left null
+//  (1) property-based (@JsonCreator) constructor, property hidden      -> null
+//  (2) field of the resolved subtype hidden (property-based creator)   -> field null
+//  (3) type id is ITSELF a creator param, only the value hidden        -> value null, type id kept
+//  (4) default-constructor bean (eager binding), property hidden       -> null
+//  (5) @JsonPOJOBuilder-based bean, property hidden                    -> null
+//  (6) reverse of (3): type id creator param hidden, value visible     -> value kept, type id null
 public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
 {
     static class PublicView { }
@@ -131,6 +139,76 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
         public String label;
     }
 
+    // Case (5): admin-only external-type property on a @JsonPOJOBuilder-based bean --
+    // exercises the BuilderBasedDeserializer external-type path.
+    @JsonDeserialize(builder = BuilderContainer.Builder.class)
+    static class BuilderContainer {
+        public final String label;
+        public final Asset asset;
+
+        BuilderContainer(String label, Asset asset) {
+            this.label = label;
+            this.asset = asset;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "with")
+        static class Builder {
+            String label;
+            Asset asset;
+
+            public Builder withLabel(String label) {
+                this.label = label;
+                return this;
+            }
+
+            @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                    include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                    property = "kind")
+            @JsonSubTypes({
+                    @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                    @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
+            })
+            @JsonView(AdminView.class)
+            public Builder withAsset(Asset asset) {
+                this.asset = asset;
+                return this;
+            }
+
+            public BuilderContainer build() {
+                return new BuilderContainer(label, asset);
+            }
+        }
+    }
+
+    // Case (6): reverse of (3) -- the type id "kind" is a creator parameter carrying
+    // the view, while the value "asset" is visible. Under PublicView the value must
+    // still be bound and resolve correctly (the type id string still drives type
+    // resolution), but the hidden "kind" creator parameter must be left null.
+    static class TypeIdGatedContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind",
+                visible = true)
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
+        })
+        public Asset asset;
+
+        public String label;
+        public String kind;
+
+        @JsonCreator
+        public TypeIdGatedContainer(
+                @JsonProperty("label") String label,
+                @JsonProperty("kind") @JsonView(AdminView.class) String kind,
+                @JsonProperty("asset") Asset asset) {
+            this.label = label;
+            this.kind = kind;
+            this.asset = asset;
+        }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // Case (1): admin-only polymorphic property must NOT be bound when reading
@@ -222,5 +300,42 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
 
         assertEquals("hello", result.label);
         assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
+    }
+
+    // Case (5): admin-only external-type property on a @JsonPOJOBuilder bean must be
+    // skipped under PublicView (covers the BuilderBasedDeserializer external-type path).
+    @Test
+    void testViewGatedExternalTypePropertyBuilder() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        BuilderContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(BuilderContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
+    }
+
+    // Case (6): reverse of case (3) -- @JsonView on the type-id creator param but not
+    // the value. Under PublicView the value is still bound (and resolves to the admin
+    // subtype via the type id), but the hidden type-id property must be left null.
+    @Test
+    void testViewGatedTypeIdCreatorPropKeepsVisibleValue() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'shh'}}");
+
+        TypeIdGatedContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(TypeIdGatedContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        // Value carries no view -> still bound, and the type id still selects the subtype
+        AdminAsset asset = assertInstanceOf(AdminAsset.class, result.asset);
+        assertEquals("foo", asset.name);
+        // ...but the admin-only type id creator property must not be bound
+        assertNull(result.kind, "Admin-only type id 'kind' must not be bound under PublicView");
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/views/JsonViewExternalTypeIdBypassTest.java
@@ -1,28 +1,53 @@
 package com.fasterxml.jackson.databind.views;
 
 import com.fasterxml.jackson.annotation.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
-    public static class PublicView {}
-    public static class AdminView extends PublicView {}
+// Tests to verify that {@code @JsonView} is honored for polymorphic properties
+// that use an EXTERNAL_PROPERTY type id AND are bound via a property-based
+// (@JsonCreator) constructor. A {@code @JsonView} never changes the type id, so
+// these tests check the two distinct things a view CAN do:
+//
+//  (1) hide the whole polymorphic property -> property left null
+//  (2) hide a field of the resolved subtype -> subtype built, field left null
+public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil
+{
+    static class PublicView { }
+    static class AdminView extends PublicView { }
 
-    public static abstract class Asset { public String name; }
-    public static class PublicAsset extends Asset {}
-    public static class AdminAsset extends Asset { public String secret; }
+    static abstract class Asset {
+        public String name;
+    }
 
-    public static class Container {
+    static class PublicAsset extends Asset { }
+
+    static class AdminAsset extends Asset {
+        public String secret;
+    }
+
+    // Subtype used by case (2): here the admin-only marker is on the field, not
+    // on the owning property.
+    static class FieldGatedAdminAsset extends Asset {
+        @JsonView(AdminView.class)
+        public String secret;
+    }
+
+    // Case (1): the entire polymorphic property is admin-only.
+    static class PropertyGatedContainer {
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
                 include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
                 property = "kind")
         @JsonSubTypes({
                 @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
-                @JsonSubTypes.Type(value = AdminAsset.class,  name = "admin")
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
         })
         @JsonView(AdminView.class)
         public Asset asset;
@@ -30,7 +55,7 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
         public String label;
 
         @JsonCreator
-        public Container(
+        public PropertyGatedContainer(
                 @JsonProperty("label") String label,
                 @JsonProperty("asset") @JsonView(AdminView.class) Asset asset) {
             this.label = label;
@@ -38,23 +63,164 @@ public class JsonViewExternalTypeIdBypassTest extends DatabindTestUtil {
         }
     }
 
-    public static class Wrapper {
-        @JsonView(PublicView.class)
-        public Container data;
+    // Case (2): the property is always visible, but the resolved subtype has an
+    // admin-only field.
+    static class FieldGatedContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind")
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = FieldGatedAdminAsset.class, name = "admin")
+        })
+        public Asset asset;
+
+        public String label;
+
+        @JsonCreator
+        public FieldGatedContainer(
+                @JsonProperty("label") String label,
+                @JsonProperty("asset") Asset asset) {
+            this.label = label;
+            this.asset = asset;
+        }
     }
 
-    @Test
-    void testJsonViewExternalTypeIdBypass() throws Exception {
-        // Admin-only "asset" should be blocked when reading with PublicView
-        String json = a2q("{'data':{'label':'hello','kind':'admin',"
-                + "'asset':{'name':'foo','secret':'LEAKED'}}}");
+    // Case (3): like case (1), but the external type id "kind" is ITSELF a creator
+    // parameter ([databind#999]). The value "asset" is admin-only, but "kind" carries
+    // no view, so hiding the value must not also drop the (visible) type id property.
+    static class TypeIdCreatorContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind",
+                visible = true)
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
+        })
+        @JsonView(AdminView.class)
+        public Asset asset;
 
-        ObjectMapper om = sharedMapper();
-        Wrapper r = om.readerWithView(PublicView.class)
-                .forType(Wrapper.class)
+        public String label;
+        public String kind;
+
+        @JsonCreator
+        public TypeIdCreatorContainer(
+                @JsonProperty("label") String label,
+                @JsonProperty("kind") String kind,
+                @JsonProperty("asset") @JsonView(AdminView.class) Asset asset) {
+            this.label = label;
+            this.kind = kind;
+            this.asset = asset;
+        }
+    }
+
+    // Case (4): admin-only external-type property on a default-constructor (no
+    // @JsonCreator) bean -- exercises the other ExternalTypeHandler.complete() path.
+    static class DefaultCtorContainer {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "kind")
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = PublicAsset.class, name = "pub"),
+                @JsonSubTypes.Type(value = AdminAsset.class, name = "admin")
+        })
+        @JsonView(AdminView.class)
+        public Asset asset;
+
+        public String label;
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // Case (1): admin-only polymorphic property must NOT be bound when reading
+    // with the less-privileged PublicView. A view never rewrites the type id, so
+    // the only correct outcome is that "asset" is skipped entirely (left null).
+    @Test
+    void testViewGatedExternalTypeProperty() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        PropertyGatedContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(PropertyGatedContainer.class)
                 .readValue(json);
 
-        PublicAsset asset = assertInstanceOf(PublicAsset.class, r.data.asset);
+        assertEquals("hello", result.label);
+        // Admin-only property hidden from PublicView -> not bound at all
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
+    }
+
+    // Sanity check: with the AdminView active, the same property IS bound, and
+    // resolves to AdminAsset (the type id is "admin").
+    @Test
+    void testViewGatedExternalTypePropertyVisibleForAdmin() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'shh'}}");
+
+        PropertyGatedContainer result = MAPPER.readerWithView(AdminView.class)
+                .forType(PropertyGatedContainer.class)
+                .readValue(json);
+
+        AdminAsset asset = assertInstanceOf(AdminAsset.class, result.asset);
         assertEquals("foo", asset.name);
+        assertEquals("shh", asset.secret);
+    }
+
+    // Case (2): the property itself is always visible, so the type id "admin"
+    // correctly produces the admin subtype -- but its admin-only "secret" field
+    // must be left out when reading with PublicView.
+    @Test
+    void testViewGatedFieldOfExternalTypeSubtype() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        FieldGatedContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(FieldGatedContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        // View does not change the type id: still the admin subtype...
+        FieldGatedAdminAsset asset = assertInstanceOf(FieldGatedAdminAsset.class, result.asset);
+        assertEquals("foo", asset.name);
+        // ...but the admin-only field must not leak under PublicView
+        assertNull(asset.secret, "Admin-only 'secret' must not leak under PublicView");
+    }
+
+    // Case (3): hiding the admin-only value must NOT drop the (non-view) type id
+    // property when the type id is itself a creator parameter ([databind#999]).
+    @Test
+    void testViewGatedValueKeepsVisibleTypeIdCreatorProp() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        TypeIdCreatorContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(TypeIdCreatorContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        // Admin-only value is hidden...
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
+        // ...but the visible type id creator property must still be bound
+        assertEquals("admin", result.kind, "Visible type id 'kind' must still be bound");
+    }
+
+    // Case (4): admin-only external-type property on a default-constructor bean must
+    // also be skipped under PublicView (covers the other complete() overload).
+    @Test
+    void testViewGatedExternalTypePropertyDefaultCtor() throws Exception
+    {
+        String json = a2q("{'label':'hello','kind':'admin',"
+                + "'asset':{'name':'foo','secret':'LEAKED'}}");
+
+        DefaultCtorContainer result = MAPPER.readerWithView(PublicView.class)
+                .forType(DefaultCtorContainer.class)
+                .readValue(json);
+
+        assertEquals("hello", result.label);
+        assertNull(result.asset, "Admin-only 'asset' must not be bound under PublicView");
     }
 }


### PR DESCRIPTION
Fix [[GHSA-mhm7-754m-9p8w]](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-mhm7-754m-9p8w): incomplete handling of `@JsonView` for `EXTERNAL_PROPERTY` case, for 2.x branch (specifically 2.18 and up)

3.1 variant is #6055 
