### PR TITLE
Fix #4762: @JsonValue should honor @JsonInclude on annotated accessor

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -583,6 +583,16 @@ Alex Crowell (@alex-crowell)
    arrays of polymorphic types
   [3.3.0]
 
+Alexander Sikorskiy (@sikorskii)
+ * Reported #4762: `@JsonValue` ignores annotations on annotated accessor
+   (particularly `@JsonInclude`)
+  [3.3.0]
+
+seonwoo_jung (@seonwooj0810)
+ * Fixed #4762: `@JsonValue` ignores annotations on annotated accessor
+   (particularly `@JsonInclude`)
+  [3.3.0]
+
 Ivan (@pctF)
  * Reported #6069: tools.jackson.databind.ObjectMapper#convertValue does not throw
    `IllegalArgumentException` but throws `MismatchedInputException` when input and

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -14,12 +14,16 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @cowtowncoder, w/ Claude code)
 #1803: `TreeTraversingParser` should allow passing of parent context
  (fix by @cowtowncoder, w/ Claude code)
+#4762: `@JsonValue` serialization ignores annotations on the annotated accessor
+  (particularly `@JsonInclude`, `@JsonFormat`)
+ (reported by @sikorskii)
+ (fix by @seonwooj0810)
 #6069: Change throws declaration on convertValue to JacksonException to match what
   is actually thrown
  (reported by @pctF)
  (fix by @pjfanning)
 
-3.2.1 (not yet released)
+3.2.1 (10-Jul-2026)
 
 #6022: Follow-up to #5369: apply content @JsonInclude in
   `StringCollectionSerializer.serializeWithType`

