### PR TITLE
Honor `@JsonFilter` for POJOs written with `shape=ARRAY`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -602,3 +602,8 @@ Ivan (@pctF)
 Bowang (@dong0713)
  * Fixed #6113: `DOMSerializer` to support polymorphic serialization
   [3.3.0]
+
+Aysha Afrah Ziya (@aysha-afrah26)
+ * Fixed #6126: `@JsonFilter` ignored for POJO serialized with
+   `@JsonFormat(shape=ARRAY)`
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6120: Use per-node-type Type Ids for DOM values, reconstruct via DOM factory
   instead of always parsing a `Document`
  (fix by @cowtowncoder, w/ Claude code)
+#6126: `@JsonFilter` ignored for POJO serialized with `@JsonFormat(shape=ARRAY)`:
+  now declines the as-array shape (writing JSON Object instead), same as 2.x,
+  since positional output cannot express omission of a property
+ (fix by @aysha-afrah26)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -690,12 +690,14 @@ public abstract class BeanSerializerBase
 
     /**
      * Helper method for sub-classes to check if it should be possible to
-     * construct an "as-array" serializer. Returns if all of following
-     * hold true:
+     * construct an "as-array" serializer. Returns {@code false} -- that is,
+     * as-array serializer cannot be used -- if any of following holds true:
      *<ul>
-     * <li>have Object Id (may be allowed in future)</li>
-     * <li>have "any getter"</li>
-     * <li>have per-property filter (from {@code @JsonFilter})</li>
+     * <li>has Object Id (may be allowed in future)</li>
+     * <li>has per-property filter (from {@code @JsonFilter}): positions in
+     *   array output are implicit, so dropping a property would shift all
+     *   values that follow it
+     *  </li>
      * </ul>
      *
      * @since 3.0
@@ -704,9 +706,7 @@ public abstract class BeanSerializerBase
         return (_objectIdWriter == null)
                 // 08-Feb-2025, tatu: [databind#4775] any-getter is fine now
                 //&& (_anyGetterWriter == null)
-                // As-array output has no place to express per-property filtering:
-                // positions are implicit, so a filter that drops a property would
-                // silently shift every following value
+                // 28-Jul-2026: as-array output cannot express per-property filtering
                 && (_propertyFilterId == null)
                 ;
     }

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -695,6 +695,7 @@ public abstract class BeanSerializerBase
      *<ul>
      * <li>have Object Id (may be allowed in future)</li>
      * <li>have "any getter"</li>
+     * <li>have per-property filter (from {@code @JsonFilter})</li>
      * </ul>
      *
      * @since 3.0
@@ -703,6 +704,10 @@ public abstract class BeanSerializerBase
         return (_objectIdWriter == null)
                 // 08-Feb-2025, tatu: [databind#4775] any-getter is fine now
                 //&& (_anyGetterWriter == null)
+                // As-array output has no place to express per-property filtering:
+                // positions are implicit, so a filter that drops a property would
+                // silently shift every following value
+                && (_propertyFilterId == null)
                 ;
     }
 

--- a/src/test/java/tools/jackson/databind/ser/filter/POJOAsArrayFilterTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/POJOAsArrayFilterTest.java
@@ -1,0 +1,68 @@
+package tools.jackson.databind.ser.filter;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.ser.std.SimpleBeanPropertyFilter;
+import tools.jackson.databind.ser.std.SimpleFilterProvider;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for verifying that a {@code @JsonFilter} is still applied to a POJO that
+ * also asks for {@code @JsonFormat(shape=ARRAY)} output.
+ */
+public class POJOAsArrayFilterTest extends DatabindTestUtil
+{
+    @JsonFilter("beanFilter")
+    @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+    @JsonPropertyOrder({ "name", "secret", "age" })
+    static class AsArrayBean {
+        public String name = "Bob";
+        public String secret = "s3cr3t";
+        public int age = 30;
+    }
+
+    @JsonFilter("beanFilter")
+    @JsonPropertyOrder({ "name", "secret", "age" })
+    static class AsObjectBean {
+        public String name = "Bob";
+        public String secret = "s3cr3t";
+        public int age = 30;
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    private ObjectWriter writerExcluding(String... toExclude) {
+        return MAPPER.writer(new SimpleFilterProvider()
+                .addFilter("beanFilter", SimpleBeanPropertyFilter.serializeAllExcept(toExclude)));
+    }
+
+    private ObjectWriter writerIncludingOnly(String... toInclude) {
+        return MAPPER.writer(new SimpleFilterProvider()
+                .addFilter("beanFilter", SimpleBeanPropertyFilter.filterOutAllExcept(toInclude)));
+    }
+
+    @Test
+    public void excludeFilterWithArrayShape() throws Exception {
+        assertEquals("{\"name\":\"Bob\",\"age\":30}",
+                writerExcluding("secret").writeValueAsString(new AsArrayBean()));
+        // ... and same as without the shape override:
+        assertEquals("{\"name\":\"Bob\",\"age\":30}",
+                writerExcluding("secret").writeValueAsString(new AsObjectBean()));
+    }
+
+    @Test
+    public void includeFilterWithArrayShape() throws Exception {
+        assertEquals("{\"name\":\"Bob\"}",
+                writerIncludingOnly("name").writeValueAsString(new AsArrayBean()));
+        assertEquals("{\"name\":\"Bob\"}",
+                writerIncludingOnly("name").writeValueAsString(new AsObjectBean()));
+    }
+}


### PR DESCRIPTION
A POJO annotated with `@JsonFormat(shape=ARRAY)` gets transmuted into a `BeanAsArraySerializer` during contextualization, and that class writes positional values only: it looks at `_filteredProps` for the active view but never consults `_propertyFilterId`. `BeanSerializerBase.canCreateArraySerializer()` gates the switch on Object Id alone, so a bean carrying both `@JsonFilter` and the array shape has its filter quietly dropped and every property is written, including the ones the filter exists to remove. An allow-list filter behaves the same way, which is what made me look: `filterOutAllExcept("name")` still emitted all three values. 2.x refuses the switch in this case (`BeanSerializer.asArraySerializer()` checks `_propertyFilterId == null`) and `UnrolledBeanAsArraySerializer.tryConstruct()` still declines when `getFilterId() != null`, so falling back to object shape is the established behavior here. Putting the condition back in `canCreateArraySerializer()` covers both callers that use it, and makes the note in `BeanAsArraySerializer.serialize()` about filtering having already been checked true again. Filtering has nowhere to go in as-array output regardless, since removing a property would shift every position after it. 3.1 and 3.2 carry the same gap if you want this backported.