### PR TITLE
Reject non-ASCII digits in `InetAddress` literal validation

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1918,3 +1918,5 @@ Omkhar Arasaratnam (@omkhar)
 Aysha Afrah Ziya (@aysha-afrah26)
  * Fixed #6099: Resolve classes without initialization in `TypeFactory.findClass()`
   (2.18.10)
+ * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
+  (2.18.10)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,8 @@ Project: jackson-databind
 
 #6099: Resolve classes without initialization in `TypeFactory.findClass()`
  (fixed by Aysha A-Z)
+#6116: Reject non-ASCII digits in `InetAddress` literal validation
+ (fixed by Aysha A-Z)
 
 2.18.9 (07-Jul-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/InetAddressValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/InetAddressValidator.java
@@ -45,7 +45,7 @@ class InetAddressValidator
             } else if (c == '%') {
                 percentIndex = i;
                 break; // Scope ID; stop scanning
-            } else if (Character.digit(c, 16) == -1) {
+            } else if (_digit(c, 16) == -1) {
                 return null; // Everything else must be a decimal or hex digit.
             }
         }
@@ -191,7 +191,7 @@ class InetAddressValidator
         int octet = 0;
         for (int i = start; i < end; i++) {
             octet *= 10;
-            int digit = Character.digit(ipString.charAt(i), 10);
+            int digit = _digit(ipString.charAt(i), 10);
             if (digit < 0) {
                 throw new NumberFormatException();
             }
@@ -211,8 +211,19 @@ class InetAddressValidator
         int hextet = 0;
         for (int i = start; i < end; i++) {
             hextet = hextet << 4;
-            hextet |= Character.digit(ipString.charAt(i), 16);
+            hextet |= _digit(ipString.charAt(i), 16);
         }
         return (short) hextet;
+    }
+
+    // Like Character.digit(), but only recognizes ASCII digits: Character.digit()
+    // also accepts non-ASCII forms (full-width, Arabic-Indic, ...) that
+    // InetAddress.getByName() does not treat as an address literal and would
+    // instead resolve via DNS.
+    private static int _digit(char c, int radix) {
+        if (c > 0x7f) {
+            return -1;
+        }
+        return Character.digit(c, radix);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/InetAddressValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/InetAddressValidator.java
@@ -216,10 +216,10 @@ class InetAddressValidator
         return (short) hextet;
     }
 
-    // Like Character.digit(), but only recognizes ASCII digits: Character.digit()
-    // also accepts non-ASCII forms (full-width, Arabic-Indic, ...) that
-    // InetAddress.getByName() does not treat as an address literal and would
-    // instead resolve via DNS.
+    // 24-Jul-2026, aysha: [databind#6116] Like Character.digit(), but only recognizes
+    // ASCII digits: Character.digit() also accepts non-ASCII forms (full-width,
+    // Arabic-Indic, ...) that InetAddress.getByName() does not treat as an address
+    // literal and would instead resolve via DNS.
     private static int _digit(char c, int radix) {
         if (c > 0x7f) {
             return -1;

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -197,6 +197,18 @@ public class JDKStringLikeTypeDeserTest
         expectInvalidInetAddress("xn--bcher-kva.example.com");
     }
 
+    @Test
+    public void testInetAddressNonAsciiDigits() throws Exception
+    {
+        // [databind#6058] follow-up: Character.digit() accepts non-ASCII digits, but
+        // InetAddress.getByName() only treats ASCII literals as addresses and resolves
+        // the rest via DNS, so these must be rejected too.
+        expectInvalidInetAddress("１２７.0.0.1"); // full-width "127".0.0.1
+        expectInvalidInetAddress("١٢٧.0.0.1"); // Arabic-Indic "127".0.0.1
+        expectInvalidInetAddress("２001:db8::1"); // full-width digit in IPv6 hextet
+        expectInvalidInetAddress("fe80::１"); // full-width digit in IPv6 hextet
+    }
+
     private void expectInvalidInetAddress(String address) throws Exception {
         try {
             MAPPER.readValue(q(address), InetAddress.class);

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -200,13 +200,17 @@ public class JDKStringLikeTypeDeserTest
     @Test
     public void testInetAddressNonAsciiDigits() throws Exception
     {
-        // [databind#6058] follow-up: Character.digit() accepts non-ASCII digits, but
-        // InetAddress.getByName() only treats ASCII literals as addresses and resolves
-        // the rest via DNS, so these must be rejected too.
-        expectInvalidInetAddress("１２７.0.0.1"); // full-width "127".0.0.1
-        expectInvalidInetAddress("١٢٧.0.0.1"); // Arabic-Indic "127".0.0.1
-        expectInvalidInetAddress("２001:db8::1"); // full-width digit in IPv6 hextet
-        expectInvalidInetAddress("fe80::１"); // full-width digit in IPv6 hextet
+        // [databind#6116], follow-up to [databind#6058]: Character.digit() accepts
+        // non-ASCII digits, but InetAddress.getByName() only treats ASCII literals as
+        // addresses and resolves the rest via DNS, so these must be rejected too.
+        // NOTE: unicode escapes used on purpose -- non-ASCII digit forms are visually
+        // hard to tell apart from the ASCII ones they mimic.
+        expectInvalidInetAddress("\uFF11\uFF12\uFF17.0.0.1"); // full-width "127".0.0.1
+        expectInvalidInetAddress("\u0661\u0662\u0667.0.0.1"); // Arabic-Indic "127".0.0.1
+        expectInvalidInetAddress("\uFF12001:db8::1"); // full-width digit in IPv6 hextet
+        expectInvalidInetAddress("fe80::\uFF11"); // full-width digit in IPv6 hextet
+        // and same goes for non-ASCII hex letters (radix 16), not just digits
+        expectInvalidInetAddress("\uFF41bcd::1"); // full-width "a"bcd::1
     }
 
     private void expectInvalidInetAddress(String address) throws Exception {


### PR DESCRIPTION
The `InetAddress` deserializer only accepts IP address literals now, checked through `InetAddressValidator` so that #6058 keeps a host name from triggering a DNS lookup. The validator decides whether each character is a digit with `Character.digit(c, 10)` and `Character.digit(c, 16)`, and those also accept non-ASCII digit forms, so full-width or Arabic-Indic digits pass as valid. `InetAddress.getByName()` parses only ASCII literals, which means a value like a full-width `127.0.0.1` or `2001:db8::1` clears the validator but reaches `getByName` as a value it treats as a host name and resolves over DNS, reopening the lookup #6058 was meant to stop. I ran into it while checking which strings the validator and `getByName` disagree on. Restricting the three digit checks to ASCII closes the gap, and I kept the change inside the validator so the accepted-literal set is the only thing that narrows.
