### PR TITLE
 Limit the supported URL schemes for `java.nio.file.Path` deserialization [CVE-2026-19032]

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1925,3 +1925,6 @@ Aysha Afrah Ziya (@aysha-afrah26)
  * Reported #6127: Add `StreamReadConstraints` number len constraint to GregorianCalendar
    and Duration [GHSA-q4xh-88c3-wmh7]
   (2.18.10)
+ * Reported #6129: Limit the supported URL schemes for `java.nio.file.Path`
+   deserialization [GHSA-wjgm-6hv5-3cvf]
+  (2.18.10)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,10 @@ Project: jackson-databind
   and Duration [GHSA-q4xh-88c3-wmh7] GHSA-q4xh-88c3-wmh7
  (reported by @waydeshi)
  (fix by @pjfanning)
+#6129: Limit the supported URL schemes for `java.nio.file.Path`
+  deserialization [GHSA-wjgm-6hv5-3cvf]
+ (reported by @waydeshi)
+ (fix by @pjfanning)
 
 2.18.9 (07-Jul-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
@@ -4,12 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.spi.FileSystemProvider;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -66,22 +62,14 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
         } catch (URISyntaxException e) {
             return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
         }
+        // Only accept "file" scheme or no scheme at all; reject jar:, http:, s3:, etc.
+        final String scheme = uri.getScheme();
+        if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
+            return (Path) ctxt.handleWeirdStringValue(Path.class, value,
+                    "only 'file' scheme is supported for Path deserialization, got '%s'", scheme);
+        }
         try {
             return Paths.get(uri);
-        } catch (FileSystemNotFoundException cause) {
-            try {
-                final String scheme = uri.getScheme();
-                // We want to use the current thread's context class loader, not system class loader that is used in Paths.get():
-                for (FileSystemProvider provider : ServiceLoader.load(FileSystemProvider.class)) {
-                    if (provider.getScheme().equalsIgnoreCase(scheme)) {
-                        return provider.getPath(uri);
-                    }
-                }
-                return (Path) ctxt.handleInstantiationProblem(handledType(), value, cause);
-            } catch (ServiceConfigurationError e) {
-                e.addSuppressed(cause);
-                return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
-            }
         } catch (Exception e) {
             return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
@@ -6,6 +6,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -21,6 +23,14 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
 {
     private static final long serialVersionUID = 1;
 
+    /**
+     * URI schemes accepted unless overridden: only "file", scheme of the
+     * default {@link java.nio.file.FileSystem}.
+     *
+     * @since 2.18.10
+     */
+    public final static Collection<String> DEFAULT_ALLOWED_SCHEMES = Collections.singletonList("file");
+
     private static final boolean areWindowsFilePathsSupported;
     static {
         boolean isWindowsRootFound = false;
@@ -34,7 +44,32 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
         areWindowsFilePathsSupported = isWindowsRootFound;
     }
 
-    public NioPathDeserializer() { super(Path.class); }
+    /**
+     * URI schemes accepted by this instance; values with no scheme at all are
+     * always accepted (and read as local file system paths).
+     *
+     * @since 2.18.10
+     */
+    protected final Collection<String> _allowedSchemes;
+
+    public NioPathDeserializer() { this(DEFAULT_ALLOWED_SCHEMES); }
+
+    /**
+     * Constructor for specifying URI schemes to accept: matching is done
+     * case-insensitively, same as by {@code java.nio.file.Paths.get(URI)}.
+     *
+     * @param allowedSchemes URI schemes to accept; must not be {@code null}
+     *   (but may be empty to only accept scheme-less values)
+     *
+     * @since 2.18.10
+     */
+    public NioPathDeserializer(Collection<String> allowedSchemes) {
+        super(Path.class);
+        if (allowedSchemes == null) {
+            throw new IllegalArgumentException("Argument `allowedSchemes` must not be null");
+        }
+        _allowedSchemes = allowedSchemes;
+    }
 
     @Override
     public Path deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
@@ -62,16 +97,56 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
         } catch (URISyntaxException e) {
             return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
         }
-        // Only accept "file" scheme or no scheme at all; reject jar:, http:, s3:, etc.
+        // Only accept allowed schemes (by default just "file"), or no scheme at all;
+        // reject jar:, http:, s3: and other schemes unless explicitly allowed
         final String scheme = uri.getScheme();
-        if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
+        if (scheme != null && !_isSchemeAllowed(scheme)) {
             return (Path) ctxt.handleWeirdStringValue(Path.class, value,
-                    "only 'file' scheme is supported for Path deserialization, got '%s'", scheme);
+                    "scheme '%s' not allowed for Path deserialization (allowed: %s)",
+                    scheme, _allowedSchemesDesc());
         }
         try {
             return Paths.get(uri);
         } catch (Exception e) {
             return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
         }
