### PR TITLE
refactor tests

### DIFF
--- a/src/test/java/tools/jackson/databind/HandlerInstantiationTest.java
+++ b/src/test/java/tools/jackson/databind/HandlerInstantiationTest.java
@@ -17,12 +17,13 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.TypeIdResolver;
 import tools.jackson.databind.jsontype.TypeResolverBuilder;
 import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static tools.jackson.databind.testutil.DatabindTestUtil.q;
 
-public class HandlerInstantiationTest
+public class HandlerInstantiationTest extends DatabindTestUtil
 {
     /*
     /**********************************************************************
@@ -233,7 +234,7 @@ public class HandlerInstantiationTest
     @Test
     public void testDeserializer() throws Exception
     {
-        JsonMapper mapper = JsonMapper.builder()
+        JsonMapper mapper = jsonMapperBuilder()
                 .handlerInstantiator(new MyInstantiator("abc:"))
                 .build();
         MyBean result = mapper.readValue(q("123"), MyBean.class);
@@ -243,18 +244,18 @@ public class HandlerInstantiationTest
     @Test
     public void testKeyDeserializer() throws Exception
     {
-        JsonMapper mapper = JsonMapper.builder()
+        JsonMapper mapper = jsonMapperBuilder()
                 .handlerInstantiator(new MyInstantiator("abc:"))
                 .build();
-        MyMap map = mapper.readValue("{\"a\":\"b\"}", MyMap.class);
+        MyMap map = mapper.readValue(a2q("{'a':'b'}"), MyMap.class);
         // easiest to test by just serializing...
-        assertEquals("{\"KEY\":\"b\"}", mapper.writeValueAsString(map));
+        assertEquals(a2q("{'KEY':'b'}"), mapper.writeValueAsString(map));
     }
 
     @Test
     public void testSerializer() throws Exception
     {
-        JsonMapper mapper = JsonMapper.builder()
+        JsonMapper mapper = jsonMapperBuilder()
                 .handlerInstantiator(new MyInstantiator("xyz:"))
                 .build();
         assertEquals(q("xyz:456"), mapper.writeValueAsString(new MyBean("456")));
@@ -268,7 +269,7 @@ public class HandlerInstantiationTest
                 .build();
         String json = mapper.writeValueAsString(new TypeIdBeanWrapper(new TypeIdBean(123)));
         // should now use our custom id scheme:
-        assertEquals("{\"bean\":[\"!!!\",{\"x\":123}]}", json);
+        assertEquals(a2q("{'bean':['!!!',{'x':123}]}"), json);
         // and bring it back too:
         TypeIdBeanWrapper result = mapper.readValue(json, TypeIdBeanWrapper.class);
         TypeIdBean bean = result.bean;

--- a/src/test/java/tools/jackson/databind/ObjectReaderTest.java
+++ b/src/test/java/tools/jackson/databind/ObjectReaderTest.java
@@ -92,7 +92,7 @@ public class ObjectReaderTest extends DatabindTestUtil
     public void testReaderForArrayOf() throws Exception
     {
         Object value = MAPPER.readerForArrayOf(ABC.class)
-                .readValue("[ \"A\", \"C\" ]");
+                .readValue(a2q("[ 'A', 'C' ]"));
         assertEquals(ABC[].class, value.getClass());
         ABC[] abcs = (ABC[]) value;
         assertEquals(2, abcs.length);
@@ -105,7 +105,7 @@ public class ObjectReaderTest extends DatabindTestUtil
     public void testReaderForListOf() throws Exception
     {
         Object value = MAPPER.readerForListOf(ABC.class)
-                .readValue("[ \"B\", \"C\" ]");
+                .readValue(a2q("[ 'B', 'C' ]"));
         assertEquals(ArrayList.class, value.getClass());
         assertEquals(Arrays.asList(ABC.B, ABC.C), value);
     }
@@ -115,7 +115,7 @@ public class ObjectReaderTest extends DatabindTestUtil
     public void testReaderForMapOf() throws Exception
     {
         Object value = MAPPER.readerForMapOf(ABC.class)
-                .readValue("{\"key\" : \"B\" }");
+                .readValue(a2q("{'key' : 'B' }"));
         assertEquals(LinkedHashMap.class, value.getClass());
         assertEquals(Collections.singletonMap("key", ABC.B), value);
     }
@@ -427,7 +427,7 @@ public class ObjectReaderTest extends DatabindTestUtil
 
     @Test
     public void testNoPointerLoading() throws Exception {
-        final String source = "{\"foo\":{\"bar\":{\"caller\":{\"name\":{\"value\":1234}}}}}";
+        final String source = a2q("{'foo':{'bar':{'caller':{'name':{'value':1234}}}}}");
 
         JsonNode tree = MAPPER.readTree(source);
         JsonNode node = tree.at("/foo/bar/caller");
@@ -438,7 +438,7 @@ public class ObjectReaderTest extends DatabindTestUtil
 
     @Test
     public void testPointerLoading() throws Exception {
-        final String source = "{\"foo\":{\"bar\":{\"caller\":{\"name\":{\"value\":1234}}}}}";
+        final String source = a2q("{'foo':{'bar':{'caller':{'name':{'value':1234}}}}}");
 
         ObjectReader reader = MAPPER.readerFor(POJO.class).at("/foo/bar/caller");
 
@@ -449,18 +449,18 @@ public class ObjectReaderTest extends DatabindTestUtil
 
     @Test
     public void testPointerLoadingAsJsonNode() throws Exception {
-        final String source = "{\"foo\":{\"bar\":{\"caller\":{\"name\":{\"value\":1234}}}}}";
+        final String source = a2q("{'foo':{'bar':{'caller':{'name':{'value':1234}}}}}");
 
         ObjectReader reader = MAPPER.readerFor(POJO.class).at(JsonPointer.compile("/foo/bar/caller"));
 
         JsonNode node = reader.readTree(source);
         assertTrue(node.has("name"));
-        assertEquals("{\"value\":1234}", node.get("name").toString());
+        assertEquals(a2q("{'value':1234}"), node.get("name").toString());
     }
 
     @Test
     public void testPointerLoadingMappingIteratorOne() throws Exception {
-        final String source = "{\"foo\":{\"bar\":{\"caller\":{\"name\":{\"value\":1234}}}}}";
+        final String source = a2q("{'foo':{'bar':{'caller':{'name':{'value':1234}}}}}");
 
         ObjectReader reader = MAPPER.readerFor(POJO.class).at("/foo/bar/caller");
 
@@ -476,7 +476,7 @@ public class ObjectReaderTest extends DatabindTestUtil
 
     @Test
     public void testPointerLoadingMappingIteratorMany() throws Exception {
-        final String source = "{\"foo\":{\"bar\":{\"caller\":[{\"name\":{\"value\":1234}}, {\"name\":{\"value\":5678}}]}}}";
+        final String source = a2q("{'foo':{'bar':{'caller':[{'name':{'value':1234}}, {'name':{'value':5678}}]}}}");
 
         ObjectReader reader = MAPPER.readerFor(POJO.class).at("/foo/bar/caller");
 
@@ -633,7 +633,7 @@ public class ObjectReaderTest extends DatabindTestUtil
                 return true;
             }
         }).build();
-        A2297 aObject = mapper.readValue("{\"unknownField\" : 1, \"knownField\": \"test\"}",
+        A2297 aObject = mapper.readValue(a2q("{'unknownField' : 1, 'knownField': 'test'}"),
                 A2297.class);
 
         assertEquals("test", aObject.knownField);
@@ -653,7 +653,7 @@ public class ObjectReaderTest extends DatabindTestUtil
     @Test
     public void testCustomObjectNode() throws Exception
     {
-        ObjectNode defaultNode = (ObjectNode) MAPPER.readTree("{\"x\": 1, \"y\": 2}");
+        ObjectNode defaultNode = (ObjectNode) MAPPER.readTree(a2q("{'x': 1, 'y': 2}"));
         CustomObjectNode customObjectNode = new CustomObjectNode(defaultNode);
         Point point = MAPPER.readerFor(Point.class).readValue(customObjectNode);
         assertEquals(1, point.x);
@@ -665,7 +665,7 @@ public class ObjectReaderTest extends DatabindTestUtil
     public void testCustomArrayNode() throws Exception
     {
         ArrayNode defaultNode = (ArrayNode) MAPPER.readTree(
-                new StringReader("[{\"x\": 1, \"y\": 2}]"));
+                new StringReader(a2q("[{'x': 1, 'y': 2}]")));
         DelegatingArrayNode customArrayNode = new DelegatingArrayNode(defaultNode);
         Point[] points = MAPPER.readerFor(Point[].class).readValue(customArrayNode);
         Point point = points[0];

--- a/src/test/java/tools/jackson/databind/ObjectWriterTest.java
+++ b/src/test/java/tools/jackson/databind/ObjectWriterTest.java
@@ -17,6 +17,7 @@ import tools.jackson.core.json.JsonWriteFeature;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.cfg.EnumFeature;
 import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,7 +27,7 @@ import static tools.jackson.databind.testutil.DatabindTestUtil.*;
  * Unit tests for checking features added to {@link ObjectWriter}, such
  * as adding of explicit pretty printer.
  */
-public class ObjectWriterTest
+public class ObjectWriterTest extends DatabindTestUtil
 {
     static class CloseableValue implements Closeable
     {
@@ -86,18 +87,18 @@ public class ObjectWriterTest
         data.put("a", 1);
 
         // default: no indentation
-        assertEquals("{\"a\":1}", writer.writeValueAsString(data));
+        assertEquals(a2q("{'a':1}"), writer.writeValueAsString(data));
 
         // and then with standard
         writer = writer.withDefaultPrettyPrinter();
 
         // pretty printer uses system-specific line feeds, so we do that as well.
-        String lf = System.getProperty("line.separator");
-        assertEquals("{" + lf + "  \"a\" : 1" + lf + "}", writer.writeValueAsString(data));
+        String lf = System.lineSeparator();
+        assertEquals(a2q("{" + lf + "  'a' : 1" + lf + "}"), writer.writeValueAsString(data));
 
         // and finally, again without indentation
         writer = writer.with((PrettyPrinter) null);
-        assertEquals("{\"a\":1}", writer.writeValueAsString(data));
+        assertEquals(a2q("{'a':1}"), writer.writeValueAsString(data));
     }
 
     @Test
@@ -118,7 +119,7 @@ public class ObjectWriterTest
         map.put("a", 1);
         assertEquals("{a:1}", writer.writeValueAsString(map));
         // but can also reconfigure
-        assertEquals("{\"a\":1}", writer.with(JsonWriteFeature.QUOTE_PROPERTY_NAMES)
+        assertEquals(a2q("{'a':1}"), writer.with(JsonWriteFeature.QUOTE_PROPERTY_NAMES)
                 .writeValueAsString(map));
     }
 
@@ -131,7 +132,7 @@ public class ObjectWriterTest
         stuff.put("a", 5);
         ObjectWriter writer = MAPPER.writerFor(JsonNode.class);
         String json = writer.writeValueAsString(stuff);
-        assertEquals("{\"a\":5}", json);
+        assertEquals(a2q("{'a':5}"), json);
 
         assertTrue(W.createArrayNode().isArray());
     }
@@ -358,7 +359,7 @@ public class ObjectWriterTest
             w.acceptJsonFormatVisitor((JavaType) null, null);
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "argument \"type\" is null");
+            verifyException(e, a2q("argument 'type' is null"));
         }
     }
 
