### PR TITLE
Limit number sizes allowed in `java.time.Instant` deserializer

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -34,6 +34,8 @@ No changes since 3.1
   deserialization [CVE-2026-19032]
  (reported by @waydeshi)
  (fix by @pjfanning)
+#6133: Limit number sizes allowed in `java.time.Instant` deserializer
+ (fix by @pjfanning)
 #6137: `DefaultCacheProvider.Builder` does not preserve default cache sizes
   for unspecified values
  (reported, fixed by DongNyoung L)

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
@@ -366,11 +366,11 @@ public class InstantDeserializer<T extends Temporal>
             if (dots >= 0) { // negative if not simple number
                 try {
                     if (dots == 0) {
-                        ctxt.streamReadConstraints().validateIntegerLength(string.length());
+                        _validateTimestampLength(ctxt, string);
                         return _fromLong(ctxt, NumberInput.parseLong(string));
                     }
                     if (dots == 1) {
-                        ctxt.streamReadConstraints().validateFPLength(string.length());
+                        _validateTimestampLength(ctxt, string);
                         return _fromDecimal(ctxt, NumberInput.parseBigDecimal(string, false));
                     }
                 } catch (NumberFormatException e) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/InstantDeserializer.java
@@ -366,9 +366,11 @@ public class InstantDeserializer<T extends Temporal>
             if (dots >= 0) { // negative if not simple number
                 try {
                     if (dots == 0) {
+                        ctxt.streamReadConstraints().validateIntegerLength(string.length());
                         return _fromLong(ctxt, NumberInput.parseLong(string));
                     }
                     if (dots == 1) {
+                        ctxt.streamReadConstraints().validateFPLength(string.length());
                         return _fromDecimal(ctxt, NumberInput.parseBigDecimal(string, false));
                     }
                 } catch (NumberFormatException e) {

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Timeout;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.type.TypeReference;
 
 import tools.jackson.databind.ObjectMapper;
@@ -673,37 +674,37 @@ public class InstantDeserTest extends DateTimeTestBase
     }
 
     // [databind#6133]: StreamReadConstraints should limit numeric string lengths
-    // parsed via _fromString to prevent excessive BigDecimal construction
+    // parsed via _fromString to prevent excessive BigDecimal construction.
+    // NOTE: values MUST be quoted -- unquoted ones are Number tokens, limits for
+    // which are enforced by the streaming parser and not by this deserializer.
     @Test
     public void testNumericStringRespectsStreamReadConstraints() throws Exception
     {
         final int MAX_ALLOWED_LEN = StreamReadConstraints.DEFAULT_MAX_NUM_LEN;
 
         // Normal epoch seconds as integer should work
-        Instant result = MAPPER.readValue("1234567890", Instant.class);
-        assertNotNull(result);
+        assertNotNull(MAPPER.readValue(q("1234567890"), Instant.class));
 
         // Normal epoch seconds with decimal should work
-        result = MAPPER.readValue("1234567890.123456789", Instant.class);
-        assertNotNull(result);
+        assertNotNull(MAPPER.readValue(q("1234567890.123456789"), Instant.class));
 
         // A very long integer string (exceeding default 1000-digit limit) should fail
         String longInt = "1".repeat(MAX_ALLOWED_LEN + 1);
         try {
-            MAPPER.readValue(longInt, Instant.class);
+            MAPPER.readValue(q(longInt), Instant.class);
             fail("Should not pass with excessively long integer string");
-        } catch (Exception e) {
-            verifyException(e, "Number value length");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Date/time value length");
             verifyException(e, "exceeds the maximum allowed");
         }
 
         // A very long decimal string (exceeding default 1000-char limit) should fail
         String longDecimal = "1234." + "9".repeat(MAX_ALLOWED_LEN);
         try {
-            MAPPER.readValue(longDecimal, Instant.class);
+            MAPPER.readValue(q(longDecimal), Instant.class);
             fail("Should not pass with excessively long decimal string");
-        } catch (Exception e) {
-            verifyException(e, "Number value length");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Date/time value length");
             verifyException(e, "exceeds the maximum allowed");
         }
     }

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Timeout;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.type.TypeReference;
 
 import tools.jackson.databind.ObjectMapper;
@@ -671,25 +672,25 @@ public class InstantDeserTest extends DateTimeTestBase
         assertEquals(matcher.group(), "+0100", "Matcher groups +0100 as an colonless offset");
     }
 
-    // [databind#]: StreamReadConstraints should limit numeric string lengths
+    // [databind#6133]: StreamReadConstraints should limit numeric string lengths
     // parsed via _fromString to prevent excessive BigDecimal construction
     @Test
     public void testNumericStringRespectsStreamReadConstraints() throws Exception
     {
-        ObjectMapper mapper = new ObjectMapper();
+        final int MAX_ALLOWED_LEN = StreamReadConstraints.DEFAULT_MAX_NUM_LEN;
 
         // Normal epoch seconds as integer should work
-        Instant result = mapper.readValue("1234567890", Instant.class);
+        Instant result = MAPPER.readValue("1234567890", Instant.class);
         assertNotNull(result);
 
         // Normal epoch seconds with decimal should work
-        result = mapper.readValue("1234567890.123456789", Instant.class);
+        result = MAPPER.readValue("1234567890.123456789", Instant.class);
         assertNotNull(result);
 
         // A very long integer string (exceeding default 1000-digit limit) should fail
-        String longInt = "1".repeat(1001);
+        String longInt = "1".repeat(MAX_ALLOWED_LEN + 1);
         try {
-            mapper.readValue(longInt, Instant.class);
+            MAPPER.readValue(longInt, Instant.class);
             fail("Should not pass with excessively long integer string");
         } catch (Exception e) {
             verifyException(e, "Number value length");
@@ -697,9 +698,9 @@ public class InstantDeserTest extends DateTimeTestBase
         }
 
         // A very long decimal string (exceeding default 1000-char limit) should fail
-        String longDecimal = "1234." + "9".repeat(1000);
+        String longDecimal = "1234." + "9".repeat(MAX_ALLOWED_LEN);
         try {
-            mapper.readValue(longDecimal, Instant.class);
+            MAPPER.readValue(longDecimal, Instant.class);
             fail("Should not pass with excessively long decimal string");
         } catch (Exception e) {
             verifyException(e, "Number value length");

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/InstantDeserTest.java
@@ -670,4 +670,40 @@ public class InstantDeserTest extends DateTimeTestBase
         assertTrue(matcher.find(), "Matcher finds +0100 as an colonless offset");
         assertEquals(matcher.group(), "+0100", "Matcher groups +0100 as an colonless offset");
     }
+
+    // [databind#]: StreamReadConstraints should limit numeric string lengths
+    // parsed via _fromString to prevent excessive BigDecimal construction
+    @Test
+    public void testNumericStringRespectsStreamReadConstraints() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Normal epoch seconds as integer should work
+        Instant result = mapper.readValue("1234567890", Instant.class);
+        assertNotNull(result);
+
+        // Normal epoch seconds with decimal should work
+        result = mapper.readValue("1234567890.123456789", Instant.class);
+        assertNotNull(result);
+
+        // A very long integer string (exceeding default 1000-digit limit) should fail
+        String longInt = "1".repeat(1001);
+        try {
+            mapper.readValue(longInt, Instant.class);
+            fail("Should not pass with excessively long integer string");
+        } catch (Exception e) {
+            verifyException(e, "Number value length");
+            verifyException(e, "exceeds the maximum allowed");
+        }
+
+        // A very long decimal string (exceeding default 1000-char limit) should fail
+        String longDecimal = "1234." + "9".repeat(1000);
+        try {
+            mapper.readValue(longDecimal, Instant.class);
+            fail("Should not pass with excessively long decimal string");
+        } catch (Exception e) {
+            verifyException(e, "Number value length");
+            verifyException(e, "exceeds the maximum allowed");
+        }
+    }
 }


### PR DESCRIPTION
I can create a PR for the jackson-datatypes-java8 version of this code for 2.18 if needed. This code moved repo for Jackson 3.