### PR TITLE
Fix #6100: preserve field defaults when no-arg and all-args constructors coexist

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
   is actually thrown
  (reported by @pctF)
  (fix by @pjfanning)
+#6100: Preserve field / no-arg constructor defaults for missing creator
+  properties when a default constructor is available (sample from default instance)
+ (reported by @gtaverniti-finomnia)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/databind/deser/CreatorProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/CreatorProperty.java
@@ -206,6 +206,16 @@ public class CreatorProperty
         return _fallbackSetter != null;
     }
 
+    /**
+     * Accessor for the non-creator mutator used when updating an already
+     * constructed instance (field or setter), if any.
+     *
+     * @since 3.3
+     */
+    public SettableBeanProperty getFallbackSetter() {
+        return _fallbackSetter;
+    }
+
     @Override
     public void markAsIgnorable() {
         _ignorable = true;

--- a/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/PropertyBasedCreator.java
@@ -309,7 +309,7 @@ public final class PropertyBasedCreator
     public PropertyValueBuffer startBuilding(JsonParser p, DeserializationContext ctxt,
             ObjectIdReader oir, boolean mayRebind) {
         return new PropertyValueBuffer(p, ctxt, _propertyCount, oir, null,
-                _injectablePropIndexes, mayRebind);
+                _injectablePropIndexes, mayRebind, _valueInstantiator);
     }
 
     /**
@@ -336,7 +336,7 @@ public final class PropertyBasedCreator
             ObjectIdReader oir, SettableAnyProperty anySetter, boolean mayRebind
     ) {
         return new PropertyValueBuffer(p, ctxt, _propertyCount, oir, anySetter,
-                _injectablePropIndexes, mayRebind);
+                _injectablePropIndexes, mayRebind, _valueInstantiator);
     }
 
     public Object build(DeserializationContext ctxt, PropertyValueBuffer buffer)

--- a/src/main/java/tools/jackson/databind/deser/bean/PropertyValueBuffer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/PropertyValueBuffer.java
@@ -1,5 +1,7 @@
 package tools.jackson.databind.deser.bean;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.BitSet;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -8,10 +10,13 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 
 import tools.jackson.databind.*;
+import tools.jackson.databind.deser.CreatorProperty;
 import tools.jackson.databind.deser.ReadableObjectId;
 import tools.jackson.databind.deser.SettableAnyProperty;
 import tools.jackson.databind.deser.SettableBeanProperty;
+import tools.jackson.databind.deser.ValueInstantiator;
 import tools.jackson.databind.deser.impl.ObjectIdReader;
+import tools.jackson.databind.introspect.AnnotatedField;
 import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.util.TokenBuffer;
 
@@ -121,6 +126,30 @@ public class PropertyValueBuffer
      */
     protected final boolean _mayRebind;
 
+    /**
+     * Instantiator for the value type; used to materialize a default-constructor
+     * instance when filling missing creator arguments ([databind#6100]).
+     *
+     * @since 3.3
+     */
+    protected final ValueInstantiator _valueInstantiator;
+
+    /**
+     * Lazily created instance from the no-arg constructor, used as a source of
+     * field / constructor defaults for missing creator parameters. {@code null}
+     * means either not yet resolved, or no usable default instance.
+     *
+     * @since 3.3
+     */
+    protected Object _defaultBean;
+
+    /**
+     * Whether {@link #_defaultBean} has been resolved (successfully or not).
+     *
+     * @since 3.3
+     */
+    protected boolean _defaultBeanResolved;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -136,15 +165,28 @@ public class PropertyValueBuffer
             ObjectIdReader oir, SettableAnyProperty anyParamSetter,
             BitSet injectablePropIndexes)
     {
-        this(p, ctxt, paramCount, oir, anyParamSetter, injectablePropIndexes, false);
+        this(p, ctxt, paramCount, oir, anyParamSetter, injectablePropIndexes, false, null);
     }
 
     /**
      * @since 3.2
+     * @deprecated Since 3.3
      */
+    @Deprecated
     public PropertyValueBuffer(JsonParser p, DeserializationContext ctxt, int paramCount,
             ObjectIdReader oir, SettableAnyProperty anyParamSetter,
             BitSet injectablePropIndexes, boolean mayRebind)
