### PR TITLE
Add `StreamReadConstraints` number len constraint to `javax.xml.datatype.XMLGregorianCalendar` and `javax.xml.datatype.Duration` [CVE-2026-68497]

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1920,3 +1920,8 @@ Aysha Afrah Ziya (@aysha-afrah26)
   (2.18.10)
  * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
   (2.18.10)
+
+@waydeshi
+ * Reported #6127: Add `StreamReadConstraints` number len constraint to GregorianCalendar
+   and Duration [GHSA-q4xh-88c3-wmh7] GHSA-q4xh-88c3-wmh7
+  (2.18.10)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -10,6 +10,10 @@ Project: jackson-databind
  (fixed by Aysha A-Z)
 #6116: Reject non-ASCII digits in `InetAddress` literal validation
  (fixed by Aysha A-Z)
+#6127: Add `StreamReadConstraints` number len constraint to GregorianCalendar
+  and Duration [GHSA-q4xh-88c3-wmh7] GHSA-q4xh-88c3-wmh7
+ (reported by @waydeshi)
+ (fix by @pjfanning)
 
 2.18.9 (07-Jul-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
@@ -109,17 +109,21 @@ public class CoreXMLDeserializers extends Deserializers.Base
         {
             switch (_kind) {
             case TYPE_DURATION:
-                // [databind#6127] Validate numeric component length before handing to
-                // DatatypeFactory.newDuration(), which parses each component into a
-                // BigInteger using the O(n^2) BigInteger(String) constructor.
-                ctxt.getParser().streamReadConstraints().validateFPLength(value.length());
+                // [databind#6127] DatatypeFactory.newDuration() parses date/time components
+                // into BigIntegers (and fractional seconds into BigDecimal), using the
+                // O(n^2) BigInteger(String)/BigDecimal(String) constructors. Rather than
+                // isolating individual components we check length of the whole value as a
+                // conservative upper bound: it is never shorter than any single component,
+                // and no valid Duration comes anywhere near the (default 1000) limit.
+                ctxt.getParser().streamReadConstraints().validateIntegerLength(value.length());
                 return _dataTypeFactory.newDuration(value);
             case TYPE_QNAME:
                 return QName.valueOf(value);
             case TYPE_G_CALENDAR:
-                // [databind#6127] Validate numeric component length before handing to
-                // DatatypeFactory.newXMLGregorianCalendar(), which can parse fractional
-                // seconds into a BigDecimal via the O(n^2) BigDecimal(String) constructor.
+                // [databind#6127] Similar to TYPE_DURATION above: length of the whole value
+                // is checked as a conservative upper bound for numeric components, before
+                // handing value to DatatypeFactory.newXMLGregorianCalendar(), which parses
+                // fractional seconds into a BigDecimal via O(n^2) BigDecimal(String).
                 ctxt.getParser().streamReadConstraints().validateFPLength(value.length());
                 Date d;
                 try {

--- a/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/CoreXMLDeserializers.java
@@ -109,10 +109,18 @@ public class CoreXMLDeserializers extends Deserializers.Base
         {
             switch (_kind) {
             case TYPE_DURATION:
+                // [databind#6127] Validate numeric component length before handing to
+                // DatatypeFactory.newDuration(), which parses each component into a
+                // BigInteger using the O(n^2) BigInteger(String) constructor.
+                ctxt.getParser().streamReadConstraints().validateFPLength(value.length());
                 return _dataTypeFactory.newDuration(value);
             case TYPE_QNAME:
                 return QName.valueOf(value);
             case TYPE_G_CALENDAR:
+                // [databind#6127] Validate numeric component length before handing to
+                // DatatypeFactory.newXMLGregorianCalendar(), which can parse fractional
+                // seconds into a BigDecimal via the O(n^2) BigDecimal(String) constructor.
+                ctxt.getParser().streamReadConstraints().validateFPLength(value.length());
                 Date d;
                 try {
                     d = _parseDate(value, ctxt);

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -5,7 +5,11 @@ import javax.xml.namespace.QName;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.testutil.NoCheckSubTypeValidator;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -162,5 +166,86 @@ public class MiscJavaXMLTypesReadWriteTest
             fail("Expected a `XMLGregorianCalendar`, got: "+result.getClass());
         }
         assertEquals(cal, result);
+    }
+
+    /*
+    /**********************************************************************
+    /* StreamReadConstraints validation tests
+    /**********************************************************************
+     */
+
+    @Test
+    public void testDurationNumberLengthConstraint() throws Exception
+    {
+        // Create a mapper with a small maxNumberLength to test the constraint
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(100).build())
+                .build();
+        ObjectMapper constrainedMapper = JsonMapper.builder(jsonFactory).build();
+
+        // A Duration with a year component that has 120 digits should exceed the limit
+        String bigDuration = "\"P" + "9".repeat(120) + "Y\"";
+        try {
+            constrainedMapper.readValue(bigDuration, Duration.class);
+            fail("Should not pass: expected StreamConstraintsException for oversized Duration numeric component");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "exceeds the maximum allowed");
+        } catch (Exception e) {
+            fail("Expected StreamConstraintsException, got: " + e.getClass().getName() + ": " + e.getMessage());
+        }
+
+        // A normal-length Duration should still work
+        Duration dur = constrainedMapper.readValue("\"P1Y2M3D\"", Duration.class);
+        assertNotNull(dur);
+        assertEquals(1, dur.getYears());
+        assertEquals(2, dur.getMonths());
+        assertEquals(3, dur.getDays());
+    }
+
+    @Test
+    public void testXMLGregorianCalendarNumberLengthConstraint() throws Exception
+    {
+        // Create a mapper with a small maxNumberLength to test the constraint
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(100).build())
+                .build();
+        ObjectMapper constrainedMapper = JsonMapper.builder(jsonFactory).build();
+
+        // Use a time-only format that triggers the fallback to newXMLGregorianCalendar()
+        // Time-only strings are not parseable by Jackson's _parseDate and will fall through
+        // to DatatypeFactory.newXMLGregorianCalendar() which parses fractional seconds
+        // into BigDecimal via the O(n^2) BigDecimal(String) constructor.
+        String bigCalendar = "\"T00:00:00." + "9".repeat(120) + "\"";
+        try {
+            constrainedMapper.readValue(bigCalendar, XMLGregorianCalendar.class);
+            fail("Should not pass: expected StreamConstraintsException for oversized XMLGregorianCalendar fractional seconds");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "exceeds the maximum allowed");
+        } catch (Exception e) {
+            fail("Expected StreamConstraintsException, got: " + e.getClass().getName() + ": " + e.getMessage());
+        }
+
+        // A normal-length XMLGregorianCalendar should still work
+        XMLGregorianCalendar cal = constrainedMapper.readValue("\"2023-01-01T00:00:00\"", XMLGregorianCalendar.class);
+        assertNotNull(cal);
+        assertEquals(2023, cal.getYear());
+        assertEquals(1, cal.getMonth());
+        assertEquals(1, cal.getDay());
+        assertEquals(0, cal.getHour());
+        assertEquals(0, cal.getMinute());
+        assertEquals(0, cal.getSecond());
+
+        // Use a standard ISO-8601 date-time format (the kind _parseDate handles) but
+        // with an excessively long year component. The validation fires before _parseDate
+        // is reached, so this should be rejected by the constraint check.
+        String bigDateTime = "\"" + "9".repeat(120) + "-01-01T00:00:00\"";
+        try {
+            constrainedMapper.readValue(bigDateTime, XMLGregorianCalendar.class);
+            fail("Should not pass: expected StreamConstraintsException for oversized date-time value");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "exceeds the maximum allowed");
+        } catch (Exception e) {
+            fail("Expected StreamConstraintsException, got: " + e.getClass().getName() + ": " + e.getMessage());
+        }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -238,7 +238,7 @@ public class MiscJavaXMLTypesReadWriteTest
         // Use a standard ISO-8601 date-time format (the kind _parseDate handles) but
         // with an excessively long year component. The validation fires before _parseDate
         // is reached, so this should be rejected by the constraint check.
-        String bigDateTime = "\"" + "9".repeat(120) + "-01-01T00:00:00\"";
+        String bigDateTime = "\"" + repeatString("9", 120) + "-01-01T00:00:00\"";
         try {
             constrainedMapper.readValue(bigDateTime, XMLGregorianCalendar.class);
             fail("Should not pass: expected StreamConstraintsException for oversized date-time value");

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -184,7 +184,7 @@ public class MiscJavaXMLTypesReadWriteTest
         ObjectMapper constrainedMapper = JsonMapper.builder(jsonFactory).build();
 
         // A Duration with a year component that has 120 digits should exceed the limit
-        String bigDuration = "\"P" + "9".repeat(120) + "Y\"";
+        String bigDuration = "\"P" + repeatString("9", 120) + "Y\"";
         try {
             constrainedMapper.readValue(bigDuration, Duration.class);
             fail("Should not pass: expected StreamConstraintsException for oversized Duration numeric component");
@@ -215,7 +215,7 @@ public class MiscJavaXMLTypesReadWriteTest
         // Time-only strings are not parseable by Jackson's _parseDate and will fall through
         // to DatatypeFactory.newXMLGregorianCalendar() which parses fractional seconds
         // into BigDecimal via the O(n^2) BigDecimal(String) constructor.
-        String bigCalendar = "\"T00:00:00." + "9".repeat(120) + "\"";
+        String bigCalendar = "\"T00:00:00." + repeatString("9", 120) + "\"";
         try {
             constrainedMapper.readValue(bigCalendar, XMLGregorianCalendar.class);
             fail("Should not pass: expected StreamConstraintsException for oversized XMLGregorianCalendar fractional seconds");

--- a/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/MiscJavaXMLTypesReadWriteTest.java
@@ -190,8 +190,6 @@ public class MiscJavaXMLTypesReadWriteTest
             fail("Should not pass: expected StreamConstraintsException for oversized Duration numeric component");
         } catch (StreamConstraintsException e) {
             verifyException(e, "exceeds the maximum allowed");
-        } catch (Exception e) {
-            fail("Expected StreamConstraintsException, got: " + e.getClass().getName() + ": " + e.getMessage());
         }
 
         // A normal-length Duration should still work
@@ -211,18 +209,16 @@ public class MiscJavaXMLTypesReadWriteTest
                 .build();
         ObjectMapper constrainedMapper = JsonMapper.builder(jsonFactory).build();
 
-        // Use a time-only format that triggers the fallback to newXMLGregorianCalendar()
-        // Time-only strings are not parseable by Jackson's _parseDate and will fall through
-        // to DatatypeFactory.newXMLGregorianCalendar() which parses fractional seconds
-        // into BigDecimal via the O(n^2) BigDecimal(String) constructor.
-        String bigCalendar = "\"T00:00:00." + repeatString("9", 120) + "\"";
+        // Time-only value (valid xs:time lexical form, not handled by _parseDate):
+        // without the constraint check this falls through to
+        // DatatypeFactory.newXMLGregorianCalendar(), which parses the fractional
+        // seconds via the O(n^2) BigDecimal(String) constructor.
+        String bigCalendar = "\"00:00:00." + repeatString("9", 120) + "\"";
         try {
             constrainedMapper.readValue(bigCalendar, XMLGregorianCalendar.class);
             fail("Should not pass: expected StreamConstraintsException for oversized XMLGregorianCalendar fractional seconds");
         } catch (StreamConstraintsException e) {
             verifyException(e, "exceeds the maximum allowed");
-        } catch (Exception e) {
-            fail("Expected StreamConstraintsException, got: " + e.getClass().getName() + ": " + e.getMessage());
         }
 
         // A normal-length XMLGregorianCalendar should still work
@@ -244,8 +240,39 @@ public class MiscJavaXMLTypesReadWriteTest
             fail("Should not pass: expected StreamConstraintsException for oversized date-time value");
         } catch (StreamConstraintsException e) {
             verifyException(e, "exceeds the maximum allowed");
-        } catch (Exception e) {
-            fail("Expected StreamConstraintsException, got: " + e.getClass().getName() + ": " + e.getMessage());
         }
+    }
+
+    // Same checks but relying on default StreamReadConstraints (1000), without
+    // any explicit configuration
+    @Test
+    public void testDefaultNumberLengthConstraints() throws Exception
+    {
+        final int len = StreamReadConstraints.DEFAULT_MAX_NUM_LEN + 100;
+
+        try {
+            MAPPER.readValue(q("P" + repeatString("9", len) + "Y"), Duration.class);
+            fail("Should not pass: expected StreamConstraintsException for oversized Duration");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "exceeds the maximum allowed");
+        }
+
+        try {
+            MAPPER.readValue(q("00:00:00." + repeatString("9", len)),
+                    XMLGregorianCalendar.class);
+            fail("Should not pass: expected StreamConstraintsException for oversized XMLGregorianCalendar");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "exceeds the maximum allowed");
+        }
+    }
+
+    // QName has no numeric components, so the number-length check must not
+    // apply to it: long local parts remain bound by max String length only
+    @Test
+    public void testQNameNotConstrainedByNumberLength() throws Exception
+    {
+        String localPart = repeatString("a", StreamReadConstraints.DEFAULT_MAX_NUM_LEN + 100);
+        QName qn = MAPPER.readValue(q(localPart), QName.class);
+        assertEquals(localPart, qn.getLocalPart());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/testutil/DatabindTestUtil.java
+++ b/src/test/java/com/fasterxml/jackson/databind/testutil/DatabindTestUtil.java
@@ -429,6 +429,14 @@ public class DatabindTestUtil
         return str.getBytes(StandardCharsets.UTF_8);
     }
 
+    public static String repeatString(String str, int repeatCount) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < repeatCount; ++i) {
+            sb.append(str);
+        }
+        return sb.toString();
+    }
+
     /*
     /**********************************************************************
     /* Additional assertion methods


### PR DESCRIPTION
The javax.xml.datatype have issues where values with lots of digits can cause performance issues, analagous to how numbers with lots of digits can be an issue.