### PR TITLE
Honor `@JsonIgnoreProperties` for Creator props on builder and external-type-id paths

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -1484,6 +1484,13 @@ public class BeanDeserializer
                     p.skipChildren();
                     continue;
                 }
+                // [databind#4629] Need to check for ignored properties for Creator properties since
+                // Records (and POJOs with @JsonCreator) will have a valid 'creatorProp',
+                // so if we don't check for ignore first, the ignore configuration will be bypassed.
+                if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
+                    handleIgnoredProperty(p, ctxt, handledType(), propName);
+                    continue;
+                }
 
                 // first: let's check to see if this might be part of value with external type id:
                 // 11-Sep-2015, tatu: Important; do NOT pass buffer as last arg, but null,

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -488,6 +488,13 @@ public class BuilderBasedDeserializer
                     p.skipChildren();
                     continue;
                 }
+                // [databind#4629] Need to check for ignored properties for Creator properties since
+                // Records (and POJOs with @JsonCreator) will have a valid 'creatorProp',
+                // so if we don't check for ignore first, the ignore configuration will be bypassed.
+                if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
+                    handleIgnoredProperty(p, ctxt, handledType(), propName);
+                    continue;
+                }
                 // Last creator property to set?
                 if (buffer.assignParameter(creatorProp, creatorProp.deserialize(p, ctxt))) {
                     p.nextToken(); // to move to following PROPERTY_NAME/END_OBJECT
@@ -858,6 +865,13 @@ public class BuilderBasedDeserializer
                 if (creatorProp.isInjectionOnly()) {
                     // Skip the input value, will be injected later in PropertyValueBuffer
                     p.skipChildren();
+                    continue;
+                }
+                // [databind#4629] Need to check for ignored properties for Creator properties since
+                // Records (and POJOs with @JsonCreator) will have a valid 'creatorProp',
+                // so if we don't check for ignore first, the ignore configuration will be bypassed.
+                if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
+                    handleIgnoredProperty(p, ctxt, handledType(), propName);
                     continue;
                 }
 