+    {
+        this(p, ctxt, paramCount, oir, anyParamSetter, injectablePropIndexes, mayRebind, null);
+    }
+
+    /**
+     * @since 3.3
+     */
+    public PropertyValueBuffer(JsonParser p, DeserializationContext ctxt, int paramCount,
+            ObjectIdReader oir, SettableAnyProperty anyParamSetter,
+            BitSet injectablePropIndexes, boolean mayRebind,
+            ValueInstantiator valueInstantiator)
     {
         _parser = p;
         _context = ctxt;
@@ -165,6 +207,7 @@ public class PropertyValueBuffer
         _injectablePropIndexes = (injectablePropIndexes == null)
                 ? null : (BitSet) injectablePropIndexes.clone();
         _mayRebind = mayRebind;
+        _valueInstantiator = valueInstantiator;
     }
 
     /**
@@ -324,14 +367,22 @@ public class PropertyValueBuffer
                     prop.getName(), prop.getCreatorIndex());
         }
         try {
-            // Third: NullValueProvider? (22-Sep-2019, [databind#2458])
+            // Third: [databind#6100] if a no-arg constructor exists, use property
+            // values from a default instance (field initializers / no-arg body)
+            // instead of bare JVM defaults (false/0/null).
+            Object fromDefaultBean = _findFromDefaultBean(prop);
+            if (fromDefaultBean != _DEFAULT_BEAN_NOT_AVAILABLE) {
+                return fromDefaultBean;
+            }
+
+            // Fourth: NullValueProvider? (22-Sep-2019, [databind#2458])
             // 08-Aug-2021, tatu: consider [databind#3214]; not null but "absent" value...
             Object absentValue = prop.getNullValueProvider().getAbsentValue(_context);
             if (absentValue != null) {
                 return absentValue;
             }
 
-            // Fourth: default value
+            // Fifth: deserializer-defined absent value
             ValueDeserializer<Object> deser = prop.getValueDeserializer();
             return deser.getAbsentValue(_context);
         } catch (JacksonException e) {
@@ -342,6 +393,112 @@ public class PropertyValueBuffer
             }
             throw e;
         }
+    }
+
+    /**
+     * Sentinel meaning "could not obtain a value from the default bean"
+     * (as opposed to a legitimate {@code null} property value).
+     */
+    private final static Object _DEFAULT_BEAN_NOT_AVAILABLE = new Object();
+
+    /**
+     * Try to obtain the missing creator argument from a no-arg-constructed
+     * default instance of the same type ([databind#6100]).
+     *
+     * @return property value from the default instance (may be {@code null}),
+     *   or {@link #_DEFAULT_BEAN_NOT_AVAILABLE} if sampling is not possible
+     *
+     * @since 3.3
+     */
+    protected Object _findFromDefaultBean(SettableBeanProperty prop) throws JacksonException
+    {
+        Object defaultBean = _defaultBeanInstance();
+        if (defaultBean == null) {
+            return _DEFAULT_BEAN_NOT_AVAILABLE;
+        }
+        Object value = _readPropertyFromInstance(defaultBean, prop);
+        return (value == _DEFAULT_BEAN_NOT_AVAILABLE) ? _DEFAULT_BEAN_NOT_AVAILABLE : value;
+    }
+
+    /**
+     * Lazily create (or fail) the default-constructor instance used as a
+     * source of absent creator-argument defaults.
+     *
+     * @since 3.3
+     */
+    protected Object _defaultBeanInstance() throws JacksonException
+    {
+        if (_defaultBeanResolved) {
+            return _defaultBean;
+        }
+        _defaultBeanResolved = true;
+        if ((_valueInstantiator == null) || !_valueInstantiator.canCreateUsingDefault()) {
+            return null;
+        }
+        try {
+            _defaultBean = _valueInstantiator.createUsingDefault(_context);
+        } catch (Exception e) {
+            // Not fatal: fall back to ordinary absent-value handling
+            _defaultBean = null;
+        }
+        return _defaultBean;
+    }
+
+    /**
+     * Read a property value from {@code instance} for the given creator
+     * property, using fallback field/setter metadata or JavaBeans accessors.
+     *
+     * @return value (possibly {@code null}), or {@link #_DEFAULT_BEAN_NOT_AVAILABLE}
+     *
+     * @since 3.3
+     */
+    protected Object _readPropertyFromInstance(Object instance, SettableBeanProperty prop)
+    {
+        // Prefer field accessor when the creator property has a field fallback
+        if (prop instanceof CreatorProperty) {
+            CreatorProperty cp = (CreatorProperty) prop;
+            if (cp.hasFallbackSetter()) {
+                AnnotatedMember m = cp.getFallbackSetter().getMember();
+                if (m instanceof AnnotatedField) {
+                    try {
+                        return m.getValue(instance);
+                    } catch (IllegalArgumentException e) {
+                        // fall through to other strategies
+                    }
+                }
+            }
+        }
+
+        final String name = prop.getName();
+        if (name == null || name.isEmpty()) {
+            return _DEFAULT_BEAN_NOT_AVAILABLE;
+        }
+        final Class<?> raw = instance.getClass();
+
+        // Direct field (incl. private, after setAccessible) by logical name
+        for (Class<?> c = raw; c != null && c != Object.class; c = c.getSuperclass()) {
+            try {
+                Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                return f.get(instance);
+            } catch (NoSuchFieldException e) {
+                // try superclass
+            } catch (Exception e) {
+                break;
+            }
+        }
+
+        // JavaBeans getter: getX / isX
+        final String cap = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        for (String methodName : new String[] { "get" + cap, "is" + cap }) {
+            try {
+                Method m = raw.getMethod(methodName);
+                return m.invoke(instance);
+            } catch (Exception e) {
+                // try next
+            }
+        }
+        return _DEFAULT_BEAN_NOT_AVAILABLE;
     }
 
     /**

--- a/src/test/java/tools/jackson/databind/deser/creators/FieldDefaultWithAllArgsCtor6100Test.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/FieldDefaultWithAllArgsCtor6100Test.java
@@ -1,0 +1,188 @@
+package tools.jackson.databind.deser.creators;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.ConstructorDetector;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// [databind#6100]: when a properties-based creator is used and a JSON property
+// is absent, prefer values from a no-arg-constructed default instance (field
+// initializers / no-arg body) over bare JVM defaults (false/0/null).
+public class FieldDefaultWithAllArgsCtor6100Test extends DatabindTestUtil
+{
+    // Mutable: public non-final field + no-arg + all-args (Lombok-ish)
+    static class WithBothCtors {
+        public boolean historical = true;
+
+        public WithBothCtors() { }
+
+        public WithBothCtors(boolean historical) {
+            this.historical = historical;
+        }
+    }
+
+    // Mutable: private field + accessors + both constructors
+    static class WithAccessors {
+        private boolean historical = true;
+
+        public WithAccessors() { }
+
+        public WithAccessors(boolean historical) {
+            this.historical = historical;
+        }
+
+        public boolean isHistorical() { return historical; }
+        public void setHistorical(boolean historical) { this.historical = historical; }
+    }
+
+    // Explicit @JsonCreator + no-arg: missing args still take field defaults
+    // from the no-arg instance when one is available.
+    static class ExplicitAllArgs {
+        public boolean historical = true;
+
+        public ExplicitAllArgs() { }
+
+        @JsonCreator
+        public ExplicitAllArgs(@JsonProperty("historical") boolean historical) {
+            this.historical = historical;
+        }
+    }
+
+    // Creator only (no usable no-arg): missing primitive stays JVM default
+    static class CreatorOnly {
+        public final boolean historical;
+
+        @JsonCreator
+        public CreatorOnly(@JsonProperty("historical") boolean historical) {
+            this.historical = historical;
+        }
+    }
+
+    static class OnlyNoArgs {
+        public boolean historical = true;
+
+        public OnlyNoArgs() { }
+    }
+
+    // Immutable: final fields (#5318) — multi-arg creator must still win
+    static class ImmutableBoth {
+        public final int productId;
+        public final String name;
+
+        public ImmutableBoth() {
+            this(0, null);
+        }
+
+        public ImmutableBoth(int productId, String name) {
+            this.productId = productId;
+            this.name = name;
+        }
+    }
+
+    static class ScalarDefaults {
+        public int count = 5;
+        public String label = "def";
+
+        public ScalarDefaults() { }
+
+        public ScalarDefaults(int count, String label) {
+            this.count = count;
+            this.label = label;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    void emptyObjectKeepsBooleanFieldDefault() throws Exception {
+        WithBothCtors v = MAPPER.readValue("{}", WithBothCtors.class);
+        assertTrue(v.historical);
+    }
+
+    @Test
+    void presentFalseOverridesFieldDefault() throws Exception {
+        WithBothCtors v = MAPPER.readValue("""
+                {"historical":false}""", WithBothCtors.class);
+        assertFalse(v.historical);
+    }
+
+    @Test
+    void presentTrue() throws Exception {
+        WithBothCtors v = MAPPER.readValue("""
+                {"historical":true}""", WithBothCtors.class);
+        assertTrue(v.historical);
+    }
+
+    @Test
+    void accessorsEmptyKeepsFieldDefault() throws Exception {
+        WithAccessors v = MAPPER.readValue("{}", WithAccessors.class);
+        assertTrue(v.isHistorical());
+    }
+
+    @Test
+    void accessorsPresentFalse() throws Exception {
+        WithAccessors v = MAPPER.readValue("""
+                {"historical":false}""", WithAccessors.class);
+        assertFalse(v.isHistorical());
+    }
+
+    @Test
+    void onlyNoArgsKeepsDefault() throws Exception {
+        OnlyNoArgs v = MAPPER.readValue("{}", OnlyNoArgs.class);
+        assertTrue(v.historical);
+    }
+
+    @Test
+    void explicitCreatorWithNoArgKeepsFieldDefault() throws Exception {
+        ExplicitAllArgs v = MAPPER.readValue("{}", ExplicitAllArgs.class);
+        assertTrue(v.historical);
+    }
+
+    @Test
+    void creatorOnlyMissingUsesPrimitiveDefault() throws Exception {
+        CreatorOnly v = MAPPER.readValue("{}", CreatorOnly.class);
+        assertFalse(v.historical);
+    }
+
+    // [databind#5318]
+    @Test
+    void immutableBothStillUsesAllArgsCreator() throws Exception {
+        ImmutableBoth v = MAPPER.readValue("""
+                {"productId":1,"name":"foo"}""", ImmutableBoth.class);
+        assertEquals(1, v.productId);
+        assertEquals("foo", v.name);
+    }
+
+    @Test
+    void scalarFieldDefaultsPreserved() throws Exception {
+        ScalarDefaults v = MAPPER.readValue("{}", ScalarDefaults.class);
+        assertEquals(5, v.count);
+        assertEquals("def", v.label);
+    }
+
+    @Test
+    void scalarPartialOverride() throws Exception {
+        ScalarDefaults v = MAPPER.readValue("""
+                {"count":9}""", ScalarDefaults.class);
+        assertEquals(9, v.count);
+        assertEquals("def", v.label);
+    }
+
+    @Test
+    void featureDisabledUsesNoArgForImmutable() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+                .constructorDetector(ConstructorDetector.DEFAULT
+                        .withAllowImplicitWithDefaultConstructor(false))
+                .build();
+        ImmutableBoth v = mapper.readValue("{}", ImmutableBoth.class);
+        assertEquals(0, v.productId);
+        assertNull(v.name);
+    }
+}


### PR DESCRIPTION
Fixes #6100

### Problem
Jackson 3 can auto-select an all-args constructor as a properties-based creator even when a no-arg constructor exists (#5318). For a missing JSON property, the creator then receives the JVM default (`false` / `0` / `null`) instead of the field initializer / no-arg constructor value.

Example (Lombok-style):

```java
public class MyClass {
    public boolean historical = true;
    public MyClass() { }
    public MyClass(boolean historical) { this.historical = historical; }
}
```

`readValue("{}", MyClass.class)` was producing `historical == false`.

### Change
When filling a missing creator argument, if the type has a usable no-arg constructor, build a default instance once and take the property value from it (field / JavaBeans accessor). Fall back to the existing absent-value path when no default instance is available.

Creator *selection* is unchanged, so #5318 immutable detection, property ordering, and object-id cases stay as they are.

### Tests
`FieldDefaultWithAllArgsCtor6100Test` — empty-object / partial-override cases **fail without / pass with** the fix; creator-only (no no-arg) still uses JVM defaults; #5318-style cases remain green.

Also rechecked the tests that failed under an earlier approach:
`DifferentRadixNumberFormatTest`, `JsonIdentityHashCodeIssue1546Test`, `KotlinIssueGH56UnwrappedWithCreatorTest`, `NoParamsCreator5318Test`.