### PR TITLE
Fix DOMSerializer to support polymorphic serialization

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -598,3 +598,7 @@ Ivan (@pctF)
    `IllegalArgumentException` but throws `MismatchedInputException` when input and
    expected type are not compatible
   [3.3.0]
+
+Bowang (@dong0713)
+ * Fixed #6113: `DOMSerializer` to support polymorphic serialization
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,7 +22,7 @@ Versions: 3.x (for earlier see VERSION-2.x)
   is actually thrown
  (reported by @pctF)
  (fix by @pjfanning)
-#6113 Fix `DOMSerializer` to support polymorphic serialization
+#6113: Fix `DOMSerializer` to support polymorphic serialization
  (fix by @dong0713)
 
 3.2.1 (10-Jul-2026)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
   is actually thrown
  (reported by @pctF)
  (fix by @pjfanning)
+#6113 Fix `DOMSerializer` to support polymorphic serialization
+ (fix by @dong0713)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/databind/ext/DOMSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/DOMSerializer.java
@@ -6,6 +6,7 @@ import javax.xml.XMLConstants;
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 import tools.jackson.core.*;
@@ -51,31 +52,31 @@ public class DOMSerializer extends StdSerializer<Node>
         }
     }
 
-    /**
-     * DOM {@link Node} is written as a JSON String (XML text). With default typing /
-     * {@code @JsonTypeInfo} this must go through {@code serializeWithType} — same
-     * shape as {@link XMLGregorianCalendarSerializer} ([databind#3217]) and
-     * {@code StdScalarSerializer}. Without the override the base
-     * {@code ValueSerializer.serializeWithType} throws
-     * {@code InvalidDefinitionException}.
-     */
     @Override
     public void serializeWithType(Node value, JsonGenerator g, SerializationContext ctxt,
             TypeSerializer typeSer)
         throws JacksonException
     {
-        // Need not really be string; just indicates "scalar of some kind"
-        // (XML text content is written as VALUE_STRING by serialize())
+        // 23-Jul-2026, tatu: [databind#6113] `Node` written as XML text in JSON String,
+        //    so needs same handling as `StdScalarSerializer` (compare to
+        //    `XMLGregorianCalendarSerializer` / [databind#3217])
+
+        // Also: must not use runtime type, as that is JDK-internal implementation
+        // class (like `com.sun.org.apache.xerces.internal.dom.DocumentImpl`); but
+        // cannot always use `Node` either, since that is not a subtype of `Document`
+        // and would fail on deserialization of `Document`-declared values
+        Class<?> typeForId = (value instanceof Document) ? Document.class : Node.class;
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
-                // important! Pass value AND nominal type so type id is for Node, not a subclass
-                typeSer.typeId(value, Node.class, JsonToken.VALUE_STRING));
+                typeSer.typeId(value, typeForId, JsonToken.VALUE_STRING));
         serialize(value, g, ctxt);
         typeSer.writeTypeSuffix(g, ctxt, typeIdDef);
     }
 
     @Override
     public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) {
-        if (visitor != null) visitor.expectAnyFormat(typeHint);
+        // 23-Jul-2026, tatu: [databind#6113] `Node` is written as XML text in JSON
+        //    String, so report as such (and not as "any format")
+        visitStringFormat(visitor, typeHint);
     }
 
     private static void setTransformerFactoryAttribute(final TransformerFactory transformerFactory,

--- a/src/main/java/tools/jackson/databind/ext/DOMSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/DOMSerializer.java
@@ -9,9 +9,11 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Node;
 
 import tools.jackson.core.*;
+import tools.jackson.core.type.WritableTypeId;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import tools.jackson.databind.jsontype.TypeSerializer;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 public class DOMSerializer extends StdSerializer<Node>
@@ -47,6 +49,28 @@ public class DOMSerializer extends StdSerializer<Node>
         } catch (TransformerException e) {
             provider.reportMappingProblem(e, "DOM `Node` value serialization failed: %s", e.getMessage());
         }