--- a/src/test/java/tools/jackson/databind/deser/filter/IgnorePropertiesCreator6145Test.java
+++ b/src/test/java/tools/jackson/databind/deser/filter/IgnorePropertiesCreator6145Test.java
@@ -1,0 +1,171 @@
+package tools.jackson.databind.deser.filter;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.*;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for [databind#6145]: {@code @JsonIgnoreProperties} must be honored for
+ * Creator properties on the remaining property-based-Creator deserialization
+ * paths too, that is external type id and the Builder-based deserializer.
+ */
+public class IgnorePropertiesCreator6145Test extends DatabindTestUtil
+{
+    /*
+    /**********************************************************************
+    /* Set up: external type id + property-based Creator
+    /**********************************************************************
+     */
+
+    static abstract class Animal {
+        public String name;
+    }
+
+    static class Dog extends Animal { }
+
+    static class ExtTypeValue {
+        public final String secret;
+        public final Animal value;
+
+        @JsonCreator
+        public ExtTypeValue(@JsonProperty("secret") String secret,
+                @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                        include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type")
+                @JsonSubTypes({ @JsonSubTypes.Type(value = Dog.class, name = "dog") })
+                @JsonProperty("value") Animal value) {
+            this.secret = secret;
+            this.value = value;
+        }
+    }
+
+    static class ExtTypeWrapper {
+        @JsonIgnoreProperties("secret")
+        public ExtTypeValue child;
+    }
+
+    /*
+    /**********************************************************************
+    /* Set up: Builder-based deserializer + property-based Creator
+    /**********************************************************************
+     */
+
+    @JsonDeserialize(builder = BuiltValue.Builder.class)
+    static class BuiltValue {
+        public final int id;
+        public final String secret;
+
+        BuiltValue(int id, String secret) {
+            this.id = id;
+            this.secret = secret;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        static class Builder {
+            private final int id;
+            private final String secret;
+
+            @JsonCreator
+            public Builder(@JsonProperty("id") int id,
+                    @JsonProperty("secret") String secret) {
+                this.id = id;
+                this.secret = secret;
+            }
+
+            public BuiltValue build() { return new BuiltValue(id, secret); }
+        }
+    }
+
+    static class BuilderWrapper {
+        @JsonIgnoreProperties("secret")
+        public BuiltValue child;
+    }
+
+    @JsonDeserialize(builder = UnwrappedBuiltValue.Builder.class)
+    static class UnwrappedBuiltValue {
+        public final String secret;
+        public final Name name;
+
+        UnwrappedBuiltValue(String secret, Name name) {
+            this.secret = secret;
+            this.name = name;
+        }
+
+        static class Name {
+            public String first;
+            public String last;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        static class Builder {
+            private final String secret;
+            @JsonUnwrapped
+            public Name name;
+
+            @JsonCreator
+            public Builder(@JsonProperty("secret") String secret) {
+                this.secret = secret;
+            }
+
+            public UnwrappedBuiltValue build() {
+                return new UnwrappedBuiltValue(secret, name);
+            }
+        }
+    }
+
+    static class UnwrappedBuilderWrapper {
+        @JsonIgnoreProperties("secret")
+        public UnwrappedBuiltValue child;
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    void ignoralWithExternalTypeIdCreator() throws Exception
+    {
+        ExtTypeWrapper result = MAPPER.readValue(
+                """
+                {"child":{"secret":"leaked","type":"dog","value":{"name":"Rex"}}}
+                """,
+                ExtTypeWrapper.class);
+        assertEquals("Rex", result.child.value.name);
+        assertNull(result.child.secret);
+    }
+
+    @Test
+    void ignoralWithBuilderCreator() throws Exception
+    {
+        BuilderWrapper result = MAPPER.readValue(
+                """
+                {"child":{"id":13,"secret":"leaked"}}
+                """,
+                BuilderWrapper.class);
+        assertEquals(13, result.child.id);
+        assertNull(result.child.secret);
+    }
+
+    @Test
+    void ignoralWithBuilderCreatorAndUnwrapped() throws Exception
+    {
+        UnwrappedBuilderWrapper result = MAPPER.readValue(
+                """
+                {"child":{"secret":"leaked","first":"Bob","last":"Smith"}}
+                """,
+                UnwrappedBuilderWrapper.class);
+        assertEquals("Bob", result.child.name.first);
+        assertNull(result.child.secret);
+    }
+}

--- a/src/test/java/tools/jackson/databind/deser/filter/IgnorePropertiesCreator6145Test.java
+++ b/src/test/java/tools/jackson/databind/deser/filter/IgnorePropertiesCreator6145Test.java
@@ -166,6 +166,7 @@ public class IgnorePropertiesCreator6145Test extends DatabindTestUtil
                 """,
                 UnwrappedBuilderWrapper.class);
         assertEquals("Bob", result.child.name.first);
+        assertEquals("Smith", result.child.name.last);
         assertNull(result.child.secret);
     }
 }


### PR DESCRIPTION
Jackson checks the `@JsonIgnoreProperties` set before assigning a Creator property, since a type with a property-based `@JsonCreator` resolves a valid `creatorProp` and so never falls through to the by-name ignore check later in the same loop. That guard reached `deserializeUsingPropertyBased` and `deserializeUsingPropertyBasedWithUnwrapped`, but it never reached `deserializeUsingPropertyBasedWithExternalTypeId`, and `BuilderBasedDeserializer` carries no copy of it at all. The effect is that ignoring a property works for a plain POJO or record and quietly stops working for the same type once it is built through a `@JsonPOJOBuilder`, or once it gains an `@JsonTypeInfo(include = EXTERNAL_PROPERTY)` property, so a value the application excluded from binding is read off the document and handed to the constructor. I noticed it while comparing a builder-backed type with the equivalent plain Creator type and getting different results for identical input. The fix adds the check the sibling loops already use, right after the existing `isInjectionOnly` test, at the three loops that lack it. Reported separately as #6145, which has a runnable reproduction for each of the three; the new test fails on all three before this change and passes after, and the rest of the suite is unchanged. I left `3.1` alone on purpose, because its copy of the guard is deliberately limited to records, so applying this there would widen behavior instead of closing a gap.
