### PR TITLE
Fix DefaultCacheProvider.Builder default cache sizes

### DIFF
--- a/src/main/java/tools/jackson/databind/cfg/DefaultCacheProvider.java
+++ b/src/main/java/tools/jackson/databind/cfg/DefaultCacheProvider.java
@@ -132,19 +132,19 @@ public class DefaultCacheProvider
          * Maximum Size of the {@link LookupCache} instance created by {@link #forDeserializerCache(DeserializationConfig)}.
          * Corresponds to {@link DefaultCacheProvider#_maxDeserializerCacheSize}.
          */
-        private int _maxDeserializerCacheSize;
+        private int _maxDeserializerCacheSize = DeserializerCache.DEFAULT_MAX_CACHE_SIZE;
 
         /**
          * Maximum Size of the {@link LookupCache} instance created by {@link #forSerializerCache(SerializationConfig)}
          * Corresponds to {@link DefaultCacheProvider#_maxSerializerCacheSize}.
          */
-        private int _maxSerializerCacheSize;
+        private int _maxSerializerCacheSize = SerializerCache.DEFAULT_MAX_CACHE_SIZE;
 
         /**
          * Maximum Size of the {@link LookupCache} instance created by {@link #forTypeFactory()}.
          * Corresponds to {@link DefaultCacheProvider#_maxTypeFactoryCacheSize}.
          */
-        private int _maxTypeFactoryCacheSize;
+        private int _maxTypeFactoryCacheSize = TypeFactory.DEFAULT_MAX_CACHE_SIZE;
 
         Builder() { }
 

--- a/src/test/java/tools/jackson/databind/cfg/CacheProviderTest.java
+++ b/src/test/java/tools/jackson/databind/cfg/CacheProviderTest.java
@@ -6,7 +6,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.databind.*;
+import tools.jackson.databind.deser.DeserializerCache;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.ser.SerializerCache;
+import tools.jackson.databind.type.TypeFactory;
 import tools.jackson.databind.util.LookupCache;
 import tools.jackson.databind.util.SimpleLookupCache;
 import tools.jackson.databind.util.TypeKey;
@@ -265,6 +268,34 @@ public class CacheProviderTest
         // Assert
         // 4. Should have created two cache instance
         assertEquals(2, cacheProvider.createCacheCount());
+    }
+
+    @Test
+    public void testBuilderUsesDefaultsForUnspecifiedCacheSizes() throws Exception
+    {
+        DefaultCacheProvider provider = DefaultCacheProvider.builder()
+                .build();
+        assertEquals(DeserializerCache.DEFAULT_MAX_CACHE_SIZE, provider._maxDeserializerCacheSize);
+        assertEquals(SerializerCache.DEFAULT_MAX_CACHE_SIZE, provider._maxSerializerCacheSize);
+        assertEquals(TypeFactory.DEFAULT_MAX_CACHE_SIZE, provider._maxTypeFactoryCacheSize);
+
+        provider = DefaultCacheProvider.builder()
+                .maxSerializerCacheSize(1234)
+                .build();
+        assertEquals(DeserializerCache.DEFAULT_MAX_CACHE_SIZE, provider._maxDeserializerCacheSize);
+        assertEquals(1234, provider._maxSerializerCacheSize);
+        assertEquals(TypeFactory.DEFAULT_MAX_CACHE_SIZE, provider._maxTypeFactoryCacheSize);
+    }
+
+    @Test
+    public void testBuilderAllowsDisablingIndividualCaches() throws Exception
+    {
+        DefaultCacheProvider provider = DefaultCacheProvider.builder()
+                .maxDeserializerCacheSize(0)
+                .build();
+        assertEquals(0, provider._maxDeserializerCacheSize);
+        assertEquals(SerializerCache.DEFAULT_MAX_CACHE_SIZE, provider._maxSerializerCacheSize);
+        assertEquals(TypeFactory.DEFAULT_MAX_CACHE_SIZE, provider._maxTypeFactoryCacheSize);
     }
 
     @Test


### PR DESCRIPTION
Fixes #6137

### Summary

`DefaultCacheProvider.Builder` now initializes unspecified cache size fields with the same default values used by `DefaultCacheProvider.defaultInstance()`.

Previously, the builder fields relied on Java's default `int` value (`0`), so configuring only one cache size left the remaining cache sizes at `0` instead of their documented defaults.

### Changes

- Initialize unspecified builder cache size fields with default values
- Preserve explicitly configured `0` values to allow intentionally disabling individual caches
- Add regression tests covering:
  - default builder behavior
  - partial cache size overrides
  - explicitly setting a cache size to `0`

### Tests

```bash
./mvnw.cmd test-compile
./mvnw.cmd "-Dtest=tools.jackson.databind.cfg.CacheProviderTest" "-Dsurefire.useModulePath=false" test
```