### PR TITLE
add test to UnwrappedWithAnySetterTest to highlight issue raised in 6118

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
@@ -394,9 +394,6 @@ public class BeanPropertyWriter
      * Overridable factory method used by sub-classes
      */
     protected BeanPropertyWriter _new(PropertyName newName) {
-        if (getClass() != BeanPropertyWriter.class) {
-            throw new IllegalStateException("Method must be overridden by "+getClass());
-        }
         return new BeanPropertyWriter(this, newName);
     }
 

--- a/src/test/java/tools/jackson/databind/struct/UnwrappedWithAnySetterTest.java
+++ b/src/test/java/tools/jackson/databind/struct/UnwrappedWithAnySetterTest.java
@@ -42,13 +42,49 @@ public class UnwrappedWithAnySetterTest extends DatabindTestUtil
         public String name;
     }
 
+    static class Inner6118 {
+        private final String name;
+        private final Map<String, String> extra = new HashMap<>();
+
+        public Inner6118(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @JsonAnyGetter
+        public Map<String, String> getExtra() {
+            return extra;
+        }
+
+        @JsonAnySetter
+        public void addExtra(String key, String value) {
+            extra.put(key, value);
+        }
+    }
+
+    private static class Outer6118 {
+        @JsonUnwrapped(prefix = "a-")
+        private final Inner6118 a;
+
+        public Outer6118(Inner6118 a) {
+            this.a = a;
+        }
+
+        public Inner6118 getA() {
+            return a;
+        }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     // [databind#1811]
     @Test
     public void testUnwrappedWithAnySetter() throws Exception
     {
-        String json = "{\"id\":1,\"name\":\"aaa\",\"age\":12}";
+        String json = a2q("{'id':1,'name':'aaa','age':12}");
         Outer outer = MAPPER.readValue(json, Outer.class);
 
         // "id" goes to Outer.id
@@ -66,5 +102,14 @@ public class UnwrappedWithAnySetterTest extends DatabindTestUtil
         assertFalse(outer.extra.containsKey("name"),
                 "Property 'name' handled by @JsonUnwrapped should not also appear in @JsonAnySetter map, but extra=" + outer.extra);
         assertEquals(1, outer.extra.size(), "Only 'age' should be in extra map, but got: " + outer.extra);
+    }
+
+    @Test
+    public void testUnwrappedWithPrefixWithAnyGetter() throws Exception
+    {
+        Outer6118 outer = new Outer6118(new Inner6118("aaa"));
+        outer.getA().addExtra("age", "64");
+        String json = MAPPER.writeValueAsString(outer);
+        assertEquals(a2q("{'name':'aaa','a-age':'64'}"), json);
     }
 }


### PR DESCRIPTION
This issue was mentioned in #6118 
That issue has a POC and this is a simplified version of it that adds a JsonUnwrapped prefix setting.
This would be necessary for 6118 use case to differentiate between the 2 unwrapped maps.
This use case is simplified and only has on unwrapped map.
Yet it fails when I add a 'prefix' value to the JsonUnwrapped annotation.

```
[ERROR] tools.jackson.databind.struct.UnwrappedWithAnySetterTest.testUnwrappedWithPrefixWithAnyGetter -- Time elapsed: 0.259 s <<< ERROR!
java.lang.IllegalStateException: Method must be overridden by class tools.jackson.databind.ser.AnyGetterWriter
	at tools.jackson.databind/tools.jackson.databind.ser.BeanPropertyWriter._new(BeanPropertyWriter.java:398)
	at tools.jackson.databind/tools.jackson.databind.ser.BeanPropertyWriter.rename(BeanPropertyWriter.java:390)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.BeanSerializerBase.rename(BeanSerializerBase.java:254)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.BeanSerializerBase.<init>(BeanSerializerBase.java:240)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.UnwrappingBeanSerializer.<init>(UnwrappingBeanSerializer.java:33)
	at tools.jackson.databind/tools.jackson.databind.ser.UnrolledBeanSerializer.unwrappingSerializer(UnrolledBeanSerializer.java:110)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.UnwrappingBeanPropertyWriter._asUnwrapping(UnwrappingBeanPropertyWriter.java:165)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.UnwrappingBeanPropertyWriter.findUnwrappingSerializer(UnwrappingBeanPropertyWriter.java:152)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.BeanSerializerBase._verifyNoUnwrappedPropertyConflict(BeanSerializerBase.java:409)
	at tools.jackson.databind/tools.jackson.databind.ser.bean.BeanSerializerBase.resolve(BeanSerializerBase.java:351)
	at tools.jackson.databind/tools.jackson.databind.ser.UnrolledBeanSerializer.resolve(UnrolledBeanSerializer.java:155)
	at tools.jackson.databind/tools.jackson.databind.ser.SerializerCache.addAndResolveNonTypedSerializer(SerializerCache.java:319)
	at tools.jackson.databind/tools.jackson.databind.SerializationContext._createAndCacheUntypedSerializer(SerializationContext.java:1030)
	at tools.jackson.databind/tools.jackson.databind.SerializationContext.findValueSerializer(SerializationContext.java:829)
	at tools.jackson.databind/tools.jackson.databind.SerializationContext.findTypedValueSerializer(SerializationContext.java:625)
	at tools.jackson.databind/tools.jackson.databind.ser.SerializationContextExt.serializeValue(SerializationContextExt.java:296)
	at tools.jackson.databind/tools.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:1914)
	at tools.jackson.databind/tools.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:1857)
	at tools.jackson.databind/tools.jackson.databind.struct.UnwrappedWithAnySetterTest.testUnwrappedWithPrefixWithAnyGetter(UnwrappedWithAnySetterTest.java:112)
```