### PR TITLE
Fix #6128: reject POJO-as-array with property filters

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -609,3 +609,8 @@ Aysha Afrah Ziya (@aysha-afrah26)
  * Fixed #6126: `@JsonFilter` ignored for POJO serialized with
    `@JsonFormat(shape=ARRAY)`
   [3.3.0]
+
+@DragonFSKY
+ * Fixed #6128: Follow-up to #6126: explicitly fail when a POJO combines `@JsonFilter`
+   with `@JsonFormat(shape=ARRAY)`, instead of silently writing a JSON Object
+  [3.3.0]

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -605,11 +605,10 @@ Bowang (@dong0713)
  * Fixed #6114: Fix QName object deserialization to reject non-String namespaceURI/prefix
   [3.3.0]
 
-Aysha Afrah Ziya (@aysha-afrah26)
- * Fixed #6126: `@JsonFilter` ignored for POJO serialized with
-   `@JsonFormat(shape=ARRAY)`
-  [3.3.0]
-
 @DragonFSKY
  * Fixed #6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
   [3.3.0]
+
+  Aysha Afrah Ziya (@aysha-afrah26)
+  
+  

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -611,6 +611,5 @@ Aysha Afrah Ziya (@aysha-afrah26)
   [3.3.0]
 
 @DragonFSKY