--- a/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
@@ -216,7 +216,10 @@ public class JsonValueSerializer
      */
     protected BeanProperty _accessorProperty(BeanProperty property)
     {
-        if (_accessor == null) { // defensive: always non-null in practice
+        // Defensive: `_accessor` is always non-null in practice (set by constructors).
+        // If it somehow were null we cannot build an accessor-backed property, so fall
+        // back to the enclosing `property` unchanged (i.e. pre-[databind#4762] behavior).
+        if (_accessor == null) {
             return property;
         }
         PropertyName name = (property == null)
@@ -271,6 +274,9 @@ public class JsonValueSerializer
 
         @Override
         public <A extends Annotation> A getContextAnnotation(Class<A> acls) {
+            // Only the enclosing property can carry context annotations; the accessor-backed
+            // `super` always returns null here (`BeanProperty.Std.getContextAnnotation`), so
+            // delegating to `_enclosing` alone loses nothing when it is null.
             return (_enclosing == null) ? null : _enclosing.getContextAnnotation(acls);
         }
     }

--- a/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
@@ -233,7 +233,7 @@ public class JsonValueSerializer
      */
     protected static class JsonValueProperty extends BeanProperty.Std
     {
-        protected final transient BeanProperty _enclosing;
+        protected final BeanProperty _enclosing;
 
         public JsonValueProperty(BeanProperty enclosing, PropertyName name,
                 JavaType type, PropertyName wrapperName,

--- a/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
@@ -1,17 +1,21 @@
 package tools.jackson.databind.ser.jackson;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
 import tools.jackson.core.*;
 import tools.jackson.core.type.WritableTypeId;
 import tools.jackson.databind.*;
 import tools.jackson.databind.annotation.JacksonStdImpl;
+import tools.jackson.databind.cfg.MapperConfig;
 import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
@@ -184,8 +188,13 @@ public class JsonValueSerializer
                 return withResolved(property, vts, ser, forceTypeInformation);
             }
             // [databind#2822]: better hold on to "property", regardless
-            if (property != _property) {
-                return withResolved(property, vts, ser, _forceTypeInformation);
+            // [databind#4762]: but bind it to the `@JsonValue` accessor, so that
+            //   annotations on the accessor (notably `@JsonInclude(content=...)`) are
+            //   honored when the (non-final) value serializer is resolved dynamically
+            //   at write time (via `_property` in `StdDynamicSerializer#_findAndAddDynamic`).
+            BeanProperty valueProp = _accessorProperty(property);
+            if (valueProp != _property) {
+                return withResolved(valueProp, vts, ser, _forceTypeInformation);
             }
         } else {
             // 05-Sep-2013, tatu: I _think_ this can be considered a primary property...
@@ -193,6 +202,74 @@ public class JsonValueSerializer
             return withResolved(property, vts, ser, _forceTypeInformation);
         }
         return this;
+    }
+
+    /**
+     * Constructs a {@link BeanProperty} used to contextualize the value serializer.
+     * Configuration declared on the enclosing property (e.g. {@code @JsonFormat},
+     * see [databind#2822]) continues to take precedence, while configuration declared
+     * on the {@code @JsonValue} accessor itself (e.g. {@code @JsonInclude}) is layered
+     * underneath so that it is no longer silently ignored. [databind#4762]
+     */
+    protected BeanProperty _accessorProperty(BeanProperty property)
+    {
+        if (_accessor == null) { // defensive: always non-null in practice
+            return property;
+        }
+        PropertyName name = (property == null)
+                ? PropertyName.construct(_accessor.getName()) : property.getFullName();
+        PropertyName wrapperName = (property == null) ? null : property.getWrapperName();
+        PropertyMetadata metadata = (property == null)
+                ? PropertyMetadata.STD_REQUIRED_OR_OPTIONAL : property.getMetadata();
+        return new JsonValueProperty(property, name, _valueType, wrapperName, _accessor, metadata);
+    }
+
+    /**
+     * {@link BeanProperty} used when contextualizing the value serializer for a
+     * {@code @JsonValue} accessor. It is backed by the accessor (so annotations such as
+     * {@code @JsonInclude} declared on it are seen, [databind#4762]) but lets any
+     * configuration on the enclosing property override it, preserving the established
+     * precedence where property-level {@code @JsonFormat} wins ([databind#2822]).
+     */
+    protected static class JsonValueProperty extends BeanProperty.Std
+    {
+        protected final transient BeanProperty _enclosing;
+
+        public JsonValueProperty(BeanProperty enclosing, PropertyName name,
+                JavaType type, PropertyName wrapperName,
+                AnnotatedMember accessor, PropertyMetadata metadata) {
+            super(name, type, wrapperName, accessor, metadata);
+            _enclosing = enclosing;
+        }
+
+        @Override
+        public JsonFormat.Value findPropertyFormat(MapperConfig<?> config, Class<?> baseType) {
+            JsonFormat.Value v = super.findPropertyFormat(config, baseType);
+            if (_enclosing != null) {
+                v = v.withOverrides(_enclosing.findPropertyFormat(config, baseType));
+            }
+            return v;
+        }
+
+        @Override
+        public JsonInclude.Value findPropertyInclusion(MapperConfig<?> config, Class<?> baseType) {
+            JsonInclude.Value v = super.findPropertyInclusion(config, baseType);
+            if (_enclosing != null) {
+                v = v.withOverrides(_enclosing.findPropertyInclusion(config, baseType));
+            }
+            return v;
+        }
+
+        @Override
+        public <A extends Annotation> A getAnnotation(Class<A> acls) {
+            A a = (_enclosing == null) ? null : _enclosing.getAnnotation(acls);
+            return (a != null) ? a : super.getAnnotation(acls);
+        }
+
+        @Override
+        public <A extends Annotation> A getContextAnnotation(Class<A> acls) {
+            return (_enclosing == null) ? null : _enclosing.getContextAnnotation(acls);
+        }
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jackson/JsonValueSerializer.java
@@ -166,6 +166,12 @@ public class JsonValueSerializer
         }
         ValueSerializer<?> ser = _valueSerializer;
         if (ser == null) {
+            // [databind#4762]: bind the value serializer to the `@JsonValue` accessor, so
+            //   that annotations on the accessor (notably `@JsonInclude`/`@JsonFormat`) are
+            //   honored. Configuration on the enclosing property still takes precedence
+            //   (see `JsonValueProperty`), preserving [databind#2822].
+            BeanProperty valueProp = _accessorProperty(property);
+
             // Can only assign serializer statically if the declared type is final:
             // if not, we don't really know the actual type until we get the instance.
 
@@ -178,21 +184,18 @@ public class JsonValueSerializer
                  *   to serializer factory at this point...
                  */
                 // I _think_ this can be considered a primary property...
-                ser = ctxt.findPrimaryPropertySerializer(_valueType, property);
+                ser = ctxt.findPrimaryPropertySerializer(_valueType, valueProp);
                 ser = _withIgnoreProperties(ser, _ignoredProperties);
                 /* 09-Dec-2010, tatu: Turns out we must add special handling for
                  *   cases where "native" (aka "natural") type is being serialized,
                  *   using standard serializer
                  */
                 boolean forceTypeInformation = isNaturalTypeWithStdHandling(_valueType.getRawClass(), ser);
-                return withResolved(property, vts, ser, forceTypeInformation);
+                return withResolved(valueProp, vts, ser, forceTypeInformation);
             }
-            // [databind#2822]: better hold on to "property", regardless
-            // [databind#4762]: but bind it to the `@JsonValue` accessor, so that
-            //   annotations on the accessor (notably `@JsonInclude(content=...)`) are
-            //   honored when the (non-final) value serializer is resolved dynamically
-            //   at write time (via `_property` in `StdDynamicSerializer#_findAndAddDynamic`).
-            BeanProperty valueProp = _accessorProperty(property);
+            // [databind#2822]: better hold on to "property", regardless. For the non-final
+            //   value type the serializer is resolved dynamically at write time via
+            //   `_property` in `StdDynamicSerializer#_findAndAddDynamic`.
             if (valueProp != _property) {
                 return withResolved(valueProp, vts, ser, _forceTypeInformation);
             }

--- a/src/test/java/tools/jackson/databind/ser/JsonValueIgnoresJsonInclude4762Test.java
+++ b/src/test/java/tools/jackson/databind/ser/JsonValueIgnoresJsonInclude4762Test.java
@@ -1,4 +1,4 @@
-package tools.jackson.databind.tofix;
+package tools.jackson.databind.ser;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -10,11 +10,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
-import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// [databind#4762]: `@JsonValue` ignores `@JsonInclude` declared on the annotated field
+// [databind#4762]: `@JsonValue` should honor `@JsonInclude` declared on the annotated accessor
 class JsonValueIgnoresJsonInclude4762Test extends DatabindTestUtil
 {
     static class JsonValueWithInclude {
@@ -30,7 +29,6 @@ class JsonValueIgnoresJsonInclude4762Test extends DatabindTestUtil
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    @JacksonTestFailureExpected
     @Test
     void jsonValueShouldHonorJsonIncludeOnField() throws Exception {
         Map<String, Object> map = new LinkedHashMap<>();

--- a/src/test/java/tools/jackson/databind/ser/JsonValueIgnoresJsonInclude4762Test.java
+++ b/src/test/java/tools/jackson/databind/ser/JsonValueIgnoresJsonInclude4762Test.java
@@ -1,10 +1,12 @@
 package tools.jackson.databind.ser;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -50,6 +52,30 @@ class JsonValueIgnoresJsonInclude4762Test extends DatabindTestUtil
         }
     }
 
+    // [databind#4762]: accessor annotations must also be honored when the `@JsonValue`
+    // value type is `final` (here `BigDecimal`), which takes the static-typing branch of
+    // `createContextual` rather than the dynamic one.
+    static class FinalValueWithFormat {
+        @JsonValue
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public final BigDecimal value;
+
+        FinalValueWithFormat(BigDecimal value) {
+            this.value = value;
+        }
+    }
+
+    // Enclosing property overriding the format back to NUMBER: [databind#2822] precedence
+    // must hold in the static-typing branch too, so the enclosing override wins.
+    static class WrapperFormatNumber {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public FinalValueWithFormat wrapped;
+
+        WrapperFormatNumber(FinalValueWithFormat wrapped) {
+            this.wrapped = wrapped;
+        }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     private Map<String, Object> mapWithNull() {
@@ -85,5 +111,23 @@ class JsonValueIgnoresJsonInclude4762Test extends DatabindTestUtil
         String json = MAPPER.writeValueAsString(new WrapperContentAlways(new JsonValueWithInclude(mapWithNull())));
 
         assertEquals("{\"wrapped\":{\"present\":\"x\",\"missing\":null}}", json);
+    }
+
+    // [databind#4762]: accessor-level `@JsonFormat` must be honored for a `final` value
+    // type (static-typing branch), so the `BigDecimal` is written as a String.
+    @Test
+    void jsonValueShouldHonorJsonFormatOnFinalAccessor() throws Exception {
+        String json = MAPPER.writeValueAsString(new FinalValueWithFormat(BigDecimal.ONE));
+
+        assertEquals("\"1\"", json);
+    }
+
+    // [databind#2822]: enclosing-property configuration still wins in the static-typing
+    // branch, so the enclosing `@JsonFormat(NUMBER)` overrides the accessor's STRING.
+    @Test
+    void enclosingPropertyFormatShouldOverrideAccessor() throws Exception {
+        String json = MAPPER.writeValueAsString(new WrapperFormatNumber(new FinalValueWithFormat(BigDecimal.ONE)));
+
+        assertEquals("{\"wrapped\":1}", json);
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/JsonValueIgnoresJsonInclude4762Test.java
+++ b/src/test/java/tools/jackson/databind/ser/JsonValueIgnoresJsonInclude4762Test.java
@@ -27,18 +27,63 @@ class JsonValueIgnoresJsonInclude4762Test extends DatabindTestUtil
         }
     }
 
+    // Enclosing property with no inclusion override of its own: the accessor-level
+    // `@JsonInclude` must still be honored when contextualized against a (non-null)
+    // enclosing `BeanProperty`.
+    static class Wrapper {
+        public JsonValueWithInclude wrapped;
+
+        Wrapper(JsonValueWithInclude wrapped) {
+            this.wrapped = wrapped;
+        }
+    }
+
+    // Enclosing property that overrides content inclusion to ALWAYS: per the established
+    // precedence ([databind#2822]) the enclosing property configuration wins, re-including
+    // the null map values that the accessor-level `@JsonInclude` would otherwise drop.
+    static class WrapperContentAlways {
+        @JsonInclude(content = JsonInclude.Include.ALWAYS)
+        public JsonValueWithInclude wrapped;
+
+        WrapperContentAlways(JsonValueWithInclude wrapped) {
+            this.wrapped = wrapped;
+        }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
-    @Test
-    void jsonValueShouldHonorJsonIncludeOnField() throws Exception {
+    private Map<String, Object> mapWithNull() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("present", "x");
         map.put("missing", null);
+        return map;
+    }
 
-        String json = MAPPER.writeValueAsString(new JsonValueWithInclude(map));
+    @Test
+    void jsonValueShouldHonorJsonIncludeOnField() throws Exception {
+        String json = MAPPER.writeValueAsString(new JsonValueWithInclude(mapWithNull()));
 
         // Expected: `@JsonInclude(content = NON_NULL)` on the `@JsonValue` field
         // should drop null map values.
         assertEquals("{\"present\":\"x\"}", json);
+    }
+
+    // [databind#4762]: accessor-level `@JsonInclude` must be honored even when the
+    // `@JsonValue` type is nested behind an enclosing property (exercises the
+    // `_enclosing != null` contextualization path).
+    @Test
+    void jsonValueShouldHonorJsonIncludeWhenNested() throws Exception {
+        String json = MAPPER.writeValueAsString(new Wrapper(new JsonValueWithInclude(mapWithNull())));
+
+        assertEquals("{\"wrapped\":{\"present\":\"x\"}}", json);
+    }
+
+    // [databind#2822]: configuration on the enclosing property still takes precedence over
+    // accessor-level configuration, so a `content = ALWAYS` override re-includes null values.
+    @Test
+    void enclosingPropertyInclusionShouldOverrideAccessor() throws Exception {
+        String json = MAPPER.writeValueAsString(new WrapperContentAlways(new JsonValueWithInclude(mapWithNull())));
+
+        assertEquals("{\"wrapped\":{\"present\":\"x\",\"missing\":null}}", json);
     }
 }


### PR DESCRIPTION
Fixes #4762

### Root cause
When a type is serialized via a `@JsonValue` accessor, `JsonValueSerializer` contextualizes the value serializer against the **enclosing** `BeanProperty` only. As a result, annotations declared on the `@JsonValue` accessor itself — notably `@JsonInclude` — are never seen by the value serializer, so e.g. `@JsonInclude(content = NON_NULL)` on a `@JsonValue Map` field is silently ignored and null map entries leak into the output.

### Change
`createContextual` now binds the value serializer to a `BeanProperty` backed by the `@JsonValue` accessor (new `JsonValueProperty`), so accessor-level `@JsonInclude`/`@JsonFormat`/annotations are honored. Configuration on the enclosing property still takes precedence — `findPropertyFormat`/`findPropertyInclusion` layer the enclosing overrides on top — preserving the established [databind#2822] behavior where property-level `@JsonFormat` wins.

### Test evidence
Promotes the maintainer-merged failing test from PR #5987 out of `tofix/` into `ser/JsonValueIgnoresJsonInclude4762Test` (removing `@JacksonTestFailureExpected`).
- Before the fix: `{"present":"x","missing":null}` (fails)
- After the fix: `{"present":"x"}` (passes)

Verification done: full `ser`, `jsontype` and `*JsonFormat*` test suites pass (1154 tests, 0 failures) — no regression to `@JsonValue`, `@JsonInclude`, or `[databind#2822]` `@JsonFormat` behavior.
