### PR TITLE
Fix QName object deserialization to reject non-String namespaceURI/prefix

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -600,5 +600,12 @@ Ivan (@pctF)
   [3.3.0]
 
 Bowang (@dong0713)
+ * Fixed #6113: `DOMSerializer` to support polymorphic serialization
+  [3.3.0]
  * Fixed #6114: Fix QName object deserialization to reject non-String namespaceURI/prefix
+  [3.3.0]
+
+Aysha Afrah Ziya (@aysha-afrah26)
+ * Fixed #6126: `@JsonFilter` ignored for POJO serialized with
+   `@JsonFormat(shape=ARRAY)`
   [3.3.0]

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -598,3 +598,7 @@ Ivan (@pctF)
    `IllegalArgumentException` but throws `MismatchedInputException` when input and
    expected type are not compatible
   [3.3.0]
+
+Bowang (@dong0713)
+ * Fixed #6114: Fix QName object deserialization to reject non-String namespaceURI/prefix
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,8 +22,17 @@ Versions: 3.x (for earlier see VERSION-2.x)
   is actually thrown
  (reported by @pctF)
  (fix by @pjfanning)
+#6113: Fix `DOMSerializer` to support polymorphic serialization
+ (fix by @dong0713)
 #6114: Fix QName object deserialization to reject non-String namespaceURI/prefix
  (fix by @dong0713)
