### PR TITLE
Bracket unresolved IPv6 host name in `InetSocketAddress` serialization

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/InetSocketAddressSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/InetSocketAddressSerializer.java
@@ -34,6 +34,10 @@ public class InetSocketAddressSerializer
             } else { // otherwise use name
                 str = str.substring(0, ix);
             }
+        } else if (addr == null && str.indexOf(':') >= 0 && !str.startsWith("[")) {
+            // Unresolved address exposes no `InetAddress`, so an IPv6 literal has to be
+            // recognized from the host name; without brackets the port is not separable
+            str = "[" + str + "]";
         }
 
         g.writeString(str + ":" + value.getPort());

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
@@ -142,6 +142,30 @@ public class JDKTypeSerializationTest
                 MAPPER.writeValueAsString(new InetSocketAddress("2001:db8:85a3:8d3:1319:8a2e:370:7348", 443)));
     }
 
+    // Unresolved addresses expose no `InetAddress`, so the IPv6 literal has to be
+    // bracketed based on the host name alone; otherwise the port is not separable.
+    @Test
+    public void testInetSocketAddressUnresolvedIPv6() throws IOException
+    {
+        final String ip6 = "2001:db8:85a3:8d3:1319:8a2e:370:7348";
+
+        assertEquals(q("[" + ip6 + "]:443"),
+                MAPPER.writeValueAsString(InetSocketAddress.createUnresolved(ip6, 443)));
+        // Already bracketed host name must not be bracketed twice
+        assertEquals(q("[" + ip6 + "]:443"),
+                MAPPER.writeValueAsString(InetSocketAddress.createUnresolved("[" + ip6 + "]", 443)));
+
+        // Deserialization yields unresolved addresses, so a value read back has to
+        // serialize into something that reads back the same way
+        InetSocketAddress addr = MAPPER.readValue(q(ip6), InetSocketAddress.class);
+        String json = MAPPER.writeValueAsString(addr);
+        assertEquals(q("[" + ip6 + "]:0"), json);
+
+        InetSocketAddress rt = MAPPER.readValue(json, InetSocketAddress.class);
+        assertEquals(0, rt.getPort());
+        assertEquals(json, MAPPER.writeValueAsString(rt));
+    }
+
     // [JACKSON-597]
     @Test
     public void testClass() throws IOException


### PR DESCRIPTION
`InetSocketAddressSerializer` writes `host + ":" + port`. When the address is resolved it takes the host part from `InetAddress.toString()` and brackets IPv6 literals, so a resolved address comes out as `"[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"`. When the address is unresolved there is no `InetAddress` at all, so it falls back to `getHostName()` and writes the literal bare:

```java
InetSocketAddress.createUnresolved("2001:db8:85a3:8d3:1319:8a2e:370:7348", 443)
// serialized as "2001:db8:85a3:8d3:1319:8a2e:370:7348:443"
```

The trailing `:443` is indistinguishable from another hextet, so the port is lost on the way back. This matters more since #5951, because deserialization now always produces unresolved addresses via `InetSocketAddress.createUnresolved()`, so an IPv6 value read by Jackson no longer survives a Jackson round-trip:

```java
InetSocketAddress addr = MAPPER.readValue(q("2001:db8:85a3:8d3:1319:8a2e:370:7348"), InetSocketAddress.class);
String json = MAPPER.writeValueAsString(addr);   // "2001:db8:85a3:8d3:1319:8a2e:370:7348:0"
MAPPER.readValue(json, InetSocketAddress.class); // host name now ends with ":0"
```

I noticed it while reading the `InetSocketAddress` handling in `JDKFromStringDeserializer` after #6058/#5951, and `JDKTypeSerializationTest.testInetSocketAddress()` turned out to cover the unresolved form only for IPv4 and host names.

Fix: in the unresolved branch, bracket the host name when it is an IPv6 literal, matching what the resolved branch already does. Host names that are already bracketed (which is what the deserializer stores for `"[...]:port"` input) are left alone, so the value is never bracketed twice.

Verification (JDK 21, macOS):
- `./mvnw test -Dtest=JDKTypeSerializationTest#testInetSocketAddressUnresolvedIPv6` fails on 3.x without the `InetSocketAddressSerializer` change (`expected: <"[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"> but was: <"2001:db8:85a3:8d3:1319:8a2e:370:7348:443">`) and passes with it.
- `./mvnw -B -ff -ntp verify`: BUILD SUCCESS, `Tests run: 6171, Failures: 0, Errors: 0, Skipped: 1`.

The same code is on `2.x`, and `2.x` deserialization also creates unresolved addresses since #5951, so this likely belongs on an older line first. I opened it against `3.x` since that is the default branch; I can open the equivalent PR against `2.x` (or whichever line you prefer) so it merges forward normally.
