### PR TITLE
Limit regex pattern length at deser time

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/jdk/JDKFromStringDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/JDKFromStringDeserializer.java
@@ -69,6 +69,13 @@ public class JDKFromStringDeserializer
     public final static int STD_INET_ADDRESS = 12;
     public final static int STD_INET_SOCKET_ADDRESS = 13;
 
+    /**
+     * Maximum length of a regex pattern string to compile.
+     * Regex compilation and matching can be exponential in pattern length,
+     * so this limit must be much lower than the general string value limit.
+     */
+    private final static int MAX_PATTERN_LENGTH = 1000;
+
     public static Class<?>[] types() {
         return new Class<?>[] {
             File.class,
@@ -191,6 +198,15 @@ public class JDKFromStringDeserializer
             }
         case STD_PATTERN:
             try {
+                // [databind#]: Reject excessively long regex patterns to prevent
+                // catastrophic backtracking and excessive resource usage.
+                // Regex compilation and matching can be exponential in pattern length,
+                // so this limit must be much lower than the general string length limit.
+                if (value.length() > MAX_PATTERN_LENGTH) {
+                    return ctxt.handleWeirdStringValue(_valueClass, value,
+                            "regex pattern length (%d) exceeds maximum (%d)",
+                            value.length(), MAX_PATTERN_LENGTH);
+                }
                 return Pattern.compile(value);
             } catch (PatternSyntaxException e) {
                 return ctxt.handleWeirdStringValue(_valueClass, value,

--- a/src/main/java/tools/jackson/databind/deser/jdk/JDKFromStringDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/JDKFromStringDeserializer.java
@@ -7,8 +7,6 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.*;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import tools.jackson.core.*;
@@ -62,19 +60,11 @@ public class JDKFromStringDeserializer
     public final static int STD_CLASS = 5;
     public final static int STD_JAVA_TYPE = 6;
     public final static int STD_CURRENCY = 7;
-    public final static int STD_PATTERN = 8;
     public final static int STD_LOCALE = 9;
     public final static int STD_CHARSET = 10;
     public final static int STD_TIME_ZONE = 11;
     public final static int STD_INET_ADDRESS = 12;
     public final static int STD_INET_SOCKET_ADDRESS = 13;
-
-    /**
-     * Maximum length of a regex pattern string to compile.
-     * Regex compilation and matching can be exponential in pattern length,
-     * so this limit must be much lower than the general string value limit.
-     */
-    private final static int MAX_PATTERN_LENGTH = 1000;
 
     public static Class<?>[] types() {
         return new Class<?>[] {
@@ -85,7 +75,6 @@ public class JDKFromStringDeserializer
             Class.class,
             JavaType.class,
             Currency.class,
-            Pattern.class,
             Locale.class,
             Charset.class,
             TimeZone.class,
@@ -132,8 +121,6 @@ public class JDKFromStringDeserializer
             kind = STD_JAVA_TYPE;
         } else if (rawType == Currency.class) {
             kind = STD_CURRENCY;
-        } else if (rawType == Pattern.class) {
-            kind = STD_PATTERN;
         } else if (rawType == Locale.class) {
             kind = STD_LOCALE;
         } else if (rawType == Charset.class) {
@@ -196,22 +183,6 @@ public class JDKFromStringDeserializer
                 return ctxt.handleWeirdStringValue(_valueClass, value,
                         "Unrecognized currency");
             }
-        case STD_PATTERN:
-            try {
-                // [databind#]: Reject excessively long regex patterns to prevent
-                // catastrophic backtracking and excessive resource usage.
-                // Regex compilation and matching can be exponential in pattern length,
-                // so this limit must be much lower than the general string length limit.
-                if (value.length() > MAX_PATTERN_LENGTH) {
-                    return ctxt.handleWeirdStringValue(_valueClass, value,
-                            "regex pattern length (%d) exceeds maximum (%d)",
-                            value.length(), MAX_PATTERN_LENGTH);
-                }
-                return Pattern.compile(value);
-            } catch (PatternSyntaxException e) {
-                return ctxt.handleWeirdStringValue(_valueClass, value,
-                        "Invalid Pattern, problem: "+e.getDescription());
-            }
         case STD_LOCALE:
             return _deserializeLocale(value, ctxt);
         case STD_CHARSET:
@@ -250,12 +221,6 @@ public class JDKFromStringDeserializer
         }
         VersionUtil.throwInternal();
         return null;
-    }
-
-    @Override
-    protected boolean _shouldTrim() {
-        // 04-Dec-2021, tatu: [databind#3299] Do not trim (trailing) white space:
-        return (_kind != STD_PATTERN);
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/deser/jdk/JDKMiscDeserializers.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/JDKMiscDeserializers.java
@@ -5,6 +5,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 
 import tools.jackson.databind.*;
 import tools.jackson.databind.deser.std.NullifyingDeserializer;
@@ -27,6 +28,7 @@ public class JDKMiscDeserializers
         _classNames.add(ByteBuffer.class.getName());
         _classNames.add(Void.class.getName());
         _classNames.add(ThreadGroup.class.getName());
+        _classNames.add(Pattern.class.getName());
         for (Class<?> cls : JDKFromStringDeserializer.types()) {
             _classNames.add(cls.getName());
         }
@@ -39,6 +41,9 @@ public class JDKMiscDeserializers
             ValueDeserializer<?> d = JDKFromStringDeserializer.findDeserializer(rawType);
             if (d != null) {
                 return d;
+            }
+            if (rawType == Pattern.class) {
+                return new PatternDeserializer();
             }
             if (rawType == UUID.class) {
                 return new UUIDDeserializer();

--- a/src/main/java/tools/jackson/databind/deser/jdk/PatternDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/PatternDeserializer.java
@@ -11,12 +11,24 @@ import tools.jackson.databind.deser.std.FromStringDeserializer;
 /**
  * Deserializer for {@link Pattern} values, with a limit on the length of the
  * regex String accepted: regex compilation and matching can be exponential in
- * pattern length, so the limit is much lower than the general String value
- * length limit.
+ * pattern length, so the limit ({@link #DEFAULT_MAX_PATTERN_LENGTH}) is much
+ * lower than the general String value length limit.
  *<p>
  * Registered automatically for {@link Pattern} (by {@link JDKMiscDeserializers}),
- * so explicit registration is only needed for overriding the default maximum
- * pattern length.
+ * so explicit registration is only needed for using a different maximum pattern
+ * length. Since deserializers registered via {@link tools.jackson.databind.JacksonModule}s
+ * take precedence over default ones, registering an instance replaces the
+ * default one:
+ *<pre>
+ *  SimpleModule module = new SimpleModule()
+ *          .addDeserializer(Pattern.class, new PatternDeserializer(5000));
+ *  ObjectMapper mapper = JsonMapper.builder()
+ *          .addModule(module)
+ *          .build();
+ *</pre>
+ * Length checking may also be disabled altogether by using
+ * {@link #UNLIMITED_PATTERN_LENGTH} as the maximum length -- but note that this
+ * exposes users to potential denial-of-service via maliciously crafted patterns.
  *
  * @since 3.3
  */
@@ -29,7 +41,14 @@ public class PatternDeserializer extends FromStringDeserializer<Pattern>
     public final static int DEFAULT_MAX_PATTERN_LENGTH = 1000;
 
     /**
-     * Maximum length of a regex pattern String accepted by this instance.
+     * Value to pass as maximum pattern length to disable length checking
+     * altogether (see {@link #PatternDeserializer(int)}).
+     */
+    public final static int UNLIMITED_PATTERN_LENGTH = -1;
+
+    /**
+     * Maximum length of a regex pattern String accepted by this instance, or
+     * {@link #UNLIMITED_PATTERN_LENGTH} for no limit.
      */
     protected final int _maxPatternLength;
 
@@ -39,12 +58,15 @@ public class PatternDeserializer extends FromStringDeserializer<Pattern>
      * Constructor for specifying maximum length of regex pattern String to accept.
      *
      * @param maxPatternLength Maximum length of pattern String to accept; must be
-     *   positive
+     *   positive, or {@link #UNLIMITED_PATTERN_LENGTH} to accept patterns of any
+     *   length
      */
     public PatternDeserializer(int maxPatternLength) {
         super(Pattern.class);
-        if (maxPatternLength <= 0) {
-            throw new IllegalArgumentException("Argument `maxPatternLength` must be positive");
+        if (maxPatternLength <= 0 && maxPatternLength != UNLIMITED_PATTERN_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Argument `maxPatternLength` must be positive or "+UNLIMITED_PATTERN_LENGTH
+                    +" (unlimited), was: "+maxPatternLength);
         }
         _maxPatternLength = maxPatternLength;
     }
@@ -55,7 +77,8 @@ public class PatternDeserializer extends FromStringDeserializer<Pattern>
     {
         // Reject excessively long regex patterns to prevent catastrophic backtracking
         // and excessive resource usage
-        if (value.length() > _maxPatternLength) {
+        if ((_maxPatternLength != UNLIMITED_PATTERN_LENGTH)
+                && (value.length() > _maxPatternLength)) {
             return (Pattern) ctxt.handleWeirdStringValue(_valueClass, value,
                     "regex pattern length (%d) exceeds maximum (%d)",
                     value.length(), _maxPatternLength);

--- a/src/main/java/tools/jackson/databind/deser/jdk/PatternDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/PatternDeserializer.java
@@ -1,0 +1,76 @@
+package tools.jackson.databind.deser.jdk;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.annotation.JacksonStdImpl;
+import tools.jackson.databind.deser.std.FromStringDeserializer;
+
+/**
+ * Deserializer for {@link Pattern} values, with a limit on the length of the
+ * regex String accepted: regex compilation and matching can be exponential in
+ * pattern length, so the limit is much lower than the general String value
+ * length limit.
+ *<p>
+ * Registered automatically for {@link Pattern} (by {@link JDKMiscDeserializers}),
+ * so explicit registration is only needed for overriding the default maximum
+ * pattern length.
+ *
+ * @since 3.3
+ */
+@JacksonStdImpl
+public class PatternDeserializer extends FromStringDeserializer<Pattern>
+{
+    /**
+     * Maximum length of a regex pattern String accepted unless overridden.
+     */
+    public final static int DEFAULT_MAX_PATTERN_LENGTH = 1000;
+
+    /**
+     * Maximum length of a regex pattern String accepted by this instance.
+     */
+    protected final int _maxPatternLength;
+
+    public PatternDeserializer() { this(DEFAULT_MAX_PATTERN_LENGTH); }
+
+    /**
+     * Constructor for specifying maximum length of regex pattern String to accept.
+     *
+     * @param maxPatternLength Maximum length of pattern String to accept; must be
+     *   positive
+     */
+    public PatternDeserializer(int maxPatternLength) {
+        super(Pattern.class);
+        if (maxPatternLength <= 0) {
+            throw new IllegalArgumentException("Argument `maxPatternLength` must be positive");
+        }
+        _maxPatternLength = maxPatternLength;
+    }
+
+    @Override
+    protected Pattern _deserialize(String value, DeserializationContext ctxt)
+        throws JacksonException
+    {
+        // Reject excessively long regex patterns to prevent catastrophic backtracking
+        // and excessive resource usage
+        if (value.length() > _maxPatternLength) {
+            return (Pattern) ctxt.handleWeirdStringValue(_valueClass, value,
+                    "regex pattern length (%d) exceeds maximum (%d)",
+                    value.length(), _maxPatternLength);
+        }
+        try {
+            return Pattern.compile(value);
+        } catch (PatternSyntaxException e) {
+            return (Pattern) ctxt.handleWeirdStringValue(_valueClass, value,
+                    "Invalid Pattern, problem: "+e.getDescription());
+        }
+    }
+
+    @Override
+    protected boolean _shouldTrim() {
+        // 04-Dec-2021, tatu: [databind#3299] Do not trim (trailing) white space:
+        return false;
+    }
+}

--- a/src/test/java/tools/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -5,7 +5,6 @@ import java.net.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Currency;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -209,59 +208,6 @@ public class JDKStringLikeTypeDeserTest
             verifyException(e, "Cannot deserialize value of type `java.net.InetSocketAddress`");
             verifyException(e, "from String \""+BAD_VALUE+"\"");
             verifyException(e, "Bracketed IPv6 address must contain closing bracket");
-        }
-    }
-
-    @Test
-    public void testPattern() throws Exception
-    {
-        Pattern exp = Pattern.compile("abc:\\s?(\\d+)");
-        // Ok: easiest way is to just serialize first; problem
-        // is the backslash
-        String json = MAPPER.writeValueAsString(exp);
-        Pattern result = MAPPER.readValue(json, Pattern.class);
-        assertEquals(exp.pattern(), result.pattern());
-
-        // [databind#3290]: actually need to retain at least trailing space
-        // (and since we do that, just retain all...)
-        exp = Pattern.compile("^WIN\\ ");
-        json = MAPPER.writeValueAsString(exp);
-        result = MAPPER.readValue(json, Pattern.class);
-        assertEquals(exp.pattern(), result.pattern());
-
-        // [databind#3598]: should also handle invalid pattern serialization
-        // somewhat gracefully
-        try {
-            MAPPER.readValue(q("[abc"), Pattern.class);
-            fail("Should not pass");
-        } catch (InvalidFormatException e) {
-            verifyException(e, "Cannot deserialize value of type `java.util.regex.Pattern` from String \"[abc\"");
-            verifyException(e, "Invalid pattern, problem");
-        }
-    }
-
-    // [databind#]: Reject excessively long regex patterns to prevent
-    // catastrophic backtracking and excessive resource usage
-    @Test
-    public void testPatternLengthLimit() throws Exception
-    {
-        // A normal-length pattern should still work
-        Pattern result = MAPPER.readValue(q("abc"), Pattern.class);
-        assertEquals("abc", result.pattern());
-
-        // A pattern at exactly the limit (1000 chars) should work
-        String limitPattern = "a".repeat(1000);
-        result = MAPPER.readValue(q(limitPattern), Pattern.class);
-        assertEquals(limitPattern, result.pattern());
-
-        // A pattern exceeding the limit (1001 chars) should be rejected
-        String overLimitPattern = "a".repeat(1001);
-        try {
-            MAPPER.readValue(q(overLimitPattern), Pattern.class);
-            fail("Should not pass");
-        } catch (InvalidFormatException e) {
-            verifyException(e, "regex pattern length");
-            verifyException(e, "exceeds maximum");
         }
     }
 

--- a/src/test/java/tools/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/JDKStringLikeTypeDeserTest.java
@@ -240,6 +240,31 @@ public class JDKStringLikeTypeDeserTest
         }
     }
 
+    // [databind#]: Reject excessively long regex patterns to prevent
+    // catastrophic backtracking and excessive resource usage
+    @Test
+    public void testPatternLengthLimit() throws Exception
+    {
+        // A normal-length pattern should still work
+        Pattern result = MAPPER.readValue(q("abc"), Pattern.class);
+        assertEquals("abc", result.pattern());
+
+        // A pattern at exactly the limit (1000 chars) should work
+        String limitPattern = "a".repeat(1000);
+        result = MAPPER.readValue(q(limitPattern), Pattern.class);
+        assertEquals(limitPattern, result.pattern());
+
+        // A pattern exceeding the limit (1001 chars) should be rejected
+        String overLimitPattern = "a".repeat(1001);
+        try {
+            MAPPER.readValue(q(overLimitPattern), Pattern.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "regex pattern length");
+            verifyException(e, "exceeds maximum");
+        }
+    }
+
     @Test
     public void testStringBuilder() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/deser/jdk/PatternDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/PatternDeserializerTest.java
@@ -89,11 +89,42 @@ public class PatternDeserializerTest
         }
     }
 
+    // Registered deserializer must take precedence over the default one, even
+    // when it is more permissive than the default
+    @Test
+    public void customLimitOverridesDefault() throws Exception
+    {
+        ObjectMapper mapper = _mapperWithMaxLength(2000);
+
+        String longPattern = "a".repeat(1500);
+        // Would be rejected by the default deserializer...
+        try {
+            MAPPER.readValue(q(longPattern), Pattern.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "regex pattern length");
+        }
+        // ... but accepted by the registered one
+        assertEquals(longPattern, mapper.readValue(q(longPattern), Pattern.class).pattern());
+    }
+
+    // Length checking can be disabled altogether with UNLIMITED_PATTERN_LENGTH
+    @Test
+    public void unlimitedPatternLength() throws Exception
+    {
+        ObjectMapper mapper = _mapperWithMaxLength(PatternDeserializer.UNLIMITED_PATTERN_LENGTH);
+
+        String hugePattern = "a".repeat(50_000);
+        assertEquals(hugePattern, mapper.readValue(q(hugePattern), Pattern.class).pattern());
+    }
+
     @Test
     public void invalidMaxLength() throws Exception
     {
         assertThrows(IllegalArgumentException.class, () -> new PatternDeserializer(0));
-        assertThrows(IllegalArgumentException.class, () -> new PatternDeserializer(-1));
+        assertThrows(IllegalArgumentException.class, () -> new PatternDeserializer(-2));
+        // but -1 means "unlimited", and is accepted
+        assertNotNull(new PatternDeserializer(PatternDeserializer.UNLIMITED_PATTERN_LENGTH));
     }
 
     private ObjectMapper _mapperWithMaxLength(int maxPatternLength) {

--- a/src/test/java/tools/jackson/databind/deser/jdk/PatternDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/PatternDeserializerTest.java
@@ -1,0 +1,104 @@
+package tools.jackson.databind.deser.jdk;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.module.SimpleModule;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static tools.jackson.databind.testutil.DatabindTestUtil.*;
+
+/**
+ * Tests for {@link PatternDeserializer}.
+ */
+public class PatternDeserializerTest
+{
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void patternDeser() throws Exception
+    {
+        Pattern exp = Pattern.compile("abc:\\s?(\\d+)");
+        // Ok: easiest way is to just serialize first; problem
+        // is the backslash
+        String json = MAPPER.writeValueAsString(exp);
+        Pattern result = MAPPER.readValue(json, Pattern.class);
+        assertEquals(exp.pattern(), result.pattern());
+
+        // [databind#3290]: actually need to retain at least trailing space
+        // (and since we do that, just retain all...)
+        exp = Pattern.compile("^WIN\\ ");
+        json = MAPPER.writeValueAsString(exp);
+        result = MAPPER.readValue(json, Pattern.class);
+        assertEquals(exp.pattern(), result.pattern());
+
+        // [databind#3598]: should also handle invalid pattern serialization
+        // somewhat gracefully
+        try {
+            MAPPER.readValue(q("[abc"), Pattern.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "Cannot deserialize value of type `java.util.regex.Pattern` from String \"[abc\"");
+            verifyException(e, "Invalid pattern, problem");
+        }
+    }
+
+    // Reject excessively long regex patterns to prevent catastrophic
+    // backtracking and excessive resource usage
+    @Test
+    public void patternLengthLimit() throws Exception
+    {
+        // A normal-length pattern should still work
+        Pattern result = MAPPER.readValue(q("abc"), Pattern.class);
+        assertEquals("abc", result.pattern());
+
+        // A pattern at exactly the limit (1000 chars) should work
+        String limitPattern = "a".repeat(PatternDeserializer.DEFAULT_MAX_PATTERN_LENGTH);
+        result = MAPPER.readValue(q(limitPattern), Pattern.class);
+        assertEquals(limitPattern, result.pattern());
+
+        // A pattern exceeding the limit (1001 chars) should be rejected
+        String overLimitPattern = "a".repeat(PatternDeserializer.DEFAULT_MAX_PATTERN_LENGTH + 1);
+        try {
+            MAPPER.readValue(q(overLimitPattern), Pattern.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "regex pattern length");
+            verifyException(e, "exceeds maximum");
+        }
+    }
+
+    // Maximum length is configurable by explicitly registering the deserializer
+    @Test
+    public void customPatternLengthLimit() throws Exception
+    {
+        ObjectMapper mapper = _mapperWithMaxLength(10);
+
+        assertEquals("a".repeat(10),
+                mapper.readValue(q("a".repeat(10)), Pattern.class).pattern());
+
+        try {
+            mapper.readValue(q("a".repeat(11)), Pattern.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "regex pattern length (11) exceeds maximum (10)");
+        }
+    }
+
+    @Test
+    public void invalidMaxLength() throws Exception
+    {
+        assertThrows(IllegalArgumentException.class, () -> new PatternDeserializer(0));
+        assertThrows(IllegalArgumentException.class, () -> new PatternDeserializer(-1));
+    }
+
+    private ObjectMapper _mapperWithMaxLength(int maxPatternLength) {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Pattern.class, new PatternDeserializer(maxPatternLength));
+        return jsonMapperBuilder().addModule(module).build();
+    }
+}


### PR DESCRIPTION
Pattern.compile can be very expensive. Even limiting by size may not be enough. If we do want to limit by size, we might want to make the length configurable.
There is a question mark about whether supporting Pattern as a deserializable type is a good idea - or if we could make it something that is only enabled by users opting in.