### PR TITLE
Add opt-in String canonicalizing converter

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -670,8 +670,15 @@ DongNyoung Lee (@Dongnyoung)
  * Reported, fixed #6142: Invalidate read-only lookup snapshot in `SerializerCache`
    when a typed serializer entry is replaced
   [3.3.0]
+ * Contributed #3182: Add `StringCanonicalizingConverter` for opt-in canonicalization
+   ("de-duplication") of low-cardinality `String` values
+  [3.3.0]
 
 @prvazsahnazarov
  * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic
    base types
   [3.2.2]
+
+Fabian Lange (@CodingFabian)
+ * Requested #3182: Support value deduplication for enumeration like values
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -14,6 +14,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @cowtowncoder, w/ Claude code)
 #1803: `TreeTraversingParser` should allow passing of parent context
  (fix by @cowtowncoder, w/ Claude code)
+#3182: Add `StringCanonicalizingConverter` for opt-in canonicalization
+  ("de-duplication") of low-cardinality `String` values
+ (requested by Fabian L)
+ (contributed by DongNyoung L)
 #3947: Multiple suitable annotated Creator factory methods to be used as the
   Key deserializer when using record als key in Map
  (reported by @toonborgers)

--- a/src/main/java/tools/jackson/databind/util/StringCanonicalizingConverter.java
+++ b/src/main/java/tools/jackson/databind/util/StringCanonicalizingConverter.java
@@ -1,6 +1,5 @@
 package tools.jackson.databind.util;
 
-import tools.jackson.core.util.InternCache;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.SerializationContext;
 
