### PR TITLE
Honor `FAIL_ON_UNKNOWN_PROPERTIES` in builder-based POJOs-as-Array creator path

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayBuilderDeserializer.java
@@ -277,6 +277,18 @@ public class BeanAsArrayBuilderDeserializer
         for (; p.nextToken() != JsonToken.END_ARRAY; ++i) {
             SettableBeanProperty prop = (i < propCount) ? props[i] : null;
             if (prop == null) { // we get null if there are extra elements; maybe otherwise too?
+                // [databind#6043]: extra JSON Array elements past property count must
+                // honor FAIL_ON_UNKNOWN_PROPERTIES, same as the non-creator path above.
+                // Only genuinely-extra elements (past property count) count as "unknown":
+                // in-bounds null slots (e.g. from renamed/unwrapped properties) are skipped,
+                // matching the non-creator path's position-based check.
+                if (i >= propCount
+                        && !_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
+                    ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
+                            "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                            propCount);
+                    // never gets here
+                }
                 p.skipChildren();
                 continue;
             }

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayBuilderDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayBuilderDeserializer.java
@@ -162,7 +162,7 @@ public class BeanAsArrayBuilderDeserializer
         //   non-optimal exception message so...
         if (!_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
             ctxt.reportInputMismatch(handledType(),
-                    "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                    "Unexpected JSON value(s); expected at most %d properties (in JSON Array)",
                     propCount);
             // fall through
         }
@@ -285,7 +285,7 @@ public class BeanAsArrayBuilderDeserializer
                 if (i >= propCount
                         && !_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
                     ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
-                            "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                            "Unexpected JSON value(s); expected at most %d properties (in JSON Array)",
                             propCount);
                     // never gets here
                 }

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanAsArrayDeserializer.java
@@ -231,7 +231,7 @@ public class BeanAsArrayDeserializer
             // Ok; extra fields? Let's fail, unless ignoring extra props is fine
             if (!_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
                 ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
-                        "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                        "Unexpected JSON value(s); expected at most %d properties (in JSON Array)",
                         propCount);
                 // never gets here
             }
@@ -285,7 +285,7 @@ public class BeanAsArrayDeserializer
         // Ok; extra fields? Let's fail, unless ignoring extra props is fine
         if (!_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
             ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
-                    "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                    "Unexpected JSON value(s); expected at most %d properties (in JSON Array)",
                     propCount);
             // never gets here
         }
@@ -355,7 +355,7 @@ public class BeanAsArrayDeserializer
         // Ok; extra fields? Let's fail, unless ignoring extra props is fine
         if (!_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
             ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
-                    "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                    "Unexpected JSON value(s); expected at most %d properties (in JSON Array)",
                     propCount);
             // will never reach here as exception has been thrown
         }
@@ -398,7 +398,7 @@ public class BeanAsArrayDeserializer
                 if (i >= propCount
                         && !_ignoreAllUnknown && ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
                     ctxt.reportWrongTokenException(this, JsonToken.END_ARRAY,
-                            "Unexpected JSON values; expected at most %d properties (in JSON Array)",
+                            "Unexpected JSON value(s); expected at most %d properties (in JSON Array)",
                             propCount);
                     // never gets here
                 }

--- a/src/test/java/tools/jackson/databind/struct/POJOAsArrayTest.java
+++ b/src/test/java/tools/jackson/databind/struct/POJOAsArrayTest.java
@@ -935,7 +935,7 @@ public class POJOAsArrayTest extends DatabindTestUtil
                     .readValue(json);
             fail("should not pass with extra element");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Unexpected JSON values");
+            verifyException(e, "Unexpected JSON value(s)");
         }
 
         // but actually fine if skip-unknown set
@@ -959,8 +959,7 @@ public class POJOAsArrayTest extends DatabindTestUtil
                     .readValue(json);
             fail("should not pass with extra element");
         } catch (MismatchedInputException e) {
-            // Looks like we get either "Unexpected JSON values" or "Unexpected JSON value(s)"
-            verifyException(e, "Unexpected JSON value");
+            verifyException(e, "Unexpected JSON value(s)");
         }
 
         // but actually fine if skip-unknown set
@@ -985,7 +984,7 @@ public class POJOAsArrayTest extends DatabindTestUtil
                     .readValue(json);
             fail("should not pass with extra element");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Unexpected JSON values");
+            verifyException(e, "Unexpected JSON value(s)");
         }
 
         // but actually fine if skip-unknown set
@@ -1010,7 +1009,7 @@ public class POJOAsArrayTest extends DatabindTestUtil
                     .readValue(json);
             fail("should not pass with extra element");
         } catch (MismatchedInputException e) {
-            verifyException(e, "Unexpected JSON values");
+            verifyException(e, "Unexpected JSON value(s)");
         }
 
         // but actually fine if skip-unknown set

--- a/src/test/java/tools/jackson/databind/struct/POJOAsArrayTest.java
+++ b/src/test/java/tools/jackson/databind/struct/POJOAsArrayTest.java
@@ -997,4 +997,29 @@ public class POJOAsArrayTest extends DatabindTestUtil
         assertEquals(2, v.y());
         assertEquals(3, v.z());
     }
+
+    // [databind#6043]: builder-based POJOs-as-Array using a property-based creator
+    // must honor FAIL_ON_UNKNOWN_PROPERTIES too, matching the non-builder sibling
+    @Test
+    public void testBuilderCreatorUnknownExtraProp() throws Exception
+    {
+        String json = "[1, 2, 3, 4]";
+        try {
+            MAPPER.readerFor(CreatorValue.class)
+                    .with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                    .readValue(json);
+            fail("should not pass with extra element");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Unexpected JSON values");
+        }
+
+        // but actually fine if skip-unknown set
+        CreatorValue v = MAPPER.readerFor(CreatorValue.class)
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .readValue(json);
+        assertNotNull(v);
+        assertEquals(1, v.a);
+        assertEquals(2, v.b);
+        assertEquals(3, v.c);
+    }
 }


### PR DESCRIPTION
Follow-up to #6043 / #6047. `BeanAsArrayBuilderDeserializer._deserializeUsingPropertyBased` skipped extra JSON Array elements without honoring `FAIL_ON_UNKNOWN_PROPERTIES`.

#6047 added this guard to the non-builder `BeanAsArrayDeserializer`. The reporter (@indyteo) pointed out that the builder variant at `BeanAsArrayBuilderDeserializer.java#L279` was left unchanged, while the vanilla and non-vanilla builder paths in the same class already enforce the feature.

### Changes
- Guard genuinely-extra array elements (`i >= propCount`) with `FAIL_ON_UNKNOWN_PROPERTIES` in the builder creator path, mirroring #6047; in-bounds null slots are still skipped.

### Testing
- `POJOAsArrayTest.testBuilderCreatorUnknownExtraProp`