### PR TITLE
Fix #6136: honor `@JsonFilter` for `@JsonAnyGetter` entries

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -609,6 +609,7 @@ Bowang (@dong0713)
  * Fixed #6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
   [3.3.0]
 
-  Aysha Afrah Ziya (@aysha-afrah26)
-  
-  
+Aysha Afrah Ziya (@aysha-afrah26)
+ * Reported, fixed #6136: `@JsonFilter` with `serializeAllExcept()` does not filter
+   `@JsonAnyGetter` entries
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -31,6 +31,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @cowtowncoder, w/ Claude code)
 #6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
  (fix by @DragonFSKY)
+#6136: `@JsonFilter` with `serializeAllExcept()` does not filter `@JsonAnyGetter`
+  entries
+ (reported, fix by Aysha A-Z)
 
 3.2.2 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
@@ -7,6 +7,7 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ser.jdk.MapProperty;
 import tools.jackson.databind.ser.jdk.MapSerializer;
 
 /**
@@ -104,8 +105,8 @@ public class AnyGetterWriter extends BeanPropertyWriter
         }
         // [databind#3604]: Support ObjectNode/JsonNode for @JsonAnyGetter
         if (value instanceof JsonNode) {
-            // No special filtering support for ObjectNode (yet); just serialize entries
-            _serializeObjectNodeEntries(_verifyObjectNode(value, ctxt), gen, ctxt);
+            _serializeFilteredObjectNodeEntries(_verifyObjectNode(value, ctxt), gen, ctxt,
+                    bean, filter);
             return;
         }
         if (!(value instanceof Map<?,?>)) {
@@ -113,10 +114,9 @@ public class AnyGetterWriter extends BeanPropertyWriter
                     "Value returned by 'any-getter' (%s()) not java.util.Map but %s".formatted(
                             _accessor.getName(), value.getClass().getName()));
         }
-        // 19-Oct-2014, tatu: Should we try to support @JsonInclude options here?
         if (_mapSerializer != null) {
-            _mapSerializer.serializeFilteredAnyProperties(ctxt, gen, bean,(Map<?,?>) value,
-                    filter, null);
+            _mapSerializer.serializeFilteredAnyProperties(ctxt, gen, bean, (Map<?,?>) value,
+                    filter);
             return;
         }
         // ... not sure how custom handler would do it
@@ -153,6 +153,28 @@ public class AnyGetterWriter extends BeanPropertyWriter
         for (Map.Entry<String, JsonNode> entry : objectNode.properties()) {
             gen.writeName(entry.getKey());
             entry.getValue().serialize(gen, ctxt);
+        }
+    }
+
+    /**
+     * Variant of {@link #_serializeObjectNodeEntries} used when a JSON Filter is in
+     * effect: entries become properties of the enclosing POJO, so each one is passed
+     * to the filter the same way {@code MapSerializer} passes entries of a
+     * {@link Map}-valued any-getter.
+     *
+     * @since 3.3
+     */
+    protected void _serializeFilteredObjectNodeEntries(ObjectNode objectNode,
+            JsonGenerator gen, SerializationContext ctxt,
+            Object bean, PropertyFilter filter)
+        throws Exception
+    {
+        final MapProperty prop = new MapProperty(null, _property);
+        final ValueSerializer<Object> keySer = ctxt.findKeySerializer(String.class, _property);
+        for (Map.Entry<String, JsonNode> entry : objectNode.properties()) {
+            final JsonNode v = entry.getValue();
+            prop.reset(entry.getKey(), v, keySer, ctxt.findValueSerializer(v.getClass()));
+            filter.serializeAsProperty(bean, gen, ctxt, prop);
         }
     }
 

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -1014,7 +1014,16 @@ public abstract class BeanSerializerBase
             for (final int len = props.length; i < len; ++i) {
                 BeanPropertyWriter prop = props[i];
                 if (prop != null) { // can have nulls in filtered list
-                    filter.serializeAsProperty(bean, g, ctxt, prop);
+                    // [databind#6136]: Name of an any-getter accessor is not a property
+                    // name in output -- the entries it produces are -- so it is unpacked
+                    // here and the filter gets to decide inclusion of each entry.
+                    // Done by caller (instead of by filter) so that this works for all
+                    // `PropertyFilter` implementations, not just standard ones.
+                    if (prop instanceof AnyGetterWriter anyGetter) {
+                        anyGetter.getAndFilter(bean, g, ctxt, filter);
+                    } else {
+                        filter.serializeAsProperty(bean, g, ctxt, prop);
+                    }
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/tools/jackson/databind/ser/jdk/MapSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/MapSerializer.java
@@ -889,6 +889,25 @@ public class MapSerializer
     }
 
     /**
+     * Variant of {@link #serializeFilteredAnyProperties(SerializationContext, JsonGenerator,
+     * Object, Map, PropertyFilter, Object)} that applies the inclusion criteria configured
+     * for this serializer, so that a filtered any-getter suppresses the same entries an
+     * unfiltered one does (see {@link #serializeWithoutTypeInfo}).
+     *<p>
+     * NOTE: {@code public} only because it is called by {@code AnyGetterWriter}
+     *
+     * @param bean Enclosing POJO that has any-getter used to obtain "any properties"
+     *
+     * @since 3.3
+     */
+    public void serializeFilteredAnyProperties(SerializationContext ctxt, JsonGenerator gen,
+            Object bean, Map<?,?> value, PropertyFilter filter)
+        throws JacksonException
+    {
+        serializeFilteredAnyProperties(ctxt, gen, bean, value, filter, _suppressableValue);
+    }
+
+    /**
      * Helper method used when we have a JSON Filter to use AND contents are
      * "any properties" of a POJO.
      *<p>

--- a/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
+++ b/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
@@ -119,14 +119,9 @@ public class SimpleBeanPropertyFilter
             SerializationContext provider, PropertyWriter writer)
         throws Exception
     {
-        // [databind#6136]: Name of the any-getter accessor is not a property name in output -- the
-        // entries it produces are -- so inclusion is decided for each entry
-        // (via `getAndFilter()` calling back into this filter), never for the
-        // any-getter writer itself.
-        if (writer instanceof AnyGetterWriter anyGetterWriter) {
-            anyGetterWriter.getAndFilter(pojo, g, provider, this);
-            return;
-        }
+        // NOTE: [databind#6136]: any-getters never reach this method -- caller
+        // (`BeanSerializerBase`) unpacks them into individual entries first, each of
+        // which is then passed here as a `MapProperty`.
         if (include(writer)) {
             writer.serializeAsProperty(pojo, g, provider);
         } else if (!g.canOmitProperties()) {

--- a/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
+++ b/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
@@ -119,7 +119,7 @@ public class SimpleBeanPropertyFilter
             SerializationContext provider, PropertyWriter writer)
         throws Exception
     {
-        // Name of the any-getter accessor is not a property name in output -- the
+        // [databind#6136]: Name of the any-getter accessor is not a property name in output -- the
         // entries it produces are -- so inclusion is decided for each entry
         // (via `getAndFilter()` calling back into this filter), never for the
         // any-getter writer itself.

--- a/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
+++ b/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
@@ -119,12 +119,18 @@ public class SimpleBeanPropertyFilter
             SerializationContext provider, PropertyWriter writer)
         throws Exception
     {
+        // Name of the any-getter accessor is not a property name in output -- the
+        // entries it produces are -- so inclusion is decided for each entry
+        // (via `getAndFilter()` calling back into this filter), never for the
+        // any-getter writer itself.
+        if (writer instanceof AnyGetterWriter anyGetterWriter) {
+            anyGetterWriter.getAndFilter(pojo, g, provider, this);
+            return;
+        }
         if (include(writer)) {
             writer.serializeAsProperty(pojo, g, provider);
         } else if (!g.canOmitProperties()) {
             writer.serializeAsOmittedProperty(pojo, g, provider);
-        } else if (writer instanceof AnyGetterWriter anyGetterWriter) {
-            anyGetterWriter.getAndFilter(pojo, g, provider, this);
         }
     }
 

--- a/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
@@ -113,6 +113,38 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         }
     }
 
+    // [databind#6136]: content inclusion has to apply on filtered path too,
+    // same as it does without a filter (see `NonEmptyAnyBean`)
+    @JsonFilter("anyFilter")
+    static class FilteredNonEmptyAnyBean
+    {
+        public String name = "bob";
+
+        @JsonAnyGetter
+        @JsonInclude(content = JsonInclude.Include.NON_EMPTY)
+        public Map<String, String> anyProperties() {
+            Map<String, String> props = new LinkedHashMap<>();
+            props.put("a", "1");
+            props.put("blank", "");
+            return props;
+        }
+    }
+
+    // [databind#6136]: same as `FilteredNonEmptyAnyBean` but without `@JsonFilter`
+    static class NonEmptyAnyBean
+    {
+        public String name = "bob";
+
+        @JsonAnyGetter
+        @JsonInclude(content = JsonInclude.Include.NON_EMPTY)
+        public Map<String, String> anyProperties() {
+            Map<String, String> props = new LinkedHashMap<>();
+            props.put("a", "1");
+            props.put("blank", "");
+            return props;
+        }
+    }
+
     // [databind#1655]
     @JsonFilter("CustomFilter")
     static class OuterObject {
@@ -234,6 +266,30 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         assertEquals("""
                 {"name":"bob","a":"1"}""",
                 MAPPER.writer(prov).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
+    }
+
+    // [databind#6136]: `@JsonInclude` content inclusion of the any-getter has to be
+    // honored on the filtered path as well -- filtering decides which entries a filter
+    // lets through, not whether inclusion criteria apply
+    @Test
+    public void anyGetterContentInclusionWithFilter() throws Exception
+    {
+        final String EXP = """
+                {"name":"bob","a":"1"}""";
+
+        // Baseline: no filter at all, empty-valued entry suppressed
+        assertEquals(EXP, MAPPER.writeValueAsString(new NonEmptyAnyBean()));
+
+        // and same has to hold for both filter styles
+        FilterProvider excluding = new SimpleFilterProvider().addFilter("anyFilter",
+                SimpleBeanPropertyFilter.serializeAllExcept("secret"));
+        assertEquals(EXP,
+                MAPPER.writer(excluding).writeValueAsString(new FilteredNonEmptyAnyBean()));
+
+        FilterProvider including = new SimpleFilterProvider().addFilter("anyFilter",
+                SimpleBeanPropertyFilter.filterOutAllExcept("name", "a", "blank"));
+        assertEquals(EXP,
+                MAPPER.writer(including).writeValueAsString(new FilteredNonEmptyAnyBean()));
     }
 
     // for [databind#1142]

--- a/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
@@ -79,6 +79,7 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         }
     }
 
+    // [databind#6136]
     @JsonFilter("anyFilter")
     static class AnyBeanWithSecret
     {
@@ -96,6 +97,7 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         }
     }
 
+    // [databind#6136]
     @JsonFilter("anyFilter")
     static class ObjectNodeAnyBeanWithSecret
     {
@@ -151,6 +153,7 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         assertEquals("{\"b\":\"2\"}", MAPPER.writer(prov).writeValueAsString(new AnyBean()));
     }
 
+    // [databind#6136]
     @Test
     public void anyGetterSerializeAllExcept() throws Exception
     {
@@ -161,6 +164,7 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
                 MAPPER.writer(prov).writeValueAsString(new AnyBeanWithSecret()));
     }
 
+    // [databind#6136]
     @Test
     public void objectNodeAnyGetterFiltering() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.*;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.ser.FilterProvider;
 import tools.jackson.databind.ser.PropertyWriter;
 import tools.jackson.databind.ser.std.SimpleBeanPropertyFilter;
@@ -77,6 +79,36 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         }
     }
 
+    @JsonFilter("anyFilter")
+    static class AnyBeanWithSecret
+    {
+        public String name = "bob";
+
+        private Map<String, String> properties = new LinkedHashMap<String, String>();
+        {
+            properties.put("a", "1");
+            properties.put("secret", "s3cr3t");
+        }
+
+        @JsonAnyGetter
+        public Map<String, String> anyProperties() {
+            return properties;
+        }
+    }
+
+    @JsonFilter("anyFilter")
+    static class ObjectNodeAnyBeanWithSecret
+    {
+        public String name = "bob";
+
+        @JsonAnyGetter
+        public ObjectNode anyProperties() {
+            return JsonNodeFactory.instance.objectNode()
+                    .put("a", "1")
+                    .put("secret", "s3cr3t");
+        }
+    }
+
     // [databind#1655]
     @JsonFilter("CustomFilter")
     static class OuterObject {
@@ -117,6 +149,32 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         FilterProvider prov = new SimpleFilterProvider().addFilter("anyFilter",
                 SimpleBeanPropertyFilter.filterOutAllExcept("b"));
         assertEquals("{\"b\":\"2\"}", MAPPER.writer(prov).writeValueAsString(new AnyBean()));
+    }
+
+    @Test
+    public void anyGetterSerializeAllExcept() throws Exception
+    {
+        FilterProvider prov = new SimpleFilterProvider().addFilter("anyFilter",
+                SimpleBeanPropertyFilter.serializeAllExcept("secret"));
+        assertEquals("""
+                {"name":"bob","a":"1"}""",
+                MAPPER.writer(prov).writeValueAsString(new AnyBeanWithSecret()));
+    }
+
+    @Test
+    public void objectNodeAnyGetterFiltering() throws Exception
+    {
+        FilterProvider excluding = new SimpleFilterProvider().addFilter("anyFilter",
+                SimpleBeanPropertyFilter.serializeAllExcept("secret"));
+        assertEquals("""
+                {"name":"bob","a":"1"}""",
+                MAPPER.writer(excluding).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
+
+        FilterProvider including = new SimpleFilterProvider().addFilter("anyFilter",
+                SimpleBeanPropertyFilter.filterOutAllExcept("name", "a"));
+        assertEquals("""
+                {"name":"bob","a":"1"}""",
+                MAPPER.writer(including).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
     }
 
     // for [databind#1142]

--- a/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
@@ -11,7 +11,9 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import tools.jackson.databind.ser.FilterProvider;
+import tools.jackson.databind.ser.PropertyFilter;
 import tools.jackson.databind.ser.PropertyWriter;
 import tools.jackson.databind.ser.std.SimpleBeanPropertyFilter;
 import tools.jackson.databind.ser.std.SimpleFilterProvider;
@@ -126,6 +128,44 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
          }
     }
 
+    // [databind#6136]: filter that implements `PropertyFilter` directly instead of
+    // extending `SimpleBeanPropertyFilter` -- must also get per-entry decisions
+    static class DirectExcludingFilter implements PropertyFilter
+    {
+        private final Set<String> _excluded;
+
+        public DirectExcludingFilter(String... names) {
+            _excluded = new HashSet<>(Arrays.asList(names));
+        }
+
+        @Override
+        public PropertyFilter snapshot() { return this; }
+
+        @Override
+        public void serializeAsProperty(Object pojo, JsonGenerator g, SerializationContext ctxt,
+                PropertyWriter writer)
+            throws Exception
+        {
+            if (!_excluded.contains(writer.getName())) {
+                writer.serializeAsProperty(pojo, g, ctxt);
+            }
+        }
+
+        @Override
+        public void serializeAsElement(Object elementValue, JsonGenerator g, SerializationContext ctxt,
+                PropertyWriter writer)
+            throws Exception
+        {
+            writer.serializeAsElement(elementValue, g, ctxt);
+        }
+
+        @Override
+        public void depositSchemaProperty(PropertyWriter writer, JsonObjectFormatVisitor v,
+                SerializationContext ctxt) {
+            writer.depositSchemaProperty(v, ctxt);
+        }
+    }
+
     static class CustomFilter extends SimpleBeanPropertyFilter {
          @Override
          public void serializeAsProperty(Object pojo, JsonGenerator gen, SerializationContext provider,
@@ -179,6 +219,21 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         assertEquals("""
                 {"name":"bob","a":"1"}""",
                 MAPPER.writer(including).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
+    }
+
+    // [databind#6136]: also has to work for filters that do not extend
+    // `SimpleBeanPropertyFilter`
+    @Test
+    public void anyGetterFilteringWithDirectFilterImpl() throws Exception
+    {
+        FilterProvider prov = new SimpleFilterProvider().addFilter("anyFilter",
+                new DirectExcludingFilter("secret"));
+        assertEquals("""
+                {"name":"bob","a":"1"}""",
+                MAPPER.writer(prov).writeValueAsString(new AnyBeanWithSecret()));
+        assertEquals("""
+                {"name":"bob","a":"1"}""",
+                MAPPER.writer(prov).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
     }
 
     // for [databind#1142]


### PR DESCRIPTION
Fixes #6136 (see the issue for usage details and reproduction).

Short version: `SimpleBeanPropertyFilter.serializeAsProperty()` runs `include()` against the name of the any-getter accessor rather than the names of the entries it emits, so an exclude filter (`serializeAllExcept()`) lets the writer straight through to `getAndSerialize()` and every entry goes out, including excluded ones. Only `filterOutAllExcept` reaches the per-entry `getAndFilter()`, since that call sits in the `else` branch. The fix routes `AnyGetterWriter` to `getAndFilter()` before the `include()` check, so inclusion is decided per entry.

A `JsonNode`-valued any-getter ([databind#3604]) leaks the same way under either filter style, because `getAndFilter()` short-circuits those to unfiltered entries; they now go through `MapProperty` the way map entries already do. Sending every any-getter down `getAndFilter()` also exposed its hardcoded `null` suppressable value, which dropped `NON_EMPTY` on the filtered path, so it now uses the one its `MapSerializer` was built with.

Targets `3.x` only, per discussion below.