@@ -11,6 +10,16 @@ import tools.jackson.databind.SerializationContext;
  * Can be used with {@link tools.jackson.databind.annotation.JsonDeserialize#converter()}
  * or {@link tools.jackson.databind.annotation.JsonDeserialize#contentConverter()}
  * to canonicalize low-cardinality String values during deserialization.
+ * Canonicalization only makes sense on deserialization, so if used on the
+ * serialization side (via {@link tools.jackson.databind.annotation.JsonSerialize#converter()})
+ * values are passed through as-is.
+ *<p>
+ * WARNING: the default canonicalization is implemented using {@link String#intern()},
+ * the effects of which are JVM-wide and not limited to the on-going read.
+ * Because of this, this Converter should only be applied to properties known to
+ * have low cardinality (enumeration-like values, identifiers from a fixed set):
+ * applying it to unbounded, caller-provided content (free-form text) allows a
+ * malicious payload to degrade performance of the whole JVM.
  *
  * @since 3.3
  */
@@ -22,13 +31,30 @@ public class StringCanonicalizingConverter
         return ctxt.canonicalizeString(value);
     }
 
+    /**
+     * Serialization-side canonicalization is a no-op: the value returned is written
+     * out and immediately discarded, so canonicalizing it would only add the cost
+     * of {@link String#intern()} without any of the memory savings this Converter
+     * exists for. Value is hence returned as-is.
+     */
     @Override
     public String convert(SerializationContext ctxt, String value) {
-        return ctxt.canonicalizeString(value);
+        return value;
     }
 
+    /**
+     * Context-less conversion is not supported: canonicalization is always done
+     * via {@link tools.jackson.databind.DatabindContext#canonicalizeString(String)}
+     * so that the context-specific canonicalization method is used.
+     * Both context-taking variants are overridden, so databind itself never calls
+     * this method.
+     *
+     * @throws IllegalStateException Always
+     */
     @Override
     public String convert(String value) {
-        return (value == null) ? null : InternCache.instance.intern(value);
+        throw new IllegalStateException(String.format(
+                "Should never be called (%s.convert(String)): must use context-taking variant",
+                getClass().getName()));
     }
 }

--- a/src/main/java/tools/jackson/databind/util/StringCanonicalizingConverter.java
+++ b/src/main/java/tools/jackson/databind/util/StringCanonicalizingConverter.java
@@ -1,0 +1,34 @@
+package tools.jackson.databind.util;
+
+import tools.jackson.core.util.InternCache;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+
+/**
+ * Converter that canonicalizes {@link String} values using databind's default
+ * String canonicalization method.
+ *<p>
+ * Can be used with {@link tools.jackson.databind.annotation.JsonDeserialize#converter()}
+ * or {@link tools.jackson.databind.annotation.JsonDeserialize#contentConverter()}
+ * to canonicalize low-cardinality String values during deserialization.
+ *
+ * @since 3.3
+ */
+public class StringCanonicalizingConverter
+    extends StdConverter<String, String>
+{
+    @Override
+    public String convert(DeserializationContext ctxt, String value) {
+        return ctxt.canonicalizeString(value);
+    }
+
+    @Override
+    public String convert(SerializationContext ctxt, String value) {
+        return ctxt.canonicalizeString(value);
+    }
+
+    @Override
+    public String convert(String value) {
+        return (value == null) ? null : InternCache.instance.intern(value);
+    }
+}

--- a/src/test/java/tools/jackson/databind/convert/StringConversionsTest.java
+++ b/src/test/java/tools/jackson/databind/convert/StringConversionsTest.java
@@ -9,13 +9,14 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.annotation.JsonSerialize;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
 import tools.jackson.databind.util.StringCanonicalizingConverter;
 import tools.jackson.databind.util.StdConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static tools.jackson.databind.testutil.DatabindTestUtil.*;
 
 public class StringConversionsTest
+    extends DatabindTestUtil
 {
     static class LCConverter extends StdConverter<String,String>
     {

--- a/src/test/java/tools/jackson/databind/convert/StringConversionsTest.java
+++ b/src/test/java/tools/jackson/databind/convert/StringConversionsTest.java
@@ -9,9 +9,11 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.annotation.JsonSerialize;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.util.StringCanonicalizingConverter;
 import tools.jackson.databind.util.StdConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static tools.jackson.databind.testutil.DatabindTestUtil.*;
 
 public class StringConversionsTest
 {
@@ -30,6 +32,18 @@ public class StringConversionsTest
 
         protected StringWrapperWithConvert() { }
         public StringWrapperWithConvert(String v) { value = v; }
+    }
+
+    static class CanonicalizedStringWrapper
+    {
+        @JsonDeserialize(converter=StringCanonicalizingConverter.class)
+        public String value;
+    }
+
+    static class CanonicalizedStringListWrapper
+    {
+        @JsonDeserialize(contentConverter=StringCanonicalizingConverter.class)
+        public List<String> values;
     }
 
     private final ObjectMapper MAPPER = new JsonMapper();
@@ -98,5 +112,28 @@ public class StringConversionsTest
         StringWrapperWithConvert value = MAPPER.readValue("{\"value\":\"XyZ\"}",
                 StringWrapperWithConvert.class);
         assertEquals("xyz", value.value);
+    }
+
+    @Test
+    public void stringCanonicalizingConverterForProperty() throws Exception
+    {
+        String raw = new String("canonical-property".toCharArray());
+        CanonicalizedStringWrapper value = MAPPER.readValue(a2q("{'value':'canonical-property'}"),
+                CanonicalizedStringWrapper.class);
+
+        assertSame(raw.intern(), value.value);
+    }
+
+    @Test
+    public void stringCanonicalizingConverterForContents() throws Exception
+    {
+        String raw = new String("canonical-content".toCharArray());
+        CanonicalizedStringListWrapper value = MAPPER.readValue(
+                a2q("{'values':['canonical-content','canonical-content']}"),
+                CanonicalizedStringListWrapper.class);
+
+        assertEquals(2, value.values.size());
+        assertSame(raw.intern(), value.values.get(0));
+        assertSame(value.values.get(0), value.values.get(1));
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `StringCanonicalizingConverter` for low-cardinality `String` values.

The converter exposes databind's existing string canonicalization through Jackson's existing converter extension points, allowing applications to reuse canonical `String` instances without introducing a global canonicalization policy.

It can be applied to individual properties:

```java
@JsonDeserialize(converter = StringCanonicalizingConverter.class)
String type;
```

or to container contents:

```java
@JsonDeserialize(contentConverter = StringCanonicalizingConverter.class)
List<String> categories;
```

This provides a simple opt-in solution for repeated enumeration-like string values while reusing the existing `DatabindContext.canonicalizeString()` implementation.

## Changes

* Add opt-in `StringCanonicalizingConverter`
* Add tests for property-level canonicalization
* Add tests for container content canonicalization

## Tests

Verified with:

```shell
./mvnw "-Dtest=tools.jackson.databind.convert.StringConversionsTest" "-Dsurefire.useModulePath=false" test
```

Part of #3182.