### PR TITLE
resolve classes without initialization in TypeFactory.findClass

### DIFF
--- a/src/main/java/tools/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/tools/jackson/databind/type/TypeFactory.java
@@ -354,7 +354,11 @@ public class TypeFactory
         }
         if (loader != null) {
             try {
-                return classForName(className, true, loader);
+                // Resolve only; do NOT initialize the class here. Class names come
+                // from input (Class-valued properties, polymorphic type ids), and a
+                // named class should not have its static initializer run just to
+                // resolve it -- initialization happens if/when it is actually used.
+                return classForName(className, false, loader);
             } catch (Exception e) {
                 prob = ClassUtil.getRootCause(e);
             }
@@ -372,11 +376,13 @@ public class TypeFactory
 
     protected Class<?> classForName(String name, boolean initialize,
             ClassLoader loader) throws ClassNotFoundException {
-        return Class.forName(name, true, loader);
+        return Class.forName(name, initialize, loader);
     }
 
     protected Class<?> classForName(String name) throws ClassNotFoundException {
-        return Class.forName(name);
+        // Match the loader used by `Class.forName(name)` (this class's loader) but
+        // without initializing the resolved class; see `findClass(...)`.
+        return Class.forName(name, false, TypeFactory.class.getClassLoader());
     }
 
     protected Class<?> _findPrimitive(String className)

--- a/src/test/java/tools/jackson/databind/deser/jdk/ClassDeserNoStaticInitTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/ClassDeserNoStaticInitTest.java
@@ -1,0 +1,47 @@
+package tools.jackson.databind.deser.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import static tools.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+// Resolving a `java.lang.Class` value from JSON must not force initialization
+// (running the static initializer) of the named class.
+public class ClassDeserNoStaticInitTest
+{
+    // Separate holder so that reading the flag does NOT initialize Gadget
+    static class InitFlag {
+        static volatile boolean gadgetInitialized = false;
+    }
+
+    static class Gadget {
+        static {
+            InitFlag.gadgetInitialized = true;
+        }
+    }
+
+    static class Holder {
+        public Class<?> type;
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void classValueDoesNotTriggerStaticInitializer() throws Exception
+    {
+        assertFalse(InitFlag.gadgetInitialized);
+
+        String json = "{\"type\":\"" + Gadget.class.getName() + "\"}";
+        Holder h = MAPPER.readValue(json, Holder.class);
+
+        // Class is still resolved correctly
+        assertEquals(Gadget.class, h.type);
+        // ...but its static initializer must not have run
+        assertFalse(InitFlag.gadgetInitialized,
+                "Deserializing a Class value must not run the target class static initializer");
+    }
+}


### PR DESCRIPTION
TypeFactory.findClass resolves class names that come straight from input: a Class-valued property or map key (JDKFromStringDeserializer / JDKKeyDeserializer), and polymorphic type ids resolved through DatabindContext. It calls Class.forName(name, true, loader), so naming a class in JSON runs that class's static initializer just to look it up. On the polymorphic path the class is loaded and initialized before the PolymorphicTypeValidator gets to deny it, so a rejected class's static block still runs.

findClass now resolves with initialize=false, so a named class is linked but not initialized; the JVM still initializes it on first real use (instantiating an allowed subtype, or actually using a Class value), so valid behavior is unchanged. classForName(name, initialize, loader) was also ignoring its initialize argument and always passing true, now corrected to honor it. Keeping this in the lookup method covers every caller that resolves a name from input without each one repeating the check.