+#6120: Use per-node-type Type Ids for DOM values, reconstruct via DOM factory
+  instead of always parsing a `Document`
+ (fix by @cowtowncoder, w/ Claude code)
+#6126: `@JsonFilter` ignored for POJO serialized with `@JsonFormat(shape=ARRAY)`:
+  now declines the as-array shape (writing JSON Object instead), same as 2.x,
+  since positional output cannot express omission of a property
+ (fix by @aysha-afrah26)
 
 3.2.1 (10-Jul-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
   is actually thrown
  (reported by @pctF)
  (fix by @pjfanning)
+#6114: Fix QName object deserialization to reject non-String namespaceURI/prefix
+ (fix by @dong0713)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
@@ -2,6 +2,7 @@ package tools.jackson.databind.ext;
 
 import java.util.*;
 
+import javax.xml.XMLConstants;
 import javax.xml.datatype.*;
 import javax.xml.namespace.QName;
 
@@ -121,15 +122,13 @@ public class CoreXMLDeserializers
             JsonNode namespaceURI = _optionalStringProperty(ctxt, tree, "namespaceURI");
             JsonNode prefix = _optionalStringProperty(ctxt, tree, "prefix");
 
-            if (namespaceURI != null) {
-                if (prefix != null) {
-                    return new QName(namespaceURI.asString(), localPart.asString(), prefix.asString());
-                }
-                return new QName(namespaceURI.asString(), localPart.asString());
+            // Missing 'namespaceURI' same as empty one ("no namespace")
+            final String ns = (namespaceURI == null)
+                    ? XMLConstants.NULL_NS_URI : namespaceURI.asString();
+            if (prefix != null) {
+                return new QName(ns, localPart.asString(), prefix.asString());
             }
-            // NOTE: 'prefix' has no meaning without 'namespaceURI' so if only it was
-            // given, it is ignored (but was still validated above)
-            return new QName(localPart.asString());
+            return new QName(ns, localPart.asString());
         }
 
         /**

--- a/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
@@ -117,16 +117,19 @@ public class CoreXMLDeserializers
                         localPart.getNodeType());
             }
 
+            // Optional properties 'namespaceURI' and 'prefix': explicit JSON `null`
+            // is taken to mean "not defined", but other non-STRING values are
+            // rejected same as for 'localPart' (since `asString()` would coerce
+            // numbers and booleans into their textual form)
             JsonNode namespaceURI = tree.get("namespaceURI");
-            if (namespaceURI != null) {
-                // Symmetric to localPart: reject non-STRING (asString() would coerce numbers/bools)
+            if ((namespaceURI != null) && !namespaceURI.isNull()) {
                 if (!namespaceURI.isString()) {
                     ctxt.reportInputMismatch(this,
                             "Object value property 'namespaceURI' for `QName` must be of type STRING, not %s",
                             namespaceURI.getNodeType());
                 }
-                if (tree.has("prefix")) {
-                    JsonNode prefix = tree.get("prefix");
+                JsonNode prefix = tree.get("prefix");
+                if ((prefix != null) && !prefix.isNull()) {
                     if (!prefix.isString()) {
                         ctxt.reportInputMismatch(this,
                                 "Object value property 'prefix' for `QName` must be of type STRING, not %s",

--- a/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
@@ -119,8 +119,19 @@ public class CoreXMLDeserializers
 
             JsonNode namespaceURI = tree.get("namespaceURI");
             if (namespaceURI != null) {
+                // Symmetric to localPart: reject non-STRING (asString() would coerce numbers/bools)
+                if (!namespaceURI.isString()) {
+                    ctxt.reportInputMismatch(this,
+                            "Object value property 'namespaceURI' for `QName` must be of type STRING, not %s",
+                            namespaceURI.getNodeType());
+                }
                 if (tree.has("prefix")) {
                     JsonNode prefix = tree.get("prefix");
+                    if (!prefix.isString()) {
+                        ctxt.reportInputMismatch(this,
+                                "Object value property 'prefix' for `QName` must be of type STRING, not %s",
+                                prefix.getNodeType());
+                    }
                     return new QName(namespaceURI.asString(), localPart.asString(), prefix.asString());
                 }
                 return new QName(namespaceURI.asString(), localPart.asString());

--- a/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
@@ -117,29 +117,44 @@ public class CoreXMLDeserializers
                         localPart.getNodeType());
             }
 
-            // Optional properties 'namespaceURI' and 'prefix': explicit JSON `null`
-            // is taken to mean "not defined", but other non-STRING values are
-            // rejected same as for 'localPart' (since `asString()` would coerce
-            // numbers and booleans into their textual form)
-            JsonNode namespaceURI = tree.get("namespaceURI");
-            if ((namespaceURI != null) && !namespaceURI.isNull()) {
-                if (!namespaceURI.isString()) {
-                    ctxt.reportInputMismatch(this,
-                            "Object value property 'namespaceURI' for `QName` must be of type STRING, not %s",
-                            namespaceURI.getNodeType());
-                }
-                JsonNode prefix = tree.get("prefix");
-                if ((prefix != null) && !prefix.isNull()) {
-                    if (!prefix.isString()) {
-                        ctxt.reportInputMismatch(this,
-                                "Object value property 'prefix' for `QName` must be of type STRING, not %s",
-                                prefix.getNodeType());
-                    }
+            // Both optional properties validated regardless of which ones are defined
+            JsonNode namespaceURI = _optionalStringProperty(ctxt, tree, "namespaceURI");
+            JsonNode prefix = _optionalStringProperty(ctxt, tree, "prefix");
+
+            if (namespaceURI != null) {
+                if (prefix != null) {
                     return new QName(namespaceURI.asString(), localPart.asString(), prefix.asString());
                 }
                 return new QName(namespaceURI.asString(), localPart.asString());
             }
+            // NOTE: 'prefix' has no meaning without 'namespaceURI' so if only it was
+            // given, it is ignored (but was still validated above)
             return new QName(localPart.asString());
+        }
+
+        /**
+         * Helper method for accessing one of optional {@code QName} properties, verifying
+         * that its value (if any) is of type STRING: explicit JSON {@code null} is taken
+         * to mean "not defined", but other non-STRING values are rejected same as for
+         * required 'localPart' (since {@code asString()} would coerce numbers and
+         * booleans into their textual form).
+         *
+         * @return Node for the property if it has usable value; {@code null} if not defined
+         */
+        private JsonNode _optionalStringProperty(DeserializationContext ctxt,
+                JsonNode tree, String propName)
+            throws JacksonException
+        {
+            JsonNode n = tree.get(propName);
+            if ((n == null) || n.isNull()) {
+                return null;
+            }
+            if (!n.isString()) {
+                ctxt.reportInputMismatch(this,
+                        "Object value property '%s' for `QName` must be of type STRING, not %s",
+                        propName, n.getNodeType());
+            }
+            return n;
         }
 
         @Override

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -165,6 +165,16 @@ public class MiscJavaXMLTypesReadWriteTest
         assertEquals("", qn.getPrefix());
     }
 
+    // 'prefix' is retained even if 'namespaceURI' not defined
+    @Test
+    public void qnameDeserFromObjectWithPrefixOnly() throws Exception
+    {
+        QName qn = MAPPER.readValue(a2q("{'localPart':'tag','prefix':'p'}"), QName.class);
+        assertEquals("", qn.getNamespaceURI());
+        assertEquals("tag", qn.getLocalPart());
+        assertEquals("p", qn.getPrefix());
+    }
+
     @Test
     public void testQNameDeserFail() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -198,6 +198,14 @@ public class MiscJavaXMLTypesReadWriteTest
             verifyException(e, "prefix");
             verifyException(e, "must be of type STRING");
         }