- * Fixed #6128: Follow-up to #6126: explicitly fail when a POJO combines `@JsonFilter`
-   with `@JsonFormat(shape=ARRAY)`, instead of silently writing a JSON Object
+ * Fixed #6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
   [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -33,8 +33,7 @@ Versions: 3.x (for earlier see VERSION-2.x)
   now declines the as-array shape (writing JSON Object instead), same as 2.x,
   since positional output cannot express omission of a property
  (fix by @aysha-afrah26)
-#6128: Follow-up to #6126: explicitly fail when a POJO combines `@JsonFilter`
-  with `@JsonFormat(shape=ARRAY)`, instead of silently writing a JSON Object
+#6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
  (fix by @DragonFSKY)
 
 3.2.2 (not yet released)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -29,10 +29,6 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6120: Use per-node-type Type Ids for DOM values, reconstruct via DOM factory
   instead of always parsing a `Document`
  (fix by @cowtowncoder, w/ Claude code)
-#6126: `@JsonFilter` ignored for POJO serialized with `@JsonFormat(shape=ARRAY)`:
-  now declines the as-array shape (writing JSON Object instead), same as 2.x,
-  since positional output cannot express omission of a property
- (fix by @aysha-afrah26)
 #6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
  (fix by @DragonFSKY)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -33,6 +33,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
   now declines the as-array shape (writing JSON Object instead), same as 2.x,
   since positional output cannot express omission of a property
  (fix by @aysha-afrah26)
+#6128: Follow-up to #6126: explicitly fail when a POJO combines `@JsonFilter`
+  with `@JsonFormat(shape=ARRAY)`, instead of silently writing a JSON Object
+ (fix by @DragonFSKY)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -642,6 +642,12 @@ public abstract class BeanSerializerBase
         }
         // last but not least; may need to transmute into as-array serialization
         if (shape == JsonFormat.Shape.ARRAY) {
+            if (contextual._propertyFilterId != null) {
+                return ctxt.reportBadDefinition(_beanType, String.format(
+                        "Cannot serialize %s with `@JsonFormat(shape = ARRAY)` because it also has `@JsonFilter`:"
+                                + " property filtering is not compatible with array serialization",
+                        ClassUtil.getTypeDescription(_beanType)));
+            }
             return contextual.asArraySerializer();
         }
         return contextual;

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -644,7 +644,7 @@ public abstract class BeanSerializerBase
         if (shape == JsonFormat.Shape.ARRAY) {
             if (contextual._propertyFilterId != null) {
                 return ctxt.reportBadDefinition(_beanType, String.format(
-                        "Cannot serialize %s with `@JsonFormat(shape = ARRAY)` because it also has `@JsonFilter`:"
+                        "Cannot serialize %s with `@JsonFormat(shape=ARRAY)` because it also has `@JsonFilter`:"
                                 + " property filtering is not compatible with array serialization",
                         ClassUtil.getTypeDescription(_beanType)));
             }

--- a/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ser/bean/BeanSerializerBase.java
@@ -642,7 +642,7 @@ public abstract class BeanSerializerBase
         }
         // last but not least; may need to transmute into as-array serialization
         if (shape == JsonFormat.Shape.ARRAY) {
-            if (contextual._propertyFilterId != null) {
+            if (contextual.getFilterId() != null) {
                 return ctxt.reportBadDefinition(_beanType, String.format(
                         "Cannot serialize %s with `@JsonFormat(shape=ARRAY)` because it also has `@JsonFilter`:"
                                 + " property filtering is not compatible with array serialization",

--- a/src/test/java/tools/jackson/databind/ser/filter/POJOAsArrayFilterTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/POJOAsArrayFilterTest.java
@@ -69,7 +69,7 @@ public class POJOAsArrayFilterTest extends DatabindTestUtil
         InvalidDefinitionException e = assertThrows(InvalidDefinitionException.class,
                 () -> writerExcluding("secret").writeValueAsString(new AsArrayBean()));
 
-        verifyException(e, "JsonFormat(shape = ARRAY)");
+        verifyException(e, "JsonFormat(shape=ARRAY)");
         verifyException(e, "JsonFilter");
         verifyException(e, "not compatible with array serialization");
     }
@@ -92,7 +92,7 @@ public class POJOAsArrayFilterTest extends DatabindTestUtil
         InvalidDefinitionException e = assertThrows(InvalidDefinitionException.class,
                 () -> writerExcluding("secret").writeValueAsString(new PropertyWrapper()));
 
-        verifyException(e, "JsonFormat(shape = ARRAY)");
+        verifyException(e, "JsonFormat(shape=ARRAY)");
         verifyException(e, "JsonFilter");
 
         // A failed contextualization must not contaminate the cached base serializer.

--- a/src/test/java/tools/jackson/databind/ser/filter/POJOAsArrayFilterTest.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/POJOAsArrayFilterTest.java
@@ -8,15 +8,17 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.exc.InvalidDefinitionException;
 import tools.jackson.databind.ser.std.SimpleBeanPropertyFilter;
 import tools.jackson.databind.ser.std.SimpleFilterProvider;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Tests for verifying that a {@code @JsonFilter} is still applied to a POJO that
- * also asks for {@code @JsonFormat(shape=ARRAY)} output.
+ * Tests for verifying handling of a POJO configured with both {@code @JsonFilter}
+ * and {@code @JsonFormat(shape=ARRAY)}.
  */
 public class POJOAsArrayFilterTest extends DatabindTestUtil
 {
@@ -37,6 +39,19 @@ public class POJOAsArrayFilterTest extends DatabindTestUtil
         public int age = 30;
     }
 
+    @JsonPropertyOrder({ "name", "secret", "age" })
+    static class PlainBean {
+        public String name = "Bob";
+        public String secret = "s3cr3t";
+        public int age = 30;
+    }
+
+    static class PropertyWrapper {
+        @JsonFilter("beanFilter")
+        @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+        public PlainBean value = new PlainBean();
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
 
     private ObjectWriter writerExcluding(String... toExclude) {
@@ -50,19 +65,37 @@ public class POJOAsArrayFilterTest extends DatabindTestUtil
     }
 
     @Test
-    public void excludeFilterWithArrayShape() throws Exception {
-        assertEquals("{\"name\":\"Bob\",\"age\":30}",
-                writerExcluding("secret").writeValueAsString(new AsArrayBean()));
-        // ... and same as without the shape override:
-        assertEquals("{\"name\":\"Bob\",\"age\":30}",
-                writerExcluding("secret").writeValueAsString(new AsObjectBean()));
+    public void filterWithArrayShapeFails() throws Exception {
+        InvalidDefinitionException e = assertThrows(InvalidDefinitionException.class,
+                () -> writerExcluding("secret").writeValueAsString(new AsArrayBean()));
+
+        verifyException(e, "JsonFormat(shape = ARRAY)");
+        verifyException(e, "JsonFilter");
+        verifyException(e, "not compatible with array serialization");
     }
 
     @Test
-    public void includeFilterWithArrayShape() throws Exception {
-        assertEquals("{\"name\":\"Bob\"}",
-                writerIncludingOnly("name").writeValueAsString(new AsArrayBean()));
+    public void filterWithObjectShapeStillWorks() throws Exception {
+        assertEquals("{\"name\":\"Bob\",\"age\":30}",
+                writerExcluding("secret").writeValueAsString(new AsObjectBean()));
         assertEquals("{\"name\":\"Bob\"}",
                 writerIncludingOnly("name").writeValueAsString(new AsObjectBean()));
+    }
+
+    @Test
+    public void propertyFilterWithArrayShapeDoesNotPoisonSerializerCache() throws Exception {
+        String plainJson = "{\"name\":\"Bob\",\"secret\":\"s3cr3t\",\"age\":30}";
+
+        // Warm the unfiltered serializer cache before applying property-level overrides.
+        assertEquals(plainJson, MAPPER.writeValueAsString(new PlainBean()));
+
+        InvalidDefinitionException e = assertThrows(InvalidDefinitionException.class,
+                () -> writerExcluding("secret").writeValueAsString(new PropertyWrapper()));
+
+        verifyException(e, "JsonFormat(shape = ARRAY)");
+        verifyException(e, "JsonFilter");
+
+        // A failed contextualization must not contaminate the cached base serializer.
+        assertEquals(plainJson, MAPPER.writeValueAsString(new PlainBean()));
     }
 }


### PR DESCRIPTION
Fixes #6128

## Root cause

After #6126, `BeanSerializerBase.canCreateArraySerializer()` declines the array serializer when a property filter is present. `asArraySerializer()` then returns the original bean serializer, so a type configured with both `@JsonFormat(shape = ARRAY)` and `@JsonFilter` is silently written as a JSON Object.

Property filtering cannot be represented safely in positional array output because omitting a property would shift every following value.

## Change

- Detect the incompatible combination after the effective shape and contextual filter id have both been resolved.
- Report an `InvalidDefinitionException` through `SerializationContext.reportBadDefinition()` before attempting the array serializer conversion.
- Keep the existing `canCreateArraySerializer()` filter guard as a defensive constraint.
- Update the 3.3 release notes with the #6128 follow-up behavior.

## Tests

Updated `POJOAsArrayFilterTest` to verify that:

- class-level ARRAY shape plus `@JsonFilter` fails with a clear message;
- ordinary Object-shaped filtering still supports exclude and include-only filters;
- property-level ARRAY/filter overrides fail after warming the base serializer cache, without contaminating later ordinary serialization.

Local verification:

- `./mvnw -q -Dtest=POJOAsArrayFilterTest test`
- `./mvnw -q test` — 6140 tests, 0 failures, 0 errors, 1 skipped
- `./mvnw -q verify -DskipTests`
- `git diff --check`

No public API or signature changes are introduced. The behavior change is limited to the unsupported ARRAY-shape/property-filter combination described in #6128.
