### PR TITLE
Fix read-only serializer cache invalidation for typed replacements

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -610,5 +610,8 @@ Bowang (@dong0713)
   [3.3.0]
 
   Aysha Afrah Ziya (@aysha-afrah26)
-  
-  
+
+DongNyoung Lee (@Dongnyoung)
+ * Reported, fixed #6142: Invalidate read-only lookup snapshot in `SerializerCache`
+   when a typed serializer entry is replaced
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -31,6 +31,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @cowtowncoder, w/ Claude code)
 #6128: Fail explicitly on POJO that has both `@JsonFormat(shape=ARRAY)` and `@JsonFilter`
  (fix by @DragonFSKY)
+#6142: Invalidate read-only lookup snapshot in `SerializerCache` when a typed
+  serializer entry is replaced (and not just when added)
+ (fix by @Dongnyoung)
 
 3.2.2 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/ser/SerializerCache.java
+++ b/src/main/java/tools/jackson/databind/ser/SerializerCache.java
@@ -243,18 +243,16 @@ public final class SerializerCache
      */
     public void addTypedSerializer(JavaType type, ValueSerializer<Object> ser)
     {
-        if (_sharedMap.put(new TypeKey(type, true), ser) == null) {
-            // let's invalidate the read-only copy, too, to get it updated
-            _readOnlyMap.set(null);
-        }
+        _sharedMap.put(new TypeKey(type, true), ser);
+        // let's invalidate the read-only copy, too, to get it updated
+        _readOnlyMap.set(null);
     }
 
     public void addTypedSerializer(Class<?> cls, ValueSerializer<Object> ser)
     {
-        if (_sharedMap.put(new TypeKey(cls, true), ser) == null) {
-            // let's invalidate the read-only copy, too, to get it updated
-            _readOnlyMap.set(null);
-        }
+        _sharedMap.put(new TypeKey(cls, true), ser);
+        // let's invalidate the read-only copy, too, to get it updated
+        _readOnlyMap.set(null);
     }
 
     public void addAndResolveNonTypedSerializer(Class<?> type, ValueSerializer<Object> ser,

--- a/src/test/java/tools/jackson/databind/ser/SerializerCacheTest.java
+++ b/src/test/java/tools/jackson/databind/ser/SerializerCacheTest.java
@@ -7,11 +7,11 @@ import tools.jackson.databind.JavaType;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.databind.ser.impl.ReadOnlyClassToSerializerMap;
-import tools.jackson.databind.type.TypeFactory;
+import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class SerializerCacheTest
+public class SerializerCacheTest extends DatabindTestUtil
 {
     static class TestSerializer extends ValueSerializer<Object>
     {
@@ -39,7 +39,7 @@ public class SerializerCacheTest
     public void replaceTypedJavaTypeSerializerInvalidatesReadOnlyLookup()
     {
         SerializerCache cache = new SerializerCache();
-        JavaType type = TypeFactory.createDefaultInstance().constructType(String.class);
+        JavaType type = defaultTypeFactory().constructType(String.class);
         TestSerializer serializer1 = new TestSerializer();
         TestSerializer serializer2 = new TestSerializer();
 

--- a/src/test/java/tools/jackson/databind/ser/SerializerCacheTest.java
+++ b/src/test/java/tools/jackson/databind/ser/SerializerCacheTest.java
@@ -1,0 +1,54 @@
+package tools.jackson.databind.ser;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.ser.impl.ReadOnlyClassToSerializerMap;
+import tools.jackson.databind.type.TypeFactory;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class SerializerCacheTest
+{
+    static class TestSerializer extends ValueSerializer<Object>
+    {
+        @Override
+        public void serialize(Object value, JsonGenerator gen, SerializationContext ctxt) { }
+    }
+
+    @Test
+    public void replaceTypedClassSerializerInvalidatesReadOnlyLookup()
+    {
+        SerializerCache cache = new SerializerCache();
+        TestSerializer serializer1 = new TestSerializer();
+        TestSerializer serializer2 = new TestSerializer();
+
+        cache.addTypedSerializer(String.class, serializer1);
+        ReadOnlyClassToSerializerMap lookup = cache.getReadOnlyLookupMap();
+        assertSame(serializer1, lookup.typedValueSerializer(String.class));
+
+        cache.addTypedSerializer(String.class, serializer2);
+
+        assertSame(serializer2, cache.getReadOnlyLookupMap().typedValueSerializer(String.class));
+    }
+
+    @Test
+    public void replaceTypedJavaTypeSerializerInvalidatesReadOnlyLookup()
+    {
+        SerializerCache cache = new SerializerCache();
+        JavaType type = TypeFactory.createDefaultInstance().constructType(String.class);
+        TestSerializer serializer1 = new TestSerializer();
+        TestSerializer serializer2 = new TestSerializer();
+
+        cache.addTypedSerializer(type, serializer1);
+        ReadOnlyClassToSerializerMap lookup = cache.getReadOnlyLookupMap();
+        assertSame(serializer1, lookup.typedValueSerializer(type));
+
+        cache.addTypedSerializer(type, serializer2);
+
+        assertSame(serializer2, cache.getReadOnlyLookupMap().typedValueSerializer(type));
+    }
+}


### PR DESCRIPTION
Fixes #6142.

### Problem

`SerializerCache` invalidated `_readOnlyMap` only when adding a new typed serializer entry. If `_sharedMap.put(...)` replaced an existing typed serializer, the cached read-only lookup snapshot was not invalidated and could continue returning the previous serializer.

### Changes

Invalidate `_readOnlyMap` after typed serializer registrations for both `Class<?>` and `JavaType` keys, including replacement cases.

### Tests

Added regression coverage for typed serializer replacement with both `Class<?>` and `JavaType` keys.

Tested with:

`./mvnw -q -Dtest=tools.jackson.databind.ser.SerializerCacheTest,tools.jackson.databind.cfg.CacheProviderTest,tools.jackson.databind.util.SimpleLookupCacheTest -Dsurefire.useModulePath=false test`