### PR TITLE
Add failing regression test for #6032

### DIFF
--- a/src/test/java/tools/jackson/databind/tofix/ConstructorPropertiesSerializationOrder6032Test.java
+++ b/src/test/java/tools/jackson/databind/tofix/ConstructorPropertiesSerializationOrder6032Test.java
@@ -1,0 +1,72 @@
+package tools.jackson.databind.tofix;
+
+import java.beans.ConstructorProperties;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+import tools.jackson.databind.testutil.failure.JacksonTestFailureExpected;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// [databind#6032]: unannotated constructor parameter is treated as
+// creator property for serialization ordering.
+class ConstructorPropertiesSerializationOrder6032Test extends DatabindTestUtil
+{
+    static final class WithoutAnnotation {
+        private final String aa = "a";
+        private final String bb;
+
+        public WithoutAnnotation(String bb) {
+            this.bb = bb;
+        }
+
+        public String getAa() {
+            return aa;
+        }
+
+        public String getBb() {
+            return bb;
+        }
+    }
+
+    static final class WithAnnotation {
+        private final String aa = "a";
+        private final String bb;
+
+        @ConstructorProperties({ "bb" })
+        public WithAnnotation(String bb) {
+            this.bb = bb;
+        }
+
+        public String getAa() {
+            return aa;
+        }
+
+        public String getBb() {
+            return bb;
+        }
+    }
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+            .enable(MapperFeature.SORT_CREATOR_PROPERTIES_FIRST)
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .build();
+
+    @Test
+    void annotatedConstructorPropertyShouldBeSortedFirst() throws Exception
+    {
+        assertEquals(a2q("{'bb':'b','aa':'a'}"),
+                MAPPER.writeValueAsString(new WithAnnotation("b")));
+    }
+
+    @JacksonTestFailureExpected
+    @Test
+    void unannotatedConstructorShouldNotChangePropertyOrder() throws Exception
+    {
+        assertEquals(a2q("{'aa':'a','bb':'b'}"),
+                MAPPER.writeValueAsString(new WithoutAnnotation("b")));
+    }
+}


### PR DESCRIPTION
Adds a failing test for #6032.

The new test covers serialization ordering when both:

- `MapperFeature.SORT_CREATOR_PROPERTIES_FIRST`
- `MapperFeature.SORT_PROPERTIES_ALPHABETICALLY`

are enabled.

It verifies the existing behavior for a constructor annotated with
`@ConstructorProperties`, where the constructor property is sorted first.

It also adds a `@JacksonTestFailureExpected` case showing that an unannotated
single-argument constructor is currently treated as a creator property for
serialization ordering, causing `bb` to be written before `aa`.

No production code changes are included.

Tested with:

```powershell
.\mvnw.cmd "-Dtest=tools.jackson.databind.tofix.ConstructorPropertiesSerializationOrder6032Test" "-Dsurefire.useModulePath=false" test