@@ -393,7 +394,7 @@ public class ObjectWriterTest
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -408,7 +409,7 @@ public class ObjectWriterTest
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -420,7 +421,7 @@ public class ObjectWriterTest
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -432,7 +433,7 @@ public class ObjectWriterTest
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(writer.toString(), "\"value\"");
+        assertEquals(a2q("'value'"), writer.toString());
 
         // the writer has not been closed by close
         writer.append('1');
@@ -448,7 +449,7 @@ public class ObjectWriterTest
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -472,7 +473,7 @@ public class ObjectWriterTest
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         MAPPER.writer().writeValue(outputStream, "value");
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -484,7 +485,7 @@ public class ObjectWriterTest
         Path path = Files.createTempFile("", "");
         MAPPER.writer().writeValue(path.toFile(), "value");
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -493,7 +494,7 @@ public class ObjectWriterTest
         Path path = Files.createTempFile("", "");
         MAPPER.writer().writeValue(path, "value");
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -502,7 +503,7 @@ public class ObjectWriterTest
         Writer writer = new StringWriter();
         MAPPER.writer().writeValue(writer, "value");
 
-        assertEquals(writer.toString(), "\"value\"");
+        assertEquals(writer.toString(), a2q("'value'"));
 
         // the writer has not been closed by close
         writer.append('1');
