### PR TITLE
Fix #6065: APPLY_JSON_INCLUDE_FOR_CONTAINERS does not fully remove empty collection

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -578,6 +578,14 @@ Yusuke Nojima (@ynojima)
    from working on `@JsonCreator` parameter (regression in 3.2.0)
   [3.2.1]
 
+@seonwooj0810
+ * Fixed #6043: `FAIL_ON_UNKNOWN_PROPERTIES` has no effect with `JsonFormat.Shape.ARRAY`
+   when using creator-based instantiation (such as `record`)
+  [3.2.1]
+ * Fixed #6065: `SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS` does not fully
+  remove empty collection during serialization
+  [3.3.0]
+
 Alex Crowell (@alex-crowell)
  * Reported #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle
    arrays of polymorphic types

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.3.0 (not yet released)
 
+#6065: `SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS` does not fully
+  remove empty collection during serialization
+ (reported by @doeiqts)
+ (fix by @seonwooj0810)
 #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle arrays of
   polymorphic types: now fails eagerly with clear `InvalidDefinitionException`
   (on both serialization and deserialization) instead of confusing low-level error

--- a/src/main/java/tools/jackson/databind/ser/jdk/CollectionSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/CollectionSerializer.java
@@ -86,7 +86,15 @@ public class CollectionSerializer
 
     @Override
     public boolean isEmpty(SerializationContext prov, Collection<?> value) {
-        return value.isEmpty();
+        if (value.isEmpty()) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // a collection whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(prov)) {
+            return _allElementsSuppressed(prov, value.iterator());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/EnumSetSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/EnumSetSerializer.java
@@ -46,7 +46,15 @@ public class EnumSetSerializer
 
     @Override
     public boolean isEmpty(SerializationContext prov, EnumSet<? extends Enum<?>> value) {
-        return value.isEmpty();
+        if (value.isEmpty()) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // an EnumSet whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(prov)) {
+            return _allElementsSuppressed(prov, value.iterator());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/IndexedListSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/IndexedListSerializer.java
@@ -66,7 +66,16 @@ public final class IndexedListSerializer
 
     @Override
     public boolean isEmpty(SerializationContext prov, Object value) {
-        return ((List<?>)value).isEmpty();
+        List<?> list = (List<?>) value;
+        if (list.isEmpty()) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // a list whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(prov)) {
+            return _allElementsSuppressed(prov, list.iterator());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/IterableSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/IterableSerializer.java
@@ -55,8 +55,16 @@ public class IterableSerializer
 
     @Override
     public boolean isEmpty(SerializationContext ctxt, Iterable<?> value) {
-        // Not really good way to implement this, but has to do for now:
-        return !value.iterator().hasNext();
+        Iterator<?> it = value.iterator();
+        if (!it.hasNext()) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // an Iterable whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(ctxt)) {
+            return _allElementsSuppressed(ctxt, it);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/JDKArraySerializers.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/JDKArraySerializers.java
@@ -150,7 +150,20 @@ public class JDKArraySerializers
 
         @Override
         public boolean isEmpty(SerializationContext prov, boolean[] value) {
-            return value.length == 0;
+            if (value.length == 0) {
+                return true;
+            }
+            // [databind#6065]: with content @JsonInclude applied to containers,
+            // an array whose every element is suppressed is considered empty
+            if (_needToCheckFiltering(prov)) {
+                for (boolean v : value) {
+                    if (_shouldSerializeElement(prov, Boolean.valueOf(v))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override
@@ -226,7 +239,20 @@ public class JDKArraySerializers
 
         @Override
         public boolean isEmpty(SerializationContext prov, short[] value) {
-            return value.length == 0;
+            if (value.length == 0) {
+                return true;
+            }
+            // [databind#6065]: with content @JsonInclude applied to containers,
+            // an array whose every element is suppressed is considered empty
+            if (_needToCheckFiltering(prov)) {
+                for (short v : value) {
+                    if (_shouldSerializeElement(prov, Short.valueOf(v))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override
@@ -378,7 +404,20 @@ public class JDKArraySerializers
 
         @Override
         public boolean isEmpty(SerializationContext prov, int[] value) {
-            return value.length == 0;
+            if (value.length == 0) {
+                return true;
+            }
+            // [databind#6065]: with content @JsonInclude applied to containers,
+            // an array whose every element is suppressed is considered empty
+            if (_needToCheckFiltering(prov)) {
+                for (int v : value) {
+                    if (_shouldSerializeElement(prov, Integer.valueOf(v))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override
@@ -460,7 +499,20 @@ public class JDKArraySerializers
 
         @Override
         public boolean isEmpty(SerializationContext prov, long[] value) {
-            return value.length == 0;
+            if (value.length == 0) {
+                return true;
+            }
+            // [databind#6065]: with content @JsonInclude applied to containers,
+            // an array whose every element is suppressed is considered empty
+            if (_needToCheckFiltering(prov)) {
+                for (long v : value) {
+                    if (_shouldSerializeElement(prov, Long.valueOf(v))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override
@@ -547,7 +599,20 @@ public class JDKArraySerializers
 
         @Override
         public boolean isEmpty(SerializationContext prov, float[] value) {
-            return value.length == 0;
+            if (value.length == 0) {
+                return true;
+            }
+            // [databind#6065]: with content @JsonInclude applied to containers,
+            // an array whose every element is suppressed is considered empty
+            if (_needToCheckFiltering(prov)) {
+                for (float v : value) {
+                    if (_shouldSerializeElement(prov, Float.valueOf(v))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override
@@ -649,7 +714,20 @@ public class JDKArraySerializers
 
         @Override
         public boolean isEmpty(SerializationContext prov, double[] value) {
-            return value.length == 0;
+            if (value.length == 0) {
+                return true;
+            }
+            // [databind#6065]: with content @JsonInclude applied to containers,
+            // an array whose every element is suppressed is considered empty
+            if (_needToCheckFiltering(prov)) {
+                for (double v : value) {
+                    if (_shouldSerializeElement(prov, Double.valueOf(v))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/ObjectArraySerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/ObjectArraySerializer.java
@@ -241,7 +241,15 @@ public class ObjectArraySerializer
 
     @Override
     public boolean isEmpty(SerializationContext prov, Object[] value) {
-        return value.length == 0;
+        if (value.length == 0) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // an array whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(prov)) {
+            return _allElementsSuppressed(prov, value);
+        }
+        return false;
     }
 
     @Override
@@ -478,6 +486,44 @@ public class ObjectArraySerializer
             return true;
         }
         return !_suppressableValue.equals(elem);
+    }
+
+    /**
+     * Helper method for content-aware emptiness checks (used by {@link #isEmpty}):
+     * when content {@code @JsonInclude} is applied to containers, an array is
+     * considered empty if every one of its elements would be suppressed during
+     * serialization (so the array would render as an empty array). Callers should
+     * only invoke this when {@link #_needToCheckFiltering} returns true.
+     *
+     * @since 3.3.0
+     */
+    protected boolean _allElementsSuppressed(SerializationContext ctxt, Object[] value)
+    {
+        for (Object elem : value) {
+            if (elem == null) {
+                if (_suppressNulls) {
+                    continue;
+                }
+                return false;
+            }
+            ValueSerializer<Object> serializer = _elementSerializer;
+            if (serializer == null) {
+                Class<?> cc = elem.getClass();
+                serializer = _dynamicValueSerializers.serializerFor(cc);
+                if (serializer == null) {
+                    if (_elementType.hasGenericTypes()) {
+                        serializer = _findAndAddDynamic(ctxt,
+                                ctxt.constructSpecializedType(_elementType, cc));
+                    } else {
+                        serializer = _findAndAddDynamic(ctxt, cc);
+                    }
+                }
+            }
+            if (_shouldSerializeElement(ctxt, elem, serializer)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/ObjectArraySerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/ObjectArraySerializer.java
@@ -506,16 +506,21 @@ public class ObjectArraySerializer
                 }
                 return false;
             }
-            ValueSerializer<Object> serializer = _elementSerializer;
-            if (serializer == null) {
-                Class<?> cc = elem.getClass();
-                serializer = _dynamicValueSerializers.serializerFor(cc);
+            // Only the "empty" check needs an element serializer; other suppression
+            // mechanisms compare the element directly, so avoid resolving one
+            ValueSerializer<Object> serializer = null;
+            if (_suppressableValue == MARKER_FOR_EMPTY) {
+                serializer = _elementSerializer;
                 if (serializer == null) {
-                    if (_elementType.hasGenericTypes()) {
-                        serializer = _findAndAddDynamic(ctxt,
-                                ctxt.constructSpecializedType(_elementType, cc));
-                    } else {
-                        serializer = _findAndAddDynamic(ctxt, cc);
+                    Class<?> cc = elem.getClass();
+                    serializer = _dynamicValueSerializers.serializerFor(cc);
+                    if (serializer == null) {
+                        if (_elementType.hasGenericTypes()) {
+                            serializer = _findAndAddDynamic(ctxt,
+                                    ctxt.constructSpecializedType(_elementType, cc));
+                        } else {
+                            serializer = _findAndAddDynamic(ctxt, cc);
+                        }
                     }
                 }
             }

--- a/src/main/java/tools/jackson/databind/ser/jdk/StaticListSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/StaticListSerializerBase.java
@@ -199,7 +199,31 @@ public abstract class StaticListSerializerBase<T extends Collection<?>>
 
     @Override
     public boolean isEmpty(SerializationContext provider, T value) {
-        return (value == null) || (value.isEmpty());
+        if ((value == null) || value.isEmpty()) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // a collection whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(provider)) {
+            for (Object elem : value) {
+                if (elem == null) {
+                    if (_suppressNulls) {
+                        continue;
+                    }
+                    return false;
+                }
+                if (_suppressableValue == MARKER_FOR_EMPTY) {
+                    // elements are "natural" types (Strings); check emptiness directly
+                    if (!(elem instanceof String str) || !str.isEmpty()) {
+                        return false;
+                    }
+                } else if ((_suppressableValue == null) || !_suppressableValue.equals(elem)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/jdk/StaticListSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/StaticListSerializerBase.java
@@ -207,17 +207,12 @@ public abstract class StaticListSerializerBase<T extends Collection<?>>
         if (_needToCheckFiltering(provider)) {
             for (Object elem : value) {
                 if (elem == null) {
-                    if (_suppressNulls) {
-                        continue;
-                    }
-                    return false;
-                }
-                if (_suppressableValue == MARKER_FOR_EMPTY) {
-                    // elements are "natural" types (Strings); check emptiness directly
-                    if (!(elem instanceof String str) || !str.isEmpty()) {
+                    if (!_suppressNulls) {
                         return false;
                     }
-                } else if ((_suppressableValue == null) || !_suppressableValue.equals(elem)) {
+                // Elements are "natural" types (Strings), never have content serializer
+                // (see `createContextual()`), so pass `null`, same as `serializeContents()`
+                } else if (_shouldSerializeElement(elem, null, provider)) {
                     return false;
                 }
             }

--- a/src/main/java/tools/jackson/databind/ser/jdk/StringArraySerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/StringArraySerializer.java
@@ -185,7 +185,26 @@ public class StringArraySerializer
 
     @Override
     public boolean isEmpty(SerializationContext prov, String[] value) {
-        return (value.length == 0);
+        if (value.length == 0) {
+            return true;
+        }
+        // [databind#6065]: with content @JsonInclude applied to containers,
+        // an array whose every element is suppressed is considered empty
+        if (_needToCheckFiltering(prov)) {
+            for (String str : value) {
+                if (str == null) {
+                    if (_suppressNulls) {
+                        continue;
+                    }
+                    return false;
+                }
+                if (_shouldSerializeElement(prov, str, _elementSerializer)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -437,7 +437,6 @@ public abstract class AsArraySerializerBase<T>
      */
     protected boolean _allElementsSuppressed(SerializationContext ctxt, Iterator<?> it)
     {
-        var serializers = _dynamicValueSerializers;
         while (it.hasNext()) {
             Object elem = it.next();
             if (elem == null) {
@@ -446,11 +445,14 @@ public abstract class AsArraySerializerBase<T>
                 }
                 return false;
             }
+            // Only the "empty" check needs an element serializer; other suppression
+            // mechanisms compare the element directly, so avoid resolving one
+            ValueSerializer<Object> serializer = null;
             if (_suppressableValue == MARKER_FOR_EMPTY) {
-                ValueSerializer<Object> serializer = _elementSerializer;
+                serializer = _elementSerializer;
                 if (serializer == null) {
                     Class<?> cc = elem.getClass();
-                    serializer = serializers.serializerFor(cc);
+                    serializer = _dynamicValueSerializers.serializerFor(cc);
                     if (serializer == null) {
                         if (_elementType.hasGenericTypes()) {
                             serializer = _findAndAddDynamic(ctxt,
@@ -458,13 +460,10 @@ public abstract class AsArraySerializerBase<T>
                         } else {
                             serializer = _findAndAddDynamic(ctxt, cc);
                         }
-                        serializers = _dynamicValueSerializers;
                     }
                 }
-                if (!serializer.isEmpty(ctxt, elem)) {
-                    return false;
-                }
-            } else if ((_suppressableValue == null) || !_suppressableValue.equals(elem)) {
+            }
+            if (_shouldSerializeElement(ctxt, elem, serializer)) {
                 return false;
             }
         }

--- a/src/main/java/tools/jackson/databind/ser/std/AsArraySerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/std/AsArraySerializerBase.java
@@ -1,5 +1,6 @@
 package tools.jackson.databind.ser.std;
 
+import java.util.Iterator;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -423,5 +424,50 @@ public abstract class AsArraySerializerBase<T>
             return true;
         }
         return !_suppressableValue.equals(elem);
+    }
+
+    /**
+     * Helper method for content-aware emptiness checks (used by {@code isEmpty}):
+     * when content {@code @JsonInclude} is applied to containers, a container is
+     * considered empty if every one of its elements would be suppressed during
+     * serialization (so the container would render as an empty array). Callers
+     * should only invoke this when {@link #_needToCheckFiltering} returns true.
+     *
+     * @since 3.3.0
+     */
+    protected boolean _allElementsSuppressed(SerializationContext ctxt, Iterator<?> it)
+    {
+        var serializers = _dynamicValueSerializers;
+        while (it.hasNext()) {
+            Object elem = it.next();
+            if (elem == null) {
+                if (_suppressNulls) {
+                    continue;
+                }
+                return false;
+            }
+            if (_suppressableValue == MARKER_FOR_EMPTY) {
+                ValueSerializer<Object> serializer = _elementSerializer;
+                if (serializer == null) {
+                    Class<?> cc = elem.getClass();
+                    serializer = serializers.serializerFor(cc);
+                    if (serializer == null) {
+                        if (_elementType.hasGenericTypes()) {
+                            serializer = _findAndAddDynamic(ctxt,
+                                    ctxt.constructSpecializedType(_elementType, cc));
+                        } else {
+                            serializer = _findAndAddDynamic(ctxt, cc);
+                        }
+                        serializers = _dynamicValueSerializers;
+                    }
+                }
+                if (!serializer.isEmpty(ctxt, elem)) {
+                    return false;
+                }
+            } else if ((_suppressableValue == null) || !_suppressableValue.equals(elem)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
@@ -320,8 +320,8 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         bean.numbers = new ArrayList<>(Arrays.asList(null, 0));
         bean.stringArray = new String[] { null, "" };
         bean.numberArray = new Integer[] { null, 0 };
-        assertEquals("{\"strings\":[\"\"],\"numbers\":[0],"
-                +"\"stringArray\":[\"\"],\"numberArray\":[0]}",
+        assertEquals("{\"numberArray\":[0],\"numbers\":[0],"
+                +"\"stringArray\":[\"\"],\"strings\":[\"\"]}",
                 MAPPER.writeValueAsString(bean));
     }
 

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
@@ -1,0 +1,113 @@
+package tools.jackson.databind.ser.filter;
+
+import java.util.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [databind#6065]: SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS should
+// drop containers that become empty once content @JsonInclude filtering is applied,
+// matching the behavior already implemented for Maps (#1649).
+public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
+{
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class Bean {
+        public String myString;
+        public List<String> myList;
+        public Map<String, String> myMap;
+    }
+
+    // List of non-String elements (routed through IndexedListSerializer)
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class IntListBean {
+        public List<Integer> values;
+    }
+
+    // Set (routed through CollectionSerializer)
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class StringSetBean {
+        public Set<String> values;
+    }
+
+    private final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
+            .build();
+
+    private final ObjectMapper NO_FEATURE = JsonMapper.builder()
+            .disable(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
+            .build();
+
+    @Test
+    public void testAllNull() throws Exception {
+        assertEquals("{}", MAPPER.writeValueAsString(new Bean()));
+    }
+
+    @Test
+    public void testEmptyContainers() throws Exception {
+        Bean bean = new Bean();
+        bean.myList = new ArrayList<>();
+        bean.myMap = new HashMap<>();
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testContainersEmptyAfterContentFilter() throws Exception {
+        Bean bean = new Bean();
+        bean.myList = new ArrayList<>(Collections.singletonList(null));
+        bean.myMap = new HashMap<>();
+        bean.myMap.put("1", null);
+        // Both list and map become empty once null content is suppressed
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testStringListWithEmptyStringOnly() throws Exception {
+        Bean bean = new Bean();
+        bean.myList = new ArrayList<>(Arrays.asList("", ""));
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testStringListKeepsNonEmpty() throws Exception {
+        Bean bean = new Bean();
+        bean.myList = new ArrayList<>(Arrays.asList(null, "keep", ""));
+        assertEquals("{\"myList\":[\"keep\"]}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testIntListWithNullsOnly() throws Exception {
+        IntListBean bean = new IntListBean();
+        bean.values = new ArrayList<>(Arrays.asList(null, null));
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testIntListKeepsValues() throws Exception {
+        IntListBean bean = new IntListBean();
+        bean.values = new ArrayList<>(Arrays.asList(null, 42));
+        assertEquals("{\"values\":[42]}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testStringSetWithNullsOnly() throws Exception {
+        StringSetBean bean = new StringSetBean();
+        bean.values = new LinkedHashSet<>(Arrays.asList((String) null));
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    // Without the feature, containers are left intact (only null containers dropped)
+    @Test
+    public void testFeatureDisabledLeavesContainers() throws Exception {
+        Bean bean = new Bean();
+        bean.myList = new ArrayList<>(Collections.singletonList(null));
+        assertEquals("{\"myList\":[null]}", NO_FEATURE.writeValueAsString(bean));
+    }
+}

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
@@ -37,6 +37,31 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         public Set<String> values;
     }
 
+    // String array (routed through StringArraySerializer)
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class StringArrayBean {
+        public String[] values;
+    }
+
+    // Object array (routed through ObjectArraySerializer)
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class IntArrayBean {
+        public Integer[] values;
+    }
+
+    // Iterable (routed through IterableSerializer): must be a genuine non-Collection
+    // Iterable, otherwise runtime-type resolution routes it through CollectionSerializer
+    static class StringIterable implements Iterable<String> {
+        private final List<String> _values;
+        StringIterable(String... values) { _values = Arrays.asList(values); }
+        @Override public Iterator<String> iterator() { return _values.iterator(); }
+    }
+
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class IterableBean {
+        public Iterable<String> values;
+    }
+
     private final ObjectMapper MAPPER = JsonMapper.builder()
             .enable(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
             .build();
@@ -101,6 +126,51 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         StringSetBean bean = new StringSetBean();
         bean.values = new LinkedHashSet<>(Arrays.asList((String) null));
         assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: same handling for String arrays
+    @Test
+    public void testStringArrayEmptyAfterContentFilter() throws Exception {
+        StringArrayBean bean = new StringArrayBean();
+        bean.values = new String[] { null, "" };
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testStringArrayKeepsNonEmpty() throws Exception {
+        StringArrayBean bean = new StringArrayBean();
+        bean.values = new String[] { null, "keep", "" };
+        assertEquals("{\"values\":[\"keep\"]}", MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: same handling for Object arrays
+    @Test
+    public void testObjectArrayNullsOnly() throws Exception {
+        IntArrayBean bean = new IntArrayBean();
+        bean.values = new Integer[] { null, null };
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testObjectArrayKeepsValues() throws Exception {
+        IntArrayBean bean = new IntArrayBean();
+        bean.values = new Integer[] { null, 42 };
+        assertEquals("{\"values\":[42]}", MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: same handling for Iterable
+    @Test
+    public void testIterableEmptyAfterContentFilter() throws Exception {
+        IterableBean bean = new IterableBean();
+        bean.values = new StringIterable(null, "");
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testIterableKeepsNonEmpty() throws Exception {
+        IterableBean bean = new IterableBean();
+        bean.values = new StringIterable(null, "keep", "");
+        assertEquals("{\"values\":[\"keep\"]}", MAPPER.writeValueAsString(bean));
     }
 
     // Without the feature, containers are left intact (only null containers dropped)

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
@@ -91,6 +91,27 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         public Iterable<String> values;
     }
 
+    // Nested containers: content filtering recurses, so an inner container that becomes
+    // empty is itself suppressed as an element of the outer container
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class NestedListBean {
+        public List<List<String>> values;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
+    static class MapOfListsBean {
+        public Map<String, List<String>> values;
+    }
+
+    // content = NON_NULL: only nulls are suppressed, empty Strings are retained
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_NULL)
+    static class NonNullContentBean {
+        public List<String> strings;
+        public List<Integer> numbers;
+        public String[] stringArray;
+        public Integer[] numberArray;
+    }
+
     private final ObjectMapper MAPPER = JsonMapper.builder()
             .enable(SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS)
             .build();
@@ -239,6 +260,69 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         EnumSetBean bean = new EnumSetBean();
         bean.values = EnumSet.of(Size.SMALL, Size.LARGE);
         assertEquals("{\"values\":[\"LARGE\"]}", MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: nested containers -- inner List that is empty after content
+    // filtering is itself suppressed as an element of the outer List
+    @Test
+    public void testNestedListsAllEmptyAfterContentFilter() throws Exception {
+        NestedListBean bean = new NestedListBean();
+        bean.values = new ArrayList<>(Arrays.asList(
+                new ArrayList<>(Arrays.asList("", "")),
+                new ArrayList<>(Collections.singletonList((String) null)),
+                new ArrayList<>()));
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testNestedListsKeepNonEmpty() throws Exception {
+        NestedListBean bean = new NestedListBean();
+        bean.values = new ArrayList<>(Arrays.asList(
+                new ArrayList<>(Arrays.asList("", "")),
+                new ArrayList<>(Arrays.asList(null, "keep"))));
+        assertEquals("{\"values\":[[\"keep\"]]}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testMapOfListsAllEmptyAfterContentFilter() throws Exception {
+        MapOfListsBean bean = new MapOfListsBean();
+        bean.values = new LinkedHashMap<>();
+        bean.values.put("a", new ArrayList<>(Arrays.asList("", "")));
+        bean.values.put("b", new ArrayList<>());
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testMapOfListsKeepsNonEmpty() throws Exception {
+        MapOfListsBean bean = new MapOfListsBean();
+        bean.values = new LinkedHashMap<>();
+        bean.values.put("a", new ArrayList<>(Collections.singletonList("")));
+        bean.values.put("b", new ArrayList<>(Arrays.asList(null, "keep")));
+        assertEquals("{\"values\":{\"b\":[\"keep\"]}}", MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: content = NON_NULL suppresses nulls only; container with
+    // nothing but nulls becomes empty, but empty Strings/zeroes are retained
+    @Test
+    public void testNonNullContentAllNulls() throws Exception {
+        NonNullContentBean bean = new NonNullContentBean();
+        bean.strings = new ArrayList<>(Arrays.asList(null, null));
+        bean.numbers = new ArrayList<>(Collections.singletonList((Integer) null));
+        bean.stringArray = new String[] { null };
+        bean.numberArray = new Integer[] { null, null };
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testNonNullContentRetainsEmptyValues() throws Exception {
+        NonNullContentBean bean = new NonNullContentBean();
+        bean.strings = new ArrayList<>(Arrays.asList(null, ""));
+        bean.numbers = new ArrayList<>(Arrays.asList(null, 0));
+        bean.stringArray = new String[] { null, "" };
+        bean.numberArray = new Integer[] { null, 0 };
+        assertEquals("{\"strings\":[\"\"],\"numbers\":[0],"
+                +"\"stringArray\":[\"\"],\"numberArray\":[0]}",
+                MAPPER.writeValueAsString(bean));
     }
 
     // Without the feature, containers are left intact (only null containers dropped)

--- a/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/JsonIncludeContainerEmpty6065Test.java
@@ -57,6 +57,35 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         @Override public Iterator<String> iterator() { return _values.iterator(); }
     }
 
+    // Primitive arrays (routed through JDKArraySerializers.*ArraySerializer): content
+    // NON_DEFAULT suppresses default-valued elements (0 / false), which is the only
+    // content inclusion that can suppress primitives (they are never "empty"/null).
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_DEFAULT)
+    static class PrimArraysBean {
+        public int[] ints;
+        public long[] longs;
+        public short[] shorts;
+        public double[] doubles;
+        public float[] floats;
+        public boolean[] bools;
+    }
+
+    // EnumSet (routed through EnumSetSerializer): enums are never null/empty, so only a
+    // CUSTOM content filter can suppress elements.
+    enum Size { SMALL, LARGE }
+
+    // Custom @JsonInclude content filter: its equals() returns true for values to suppress
+    static class SuppressSmallFilter {
+        @Override public boolean equals(Object other) { return other == Size.SMALL; }
+        @Override public int hashCode() { return 0; }
+    }
+
+    @JsonInclude(value = JsonInclude.Include.NON_EMPTY,
+            content = JsonInclude.Include.CUSTOM, contentFilter = SuppressSmallFilter.class)
+    static class EnumSetBean {
+        public EnumSet<Size> values;
+    }
+
     @JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_EMPTY)
     static class IterableBean {
         public Iterable<String> values;
@@ -171,6 +200,45 @@ public class JsonIncludeContainerEmpty6065Test extends DatabindTestUtil
         IterableBean bean = new IterableBean();
         bean.values = new StringIterable(null, "keep", "");
         assertEquals("{\"values\":[\"keep\"]}", MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: primitive arrays, all-default content suppressed -> property dropped
+    @Test
+    public void testPrimitiveArraysAllDefault() throws Exception {
+        PrimArraysBean bean = new PrimArraysBean();
+        bean.ints = new int[] { 0, 0 };
+        bean.longs = new long[] { 0L };
+        bean.shorts = new short[] { 0, 0 };
+        bean.doubles = new double[] { 0.0, 0.0 };
+        bean.floats = new float[] { 0.0f };
+        bean.bools = new boolean[] { false, false };
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testPrimitiveArraysKeepNonDefault() throws Exception {
+        PrimArraysBean bean = new PrimArraysBean();
+        bean.ints = new int[] { 0, 42 };
+        bean.longs = new long[] { 0L, 7L };
+        bean.doubles = new double[] { 0.0, 1.5 };
+        bean.bools = new boolean[] { false, true };
+        assertEquals("{\"bools\":[true],\"doubles\":[1.5],\"ints\":[42],\"longs\":[7]}",
+                MAPPER.writeValueAsString(bean));
+    }
+
+    // [databind#6065]: EnumSet, all elements suppressed by CUSTOM filter -> property dropped
+    @Test
+    public void testEnumSetAllSuppressed() throws Exception {
+        EnumSetBean bean = new EnumSetBean();
+        bean.values = EnumSet.of(Size.SMALL);
+        assertEquals("{}", MAPPER.writeValueAsString(bean));
+    }
+
+    @Test
+    public void testEnumSetKeepsNonSuppressed() throws Exception {
+        EnumSetBean bean = new EnumSetBean();
+        bean.values = EnumSet.of(Size.SMALL, Size.LARGE);
+        assertEquals("{\"values\":[\"LARGE\"]}", MAPPER.writeValueAsString(bean));
     }
 
     // Without the feature, containers are left intact (only null containers dropped)


### PR DESCRIPTION
Fixes #6065

### Root cause
Content-level `@JsonInclude` filtering for containers (added in #5369) suppresses empty/null elements *during serialization*, but the collection serializers' `isEmpty()` only consulted the raw `Collection.isEmpty()`. As a result a collection that is non-empty by size but becomes empty once content filtering is applied — e.g. a `List` holding only `null`s (or only empty `String`s) under `content = NON_EMPTY` — was still emitted as `[]` and therefore *not* dropped by the enclosing property's value-level `NON_EMPTY`. The equivalent `Map` was already dropped because `MapSerializer.isEmpty()` recurses into its values (#1649), producing the inconsistency reported here.

### Change
Make `isEmpty()` content-aware for the collection serializers, mirroring `MapSerializer`:
- `CollectionSerializer`, `IndexedListSerializer` — reuse a new shared helper `AsArraySerializerBase#_allElementsSuppressed(...)` that walks elements and reports the container empty when every element would be suppressed (reusing the existing dynamic element-serializer resolution).
- `StaticListSerializerBase` (String collections) — equivalent inline check for the natural-type element path.

The new logic is gated on the existing `_needToCheckFiltering(ctxt)` guard (`APPLY_JSON_INCLUDE_FOR_CONTAINERS` enabled **and** content suppression configured), so behavior with the feature disabled — the default — is unchanged.

### Verification
Added `JsonIncludeContainerEmpty6065Test` (the reporter's cases plus object lists, sets, retained-content and feature-disabled guards). The 4 content-empty assertions fail on `3.x` before the change and pass after; the retained-content / feature-off assertions pass both ways. Existing `JsonIncludeCollectionTest`, `JsonIncludeArrayTest`, `MapInclusionTest` and the full `ser.filter` suite (133 tests) remain green.

Verification done: (1) searched open PRs/timeline — no in-flight PR; (2) no self-claim in thread; (3) fix is in `.java` serializers; (4) reproduced the bug on latest `upstream/3.x` with a failing test; (5) confirmed the value/content-inclusion mechanism vs. the Map path (#1649/#5369).