+    }
+
+    /**
+     * DOM {@link Node} is written as a JSON String (XML text). With default typing /
+     * {@code @JsonTypeInfo} this must go through {@code serializeWithType} — same
+     * shape as {@link XMLGregorianCalendarSerializer} ([databind#3217]) and
+     * {@code StdScalarSerializer}. Without the override the base
+     * {@code ValueSerializer.serializeWithType} throws
+     * {@code InvalidDefinitionException}.
+     */
+    @Override
+    public void serializeWithType(Node value, JsonGenerator g, SerializationContext ctxt,
+            TypeSerializer typeSer)
+        throws JacksonException
+    {
+        // Need not really be string; just indicates "scalar of some kind"
+        // (XML text content is written as VALUE_STRING by serialize())
+        WritableTypeId typeIdDef = typeSer.writeTypePrefix(g, ctxt,
+                // important! Pass value AND nominal type so type id is for Node, not a subclass
+                typeSer.typeId(value, Node.class, JsonToken.VALUE_STRING));
+        serialize(value, g, ctxt);
+        typeSer.writeTypeSuffix(g, ctxt, typeIdDef);
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/tools/jackson/databind/ext/OptionalHandlerFactory.java
@@ -62,11 +62,14 @@ public class OptionalHandlerFactory
     public ValueDeserializer<?> findDeserializer(DeserializationConfig config, JavaType type)
     {
         final Class<?> rawType = type.getRawClass();
-        if (_IsXOfY(rawType, CLASS_DOM_NODE)) {
-            return new DOMDeserializer.NodeDeserializer();
-        }
+        // 23-Jul-2026, tatu: [databind#6120] Must check most-specific type first:
+        //    `Document` is a subtype of `Node`, so checking `Node` first would
+        //    leave `DocumentDeserializer` unreachable
         if (_IsXOfY(rawType, CLASS_DOM_DOCUMENT)) {
             return new DOMDeserializer.DocumentDeserializer();
+        }
+        if (_IsXOfY(rawType, CLASS_DOM_NODE)) {
+            return new DOMDeserializer.NodeDeserializer();
         }
         String className = rawType.getName();
         if (className.startsWith(PACKAGE_PREFIX_JAVAX_XML)

--- a/src/main/java/tools/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/tools/jackson/databind/ext/OptionalHandlerFactory.java
@@ -80,10 +80,10 @@ public class OptionalHandlerFactory
     }
 
     public boolean hasDeserializerFor(Class<?> valueType) {
+        // 23-Jul-2026, tatu: [databind#6113] No separate `Document` check needed
+        //    (unlike in `findDeserializer()`, which returns differing handlers):
+        //    `Document` is a subtype of `Node` so this covers both
         if (_IsXOfY(valueType, CLASS_DOM_NODE)) {
-            return true;
-        }
-        if (_IsXOfY(valueType, CLASS_DOM_DOCUMENT)) {
             return true;
         }
         String className = valueType.getName();

--- a/src/main/java/tools/jackson/databind/ext/OptionalHandlerFactory.java
+++ b/src/main/java/tools/jackson/databind/ext/OptionalHandlerFactory.java
@@ -62,7 +62,7 @@ public class OptionalHandlerFactory
     public ValueDeserializer<?> findDeserializer(DeserializationConfig config, JavaType type)
     {
         final Class<?> rawType = type.getRawClass();
-        // 23-Jul-2026, tatu: [databind#6120] Must check most-specific type first:
+        // 23-Jul-2026, tatu: [databind#6113] Must check most-specific type first:
         //    `Document` is a subtype of `Node`, so checking `Node` first would
         //    leave `DocumentDeserializer` unreachable
         if (_IsXOfY(rawType, CLASS_DOM_DOCUMENT)) {

--- a/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
@@ -139,7 +139,7 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
     /**********************************************************
      */
 
-    // [databind#6120]: `DocumentDeserializer` used to be unreachable, since lookup
+    // [databind#6113]: `DocumentDeserializer` used to be unreachable, since lookup
     // checked `Node` first and `Document` is a subtype of it. Only externally visible
     // difference is the target type reported on failure, so verify via that.
     @Test

--- a/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
@@ -14,6 +14,7 @@ import org.xml.sax.InputSource;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import tools.jackson.databind.testutil.DatabindTestUtil;
@@ -134,6 +135,32 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
 
     /*
     /**********************************************************
+    /* Deserializer resolution tests
+    /**********************************************************
+     */
+
+    // [databind#6120]: `DocumentDeserializer` used to be unreachable, since lookup
+    // checked `Node` first and `Document` is a subtype of it. Only externally visible
+    // difference is the target type reported on failure, so verify via that.
+    @Test
+    public void documentUsesDocumentDeserializer() throws Exception
+    {
+        InvalidFormatException e = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(q("not xml at all"), Document.class));
+        verifyException(e, "Cannot deserialize value of type `org.w3c.dom.Document`");
+    }
+
+    // ... whereas `Node`-declared values keep using `NodeDeserializer`
+    @Test
+    public void nodeUsesNodeDeserializer() throws Exception
+    {
+        InvalidFormatException e = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(q("not xml at all"), Node.class));
+        verifyException(e, "Cannot deserialize value of type `org.w3c.dom.Node`");
+    }
+
+    /*
+    /**********************************************************
     /* Polymorphic (`@JsonTypeInfo`) tests
     /**********************************************************
      */
@@ -149,19 +176,67 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
         assertEquals(Document.class.getName(), _typeIdOf(json));
 
         DocumentWrapper result = MAPPER.readValue(json, DocumentWrapper.class);
+        _assertNodeType(Node.DOCUMENT_NODE, Document.class, result.value);
         assertEquals(SIMPLE_XML, _asXml(result.value));
     }
 
     // [databind#6113]: `Node`-declared field gets `Document` Type Id too (that being
     // the actual shape written), which resolves fine as a subtype of `Node`
     @Test
-    public void polymorphicNodeField() throws Exception
+    public void polymorphicNodeFieldWithDocument() throws Exception
     {
         String json = MAPPER.writeValueAsString(new NodeWrapper(_simpleDocument()));
         assertEquals(Document.class.getName(), _typeIdOf(json));
 
         NodeWrapper result = MAPPER.readValue(json, NodeWrapper.class);
+        _assertNodeType(Node.DOCUMENT_NODE, Document.class, result.value);
         assertEquals(SIMPLE_XML, _asXml(result.value));
+    }
+
+    // [databind#6113]: `Element` value gets `Node` Type Id (not `Element`), since
+    // `NodeDeserializer` is the only handler that can accept it.
+    // NOTE: read side is asymmetric -- `DOMDeserializer` always parses a full
+    // `Document` -- so an `Element` written comes back as `Document`. That is
+    // pre-existing `DOMDeserializer` behavior, not something #6113 changed;
+    // see [databind#6120] for possible per-node-type handling.
+    @Test
+    public void polymorphicNodeFieldWithElement() throws Exception
+    {
+        Element leaf = (Element) _simpleDocument().getDocumentElement()
+                .getElementsByTagName("leaf").item(0);
+        _assertNodeType(Node.ELEMENT_NODE, Element.class, leaf);
+
+        String json = MAPPER.writeValueAsString(new NodeWrapper(leaf));
+        assertEquals(Node.class.getName(), _typeIdOf(json));
+        assertEquals("<leaf>Rock &amp; Roll!</leaf>", _valueOf(json));
+
+        NodeWrapper result = MAPPER.readValue(json, NodeWrapper.class);
+        // Exactly a Document -- NOT the Element that was written
+        _assertNodeType(Node.DOCUMENT_NODE, Document.class, result.value);
+        Element rootOfResult = ((Document) result.value).getDocumentElement();
+        _assertNodeType(Node.ELEMENT_NODE, Element.class, rootOfResult);
+        assertEquals("leaf", rootOfResult.getTagName());
+        assertEquals("Rock & Roll!", rootOfResult.getTextContent());
+    }
+
+    // [databind#6113]: `Text` ("String") node also gets `Node` Type Id, and write
+    // side works. Read side, however, cannot work: bare text is not a legal XML
+    // document. Again pre-existing `DOMDeserializer` limitation, verified here so
+    // that a change in behavior is caught; see [databind#6120].
+    @Test
+    public void polymorphicNodeFieldWithText() throws Exception
+    {
+        Text text = (Text) _simpleDocument().getDocumentElement()
+                .getElementsByTagName("leaf").item(0).getFirstChild();
+        _assertNodeType(Node.TEXT_NODE, Text.class, text);
+
+        String json = MAPPER.writeValueAsString(new NodeWrapper(text));
+        assertEquals(Node.class.getName(), _typeIdOf(json));
+        assertEquals("Rock &amp; Roll!", _valueOf(json));
+
+        InvalidFormatException e = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(json, NodeWrapper.class));
+        verifyException(e, "Failed to parse JSON String as XML");
     }
 
     /*
@@ -220,8 +295,28 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
     // Scalar values use WRAPPER_ARRAY inclusion, so JSON is
     // `{"value":["type.id","<xml>"]}`: dig out the Type Id
     private String _typeIdOf(String json) throws Exception {
+        return _wrapperArrayOf(json).path(0).stringValue();
+    }
+
+    // ... and matching XML text payload
+    private String _valueOf(String json) throws Exception {
+        return _wrapperArrayOf(json).path(1).stringValue();
+    }
+
+    private JsonNode _wrapperArrayOf(String json) throws Exception {
         JsonNode wrapped = MAPPER.readTree(json).path("value");
         assertTrue(wrapped.isArray(), "Expected WRAPPER_ARRAY for typed `Node`, got: "+json);
-        return wrapped.path(0).stringValue();
+        assertEquals(2, wrapped.size(), "Expected [typeId, value], got: "+json);
+        return wrapped;
+    }
+
+    // Verify exact DOM type: `getNodeType()` is the canonical discriminator (node
+    // types are mutually exclusive), since runtime classes are JDK-internal impls
+    // like `com.sun.org.apache.xerces.internal.dom.DeferredDocumentImpl`
+    private void _assertNodeType(short expNodeType, Class<? extends Node> expType, Node actual) {
+        assertNotNull(actual, "Expected "+expType.getName()+", got `null`");
+        assertEquals(expNodeType, actual.getNodeType(),
+                "Wrong `getNodeType()` for value of class "+actual.getClass().getName());
+        assertInstanceOf(expType, actual);
     }
 }

--- a/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 
+import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
+import tools.jackson.databind.testutil.NoCheckSubTypeValidator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,6 +24,11 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
             "<root xmlns='http://foo'/>";
 
     private final ObjectMapper MAPPER = new ObjectMapper();
+    // Same default-typing setup as MiscJavaXMLTypesReadWriteTest for XMLGregorianCalendar
+    private final ObjectMapper POLY_MAPPER = jsonMapperBuilder()
+            .activateDefaultTyping(NoCheckSubTypeValidator.instance,
+                    DefaultTyping.NON_FINAL)
+            .build();
 
     @Test
     public void testSerializeSimpleNonNS() throws Exception
@@ -104,6 +111,35 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
         // DOM is weird, includes ns decls as attributes...
         assertEquals(2, root.getAttributes().getLength());
         assertEquals("abc", root.getAttributeNS("http://foo", "attr"));
+    }
+
+    /*
+    /**********************************************************
+    /* Polymorphic (default typing) tests
+    /**********************************************************
+     */
+
+    /**
+     * DOM Node is serialized as a JSON String (XML text). With default typing
+     * enabled this must go through {@code serializeWithType}, same as
+     * {@code XMLGregorianCalendarSerializer} (see databind#3217). Without that
+     * override the base {@code ValueSerializer.serializeWithType} throws
+     * {@code InvalidDefinitionException}.
+     */
+    @Test
+    public void testPolymorphicDOMDocument() throws Exception
+    {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse
+            (new InputSource(new StringReader(SIMPLE_XML)));
+        // Before fix: InvalidDefinitionException "Type id handling not implemented"
+        // After fix: typed JSON string that round-trips to Document
+        String json = POLY_MAPPER.writeValueAsString(doc);
+        Object result = POLY_MAPPER.readValue(json, Object.class);
+        assertTrue(result instanceof Document || result instanceof Node,
+                "Expected a DOM Node/Document, got: " + result.getClass());
+        String output = MAPPER.writeValueAsString(result);
+        String normalized = normalizeOutput(MAPPER.readValue(output, String.class));
+        assertEquals(SIMPLE_XML, normalized);
     }
 
     /*

--- a/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
@@ -11,13 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 
-import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import tools.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import tools.jackson.databind.testutil.DatabindTestUtil;
-import tools.jackson.databind.testutil.NoCheckSubTypeValidator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,34 +29,25 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
     final static String SIMPLE_XML_DEFAULT_NS =
             "<root xmlns='http://foo'/>";
 
-    static class DocHolder {
-        public Document doc;
-
-        protected DocHolder() { }
-        public DocHolder(Document d) { doc = d; }
-    }
-
-    static class NodeHolder {
-        public Node node;
-
-        protected NodeHolder() { }
-        public NodeHolder(Node n) { node = n; }
-    }
-
-    static class AnnotatedDocHolder {
+    // [databind#6113]: wrappers for polymorphic handling, with the 2 DOM types
+    // for which deserializers exist (see `OptionalHandlerFactory`)
+    static class NodeWrapper {
         @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-        public Document doc;
+        public Node value;
 
-        protected AnnotatedDocHolder() { }
-        public AnnotatedDocHolder(Document d) { doc = d; }
+        protected NodeWrapper() { }
+        public NodeWrapper(Node n) { value = n; }
+    }
+
+    static class DocumentWrapper {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+        public Document value;
+
+        protected DocumentWrapper() { }
+        public DocumentWrapper(Document d) { value = d; }
     }
 
     private final ObjectMapper MAPPER = new ObjectMapper();
-    // Same default-typing setup as MiscJavaXMLTypesReadWriteTest for XMLGregorianCalendar
-    private final ObjectMapper POLY_MAPPER = jsonMapperBuilder()
-            .activateDefaultTyping(NoCheckSubTypeValidator.instance,
-                    DefaultTyping.NON_FINAL)
-            .build();
 
     @Test
     public void testSerializeSimpleNonNS() throws Exception
@@ -144,71 +134,34 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
 
     /*
     /**********************************************************
-    /* Polymorphic (default typing) tests
+    /* Polymorphic (`@JsonTypeInfo`) tests
     /**********************************************************
      */
 
-    /**
-     * DOM Node is serialized as a JSON String (XML text). With default typing
-     * enabled this must go through {@code serializeWithType}, same as
-     * {@code XMLGregorianCalendarSerializer} (see databind#3217). Without that
-     * override the base {@code ValueSerializer.serializeWithType} throws
-     * {@code InvalidDefinitionException}.
-     */
+    // [databind#6113]: without `serializeWithType()` override this failed with
+    // `InvalidDefinitionException` ("Type id handling not implemented")
     @Test
-    public void testPolymorphicDOMDocument() throws Exception
+    public void polymorphicDocumentField() throws Exception
     {
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse
-            (new InputSource(new StringReader(SIMPLE_XML)));
-        // Before fix: InvalidDefinitionException "Type id handling not implemented"
-        // After fix: typed JSON string that round-trips to Document
-        String json = POLY_MAPPER.writeValueAsString(doc);
-        Object result = POLY_MAPPER.readValue(json, Object.class);
-        assertTrue(result instanceof Document || result instanceof Node,
-                "Expected a DOM Node/Document, got: " + result.getClass());
-        String output = MAPPER.writeValueAsString(result);
-        String normalized = normalizeOutput(MAPPER.readValue(output, String.class));
-        assertEquals(SIMPLE_XML, normalized);
-    }
-
-    // [databind#6113]: Type Id must be `Document` (not `Node`) for `Document` values,
-    // or else read side fails with "not a subtype of `org.w3c.dom.Document`"
-    @Test
-    public void polymorphicDocumentDeclaredType() throws Exception
-    {
-        String json = POLY_MAPPER.writeValueAsString(_simpleDocument());
+        String json = MAPPER.writeValueAsString(new DocumentWrapper(_simpleDocument()));
+        // Type Id must be `Document`, not `Node`: latter is not a subtype of the
+        // declared `Document` and read side would fail with `InvalidTypeIdException`
         assertEquals(Document.class.getName(), _typeIdOf(json));
-        Document result = POLY_MAPPER.readValue(json, Document.class);
-        assertEquals(SIMPLE_XML, _asXml(result));
+
+        DocumentWrapper result = MAPPER.readValue(json, DocumentWrapper.class);
+        assertEquals(SIMPLE_XML, _asXml(result.value));
     }
 
-    // [databind#6113]
+    // [databind#6113]: `Node`-declared field gets `Document` Type Id too (that being
+    // the actual shape written), which resolves fine as a subtype of `Node`
     @Test
-    public void polymorphicDocumentProperty() throws Exception
+    public void polymorphicNodeField() throws Exception
     {
-        String json = POLY_MAPPER.writeValueAsString(new DocHolder(_simpleDocument()));
-        DocHolder result = POLY_MAPPER.readValue(json, DocHolder.class);
-        assertEquals(SIMPLE_XML, _asXml(result.doc));
-    }
+        String json = MAPPER.writeValueAsString(new NodeWrapper(_simpleDocument()));
+        assertEquals(Document.class.getName(), _typeIdOf(json));
 
-    // [databind#6113]: also needs to work via explicit `@JsonTypeInfo`, not just
-    // default typing
-    @Test
-    public void polymorphicDocumentViaAnnotation() throws Exception
-    {
-        String json = MAPPER.writeValueAsString(new AnnotatedDocHolder(_simpleDocument()));
-        AnnotatedDocHolder result = MAPPER.readValue(json, AnnotatedDocHolder.class);
-        assertEquals(SIMPLE_XML, _asXml(result.doc));
-    }
-
-    // [databind#6113]: `Node`-declared values still get `Document` Type Id (that
-    // being the runtime shape), which resolves fine as a subtype of `Node`
-    @Test
-    public void polymorphicNodeProperty() throws Exception
-    {
-        String json = POLY_MAPPER.writeValueAsString(new NodeHolder(_simpleDocument()));
-        NodeHolder result = POLY_MAPPER.readValue(json, NodeHolder.class);
-        assertEquals(SIMPLE_XML, _asXml(result.node));
+        NodeWrapper result = MAPPER.readValue(json, NodeWrapper.class);
+        assertEquals(SIMPLE_XML, _asXml(result.value));
     }
 
     /*
@@ -264,8 +217,11 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
         return normalizeOutput(MAPPER.readValue(MAPPER.writeValueAsString(n), String.class));
     }
 
-    // Extract Type Id from `["type.id", "value"]` wrapper
+    // Scalar values use WRAPPER_ARRAY inclusion, so JSON is
+    // `{"value":["type.id","<xml>"]}`: dig out the Type Id
     private String _typeIdOf(String json) throws Exception {
-        return MAPPER.readValue(json, java.util.List.class).get(0).toString();
+        JsonNode wrapped = MAPPER.readTree(json).path("value");
+        assertTrue(wrapped.isArray(), "Expected WRAPPER_ARRAY for typed `Node`, got: "+json);
+        return wrapped.path(0).stringValue();
     }
 }

--- a/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/DOMTypeReadWriteTest.java
@@ -1,14 +1,21 @@
 package tools.jackson.databind.ext.xml;
 
 import java.io.StringReader;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 
 import tools.jackson.databind.DefaultTyping;
+import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import tools.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 import tools.jackson.databind.testutil.NoCheckSubTypeValidator;
 
@@ -22,6 +29,28 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
         "<root ns:attr='abc' xmlns:ns='http://foo' />";
     final static String SIMPLE_XML_DEFAULT_NS =
             "<root xmlns='http://foo'/>";
+
+    static class DocHolder {
+        public Document doc;
+
+        protected DocHolder() { }
+        public DocHolder(Document d) { doc = d; }
+    }
+
+    static class NodeHolder {
+        public Node node;
+
+        protected NodeHolder() { }
+        public NodeHolder(Node n) { node = n; }
+    }
+
+    static class AnnotatedDocHolder {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+        public Document doc;
+
+        protected AnnotatedDocHolder() { }
+        public AnnotatedDocHolder(Document d) { doc = d; }
+    }
 
     private final ObjectMapper MAPPER = new ObjectMapper();
     // Same default-typing setup as MiscJavaXMLTypesReadWriteTest for XMLGregorianCalendar
@@ -142,6 +171,71 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
         assertEquals(SIMPLE_XML, normalized);
     }
 
+    // [databind#6113]: Type Id must be `Document` (not `Node`) for `Document` values,
+    // or else read side fails with "not a subtype of `org.w3c.dom.Document`"
+    @Test
+    public void polymorphicDocumentDeclaredType() throws Exception
+    {
+        String json = POLY_MAPPER.writeValueAsString(_simpleDocument());
+        assertEquals(Document.class.getName(), _typeIdOf(json));
+        Document result = POLY_MAPPER.readValue(json, Document.class);
+        assertEquals(SIMPLE_XML, _asXml(result));
+    }
+
+    // [databind#6113]
+    @Test
+    public void polymorphicDocumentProperty() throws Exception
+    {
+        String json = POLY_MAPPER.writeValueAsString(new DocHolder(_simpleDocument()));
+        DocHolder result = POLY_MAPPER.readValue(json, DocHolder.class);
+        assertEquals(SIMPLE_XML, _asXml(result.doc));
+    }
+
+    // [databind#6113]: also needs to work via explicit `@JsonTypeInfo`, not just
+    // default typing
+    @Test
+    public void polymorphicDocumentViaAnnotation() throws Exception
+    {
+        String json = MAPPER.writeValueAsString(new AnnotatedDocHolder(_simpleDocument()));
+        AnnotatedDocHolder result = MAPPER.readValue(json, AnnotatedDocHolder.class);
+        assertEquals(SIMPLE_XML, _asXml(result.doc));
+    }
+
+    // [databind#6113]: `Node`-declared values still get `Document` Type Id (that
+    // being the runtime shape), which resolves fine as a subtype of `Node`
+    @Test
+    public void polymorphicNodeProperty() throws Exception
+    {
+        String json = POLY_MAPPER.writeValueAsString(new NodeHolder(_simpleDocument()));
+        NodeHolder result = POLY_MAPPER.readValue(json, NodeHolder.class);
+        assertEquals(SIMPLE_XML, _asXml(result.node));
+    }
+
+    /*
+    /**********************************************************
+    /* Format visitor tests
+    /**********************************************************
+     */
+
+    // [databind#6113]: `Node` is written as JSON String, so must be reported
+    // as such (and not as "any format")
+    @Test
+    public void formatVisitorReportsString() throws Exception
+    {
+        for (Class<?> domType : new Class<?>[] { Node.class, Document.class, Element.class }) {
+            final AtomicReference<JavaType> result = new AtomicReference<>();
+            MAPPER.acceptJsonFormatVisitor(domType, new JsonFormatVisitorWrapper.Base() {
+                @Override
+                public JsonStringFormatVisitor expectStringFormat(JavaType type) {
+                    result.set(type);
+                    return null;
+                }
+            });
+            assertNotNull(result.get(), "Should have called expectStringFormat() for "+domType.getName());
+            assertEquals(domType, result.get().getRawClass());
+        }
+    }
+
     /*
     /**********************************************************
     /* Helper methods
@@ -158,5 +252,20 @@ public class DOMTypeReadWriteTest extends DatabindTestUtil
         }
         // And replace double quotes with single-quotes...
         return output.replace('"', '\'');
+    }
+
+    private Document _simpleDocument() throws Exception {
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                .parse(new InputSource(new StringReader(SIMPLE_XML)));
+    }
+
+    // Serialize given Node with non-polymorphic mapper, to get comparable XML text
+    private String _asXml(Node n) throws Exception {
+        return normalizeOutput(MAPPER.readValue(MAPPER.writeValueAsString(n), String.class));
+    }
+
+    // Extract Type Id from `["type.id", "value"]` wrapper
+    private String _typeIdOf(String json) throws Exception {
+        return MAPPER.readValue(json, java.util.List.class).get(0).toString();
     }
 }


### PR DESCRIPTION
## Problem

`DOMSerializer` overrides `serialize()` but not `serializeWithType()`. As a result, serializing a DOM `Node`/`Document` while default typing is active fails with:

```
InvalidDefinitionException: Type id handling not implemented for type
org.w3c.dom.Node (by DOMSerializer)
```

This happens for any holder typed with `@JsonTypeInfo`, or globally via
`activateDefaultTyping(NON_FINAL)` / `activateDefaultTyping(...)` when the
holder class is non-final (e.g. a `Document`/`Node` field on a polymorphic
bean).

```java
ObjectMapper polyMapper = jsonMapperBuilder()
        .activateDefaultTyping(NoCheckSubTypeValidator.instance, DefaultTyping.NON_FINAL)
        .build();
Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
        .parse(new InputSource(new StringReader("<root xmlns='http://foo'/>")));
polyMapper.writeValueAsString(doc); // throws InvalidDefinitionException
```

## Root cause

A DOM `Node` is written as a JSON String (its XML text). The base
`ValueSerializer.serializeWithType` only knows how to add a type id for
structured types, so it rejects scalar serializers that do not override
`serializeWithType()`. `DOMSerializer` is one of the few `StdSerializer`
implementations in `ext` that never got the override.

## Fix

Mirror `XMLGregorianCalendarSerializer` ([databind#3217]) and the
`StdScalarSerializer` base: write a scalar type id
(`typeSer.typeId(value, Node.class, JsonToken.VALUE_STRING)`), delegate to
`serialize()`, then `writeTypeSuffix()`. The nominal type is passed as
`Node.class` so the type id is emitted for `Node`, not an accidental
subclass.

## Tests

`DOMTypeReadWriteTest#testPolymorphicDOMDocument`: with default typing
enabled, serialize a `Document`, read it back to `Object`, and assert it
round-trips to the same XML. Fails before the fix
(`InvalidDefinitionException`), passes after.

## Notes

- No API change; only adds a `serializeWithType` override.
- The `ext` XML serializers are not exhaustively covered by the existing
  `XMLGregorianCalendarSerializer` fix, so this is the natural symmetric
  follow-up.
- CLA: I have submitted the FasterXML Individual CLA (name: Bowang,
  github: dong0713) on 2026-07-21; let me know if it has not arrived yet.

[databind#3217]: https://github.com/FasterXML/jackson-databind/issues/3217