+        // ... and 'prefix' is validated even when unusable due to missing 'namespaceURI'
+        try {
+            MAPPER.readValue(a2q("{'localPart':'tag','prefix':123}"), QName.class);
+            fail("Should not pass for non-STRING prefix");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "prefix");
+            verifyException(e, "must be of type STRING");
+        }
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -142,6 +142,29 @@ public class MiscJavaXMLTypesReadWriteTest
         assertEquals("prefix", qn.getPrefix());
     }
 
+    // Explicit JSON `null` for optional 'namespaceURI' / 'prefix' means "not defined",
+    // not a failure (unlike other non-STRING values)
+    @Test
+    public void qnameDeserFromObjectWithNulls() throws Exception
+    {
+        QName qn = MAPPER.readValue(a2q("{'localPart':'tag','namespaceURI':null}"), QName.class);
+        assertEquals("", qn.getNamespaceURI());
+        assertEquals("tag", qn.getLocalPart());
+        assertEquals("", qn.getPrefix());
+
+        qn = MAPPER.readValue(a2q("{'localPart':'tag','namespaceURI':'http://abc','prefix':null}"),
+                QName.class);
+        assertEquals("http://abc", qn.getNamespaceURI());
+        assertEquals("tag", qn.getLocalPart());
+        assertEquals("", qn.getPrefix());
+
+        // and empty Strings similarly remain valid
+        qn = MAPPER.readValue(a2q("{'localPart':'tag','namespaceURI':'','prefix':''}"), QName.class);
+        assertEquals("", qn.getNamespaceURI());
+        assertEquals("tag", qn.getLocalPart());
+        assertEquals("", qn.getPrefix());
+    }
+
     @Test
     public void testQNameDeserFail() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -159,6 +159,22 @@ public class MiscJavaXMLTypesReadWriteTest
             verifyException(e, "Object value property 'localPart'");
             verifyException(e, "must be of type STRING, not NUMBER");
         }
+
+        // Symmetric to localPart: namespaceURI / prefix must also reject non-STRING
+        try {
+            MAPPER.readValue(a2q("{'localPart':'tag','namespaceURI':123}"), QName.class);
+            fail("Should not pass for non-STRING namespaceURI");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "namespaceURI");
+            verifyException(e, "must be of type STRING");
+        }
+        try {
+            MAPPER.readValue(a2q("{'localPart':'tag','namespaceURI':'http://abc','prefix':true}"), QName.class);
+            fail("Should not pass for non-STRING prefix");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "prefix");
+            verifyException(e, "must be of type STRING");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

When a `QName` is deserialized from its object form
(`{"localPart":..., "namespaceURI":..., "prefix":...}`), the parser only
validated that `localPart` was a STRING, then silently coerced
`namespaceURI` and `prefix` via `asString()`. A malformed payload like:

```json
{"localPart":"tag","namespaceURI":123}
```

was silently turned into `QName("123","tag")` instead of being rejected,
while the same numeric value in `localPart` correctly threw
`MismatchedInputException`. `prefix` had the same issue.

```java
MAPPER.readValue(a2q("{'localPart':'tag','namespaceURI':123}"), QName.class);
// before: QName("123","tag")  — no error
// after:  MismatchedInputException "must be of type STRING, not NUMBER"
```

## Root cause

In `CoreXMLDeserializers.Std#_parseQNameObject`, the `isString()` guard
only wrapped `localPart`. `namespaceURI` and `prefix` fell through to
`asString()`, which coerces numbers/booleans to their textual form, so
garbage types were accepted where `localPart` would have rejected them.

## Fix

Add the same `isString()` validation for `namespaceURI` and `prefix` that
`localPart` already has, reporting a `MismatchedInputException` naming the
property and the offending node type. No behavior change for valid
payloads.

## Tests

Extends the existing `testQNameDeserFail` with two symmetric cases
(non-STRING `namespaceURI`, non-STRING `prefix`).

## Notes

- No API change; only tightens input validation to match `localPart`.
- CLA: I have submitted the FasterXML Individual CLA (name: Bowang,
  github: dong0713) on 2026-07-21; let me know if it has not arrived yet.