### PR TITLE
Mark built-in JDK 8 handlers as Jackson standard implementations

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -226,6 +226,9 @@ Lee Jiwon (@dlwldnjs1009)
   [3.1.3]
  * Fixed #6048: Apply content converters for String collection values (`StringCollectionDeserializer`)
   [3.1.5]
+ * Fixed #6109: Mark built-in JDK 8 handlers (`Optional`, `Stream`) with
+   `@JacksonStdImpl` so optimization modules (Blackbird) can retain optimized handlers
+  [3.1.6]
 
 Garret Wilson (@garretwilson)
  * Suggested #4157: Add `MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY` to ignore

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,6 +15,9 @@ No changes since 3.1
   after all entries are filtered
  (reported by @dlwldnjs1009)
  (fix by @seonwooj0810)
+#6109: Mark built-in JDK 8 handlers (`Optional`, `Stream`) with `@JacksonStdImpl` so
+  optimization modules (Blackbird) can retain optimized handlers
+ (fix by Lee Jiwon)
 
 3.1.5 (07-Jul-2026)
 

--- a/src/main/java/tools/jackson/databind/ext/jdk8/DoubleStreamSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/DoubleStreamSerializer.java
@@ -5,6 +5,7 @@ import java.util.stream.DoubleStream;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 /**
@@ -14,6 +15,7 @@ import tools.jackson.databind.ser.std.StdSerializer;
  * so we need to define each in a specific class
  * </p>
  */
