### PR TITLE
Resolve classes without initialization in `TypeFactory.findClass()`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1914,3 +1914,7 @@ Omkhar Arasaratnam (@omkhar)
  * Contributed fix for #5962: Case-insensitive deserialization may use
    wrong `@JsonIgnoreProperties`
   (2.18.9)
+
+Aysha Afrah Ziya (@aysha-afrah26)
+ * Fixed #6099: Resolve classes without initialization in `TypeFactory.findClass()`
+  (2.18.10)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,11 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.18.10 (not yet released)
+
+#6099: Resolve classes without initialization in `TypeFactory.findClass()`
+ (fixed by Aysha A-Z)
+
 2.18.9 (07-Jul-2026)
 
 #5962: Case-insensitive deserialization may use wrong `@JsonIgnoreProperties`

--- a/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/type/TypeFactory.java
@@ -371,7 +371,11 @@ public class TypeFactory // note: was final in 2.9, removed from 2.10
         }
         if (loader != null) {
             try {
-                return classForName(className, true, loader);
+                // Resolve only; do NOT initialize the class here. Class names come
+                // from input (Class-valued properties, polymorphic type ids), and a
+                // named class should not have its static initializer run just to
+                // resolve it -- initialization happens if/when it is actually used.
+                return classForName(className, false, loader);
             } catch (Exception e) {
                 prob = ClassUtil.getRootCause(e);
             }
@@ -389,11 +393,13 @@ public class TypeFactory // note: was final in 2.9, removed from 2.10
 
     protected Class<?> classForName(String name, boolean initialize,
             ClassLoader loader) throws ClassNotFoundException {
-        return Class.forName(name, true, loader);
+        return Class.forName(name, initialize, loader);
     }
 
     protected Class<?> classForName(String name) throws ClassNotFoundException {
-        return Class.forName(name);
+        // Match the loader used by `Class.forName(name)` (this class's loader) but
+        // without initializing the resolved class; see `findClass(...)`.
+        return Class.forName(name, false, TypeFactory.class.getClassLoader());
     }
 
     protected Class<?> _findPrimitive(String className)

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ClassDeserNoStaticInitTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ClassDeserNoStaticInitTest.java
@@ -2,10 +2,12 @@ package com.fasterxml.jackson.databind.deser.jdk;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
 
@@ -28,6 +30,21 @@ public class ClassDeserNoStaticInitTest
         public Class<?> type;
     }
 
+    // Separate holder so that reading the flag does NOT initialize Sub
+    static class SubInitFlag {
+        static volatile boolean subInitialized = false;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+    static class Base { }
+
+    static class Sub extends Base {
+        static {
+            SubInitFlag.subInitialized = true;
+        }
+        public int value;
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     @Test
@@ -43,5 +60,25 @@ public class ClassDeserNoStaticInitTest
         // ...but its static initializer must not have run
         assertFalse(InitFlag.gadgetInitialized,
                 "Deserializing a Class value must not run the target class static initializer");
+    }
+
+    // Counterpart invariant: when a polymorphic type id is not just resolved but
+    // actually instantiated during deserialization, the JVM must (still) run the
+    // subtype's static initializer -- resolving without init does not regress this.
+    @Test
+    public void polymorphicInstantiationTriggersStaticInitializer() throws Exception
+    {
+        // `Sub.class.getName()` (below) does not initialize Sub, so the flag
+        // should still be clear before we deserialize an actual instance.
+        assertFalse(SubInitFlag.subInitialized);
+
+        String json = "{\"@class\":\"" + Sub.class.getName() + "\",\"value\":42}";
+        Base result = MAPPER.readValue(json, Base.class);
+
+        assertEquals(Sub.class, result.getClass());
+        assertEquals(42, ((Sub) result).value);
+        // Instantiating the subtype must have run its static initializer
+        assertTrue(SubInitFlag.subInitialized,
+                "Instantiating a polymorphic subtype must run its static initializer");
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ClassDeserNoStaticInitTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/ClassDeserNoStaticInitTest.java
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.databind.deser.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+
+// Resolving a `java.lang.Class` value from JSON must not force initialization
+// (running the static initializer) of the named class.
+public class ClassDeserNoStaticInitTest
+{
+    // Separate holder so that reading the flag does NOT initialize Gadget
+    static class InitFlag {
+        static volatile boolean gadgetInitialized = false;
+    }
+
+    static class Gadget {
+        static {
+            InitFlag.gadgetInitialized = true;
+        }
+    }
+
+    static class Holder {
+        public Class<?> type;
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void classValueDoesNotTriggerStaticInitializer() throws Exception
+    {
+        assertFalse(InitFlag.gadgetInitialized);
+
+        String json = "{\"type\":\"" + Gadget.class.getName() + "\"}";
+        Holder h = MAPPER.readValue(json, Holder.class);
+
+        // Class is still resolved correctly
+        assertEquals(Gadget.class, h.type);
+        // ...but its static initializer must not have run
+        assertFalse(InitFlag.gadgetInitialized,
+                "Deserializing a Class value must not run the target class static initializer");
+    }
+}


### PR DESCRIPTION
2.18 version of #6097, as requested there.

TypeFactory.findClass resolves class names that come straight from input: a Class-valued property or map key, and polymorphic type ids resolved through DatabindContext. It calls Class.forName(name, true, loader), so naming a class in JSON runs that class's static initializer just to look it up. On the polymorphic path the class is loaded and initialized before the PolymorphicTypeValidator gets to deny it, so a rejected class's static block still runs.

findClass now resolves with initialize=false, so a named class is linked but not initialized; the JVM still initializes it on first real use (instantiating an allowed subtype, or actually using a Class value), so valid behavior is unchanged. classForName(name, initialize, loader) was also ignoring its initialize argument and always passing true, now corrected to honor it. Keeping this in the lookup method covers every caller that resolves a name from input without each one repeating the check.

The 3.x patch applied cleanly here; test included (fails before the change, passes after).