+    }
+
+    /**
+     * Helper method for checking whether given non-{@code null} URI scheme is one
+     * of allowed ones; comparison is case-insensitive, as per URI specification
+     * (and as done by {@code java.nio.file.Paths.get(URI)}).
+     *
+     * @since 2.18.10
+     */
+    protected boolean _isSchemeAllowed(String scheme) {
+        // Common case of exact (usually lower-case) match first:
+        if (_allowedSchemes.contains(scheme)) {
+            return true;
+        }
+        // and if no match, scan case-insensitively
+        for (String allowed : _allowedSchemes) {
+            if (scheme.equalsIgnoreCase(allowed)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Helper method for constructing description of allowed schemes for
+     * inclusion in exception message, like {@code ["file", "jar", "https"]}.
+     *
+     * @since 2.18.10
+     */
+    protected String _allowedSchemesDesc() {
+        StringBuilder sb = new StringBuilder(20 + 8 * _allowedSchemes.size()).append('[');
+        for (String scheme : _allowedSchemes) {
+            if (sb.length() > 1) {
+                sb.append(", ");
+            }
+            sb.append('"').append(scheme).append('"');
+        }
+        return sb.append(']').toString();
     }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
@@ -4,10 +4,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -58,6 +62,11 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
     /**
      * Constructor for specifying URI schemes to accept: matching is done
      * case-insensitively, same as by {@code java.nio.file.Paths.get(URI)}.
+     *<p>
+     * NOTE: for allowed schemes that have no provider installed for the system
+     * class loader, look up is also attempted using this thread's context class
+     * loader (see [databind#2120]); this is never done for schemes that are not
+     * allowed.
      *
      * @param allowedSchemes URI schemes to accept; must not be {@code null}
      *   (but may be empty to only accept scheme-less values)
@@ -108,6 +117,22 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
         }
         try {
             return Paths.get(uri);
+        } catch (FileSystemNotFoundException cause) {
+            // 05-Aug-2026, tatu: [databind#6129] Only reached for schemes caller has
+            //    explicitly allowed; retry look up using this thread's context class
+            //    loader, since `Paths.get()` only uses system class loader (see
+            //    [databind#2120])
+            try {
+                for (FileSystemProvider provider : ServiceLoader.load(FileSystemProvider.class)) {
+                    if (provider.getScheme().equalsIgnoreCase(scheme)) {
+                        return provider.getPath(uri);
+                    }
+                }
+                return (Path) ctxt.handleInstantiationProblem(handledType(), value, cause);
+            } catch (ServiceConfigurationError e) {
+                e.addSuppressed(cause);
+                return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
+            }
         } catch (Exception e) {
             return (Path) ctxt.handleInstantiationProblem(handledType(), value, e);
         }

--- a/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ext/NioPathDeserializer.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -140,13 +141,8 @@ public class NioPathDeserializer extends StdScalarDeserializer<Path>
      * @since 2.18.10
      */
     protected String _allowedSchemesDesc() {
-        StringBuilder sb = new StringBuilder(20 + 8 * _allowedSchemes.size()).append('[');
-        for (String scheme : _allowedSchemes) {
-            if (sb.length() > 1) {
-                sb.append(", ");
-            }
-            sb.append('"').append(scheme).append('"');
-        }
-        return sb.append(']').toString();
+        return _allowedSchemes.stream()
+                .map(scheme -> "\"" + scheme + "\"")
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/ext/CustomSchemeFsProvider.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/CustomSchemeFsProvider.java
@@ -1,0 +1,125 @@
+package com.fasterxml.jackson.databind.ext;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test-only {@link FileSystemProvider} used to verify that providers only visible
+ * via Thread context class loader (and not the system class loader used by
+ * {@code Paths.get(URI)}) are still usable -- but only for schemes explicitly
+ * allowed by {@link NioPathDeserializer}. See [databind#2120], [databind#6129].
+ *<p>
+ * Registered NOT at the root of test classpath but under {@code /tcclfs/}, so that
+ * it is only found when that directory is added to a class loader (see
+ * {@code TestJava7Types}); this to avoid changing globally installed providers.
+ */
+public class CustomSchemeFsProvider extends FileSystemProvider
+{
+    public final static String SCHEME = "jacksontest";
+
+    public CustomSchemeFsProvider() { }
+
+    @Override
+    public String getScheme() { return SCHEME; }
+
+    // Only method test actually needs: map to a (default file system) Path so that
+    // test need not implement full `Path` abstraction
+    @Override
+    public Path getPath(URI uri) {
+        return Paths.get("/tmp/jackson-test-fs" + uri.getPath());
+    }
+
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter)
+        throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(Path path) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void move(Path source, Path target, CopyOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSameFile(Path path, Path path2) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isHidden(Path path) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileStore getFileStore(Path path) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type,
+            LinkOption... options) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type,
+            LinkOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options)
+        throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(Path path, String attribute, Object value, LinkOption... options)
+        throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
@@ -31,6 +31,37 @@ public class TestJava7Types extends DatabindTestUtil
         assertEquals(input.toAbsolutePath(), p.toAbsolutePath());
     }
 
+    // [databind#]: Only accept "file" scheme or no scheme; reject jar:, http:, s3:, etc.
+    @Test
+    public void testRejectNonFileSchemes() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // file: scheme should work
+        Path p = mapper.readValue("\"file:///tmp/foo.txt\"", Path.class);
+        assertNotNull(p);
+
+        // Bare path (no scheme) should work
+        p = mapper.readValue("\"/tmp/foo.txt\"", Path.class);
+        assertNotNull(p);
+
+        // Non-file schemes should fail
+        _verifyRejectScheme(mapper, "jar:http://example.com/foo.jar!/path");
+        _verifyRejectScheme(mapper, "http://example.com/path");
+        _verifyRejectScheme(mapper, "s3://bucket/key");
+        _verifyRejectScheme(mapper, "custom://something");
+    }
+
+    private void _verifyRejectScheme(ObjectMapper mapper, String input) {
+        try {
+            mapper.readValue("\"" + input + "\"", Path.class);
+            fail("Should have thrown for scheme in: " + input);
+        } catch (Exception e) {
+            // expected - handleWeirdStringValue will throw by default
+            verifyException(e, "only 'file' scheme is supported");
+        }
+    }
+
     // [databind#1688]:
     @Test
     public void testPolymorphicPath() throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.databind.ext;
 
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -106,6 +108,34 @@ public class TestJava7Types extends DatabindTestUtil
         // and empty allow-list is legal, if unhelpful
         _verifyRejectScheme(_mapperWithSchemes(Collections.<String>emptyList()),
                 "file:///tmp/foo.txt");
+    }
+
+    // [databind#6129]: providers only visible via Thread context class loader are
+    // still usable (see [databind#2120]) -- but only for schemes that are allowed
+    @Test
+    public void testAllowedSchemeViaContextClassLoader() throws Exception
+    {
+        final String input = CustomSchemeFsProvider.SCHEME + ":///foo.txt";
+        final ClassLoader origLoader = Thread.currentThread().getContextClassLoader();
+        // Registration is not at root of test classpath, so provider is NOT one of
+        // installed ones (that is, not found by `Paths.get(URI)`) unless added like so:
+        final URL serviceRoot = getClass().getResource("/tcclfs/");
+        assertNotNull(serviceRoot);
+        Thread.currentThread().setContextClassLoader(
+                new URLClassLoader(new URL[] { serviceRoot }, origLoader));
+
+        try {
+            // First: not allowed by default, and must be rejected without provider lookup
+            _verifyRejectScheme(new ObjectMapper(), input);
+
+            // But if allowed, gets resolved via context class loader
+            ObjectMapper mapper = _mapperWithSchemes(
+                    Arrays.asList(CustomSchemeFsProvider.SCHEME));
+            Path p = mapper.readValue(q(input), Path.class);
+            assertEquals(Paths.get("/tmp/jackson-test-fs/foo.txt"), p);
+        } finally {
+            Thread.currentThread().setContextClassLoader(origLoader);
+        }
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ext/TestJava7Types.java
@@ -2,11 +2,15 @@ package com.fasterxml.jackson.databind.ext;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 import com.fasterxml.jackson.databind.testutil.NoCheckSubTypeValidator;
 
@@ -50,15 +54,84 @@ public class TestJava7Types extends DatabindTestUtil
         _verifyRejectScheme(mapper, "http://example.com/path");
         _verifyRejectScheme(mapper, "s3://bucket/key");
         _verifyRejectScheme(mapper, "custom://something");
+
+        // and message should list schemes that are allowed
+        try {
+            mapper.readValue(q("s3://bucket/key"), Path.class);
+            fail("Should not pass");
+        } catch (Exception e) {
+            verifyException(e, "scheme 's3' not allowed");
+            verifyException(e, "allowed: [\"file\"]");
+        }
+    }
+
+    // [databind#]: scheme matching case-insensitive, as by `Paths.get(URI)` itself
+    @Test
+    public void testAllowedSchemeCaseInsensitive() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (String input : new String[] {
+                "FILE:///tmp/foo.txt", "FiLe:///tmp/foo.txt"
+        }) {
+            Path p = mapper.readValue(q(input), Path.class);
+            assertNotNull(p);
+            assertEquals(Paths.get("/tmp", "foo.txt").toAbsolutePath(), p.toAbsolutePath());
+        }
+    }
+
+    // [databind#]: allowed schemes may be overridden
+    @Test
+    public void testCustomAllowedSchemes() throws Exception
+    {
+        // Case-insensitive both ways: allow-list entry in upper case, input in lower
+        ObjectMapper mapper = _mapperWithSchemes(Arrays.asList("FILE"));
+        Path p = mapper.readValue(q("file:///tmp/foo.txt"), Path.class);
+        assertNotNull(p);
+        assertEquals(Paths.get("/tmp", "foo.txt").toAbsolutePath(), p.toAbsolutePath());
+
+        // But if "file" not included, it gets rejected like any other scheme
+        mapper = _mapperWithSchemes(Arrays.asList("jar", "jrt"));
+        try {
+            mapper.readValue(q("file:///tmp/foo.txt"), Path.class);
+            fail("Should have thrown for scheme in: file:///tmp/foo.txt");
+        } catch (Exception e) {
+            verifyException(e, "scheme 'file' not allowed");
+            verifyException(e, "allowed: [\"jar\", \"jrt\"]");
+        }
+
+        // Scheme-less values, however, are always accepted
+        assertNotNull(mapper.readValue(q("/tmp/foo.txt"), Path.class));
+
+        // and empty allow-list is legal, if unhelpful
+        _verifyRejectScheme(_mapperWithSchemes(Collections.<String>emptyList()),
+                "file:///tmp/foo.txt");
+    }
+
+    @Test
+    public void testNullAllowedSchemes() throws Exception
+    {
+        try {
+            new NioPathDeserializer(null);
+            fail("Should not pass");
+        } catch (IllegalArgumentException e) {
+            verifyException(e, "`allowedSchemes` must not be null");
+        }
+    }
+
+    private ObjectMapper _mapperWithSchemes(Collection<String> allowedSchemes) {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Path.class, new NioPathDeserializer(allowedSchemes));
+        return jsonMapperBuilder().addModule(module).build();
     }
 
     private void _verifyRejectScheme(ObjectMapper mapper, String input) {
         try {
-            mapper.readValue("\"" + input + "\"", Path.class);
+            mapper.readValue(q(input), Path.class);
             fail("Should have thrown for scheme in: " + input);
         } catch (Exception e) {
             // expected - handleWeirdStringValue will throw by default
-            verifyException(e, "only 'file' scheme is supported");
+            verifyException(e, "not allowed for Path deserialization");
         }
     }
 

--- a/src/test/resources/tcclfs/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/src/test/resources/tcclfs/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+com.fasterxml.jackson.databind.ext.CustomSchemeFsProvider


### PR DESCRIPTION
tidy up code so that we don't support custom schemes in this deserialization path