+@JacksonStdImpl
 public class DoubleStreamSerializer extends StdSerializer<DoubleStream>
 {
     /**

--- a/src/main/java/tools/jackson/databind/ext/jdk8/IntStreamSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/IntStreamSerializer.java
@@ -5,6 +5,7 @@ import java.util.stream.IntStream;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 /**
@@ -13,6 +14,7 @@ import tools.jackson.databind.ser.std.StdSerializer;
  * Unfortunately there to common ancestor between number base stream, so we need to define each in a specific class
  * </p>
  */
+@JacksonStdImpl
 public class IntStreamSerializer extends StdSerializer<IntStream>
 {
     /**

--- a/src/main/java/tools/jackson/databind/ext/jdk8/Jdk8OptionalDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/Jdk8OptionalDeserializer.java
@@ -3,10 +3,12 @@ package tools.jackson.databind.ext.jdk8;
 import java.util.Optional;
 
 import tools.jackson.databind.*;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.deser.ValueInstantiator;
 import tools.jackson.databind.deser.std.ReferenceTypeDeserializer;
 import tools.jackson.databind.jsontype.TypeDeserializer;
 
+@JacksonStdImpl
 public class Jdk8OptionalDeserializer
     extends ReferenceTypeDeserializer<Optional<?>>
 {

--- a/src/main/java/tools/jackson/databind/ext/jdk8/Jdk8OptionalSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/Jdk8OptionalSerializer.java
@@ -3,11 +3,13 @@ package tools.jackson.databind.ext.jdk8;
 import java.util.Optional;
 
 import tools.jackson.databind.*;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.jsontype.TypeSerializer;
 import tools.jackson.databind.ser.std.ReferenceTypeSerializer;
 import tools.jackson.databind.type.ReferenceType;
 import tools.jackson.databind.util.NameTransformer;
 
+@JacksonStdImpl
 public class Jdk8OptionalSerializer
     extends ReferenceTypeSerializer<Optional<?>>
 {

--- a/src/main/java/tools/jackson/databind/ext/jdk8/Jdk8StreamSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/Jdk8StreamSerializer.java
@@ -5,12 +5,14 @@ import java.util.stream.Stream;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.*;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 /**
  * Common typed stream serializer
  *
  */
+@JacksonStdImpl
 public class Jdk8StreamSerializer extends StdSerializer<Stream<?>>
 {
     /**

--- a/src/main/java/tools/jackson/databind/ext/jdk8/LongStreamSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/LongStreamSerializer.java
@@ -5,6 +5,7 @@ import java.util.stream.LongStream;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 /**
@@ -13,6 +14,7 @@ import tools.jackson.databind.ser.std.StdSerializer;
  * Unfortunately there to common ancestor between number base stream, so we need to define each in a specific class
  * </p>
  */
+@JacksonStdImpl
 public class LongStreamSerializer extends StdSerializer<LongStream>
 {
     /**

--- a/src/main/java/tools/jackson/databind/ext/jdk8/OptionalDoubleDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/OptionalDoubleDeserializer.java
@@ -8,9 +8,11 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.core.JsonTokenId;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.cfg.CoercionAction;
 import tools.jackson.databind.type.LogicalType;
 
+@JacksonStdImpl
 public class OptionalDoubleDeserializer extends BaseScalarOptionalDeserializer<OptionalDouble>
 {
     static final OptionalDoubleDeserializer INSTANCE = new OptionalDoubleDeserializer();

--- a/src/main/java/tools/jackson/databind/ext/jdk8/OptionalDoubleSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/OptionalDoubleSerializer.java
@@ -7,10 +7,12 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor;
 import tools.jackson.databind.ser.std.StdScalarSerializer;
 
+@JacksonStdImpl
 public class OptionalDoubleSerializer extends StdScalarSerializer<OptionalDouble>
 {
     static final OptionalDoubleSerializer INSTANCE = new OptionalDoubleSerializer();

--- a/src/main/java/tools/jackson/databind/ext/jdk8/OptionalIntDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/OptionalIntDeserializer.java
@@ -8,9 +8,11 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.core.JsonTokenId;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.cfg.CoercionAction;
 import tools.jackson.databind.type.LogicalType;
 
+@JacksonStdImpl
 public class OptionalIntDeserializer extends BaseScalarOptionalDeserializer<OptionalInt>
 {
     static final OptionalIntDeserializer INSTANCE = new OptionalIntDeserializer();

--- a/src/main/java/tools/jackson/databind/ext/jdk8/OptionalIntSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/OptionalIntSerializer.java
@@ -7,10 +7,12 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
 import tools.jackson.databind.ser.std.StdScalarSerializer;
 
+@JacksonStdImpl
 public class OptionalIntSerializer extends StdScalarSerializer<OptionalInt>
 {
     public OptionalIntSerializer() {

--- a/src/main/java/tools/jackson/databind/ext/jdk8/OptionalLongDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/OptionalLongDeserializer.java
@@ -8,9 +8,11 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.core.JsonTokenId;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.cfg.CoercionAction;
 import tools.jackson.databind.type.LogicalType;
 
+@JacksonStdImpl
 public class OptionalLongDeserializer extends BaseScalarOptionalDeserializer<OptionalLong>
 {
     static final OptionalLongDeserializer INSTANCE = new OptionalLongDeserializer();

--- a/src/main/java/tools/jackson/databind/ext/jdk8/OptionalLongSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/jdk8/OptionalLongSerializer.java
@@ -7,10 +7,12 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
 import tools.jackson.databind.ser.std.StdScalarSerializer;
 
+@JacksonStdImpl
 public class OptionalLongSerializer extends StdScalarSerializer<OptionalLong>
 {
     static final OptionalLongSerializer INSTANCE = new OptionalLongSerializer();

--- a/src/test/java/tools/jackson/databind/ext/jdk8/Jdk8HandlersStdImplTest.java
+++ b/src/test/java/tools/jackson/databind/ext/jdk8/Jdk8HandlersStdImplTest.java
@@ -1,0 +1,37 @@
+package tools.jackson.databind.ext.jdk8;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.testutil.DatabindTestUtil;
+import tools.jackson.databind.util.ClassUtil;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// [modules-base#355]: built-in JDK 8 handlers must be recognized as standard
+// implementations, so that optimization modules (like Blackbird) do not revert
+// optimized properties to reflection when one of these handlers is resolved.
+public class Jdk8HandlersStdImplTest
+    extends DatabindTestUtil
+{
+    @Test
+    public void jdk8HandlersMarkedAsStdImpl() {
+        Class<?>[] handlers = new Class<?>[] {
+                Jdk8OptionalDeserializer.class,
+                OptionalIntDeserializer.class,
+                OptionalLongDeserializer.class,
+                OptionalDoubleDeserializer.class,
+                Jdk8OptionalSerializer.class,
+                OptionalIntSerializer.class,
+                OptionalLongSerializer.class,
+                OptionalDoubleSerializer.class,
+                Jdk8StreamSerializer.class,
+                IntStreamSerializer.class,
+                LongStreamSerializer.class,
+                DoubleStreamSerializer.class,
+        };
+        for (Class<?> handler : handlers) {
+            assertTrue(ClassUtil.isJacksonStdImpl(handler),
+                    "Expected @JacksonStdImpl on "+handler.getName());
+        }
+    }
+}


### PR DESCRIPTION
The built-in JDK 8 handlers are not marked with `@JacksonStdImpl`, so Blackbird classifies them as custom handlers and drops its optimized property path during late handler resolution.

Addresses the databind side of FasterXML/jackson-modules-base#355.

Changes:
- Add `@JacksonStdImpl` to all 12 concrete handlers under `tools.jackson.databind.ext.jdk8`
- Add `Jdk8HandlersStdImplTest` to verify their `ClassUtil` classification

Testing:
- `./mvnw test -Dtest=Jdk8HandlersStdImplTest,OptionalBasicTest,OptionalNumbersTest`

Blackbird regression coverage is in FasterXML/jackson-modules-base#356.