### PR TITLE
Honor `FAIL_ON_UNEXPECTED_VIEW_PROPERTIES` in property-based Creator deserialization

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -374,8 +374,12 @@ public class BeanDeserializer
             if (creatorProp != null) {
                 // [databind#5966] Honor @JsonView visibility, injection-only on creator parameters
                 // (also covers [databind#5971] view check on the record-update path)
-                if (((activeView != null) && !creatorProp.visibleInView(activeView))
-                        || creatorProp.isInjectionOnly()) {
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
+                if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
+                    _handleUnexpectedView(p, ctxt, creatorProp, activeView);
+                    continue;
+                }
+                if (creatorProp.isInjectionOnly()) {
                     p.skipChildren();
                     continue;
                 }
@@ -747,8 +751,9 @@ public class BeanDeserializer
 
             // Creator property?
             if (creatorProp != null) {
+                // [databind#6077]: honor FAIL_ON_UNEXPECTED_VIEW_PROPERTIES on Creator props too
                 if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, creatorProp, activeView);
                     continue;
                 }
                 // [databind#1381]: if useInput=FALSE, skip deserialization from input
@@ -791,8 +796,9 @@ public class BeanDeserializer
                 // [databind#5969]: must honor active view here too -- otherwise
                 // setterless/merging collection properties hidden by view can be
                 // populated via the buffering path below.
+                // [databind#6077]: and fail rather than skip when the feature is enabled
                 if ((activeView != null) && !prop.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 // [databind#3724]: Special handling because Records' ignored creator props
@@ -1030,6 +1036,34 @@ public class BeanDeserializer
     /**********************************************************************
      */
 
+    /**
+     * Helper method called when a property found in input is not visible in the
+     * currently active View: either skips the value quietly, or -- if
+     * {@link DeserializationFeature#FAIL_ON_UNEXPECTED_VIEW_PROPERTIES} is enabled --
+     * reports an input mismatch.
+     *<p>
+     * Extracted so that the property-based Creator paths behave consistently with
+     * the setter-based {@link #deserializeWithView} path: previously only the latter
+     * honored {@code FAIL_ON_UNEXPECTED_VIEW_PROPERTIES}, so a value deserialized via
+     * a Creator (constructor / factory) silently skipped out-of-view properties even
+     * when the feature was enabled (see [databind#6077]).
+     *
+     * @since 3.3
+     */
+    protected void _handleUnexpectedView(JsonParser p, DeserializationContext ctxt,
+            SettableBeanProperty prop, Class<?> activeView)
+        throws JacksonException
+    {
+        // [databind#437] / [databind#6077]: properties in other views treated as unknown properties
+        if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)) {
+            ctxt.reportInputMismatch(handledType(),
+                    String.format("Input mismatch while deserializing %s. Property '%s' is not part of current active view '%s'" +
+                            " (disable 'DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES' to allow)",
+                            ClassUtil.nameOf(handledType()), prop.getName(), activeView.getName()));
+        }
+        p.skipChildren();
+    }
+
     protected final Object deserializeWithView(JsonParser p, DeserializationContext ctxt,
             Object bean, Class<?> activeView)
         throws JacksonException