@@ -515,7 +516,7 @@ public class ObjectWriterTest
         DataOutput dataOutput = new DataOutputStream(outputStream);
         MAPPER.writer().writeValue(dataOutput, "value");
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -528,7 +529,7 @@ public class ObjectWriterTest
         JsonGenerator jsonGenerator = MAPPER.createGenerator(outputStream);
         MAPPER.writer().writeValue(jsonGenerator, "value");
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the output stream has not been closed by close
         outputStream.write(1);
@@ -553,7 +554,7 @@ public class ObjectWriterTest
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(outputStream);
         sequenceWriter.write("value");
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -566,7 +567,7 @@ public class ObjectWriterTest
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(path.toFile());
         sequenceWriter.write("value");
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -576,7 +577,7 @@ public class ObjectWriterTest
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(path);
         sequenceWriter.write("value");
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -586,7 +587,7 @@ public class ObjectWriterTest
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(writer);
         sequenceWriter.write("value");
 
-        assertEquals(writer.toString(), "\"value\"");
+        assertEquals(writer.toString(), a2q("'value'"));
 
         // the writer has not been closed by close
         writer.append('1');
@@ -600,7 +601,7 @@ public class ObjectWriterTest
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(dataOutput);
         sequenceWriter.write("value");
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -614,7 +615,7 @@ public class ObjectWriterTest
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(jsonGenerator);
         sequenceWriter.write("value");
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "\"value\"");
+        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the data output has not been closed by close
         outputStream.write(1);
