### PR TITLE
Remove unused import for Charsets

### DIFF
--- a/src/test/java/tools/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
+++ b/src/test/java/tools/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
@@ -11,7 +11,6 @@ import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Charsets;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Removed unused import for Charsets from Google Guava.

I accidentally added this in #6087