@@ -1040,13 +1074,7 @@ public class BeanDeserializer
                 SettableBeanProperty prop = _propsByIndex[ix];
                 if (!prop.visibleInView(activeView)) {
                     // [databind#437]: fields in other views to be considered as unknown properties
-                    if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)){
-                        ctxt.reportInputMismatch(handledType(),
-                                String.format("Input mismatch while deserializing %s. Property '%s' is not part of current active view '%s'" +
-                                        " (disable 'DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES' to allow)",
-                                        ClassUtil.nameOf(handledType()), prop.getName(), activeView.getName()));
-                    }
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 try {
@@ -1105,8 +1133,9 @@ public class BeanDeserializer
             if (ix >= 0) { // common case
                 p.nextToken();
                 SettableBeanProperty prop = _propsByIndex[ix];
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if ((activeView != null) && !prop.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 try {
@@ -1179,8 +1208,9 @@ public class BeanDeserializer
             if (ix >= 0) { // common case
                 p.nextToken();
                 SettableBeanProperty prop = _propsByIndex[ix];
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if ((activeView != null) && !prop.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 try {
@@ -1254,8 +1284,9 @@ public class BeanDeserializer
 
             if (creatorProp != null) {
                 // [databind#5971]: must honor active view here too
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, creatorProp, activeView);
                     continue;
                 }
                 // [databind#1381]: if useInput=FALSE, skip deserialization from input
@@ -1284,8 +1315,9 @@ public class BeanDeserializer
             if (ix >= 0) {
                 SettableBeanProperty prop = _propsByIndex[ix];
                 // [databind#5969]: must honor active view here too
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if ((activeView != null) && !prop.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 buffer.bufferProperty(prop, _deserializeWithErrorWrapping(p, ctxt, prop));
@@ -1405,8 +1437,9 @@ public class BeanDeserializer
                         && ext.handleTypePropertyValue(p, ctxt, p.currentName(), bean)) {
                     continue;
                 }
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if (activeView != null && !prop.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 try {
@@ -1470,8 +1503,9 @@ public class BeanDeserializer
             }
             if (creatorProp != null) {
                 // [databind#5971]: must honor active view here too
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if ((activeView != null) && !creatorProp.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, creatorProp, activeView);
                     continue;
                 }
                 // [databind#1381]: if useInput=FALSE, skip deserialization from input
@@ -1499,8 +1533,9 @@ public class BeanDeserializer
                 SettableBeanProperty prop = _propsByIndex[ix];
                 // [databind#5958]: check view before storing external type ID so that a
                 // view-restricted type discriminator is not processed in other views.
+                // [databind#6077]: fail (not just skip) when FAIL_ON_UNEXPECTED_VIEW_PROPERTIES is enabled
                 if (activeView != null && !prop.visibleInView(activeView)) {
-                    p.skipChildren();
+                    _handleUnexpectedView(p, ctxt, prop, activeView);
                     continue;
                 }
                 // [databind#3045]: may have property AND be used as external type id:

--- a/src/test/java/tools/jackson/databind/views/MultipleViewsDeser437Test.java
+++ b/src/test/java/tools/jackson/databind/views/MultipleViewsDeser437Test.java
@@ -2,6 +2,8 @@ package tools.jackson.databind.views;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import tools.jackson.databind.*;
@@ -10,6 +12,7 @@ import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultipleViewsDeser437Test extends DatabindTestUtil
@@ -26,6 +29,25 @@ public class MultipleViewsDeser437Test extends DatabindTestUtil
         public String view1Field;
         @JsonView(View2.class)
         public String view2Field;
+    }
+
+    // [databind#6077]: same as Bean437 but populated via a property-based Creator
+    // (constructor) instead of setters/fields
+    static class CreatorBean6077 {
+        public final String nonViewField;
+        @JsonView(View1.class)
+        public final String view1Field;
+        @JsonView(View2.class)
+        public final String view2Field;
+
+        @JsonCreator
+        public CreatorBean6077(@JsonProperty("nonViewField") String nonViewField,
+                @JsonProperty("view1Field") String view1Field,
+                @JsonProperty("view2Field") String view2Field) {
+            this.nonViewField = nonViewField;
+            this.view1Field = view1Field;
+            this.view2Field = view2Field;
+        }
     }
 
     @JsonDeserialize(builder = SimpleBuilderXY.class)
@@ -115,6 +137,37 @@ public class MultipleViewsDeser437Test extends DatabindTestUtil
         assertEquals(1, withY._x);
         assertEquals(11, withY._y);
         assertEquals(1, withY._z);
+    }
+
+    // [databind#6077]: property-based Creator path must honor FAIL_ON_UNEXPECTED_VIEW_PROPERTIES
+    // just like the setter-based path already did
+    @Test
+    public void testDeserMultipleViewsWithCreator() throws Exception
+    {
+        // Mirror [databind#6077]: with DEFAULT_VIEW_INCLUSION on, only 'view2Field' is
+        // out-of-view under View1 (nonViewField has no @JsonView so it stays visible)
+        final ObjectMapper enabled = jsonMapperBuilder()
+            .enable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .enable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+            .build();
+        final ObjectMapper disabled = jsonMapperBuilder()
+            .enable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+            .build();
+        final String json = a2q("{'nonViewField':'a','view1Field':'b','view2Field':'c'}");
+
+        // When enabled, a value built via a Creator must also fail on the out-of-view property
+        _testMismatchException(
+            enabled.readerWithView(View1.class).forType(CreatorBean6077.class),
+            json);
+
+        // When disabled, out-of-view properties are silently ignored (behavior unchanged)
+        CreatorBean6077 result = disabled.readerWithView(View1.class)
+            .forType(CreatorBean6077.class)
+            .readValue(json);
+        assertEquals("a", result.nonViewField);
+        assertEquals("b", result.view1Field);
+        assertNull(result.view2Field);
     }
 
     private void _testMismatchException(ObjectReader reader, String json) throws Exception {


### PR DESCRIPTION
Fixes #6077

### Root cause
Only the setter-based `deserializeWithView` path checked `DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES`. The property-based **Creator** paths in `BeanDeserializer` (constructor/factory deserialization — plus the unwrapped, external-type-id and record-update variants) unconditionally called `p.skipChildren()` for a property hidden by the active `@JsonView`. So a POJO deserialized via a Creator silently ignored out-of-view properties even with the feature enabled, while the same POJO using setters correctly threw — exactly the inconsistency reported in #6077.

### Change
Extracted the skip-or-fail decision into a `_handleUnexpectedView(...)` helper (as @joca-bt suggested in the issue) and used it at every view-visibility skip point in `BeanDeserializer`, so Creator and setter paths behave identically. The feature is opt-in (`DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES` defaults to `false`), so default behavior is unchanged — only users who already enabled it, and were silently getting the wrong result on Creator-based types, are affected.

### Test evidence
Added `MultipleViewsDeser437Test#testDeserMultipleViewsWithCreator`, mirroring the issue reproducer (property-based Creator + `DEFAULT_VIEW_INCLUSION`). It **fails before** the change (out-of-view `view2Field` silently accepted) and **passes after**; the disabled-feature case still ignores the property, confirming no behavior change when the flag is off.

Verification done:
- `mvn test -Dtest=MultipleViewsDeser437Test` — passes with fix, `testDeserMultipleViewsWithCreator` fails when the production change is reverted (confirmed).
- Full `tools.jackson.databind.views.**` + `tools.jackson.databind.records.**` packages: 287 tests, 0 failures.

Note: `BuilderBasedDeserializer` has the analogous gap on its Creator paths; happy to apply the same helper there in a follow-up if you would prefer to keep this PR focused on the reported `BeanDeserializer` case.

Automated contribution assisted by an AI coding agent; all changes were reviewed and tested locally by me.