@@ -641,7 +642,7 @@ public class ObjectWriterTest
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "[\"value\"]");
+        assertEquals(a2q("['value']"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -656,7 +657,7 @@ public class ObjectWriterTest
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "[\"value\"]");
+        assertEquals(a2q("['value']"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -668,7 +669,7 @@ public class ObjectWriterTest
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(new String(Files.readAllBytes(path), StandardCharsets.UTF_8), "[\"value\"]");
+        assertEquals(a2q("['value']"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -680,7 +681,7 @@ public class ObjectWriterTest
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(writer.toString(), "[\"value\"]");
+        assertEquals(a2q("['value']"), writer.toString());
 
         // the writer has not been closed by close
         writer.append('1');
@@ -696,7 +697,7 @@ public class ObjectWriterTest
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "[\"value\"]");
+        assertEquals(a2q("['value']"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -714,7 +715,7 @@ public class ObjectWriterTest
         jsonGenerator.flush();
         jsonGenerator.close();
 
-        assertEquals(new String(outputStream.toByteArray(), StandardCharsets.UTF_8), "[\"value\"]");
+        assertEquals(a2q("['value']"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
 
         // the data output has not been closed by close
         outputStream.write(1);

--- a/src/test/java/tools/jackson/databind/ObjectWriterTest.java
+++ b/src/test/java/tools/jackson/databind/ObjectWriterTest.java
@@ -394,7 +394,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -449,7 +449,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -473,7 +473,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         MAPPER.writer().writeValue(outputStream, "value");
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -503,7 +503,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         Writer writer = new StringWriter();
         MAPPER.writer().writeValue(writer, "value");
 
-        assertEquals(writer.toString(), a2q("'value'"));
+        assertEquals(a2q("'value'"), writer.toString());
 
         // the writer has not been closed by close
         writer.append('1');
@@ -516,7 +516,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         DataOutput dataOutput = new DataOutputStream(outputStream);
         MAPPER.writer().writeValue(dataOutput, "value");
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -529,7 +529,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         JsonGenerator jsonGenerator = MAPPER.createGenerator(outputStream);
         MAPPER.writer().writeValue(jsonGenerator, "value");
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the output stream has not been closed by close
         outputStream.write(1);
@@ -554,7 +554,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(outputStream);
         sequenceWriter.write("value");
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -587,7 +587,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(writer);
         sequenceWriter.write("value");
 
-        assertEquals(writer.toString(), a2q("'value'"));
+        assertEquals(a2q("'value'"), writer.toString());
 
         // the writer has not been closed by close
         writer.append('1');
@@ -601,7 +601,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(dataOutput);
         sequenceWriter.write("value");
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -615,7 +615,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(jsonGenerator);
         sequenceWriter.write("value");
 
-        assertEquals(a2q("'value'"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(outputStream));
 
         // the data output has not been closed by close
         outputStream.write(1);
@@ -642,7 +642,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(a2q("['value']"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("['value']"), utf8String(outputStream));
 
         // the stream has not been closed by close
         outputStream.write(1);
@@ -697,7 +697,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(a2q("['value']"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("['value']"), utf8String(outputStream));
 
         // the data output has not been closed by close
         dataOutput.write(1);
@@ -715,7 +715,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         jsonGenerator.flush();
         jsonGenerator.close();
 
-        assertEquals(a2q("['value']"), new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(a2q("['value']"), utf8String(outputStream));
 
         // the data output has not been closed by close
         outputStream.write(1);

--- a/src/test/java/tools/jackson/databind/ObjectWriterTest.java
+++ b/src/test/java/tools/jackson/databind/ObjectWriterTest.java
@@ -1,7 +1,6 @@
 package tools.jackson.databind;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 
@@ -409,7 +408,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -421,7 +420,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         jsonGenerator.writeString("value");
         jsonGenerator.close();
 
-        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -485,7 +484,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         Path path = Files.createTempFile("", "");
         MAPPER.writer().writeValue(path.toFile(), "value");
 
-        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -494,7 +493,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         Path path = Files.createTempFile("", "");
         MAPPER.writer().writeValue(path, "value");
 
-        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -567,7 +566,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(path.toFile());
         sequenceWriter.write("value");
 
-        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -577,7 +576,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         SequenceWriter sequenceWriter = MAPPER.writer().writeValues(path);
         sequenceWriter.write("value");
 
-        assertEquals(a2q("'value'"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("'value'"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -657,7 +656,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(a2q("['value']"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("['value']"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test
@@ -669,7 +668,7 @@ public class ObjectWriterTest extends DatabindTestUtil
         sequenceWriter.flush();
         sequenceWriter.close();
 
-        assertEquals(a2q("['value']"), new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        assertEquals(a2q("['value']"), utf8String(Files.readAllBytes(path)));
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/deser/AnySetterTest.java
+++ b/src/test/java/tools/jackson/databind/deser/AnySetterTest.java
@@ -336,10 +336,9 @@ public class AnySetterTest extends DatabindTestUtil
         assertEquals(Integer.valueOf(3), result.get("a"));
         assertEquals(Boolean.TRUE, result.get("b"));
         Object ob = result.get("c");
-        assertInstanceOf(List.class, ob);
-        List<?> l = (List<?>)ob;
+        List<?> l = assertInstanceOf(List.class, ob);
         assertEquals(3, l.size());
-        assertEquals(Integer.valueOf(3), l.get(2));
+        assertEquals(3, l.get(2));
     }
 
     @Test
@@ -445,8 +444,8 @@ public class AnySetterTest extends DatabindTestUtil
         assertEquals(1, result.props.size());
         Base ob = result.props.get("a");
         assertNotNull(ob);
-        assertInstanceOf(Impl.class, ob);
-        assertEquals("xyz", ((Impl) ob).value);
+        Impl impl = assertInstanceOf(Impl.class, ob);
+        assertEquals("xyz", impl.value);
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/deser/MergePolymorphicTest.java
+++ b/src/test/java/tools/jackson/databind/deser/MergePolymorphicTest.java
@@ -12,7 +12,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MergePolymorphicTest
 {
@@ -44,16 +44,16 @@ public class MergePolymorphicTest
     @Test
     public void testPolymorphicNewObject() throws Exception {
         Root root = MAPPER.readValue("{\"child\": { \"@type\": \"ChildA\", \"name\": \"I'm child A\" }}", Root.class);
-        assertInstanceOf(ChildA.class, root.child);
-        assertEquals("I'm child A", ((ChildA) root.child).name);
+        ChildA childA = assertInstanceOf(ChildA.class, root.child);
+        assertEquals("I'm child A", childA.name);
     }
 
     @Test
     public void testPolymorphicFromNullToNewObject() throws Exception {
         Root root = new Root();
         MAPPER.readerForUpdating(root).readValue("{\"child\": { \"@type\": \"ChildA\", \"name\": \"I'm the new name\" }}");
-        assertInstanceOf(ChildA.class, root.child);
-        assertEquals("I'm the new name", ((ChildA) root.child).name);
+        ChildA childA = assertInstanceOf(ChildA.class, root.child);
+        assertEquals("I'm the new name", childA.name);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class MergePolymorphicTest
         childA.name = "I'm child A";
         root.child = childA;
         MAPPER.readerForUpdating(root).readValue("{\"child\": null }");
-        assertTrue(root.child == null);
+        assertNull(root.child);
     }
 
     @Test
@@ -73,8 +73,8 @@ public class MergePolymorphicTest
         childA.name = "I'm child A";
         root.child = childA;
         MAPPER.readerForUpdating(root).readValue("{\"child\": { \"@type\": \"ChildA\", \"name\": \"I'm the new name\" }}");
-        assertInstanceOf(ChildA.class, root.child);
-        assertEquals("I'm the new name", ((ChildA) root.child).name);
+        ChildA childA1 = assertInstanceOf(ChildA.class, root.child);
+        assertEquals("I'm the new name", childA1.name);
     }
 
     @Test
@@ -85,8 +85,8 @@ public class MergePolymorphicTest
         root.child = childA;
         MAPPER.readerForUpdating(root).readValue("{\"child\": { \"@type\": \"ChildB\", \"code\": \"I'm the code\" }}");
         // The polymorphic type can't be changed
-        assertInstanceOf(ChildA.class, root.child);
-        assertEquals("I'm child A", ((ChildA) root.child).name);
+        ChildA childA1 = assertInstanceOf(ChildA.class, root.child);
+        assertEquals("I'm child A", childA1.name);
     }
 
 }

--- a/src/test/java/tools/jackson/databind/jsontype/ExistingPropertyTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/ExistingPropertyTest.java
@@ -341,11 +341,11 @@ public class ExistingPropertyTest extends DatabindTestUtil
     public void testSimpleClassAsExistingPropertyDeserializationFruits() throws Exception
     {
         Fruit pinguoDeserialized = MAPPER.readValue(pinguoJson, Fruit.class);
-        assertInstanceOf(Apple.class, pinguoDeserialized);
+        Apple apple = assertInstanceOf(Apple.class, pinguoDeserialized);
         assertSame(pinguoDeserialized.getClass(), Apple.class);
         assertEquals(pinguo.name, pinguoDeserialized.name);
-        assertEquals(pinguo.seedCount, ((Apple) pinguoDeserialized).seedCount);
-        assertEquals(pinguo.type, ((Apple) pinguoDeserialized).type);
+        assertEquals(pinguo.seedCount, apple.seedCount);
+        assertEquals(pinguo.type, apple.type);
 
         FruitWrapper pinguoWrapperDeserialized = MAPPER.readValue(pinguoWrapperJson, FruitWrapper.class);
         Fruit pinguoExtracted = pinguoWrapperDeserialized.fruit;

--- a/src/test/java/tools/jackson/databind/jsontype/JsonTypeInfoSimpleClassName4061Test.java
+++ b/src/test/java/tools/jackson/databind/jsontype/JsonTypeInfoSimpleClassName4061Test.java
@@ -209,9 +209,9 @@ public class JsonTypeInfoSimpleClassName4061Test extends DatabindTestUtil
         String jsonStr = "{\"child\": { \"@type\": \"MergeChildA\", \"name\": \"I'm child A\" }}";
         
         Root root = MAPPER.readValue(jsonStr, Root.class);
-        
-        assertInstanceOf(MergeChildA.class, root.child);
-        assertEquals("I'm child A", ((MergeChildA) root.child).name);
+
+        MergeChildA mergeChildA = assertInstanceOf(MergeChildA.class, root.child);
+        assertEquals("I'm child A", mergeChildA.name);
     }
 
     // case insenstive type name
@@ -224,9 +224,9 @@ public class JsonTypeInfoSimpleClassName4061Test extends DatabindTestUtil
                 .build();
 
         Root root = mapper.readValue(jsonStr, Root.class);
-        
-        assertInstanceOf(MergeChildA.class, root.child);
-        assertEquals("I'm child A", ((MergeChildA) root.child).name);
+
+        MergeChildA mergeChildA = assertInstanceOf(MergeChildA.class, root.child);
+        assertEquals("I'm child A", mergeChildA.name);
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithExistingPropertyTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithExistingPropertyTest.java
@@ -316,11 +316,11 @@ public class SealedTypesWithExistingPropertyTest extends DatabindTestUtil
     public void testSimpleClassAsExistingPropertyDeserializationFruits() throws Exception
     {
         Fruit pinguoDeserialized = MAPPER.readValue(pinguoJson, Fruit.class);
-        assertInstanceOf(Apple.class, pinguoDeserialized);
+        Apple apple = assertInstanceOf(Apple.class, pinguoDeserialized);
         assertSame(pinguoDeserialized.getClass(), Apple.class);
         assertEquals(pinguo.name, pinguoDeserialized.name);
-        assertEquals(pinguo.seedCount, ((Apple) pinguoDeserialized).seedCount);
-        assertEquals(pinguo.type, ((Apple) pinguoDeserialized).type);
+        assertEquals(pinguo.seedCount, apple.seedCount);
+        assertEquals(pinguo.type, apple.type);
 
         FruitWrapper pinguoWrapperDeserialized = MAPPER.readValue(pinguoWrapperJson, FruitWrapper.class);
         Fruit pinguoExtracted = pinguoWrapperDeserialized.fruit;
@@ -383,18 +383,18 @@ public class SealedTypesWithExistingPropertyTest extends DatabindTestUtil
     public void testSimpleClassAsExistingPropertyDeserializationAnimals() throws Exception
     {
         Animal beelzebubDeserialized = MAPPER.readValue(beelzebubJson, Animal.class);
-        assertInstanceOf(Cat.class, beelzebubDeserialized);
+        Cat catB = assertInstanceOf(Cat.class, beelzebubDeserialized);
         assertSame(beelzebubDeserialized.getClass(), Cat.class);
         assertEquals(beelzebub.name, beelzebubDeserialized.name);
-        assertEquals(beelzebub.furColor, ((Cat) beelzebubDeserialized).furColor);
+        assertEquals(beelzebub.furColor, catB.furColor);
         assertEquals(beelzebub.getType(), beelzebubDeserialized.getType());
 
         AnimalWrapper beelzebubWrapperDeserialized = MAPPER.readValue(beelzebubWrapperJson, AnimalWrapper.class);
         Animal beelzebubExtracted = beelzebubWrapperDeserialized.animal;
-        assertInstanceOf(Cat.class, beelzebubExtracted);
+        catB = assertInstanceOf(Cat.class, beelzebubExtracted);
         assertSame(beelzebubExtracted.getClass(), Cat.class);
         assertEquals(beelzebub.name, beelzebubExtracted.name);
-        assertEquals(beelzebub.furColor, ((Cat) beelzebubExtracted).furColor);
+        assertEquals(beelzebub.furColor, catB.furColor);
         assertEquals(beelzebub.getType(), beelzebubExtracted.getType());
 
         @SuppressWarnings("unchecked")
@@ -447,24 +447,24 @@ public class SealedTypesWithExistingPropertyTest extends DatabindTestUtil
     public void testSimpleClassAsExistingPropertyDeserializationCars() throws Exception
     {
         Car camryDeserialized = MAPPER.readValue(camryJson, Camry.class);
-        assertInstanceOf(Camry.class, camryDeserialized);
+        Camry camry1 = assertInstanceOf(Camry.class, camryDeserialized);
         assertSame(camryDeserialized.getClass(), Camry.class);
         assertEquals(camry.name, camryDeserialized.name);
-        assertEquals(camry.exteriorColor, ((Camry) camryDeserialized).exteriorColor);
-        assertEquals(camry.getType(), ((Camry) camryDeserialized).getType());
+        assertEquals(camry.exteriorColor, camry1.exteriorColor);
+        assertEquals(camry.getType(), camry1.getType());
 
         CarWrapper camryWrapperDeserialized = MAPPER.readValue(camryWrapperJson, CarWrapper.class);
         Car camryExtracted = camryWrapperDeserialized.car;
-        assertInstanceOf(Camry.class, camryExtracted);
+        Camry camry2 = assertInstanceOf(Camry.class, camryExtracted);
         assertSame(camryExtracted.getClass(), Camry.class);
         assertEquals(camry.name, camryExtracted.name);
-        assertEquals(camry.exteriorColor, ((Camry) camryExtracted).exteriorColor);
-        assertEquals(camry.getType(), ((Camry) camryExtracted).getType());
+        assertEquals(camry.exteriorColor, camry2.exteriorColor);
+        assertEquals(camry.getType(), camry2.getType());
 
         @SuppressWarnings("unchecked")
         List<Car> carListDeserialized = MAPPER.readValue(carListJson, List.class);
         assertNotNull(carListDeserialized);
-        assertTrue(carListDeserialized.size() == 2);
+        assertEquals(2, carListDeserialized.size());
         Car result = MAPPER.convertValue(carListDeserialized.get(0), Car.class);
         assertInstanceOf(Camry.class, result);
         assertSame(result.getClass(), Camry.class);

--- a/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithExistingPropertyTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithExistingPropertyTest.java
@@ -383,18 +383,18 @@ public class SealedTypesWithExistingPropertyTest extends DatabindTestUtil
     public void testSimpleClassAsExistingPropertyDeserializationAnimals() throws Exception
     {
         Animal beelzebubDeserialized = MAPPER.readValue(beelzebubJson, Animal.class);
-        Cat catB = assertInstanceOf(Cat.class, beelzebubDeserialized);
+        Cat beelzebubCat = assertInstanceOf(Cat.class, beelzebubDeserialized);
         assertSame(beelzebubDeserialized.getClass(), Cat.class);
         assertEquals(beelzebub.name, beelzebubDeserialized.name);
-        assertEquals(beelzebub.furColor, catB.furColor);
+        assertEquals(beelzebub.furColor, beelzebubCat.furColor);
         assertEquals(beelzebub.getType(), beelzebubDeserialized.getType());
 
         AnimalWrapper beelzebubWrapperDeserialized = MAPPER.readValue(beelzebubWrapperJson, AnimalWrapper.class);
         Animal beelzebubExtracted = beelzebubWrapperDeserialized.animal;
-        catB = assertInstanceOf(Cat.class, beelzebubExtracted);
+        Cat beelzebubExtractedCat = assertInstanceOf(Cat.class, beelzebubExtracted);
         assertSame(beelzebubExtracted.getClass(), Cat.class);
         assertEquals(beelzebub.name, beelzebubExtracted.name);
-        assertEquals(beelzebub.furColor, catB.furColor);
+        assertEquals(beelzebub.furColor, beelzebubExtractedCat.furColor);
         assertEquals(beelzebub.getType(), beelzebubExtracted.getType());
 
         @SuppressWarnings("unchecked")
@@ -447,19 +447,19 @@ public class SealedTypesWithExistingPropertyTest extends DatabindTestUtil
     public void testSimpleClassAsExistingPropertyDeserializationCars() throws Exception
     {
         Car camryDeserialized = MAPPER.readValue(camryJson, Camry.class);
-        Camry camry1 = assertInstanceOf(Camry.class, camryDeserialized);
+        Camry camryTyped = assertInstanceOf(Camry.class, camryDeserialized);
         assertSame(camryDeserialized.getClass(), Camry.class);
         assertEquals(camry.name, camryDeserialized.name);
-        assertEquals(camry.exteriorColor, camry1.exteriorColor);
-        assertEquals(camry.getType(), camry1.getType());
+        assertEquals(camry.exteriorColor, camryTyped.exteriorColor);
+        assertEquals(camry.getType(), camryTyped.getType());
 
         CarWrapper camryWrapperDeserialized = MAPPER.readValue(camryWrapperJson, CarWrapper.class);
         Car camryExtracted = camryWrapperDeserialized.car;
-        Camry camry2 = assertInstanceOf(Camry.class, camryExtracted);
+        Camry camryExtractedTyped = assertInstanceOf(Camry.class, camryExtracted);
         assertSame(camryExtracted.getClass(), Camry.class);
         assertEquals(camry.name, camryExtracted.name);
-        assertEquals(camry.exteriorColor, camry2.exteriorColor);
-        assertEquals(camry.getType(), camry2.getType());
+        assertEquals(camry.exteriorColor, camryExtractedTyped.exteriorColor);
+        assertEquals(camry.getType(), camryExtractedTyped.getType());
 
         @SuppressWarnings("unchecked")
         List<Car> carListDeserialized = MAPPER.readValue(carListJson, List.class);

--- a/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithJsonTypeInfoSimpleClassName4061Test.java
+++ b/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithJsonTypeInfoSimpleClassName4061Test.java
@@ -192,8 +192,8 @@ public class SealedTypesWithJsonTypeInfoSimpleClassName4061Test extends Databind
 
     Root root = MAPPER.readValue(jsonStr, Root.class);
 
-    assertInstanceOf(MergeChildA.class, root.child);
-    assertEquals("I'm child A", ((MergeChildA) root.child).name);
+    MergeChildA mergeChildA = assertInstanceOf(MergeChildA.class, root.child);
+    assertEquals("I'm child A", mergeChildA.name);
   }
 
   // case insenstive type name
@@ -205,8 +205,8 @@ public class SealedTypesWithJsonTypeInfoSimpleClassName4061Test extends Databind
 
     Root root = mapper.readValue(jsonStr, Root.class);
 
-    assertInstanceOf(MergeChildA.class, root.child);
-    assertEquals("I'm child A", ((MergeChildA) root.child).name);
+    MergeChildA mergeChildA = assertInstanceOf(MergeChildA.class, root.child);
+    assertEquals("I'm child A", mergeChildA.name);
   }
 
   @Test

--- a/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithTypedDeserializationTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/SealedTypesWithTypedDeserializationTest.java
@@ -181,8 +181,7 @@ public class SealedTypesWithTypedDeserializationTest
             +asJSONObjectValueString(m, "name", "Scooby", "boneCount", "6")+" }";
         Animal a = m.readValue(JSON, Animal.class);
         assertInstanceOf(Animal.class, a);
-        assertEquals(Dog.class, a.getClass());
-        Dog d = (Dog) a;
+        Dog d = assertInstanceOf(Dog.class, a);
         assertEquals("Scooby", d.name);
         assertEquals(6, d.boneCount);
     }

--- a/src/test/java/tools/jackson/databind/jsontype/TestMultipleTypeNames.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestMultipleTypeNames.java
@@ -120,10 +120,10 @@ public class TestMultipleTypeNames extends DatabindTestUtil
         assertEquals(3, w.base.size());
         A aResult = assertInstanceOf(A.class, w.base.get(0).data);
         assertEquals(5l, aResult.x);
-        B bResult = assertInstanceOf(B.class, w.base.get(1).data);
-        assertEquals(3.1f, bResult.y, 0);
-        bResult = assertInstanceOf(B.class, w.base.get(2).data);
-        assertEquals(33.8f, bResult.y, 0);
+        B bResult1 = assertInstanceOf(B.class, w.base.get(1).data);
+        assertEquals(3.1f, bResult1.y, 0);
+        B bResult2 = assertInstanceOf(B.class, w.base.get(2).data);
+        assertEquals(33.8f, bResult2.y, 0);
 
 
         // TC 2 : incorrect serialisation
@@ -146,10 +146,10 @@ public class TestMultipleTypeNames extends DatabindTestUtil
         assertEquals(3, w.base.size());
         A aResult = assertInstanceOf(A.class, w.base.get(0).data);
         assertEquals(5l, aResult.x);
-        B bResult = assertInstanceOf(B.class, w.base.get(1).data);
-        assertEquals(3.1f, bResult.y, 0);
-        bResult = assertInstanceOf(B.class, w.base.get(2).data);
-        assertEquals(33.8f, bResult.y, 0);
+        B bResult1 = assertInstanceOf(B.class, w.base.get(1).data);
+        assertEquals(3.1f, bResult1.y, 0);
+        B bResult2 = assertInstanceOf(B.class, w.base.get(2).data);
+        assertEquals(33.8f, bResult2.y, 0);
 
 
         // TC 2 : incorrect serialisation

--- a/src/test/java/tools/jackson/databind/jsontype/TestMultipleTypeNames.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestMultipleTypeNames.java
@@ -118,12 +118,12 @@ public class TestMultipleTypeNames extends DatabindTestUtil
         w = MAPPER.readValue(json, WrapperForNamesTest.class);
         assertNotNull(w);
         assertEquals(3, w.base.size());
-        assertInstanceOf(A.class, w.base.get(0).data);
-        assertEquals(5l, ((A) w.base.get(0).data).x);
-        assertInstanceOf(B.class, w.base.get(1).data);
-        assertEquals(3.1f, ((B) w.base.get(1).data).y, 0);
-        assertInstanceOf(B.class, w.base.get(2).data);
-        assertEquals(33.8f, ((B) w.base.get(2).data).y, 0);
+        A aResult = assertInstanceOf(A.class, w.base.get(0).data);
+        assertEquals(5l, aResult.x);
+        B bResult = assertInstanceOf(B.class, w.base.get(1).data);
+        assertEquals(3.1f, bResult.y, 0);
+        bResult = assertInstanceOf(B.class, w.base.get(2).data);
+        assertEquals(33.8f, bResult.y, 0);
 
 
         // TC 2 : incorrect serialisation
@@ -144,12 +144,12 @@ public class TestMultipleTypeNames extends DatabindTestUtil
         w = MAPPER.readValue(json, WrapperForNameAndNamesTest.class);
         assertNotNull(w);
         assertEquals(3, w.base.size());
-        assertInstanceOf(A.class, w.base.get(0).data);
-        assertEquals(5l, ((A) w.base.get(0).data).x);
-        assertInstanceOf(B.class, w.base.get(1).data);
-        assertEquals(3.1f, ((B) w.base.get(1).data).y, 0);
-        assertInstanceOf(B.class, w.base.get(2).data);
-        assertEquals(33.8f, ((B) w.base.get(2).data).y, 0);
+        A aResult = assertInstanceOf(A.class, w.base.get(0).data);
+        assertEquals(5l, aResult.x);
+        B bResult = assertInstanceOf(B.class, w.base.get(1).data);
+        assertEquals(3.1f, bResult.y, 0);
+        bResult = assertInstanceOf(B.class, w.base.get(2).data);
+        assertEquals(33.8f, bResult.y, 0);
 
 
         // TC 2 : incorrect serialisation

--- a/src/test/java/tools/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestPolymorphicWithDefaultImpl.java
@@ -228,9 +228,9 @@ public class TestPolymorphicWithDefaultImpl extends DatabindTestUtil
     public void testDeserializationWithObject() throws Exception
     {
         Inter inter = MAPPER.readerFor(Inter.class).readValue("{\"type\": \"mine\", \"blah\": [\"a\", \"b\", \"c\"]}");
-        assertInstanceOf(MyInter.class, inter);
         assertFalse(inter instanceof LegacyInter);
-        assertEquals(Arrays.asList("a", "b", "c"), ((MyInter) inter).blah);
+        MyInter myInter = assertInstanceOf(MyInter.class, inter);
+        assertEquals(Arrays.asList("a", "b", "c"), myInter.blah);
     }
 
     @Test
@@ -238,23 +238,24 @@ public class TestPolymorphicWithDefaultImpl extends DatabindTestUtil
     {
         Inter inter = MAPPER.readerFor(Inter.class).readValue("\"a,b,c,d\"");
         assertInstanceOf(LegacyInter.class, inter);
-        assertEquals(Arrays.asList("a", "b", "c", "d"), ((MyInter) inter).blah);
+        MyInter myInter = assertInstanceOf(MyInter.class, inter);
+        assertEquals(Arrays.asList("a", "b", "c", "d"), myInter.blah);
     }
 
     @Test
     public void testDeserializationWithArray() throws Exception
     {
         Inter inter = MAPPER.readerFor(Inter.class).readValue("[\"a\", \"b\", \"c\", \"d\"]");
-        assertInstanceOf(LegacyInter.class, inter);
-        assertEquals(Arrays.asList("a", "b", "c", "d"), ((MyInter) inter).blah);
+        LegacyInter legacyInter = assertInstanceOf(LegacyInter.class, inter);
+        assertEquals(Arrays.asList("a", "b", "c", "d"), legacyInter.blah);
     }
 
     @Test
     public void testDeserializationWithArrayOfSize2() throws Exception
     {
         Inter inter = MAPPER.readerFor(Inter.class).readValue("[\"a\", \"b\"]");
-        assertInstanceOf(LegacyInter.class, inter);
-        assertEquals(Arrays.asList("a", "b"), ((MyInter) inter).blah);
+        LegacyInter legacyInter = assertInstanceOf(LegacyInter.class, inter);
+        assertEquals(Arrays.asList("a", "b"), legacyInter.blah);
     }
 
     // [databind#148]
@@ -303,7 +304,8 @@ public class TestPolymorphicWithDefaultImpl extends DatabindTestUtil
         BaseFor656 value = MAPPER.readValue(a2q("{'foobar':{'a':3}}"), BaseFor656.class);
         assertNotNull(value);
         assertEquals(ImplFor656.class, value.getClass());
-        assertEquals(3, ((ImplFor656) value).a);
+        ImplFor656 impl = assertInstanceOf(ImplFor656.class, value);
+        assertEquals(3, impl.a);
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/jsontype/TestSubtypesSubPackage.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestSubtypesSubPackage.java
@@ -56,8 +56,8 @@ public class TestSubtypesSubPackage extends DatabindTestUtil
         SubCSubPackage original = new SubCSubPackage();
         String json = MAPPER.writeValueAsString(original);
         SuperType result = MAPPER.readValue(json, SuperType.class);
-        assertInstanceOf(SubCSubPackage.class, result);
-        assertEquals(original.c, ((SubCSubPackage) result).c);
+        SubCSubPackage subCSubPackage = assertInstanceOf(SubCSubPackage.class, result);
+        assertEquals(original.c, subCSubPackage.c);
     }
 
     // [databind#5247]: verify round-trip works for inner types too
@@ -67,7 +67,7 @@ public class TestSubtypesSubPackage extends DatabindTestUtil
         InnerType original = new InnerType();
         String json = MAPPER.writeValueAsString(original);
         SuperType result = MAPPER.readValue(json, SuperType.class);
-        assertInstanceOf(InnerType.class, result);
-        assertEquals(original.b, ((InnerType) result).b);
+        InnerType innerType = assertInstanceOf(InnerType.class, result);
+        assertEquals(original.b, innerType.b);
     }
 }

--- a/src/test/java/tools/jackson/databind/jsontype/TestVisibleTypeId.java
+++ b/src/test/java/tools/jackson/databind/jsontype/TestVisibleTypeId.java
@@ -242,8 +242,8 @@ public class TestVisibleTypeId extends DatabindTestUtil
 
         // then bring back:
         I263Base result = MAPPER.readValue("{\"age\":19,\"name\":\"bob\"}", I263Base.class);
-        assertInstanceOf(I263Impl.class, result);
-        assertEquals(19, ((I263Impl) result).age);
+        I263Impl impl = assertInstanceOf(I263Impl.class, result);
+        assertEquals(19, impl.age);
     }
 
     // [databind#408]

--- a/src/test/java/tools/jackson/databind/objectid/JSOGDeserialize622Test.java
+++ b/src/test/java/tools/jackson/databind/objectid/JSOGDeserialize622Test.java
@@ -224,8 +224,7 @@ public class JSOGDeserialize622Test extends DatabindTestUtil
         JSOGWrapper out = mapper.readValue(json, JSOGWrapper.class);
         assertNotNull(out);
         assertEquals(15, out.value);
-        assertInstanceOf(IdentifiableExampleJSOG.class, out.jsog);
-        IdentifiableExampleJSOG jsog = (IdentifiableExampleJSOG) out.jsog;
+        IdentifiableExampleJSOG jsog = assertInstanceOf(IdentifiableExampleJSOG.class, out.jsog);
         assertEquals(123, jsog.foo);
         assertSame(jsog, jsog.next);
     }

--- a/src/test/java/tools/jackson/databind/records/RecordUnknownProps5897Test.java
+++ b/src/test/java/tools/jackson/databind/records/RecordUnknownProps5897Test.java
@@ -99,8 +99,8 @@ public class RecordUnknownProps5897Test extends DatabindTestUtil
         // it must be buffered and replayed through Dog's deserializer.
         String json = "{\"breed\":\"poodle\",\"name\":\"Rex\",\"kind\":\"dog\"}";
         Animal a = mapper.readValue(json, Animal.class);
-        assertInstanceOf(Dog.class, a);
+        Dog dog = assertInstanceOf(Dog.class, a);
         assertEquals("Rex", a.name);
-        assertEquals("poodle", ((Dog) a).breed);
+        assertEquals("poodle", dog.breed);
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/SerializationFeaturesTest.java
+++ b/src/test/java/tools/jackson/databind/ser/SerializationFeaturesTest.java
@@ -594,6 +594,6 @@ public class SerializationFeaturesTest
     }
 
     private final static String getLF() {
-        return System.getProperty("line.separator");
+        return System.lineSeparator();
     }
 }

--- a/src/test/java/tools/jackson/databind/testutil/JacksonTestUtilBase.java
+++ b/src/test/java/tools/jackson/databind/testutil/JacksonTestUtilBase.java
@@ -153,6 +153,10 @@ public class JacksonTestUtilBase
         return new String(bytes.toByteArray(), StandardCharsets.UTF_8);
     }
 
+    public String utf8String(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
     /*
     /**********************************************************************
     /* Resource reading helpers

--- a/src/test/java/tools/jackson/databind/type/TypeFactoryTest.java
+++ b/src/test/java/tools/jackson/databind/type/TypeFactoryTest.java
@@ -579,8 +579,7 @@ public class TypeFactoryTest extends DatabindTestUtil
 
         field = SneakyBean.class.getDeclaredField("longList");
         type = TF.constructType(field.getGenericType());
-        assertInstanceOf(CollectionType.class, type);
-        CollectionType collectionType = (CollectionType) type;
+        CollectionType collectionType = assertInstanceOf(CollectionType.class, type);
         assertEquals(TF.constructType(Long.class), collectionType.getContentType());
     }
 

--- a/src/test/java/tools/jackson/databind/util/BeanUtilTest.java
+++ b/src/test/java/tools/jackson/databind/util/BeanUtilTest.java
@@ -82,20 +82,20 @@ public class BeanUtilTest extends DatabindTestUtil
         // java.util.Date
         Object result = BeanUtil.propertyDefaultValue(tf.constructType(Date.class), true);
         assertNotNull(result);
-        assertInstanceOf(Date.class, result);
-        assertEquals(0L, ((Date) result).getTime());
+        Date date = assertInstanceOf(Date.class, result);
+        assertEquals(0L, date.getTime());
 
         // java.util.Calendar
         result = BeanUtil.propertyDefaultValue(tf.constructType(Calendar.class), true);
         assertNotNull(result);
-        assertInstanceOf(Calendar.class, result);
-        assertEquals(0L, ((Calendar) result).getTimeInMillis());
+        Calendar calendar = assertInstanceOf(Calendar.class, result);
+        assertEquals(0L, calendar.getTimeInMillis());
 
         // java.util.GregorianCalendar
         result = BeanUtil.propertyDefaultValue(tf.constructType(GregorianCalendar.class), true);
         assertNotNull(result);
-        assertInstanceOf(Calendar.class, result);
-        assertEquals(0L, ((Calendar) result).getTimeInMillis());
+        Calendar calendar1 = assertInstanceOf(Calendar.class, result);
+        assertEquals(0L, calendar1.getTimeInMillis());
 
         // java.util.UUID
         result = BeanUtil.propertyDefaultValue(tf.constructType(UUID.class), true);

--- a/src/test/java/tools/jackson/databind/util/TokenBufferTest.java
+++ b/src/test/java/tools/jackson/databind/util/TokenBufferTest.java
@@ -388,8 +388,8 @@ public class TokenBufferTest extends DatabindTestUtil
         assertToken(JsonToken.VALUE_EMBEDDED_OBJECT, p.nextToken());
         Object ob = p.getEmbeddedObject();
         assertNotNull(ob);
-        assertInstanceOf(byte[].class, ob);
-        assertEquals(3, ((byte[]) ob).length);
+        byte[] bytes = assertInstanceOf(byte[].class, ob);
+        assertEquals(3, bytes.length);
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         assertNull(p.nextToken());


### PR DESCRIPTION
* use feature of assertInstanceOf where it returns the cast instance
* use a2q to avoid having `\"` in the inlined JSON
* reorder some asserts where the expected value was last
* there are plenty of other changes like this that can be made but this PR focuses on a manageable set