### PR TITLE
Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -605,14 +605,11 @@ seonwoo_jung (@seonwooj0810)
  * Fixed #6065: `SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS` does not fully
    remove empty collection during serialization
   [3.2.1]
- * Contributed [modules-java8#76]: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
-   to always write millisecond+ sub-second digits when serializing `Instant`,
-   `OffsetDateTime`, `ZonedDateTime` and `LocalDateTime` (ported from the 2.x
-   `JavaTimeFeature` of the same name, modules-java8#386)
-  [3.3.0]
  * Fixed #6101: `@JsonInclude(NON_EMPTY, content=CUSTOM)` does not omit a Map property
    after all entries are filtered
   [3.2.2]
+ * Contributed #6151: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
+  [3.3.0]
 
 @doeiqts
  * Reported #6065: `SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS` does not fully

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -605,6 +605,11 @@ seonwoo_jung (@seonwooj0810)
  * Fixed #6065: `SerializationFeature.APPLY_JSON_INCLUDE_FOR_CONTAINERS` does not fully
    remove empty collection during serialization
   [3.2.1]
+ * Contributed [modules-java8#76]: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
+   to always write millisecond+ sub-second digits when serializing `Instant`,
+   `OffsetDateTime`, `ZonedDateTime` and `LocalDateTime` (ported from the 2.x
+   `JavaTimeFeature` of the same name, modules-java8#386)
+  [3.3.0]
  * Fixed #6101: `@JsonInclude(NON_EMPTY, content=CUSTOM)` does not omit a Map property
    after all entries are filtered
   [3.2.2]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,11 +7,6 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.3.0 (not yet released)
 
-[modules-java8#76]: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS` to always write
-  millisecond+ sub-second digits when serializing `Instant`, `OffsetDateTime`,
-  `ZonedDateTime` and `LocalDateTime` (ported from the 2.x `JavaTimeFeature` of the
-  same name, modules-java8#386)
- (contributed by @seonwooj0810)
 #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle arrays of
   polymorphic types: now fails eagerly with clear `InvalidDefinitionException`
   (on both serialization and deserialization) instead of confusing low-level error
@@ -43,6 +38,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6142: Invalidate read-only lookup snapshot in `SerializerCache` when a typed
   serializer entry is replaced (and not just when added)
  (fix by @Dongnyoung)
+#6151: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
+ (contributed by @seonwooj0810)
 
 3.2.2 (not yet released)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,11 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.3.0 (not yet released)
 
+[modules-java8#76]: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS` to always write
+  millisecond+ sub-second digits when serializing `Instant`, `OffsetDateTime`,
+  `ZonedDateTime` and `LocalDateTime` (ported from the 2.x `JavaTimeFeature` of the
+  same name, modules-java8#386)
+ (contributed by @seonwooj0810)
 #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle arrays of
   polymorphic types: now fails eagerly with clear `InvalidDefinitionException`
   (on both serialization and deserialization) instead of confusing low-level error

--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -69,6 +69,11 @@ public enum DateTimeFeature implements DatatypeFeature
      * a {@link com.fasterxml.jackson.annotation.JsonFormat} pattern takes precedence,
      * as does writing values as numeric timestamps.
      *<p>
+     * Note, too, that the very extremes of the {@link java.time.Instant} range
+     * (notably {@link java.time.Instant#MIN} and {@link java.time.Instant#MAX}, which
+     * fall outside the range of {@link java.time.LocalDate}) cannot be written with
+     * Date/Time fields at all, and retain default handling regardless of this setting.
+     *<p>
      * Default setting is disabled, for backwards compatibility.
      *
      * @since 3.3

--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -50,6 +50,32 @@ public enum DateTimeFeature implements DatatypeFeature
     ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS(false),
 
     /**
+     * Feature that determines whether sub-second digits are always written when
+     * serializing {@link java.time.Instant}, {@link java.time.OffsetDateTime},
+     * {@link java.time.ZonedDateTime} and {@link java.time.LocalDateTime} as
+     * ISO-8601 Strings using the default format.
+     *<p>
+     * When disabled (the default), the JDK-provided ISO formatters are used and
+     * a zero sub-second value is omitted altogether -- {@code 2017-09-14T04:28:48Z}
+     * -- which means that output width varies with the value, breaking systems
+     * that expect fixed-precision timestamps (or that sort timestamps as text).
+     *<p>
+     * When enabled, at least 3 (millisecond) sub-second digits are always written,
+     * zero-padded if necessary -- {@code 2017-09-14T04:28:48.000Z}. Higher precision
+     * is preserved: a value with microsecond or nanosecond precision is written with
+     * 6 or 9 digits respectively, so no information is lost.
+     *<p>
+     * Only affects the default format: an explicit {@code DateTimeFormatter} or
+     * a {@link com.fasterxml.jackson.annotation.JsonFormat} pattern takes precedence,
+     * as does writing values as numeric timestamps.
+     *<p>
+     * Default setting is disabled, for backwards compatibility.
+     *
+     * @since 3.3
+     */
+    ALWAYS_WRITE_SUBSECOND_DIGITS(false),
+
+    /**
      * Feature that determines whether {@link java.time.ZoneId} is normalized
      * (via call to {@code java.time.ZoneId#normalized()}) when deserializing
      * types like {@link java.time.ZonedDateTime}.

--- a/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
+++ b/src/main/java/tools/jackson/databind/cfg/DateTimeFeature.java
@@ -62,12 +62,17 @@ public enum DateTimeFeature implements DatatypeFeature
      *<p>
      * When enabled, at least 3 (millisecond) sub-second digits are always written,
      * zero-padded if necessary -- {@code 2017-09-14T04:28:48.000Z}. Higher precision
-     * is preserved: a value with microsecond or nanosecond precision is written with
-     * 6 or 9 digits respectively, so no information is lost.
+     * is preserved: up to 9 digits are written, as many as needed to avoid losing
+     * information (but with no trailing zeroes beyond the 3 digit minimum, so
+     * {@code 123400000} nanoseconds is written as {@code .1234}).
      *<p>
      * Only affects the default format: an explicit {@code DateTimeFormatter} or
      * a {@link com.fasterxml.jackson.annotation.JsonFormat} pattern takes precedence,
      * as does writing values as numeric timestamps.
+     *<p>
+     * NOTE: only applies to Date/Time values, and NOT to Date/Time values used as
+     * {@link java.util.Map} keys: keys are written by separate key serializers that
+     * are not affected by this setting.
      *<p>
      * Note, too, that the very extremes of the {@link java.time.Instant} range
      * (notably {@link java.time.Instant#MIN} and {@link java.time.Instant#MAX}, which

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializer.java
@@ -18,6 +18,7 @@ package tools.jackson.databind.ext.javatime.ser;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -30,6 +31,12 @@ import java.time.format.DateTimeFormatter;
 public class InstantSerializer extends InstantSerializerBase<Instant>
 {
     public static final InstantSerializer INSTANCE = new InstantSerializer();
+
+    private final static long SECONDS_PER_DAY = 86400L;
+
+    private final static long MIN_EPOCH_DAY = LocalDate.MIN.toEpochDay();
+
+    private final static long MAX_EPOCH_DAY = LocalDate.MAX.toEpochDay();
 
     protected InstantSerializer() {
         super(Instant.class, Instant::toEpochMilli, Instant::getEpochSecond, Instant::getNano,
@@ -64,9 +71,21 @@ public class InstantSerializer extends InstantSerializerBase<Instant>
     }
 
     @Override
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(Instant value,
+            DateTimeFormatter defaultFormat) {
         // Standard default for `Instant` is `null` (meaning `Instant.toString()`);
         // anything else is caller-provided and must be left alone
-        return (defaultFormat == null) ? SubSecondFormatters.INSTANT : null;
+        if (defaultFormat != null) {
+            return null;
+        }
+        // Replacement formatter is Date/Time-field-based, so value must be convertible
+        // into `LocalDate`; `Instant` range is wider than that (by less than a year on
+        // both ends, but that includes `Instant.MIN` and `Instant.MAX`). For such
+        // extreme values retain default `Instant.toString()` handling instead of failing
+        final long epochDay = Math.floorDiv(value.getEpochSecond(), SECONDS_PER_DAY);
+        if ((epochDay < MIN_EPOCH_DAY) || (epochDay > MAX_EPOCH_DAY)) {
+            return null;
+        }
+        return SubSecondFormatters.INSTANT;
     }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializer.java
@@ -64,7 +64,9 @@ public class InstantSerializer extends InstantSerializerBase<Instant>
     }
 
     @Override
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
-        return SubSecondFormatters.INSTANT;
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+        // Standard default for `Instant` is `null` (meaning `Instant.toString()`);
+        // anything else is caller-provided and must be left alone
+        return (defaultFormat == null) ? SubSecondFormatters.INSTANT : null;
     }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializer.java
@@ -62,4 +62,9 @@ public class InstantSerializer extends InstantSerializerBase<Instant>
         return new InstantSerializer(this, _formatter, _useTimestamp, writeNanoseconds,
                 this._shape);
     }
+
+    @Override
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
+        return SubSecondFormatters.INSTANT;
+    }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
@@ -142,15 +142,19 @@ public abstract class InstantSerializerBase<T extends Temporal>
      * Implementations MUST return {@code null} unless given {@code defaultFormat} is
      * the standard built-in default of the subclass: some subclasses (notably
      * {@link ZonedDateTimeSerializer}) allow caller-provided default formatters, and
-     * those must not be overridden by the feature. Returning {@code null} (which the
-     * base implementation always does) means the feature has no effect.
+     * those must not be overridden by the feature. Implementations should also return
+     * {@code null} for values the replacement cannot express, so that default handling
+     * is retained instead of failing. Returning {@code null} (which the base
+     * implementation always does) means the feature has no effect.
      *
+     * @param value Value being serialized
      * @param defaultFormat Default formatter that would be used if the feature was
      *   not enabled (possibly {@code null})
      *
      * @since 3.3
      */
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(T value,
+            DateTimeFormatter defaultFormat) {
         return null;
     }
 
@@ -158,7 +162,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     {
         DateTimeFormatter formatter = (_formatter == null) ? defaultFormat :_formatter;
         if ((_formatter == null) && ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)) {
-            DateTimeFormatter subSecondFormatter = _alwaysWriteSubSecondDigitsFormatter(defaultFormat);
+            DateTimeFormatter subSecondFormatter = _alwaysWriteSubSecondDigitsFormatter(value, defaultFormat);
             if (subSecondFormatter != null) {
                 formatter = subSecondFormatter;
             }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
@@ -135,6 +135,20 @@ public abstract class InstantSerializerBase<T extends Temporal>
     }
 
     /**
+     * Accessor for the default formatter this serializer was constructed with: used
+     * when no explicit {@link #_formatter} is defined. May be {@code null} (meaning
+     * default {@code toString()} handling), and may be caller-provided (see
+     * {@link ZonedDateTimeSerializer#ZonedDateTimeSerializer(DateTimeFormatter)}),
+     * in which case it must not be overridden by settings like
+     * {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}.
+     *
+     * @since 3.3
+     */
+    protected DateTimeFormatter _defaultFormat() {
+        return defaultFormat;
+    }
+
+    /**
      * Overridden by subclasses to supply a formatter equivalent to the standard
      * built-in default that always writes at least millisecond-precision sub-second
      * digits, for use with {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}.

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
@@ -134,9 +134,27 @@ public abstract class InstantSerializerBase<T extends Temporal>
         return JsonToken.VALUE_STRING;
     }
 
+    /**
+     * Overridden by subclasses to supply a formatter equivalent to {@link #defaultFormat}
+     * that always writes at least millisecond-precision sub-second digits, for use with
+     * {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}. Returning {@code null} (the
+     * default) means the subclass has no such counterpart, and the feature has no effect.
+     *
+     * @since 3.3
+     */
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
+        return null;
+    }
+
     protected String formatValue(T value, SerializationContext ctxt)
     {
         DateTimeFormatter formatter = (_formatter == null) ? defaultFormat :_formatter;
+        if ((_formatter == null) && ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)) {
+            DateTimeFormatter subSecondFormatter = _alwaysWriteSubSecondDigitsFormatter();
+            if (subSecondFormatter != null) {
+                formatter = subSecondFormatter;
+            }
+        }
         if (formatter != null) {
             if (formatter.getZone() == null) { // timezone set if annotated on property
                 // If the user specified to use the context TimeZone explicitly, and the formatter provided doesn't contain a TZ

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/InstantSerializerBase.java
@@ -135,14 +135,22 @@ public abstract class InstantSerializerBase<T extends Temporal>
     }
 
     /**
-     * Overridden by subclasses to supply a formatter equivalent to {@link #defaultFormat}
-     * that always writes at least millisecond-precision sub-second digits, for use with
-     * {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}. Returning {@code null} (the
-     * default) means the subclass has no such counterpart, and the feature has no effect.
+     * Overridden by subclasses to supply a formatter equivalent to the standard
+     * built-in default that always writes at least millisecond-precision sub-second
+     * digits, for use with {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}.
+     *<p>
+     * Implementations MUST return {@code null} unless given {@code defaultFormat} is
+     * the standard built-in default of the subclass: some subclasses (notably
+     * {@link ZonedDateTimeSerializer}) allow caller-provided default formatters, and
+     * those must not be overridden by the feature. Returning {@code null} (which the
+     * base implementation always does) means the feature has no effect.
+     *
+     * @param defaultFormat Default formatter that would be used if the feature was
+     *   not enabled (possibly {@code null})
      *
      * @since 3.3
      */
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
         return null;
     }
 
@@ -150,7 +158,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     {
         DateTimeFormatter formatter = (_formatter == null) ? defaultFormat :_formatter;
         if ((_formatter == null) && ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)) {
-            DateTimeFormatter subSecondFormatter = _alwaysWriteSubSecondDigitsFormatter();
+            DateTimeFormatter subSecondFormatter = _alwaysWriteSubSecondDigitsFormatter(defaultFormat);
             if (subSecondFormatter != null) {
                 formatter = subSecondFormatter;
             }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerializer.java
@@ -104,9 +104,10 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
 
     /**
      * Resolves the formatter to use when no numeric-timestamp shape applies: the
-     * explicit per-property {@code _formatter} if set, else the plain default, or --
-     * if {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS} is enabled -- a
-     * counterpart that always writes sub-second digits.
+     * explicit per-property {@code _formatter} if set, else the default from
+     * {@link #_defaultFormatter()}, or -- if
+     * {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS} is enabled -- a
+     * counterpart of the standard default that always writes sub-second digits.
      *
      * @since 3.3
      */
@@ -114,10 +115,14 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
         if (_formatter != null) {
             return _formatter;
         }
-        if (ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)) {
+        DateTimeFormatter dtf = _defaultFormatter();
+        // Sub-second replacement is a counterpart of the standard built-in default
+        // only: a subclass-provided default must not be overridden by the feature
+        if ((dtf == DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                && ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)) {
             return SubSecondFormatters.LOCAL_DATE_TIME;
         }
-        return _defaultFormatter();
+        return dtf;
     }
 
     private final void _serializeAsArrayContents(LocalDateTime value, JsonGenerator g,

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerializer.java
@@ -76,11 +76,7 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
             _serializeAsArrayContents(value, g, ctxt);
             g.writeEndArray();
         } else {
-            DateTimeFormatter dtf = _formatter;
-            if (dtf == null) {
-                dtf = _defaultFormatter();
-            }
-            g.writeString(value.format(dtf));
+            g.writeString(value.format(_effectiveFormatter(ctxt)));
         }
     }
 
@@ -101,13 +97,27 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
                 && typeIdDef.valueShape == JsonToken.START_ARRAY) {
             _serializeAsArrayContents(value, g, ctxt);
         } else {
-            DateTimeFormatter dtf = _formatter;
-            if (dtf == null) {
-                dtf = _defaultFormatter();
-            }
-            g.writeString(value.format(dtf));
+            g.writeString(value.format(_effectiveFormatter(ctxt)));
         }
         typeSer.writeTypeSuffix(g, ctxt, typeIdDef);
+    }
+
+    /**
+     * Resolves the formatter to use when no numeric-timestamp shape applies: the
+     * explicit per-property {@code _formatter} if set, else the plain default, or --
+     * if {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS} is enabled -- a
+     * counterpart that always writes sub-second digits.
+     *
+     * @since 3.3
+     */
+    private DateTimeFormatter _effectiveFormatter(SerializationContext ctxt) {
+        if (_formatter != null) {
+            return _formatter;
+        }
+        if (ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)) {
+            return SubSecondFormatters.LOCAL_DATE_TIME;
+        }
+        return _defaultFormatter();
     }
 
     private final void _serializeAsArrayContents(LocalDateTime value, JsonGenerator g,

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetDateTimeSerializer.java
@@ -63,7 +63,8 @@ public class OffsetDateTimeSerializer extends InstantSerializerBase<OffsetDateTi
     }
 
     @Override
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(OffsetDateTime value,
+            DateTimeFormatter defaultFormat) {
         return (defaultFormat == DateTimeFormatter.ISO_OFFSET_DATE_TIME)
                 ? SubSecondFormatters.OFFSET_DATE_TIME : null;
     }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetDateTimeSerializer.java
@@ -61,4 +61,9 @@ public class OffsetDateTimeSerializer extends InstantSerializerBase<OffsetDateTi
         return new OffsetDateTimeSerializer(this, _formatter,
                 _useTimestamp, writeNanoseconds, _shape);
     }
+
+    @Override
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
+        return SubSecondFormatters.OFFSET_DATE_TIME;
+    }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/OffsetDateTimeSerializer.java
@@ -63,7 +63,8 @@ public class OffsetDateTimeSerializer extends InstantSerializerBase<OffsetDateTi
     }
 
     @Override
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
-        return SubSecondFormatters.OFFSET_DATE_TIME;
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+        return (defaultFormat == DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                ? SubSecondFormatters.OFFSET_DATE_TIME : null;
     }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/SubSecondFormatters.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/SubSecondFormatters.java
@@ -1,0 +1,74 @@
+package tools.jackson.databind.ext.javatime.ser;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+/**
+ * Container for the ISO-8601 {@link DateTimeFormatter}s used in place of the
+ * JDK-provided defaults when
+ * {@link tools.jackson.databind.cfg.DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}
+ * is enabled.
+ *<p>
+ * These differ from the JDK counterparts only in the sub-second field: instead of
+ * omitting it when zero, at least 3 (millisecond) digits are always written, and up
+ * to 9 when the value carries higher precision (so nothing is truncated).
+ *
+ * @since 3.3
+ */
+final class SubSecondFormatters
+{
+    private SubSecondFormatters() { }
+
+    /**
+     * Date and time down to the seconds field, followed by 3 to 9 sub-second digits:
+     * the shared prefix of all formatters here.
+     */
+    private static DateTimeFormatterBuilder _localDateTimeBuilder() {
+        return new DateTimeFormatterBuilder()
+                .append(DateTimeFormatter.ISO_LOCAL_DATE)
+                .appendLiteral('T')
+                .appendValue(ChronoField.HOUR_OF_DAY, 2)
+                .appendLiteral(':')
+                .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+                .appendLiteral(':')
+                .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+                .appendFraction(ChronoField.NANO_OF_SECOND, 3, 9, true);
+    }
+
+    /**
+     * Counterpart of {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME}.
+     */
+    static final DateTimeFormatter LOCAL_DATE_TIME = _localDateTimeBuilder()
+            .toFormatter();
+
+    /**
+     * Counterpart of {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}.
+     */
+    static final DateTimeFormatter OFFSET_DATE_TIME = _localDateTimeBuilder()
+            .appendOffsetId()
+            .toFormatter();
+
+    /**
+     * Counterpart of {@link DateTimeFormatter#ISO_ZONED_DATE_TIME}, that is,
+     * {@link #OFFSET_DATE_TIME} with the optional {@code [Zone/Id]} suffix.
+     */
+    static final DateTimeFormatter ZONED_DATE_TIME = new DateTimeFormatterBuilder()
+            .append(OFFSET_DATE_TIME)
+            .optionalStart()
+            .appendLiteral('[')
+            .parseCaseSensitive()
+            .appendZoneRegionId()
+            .appendLiteral(']')
+            .toFormatter();
+
+    /**
+     * Counterpart of {@link DateTimeFormatter#ISO_INSTANT} (and of
+     * {@link java.time.Instant#toString()}, which is what the default
+     * {@code Instant} serialization actually uses): UTC-based, so the
+     * offset is always rendered as {@code Z}.
+     */
+    static final DateTimeFormatter INSTANT = OFFSET_DATE_TIME
+            .withZone(ZoneOffset.UTC);
+}

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
@@ -116,7 +116,10 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     }
 
     @Override
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
-        return SubSecondFormatters.OFFSET_DATE_TIME;
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+        // 10-Aug-2026, tatu: Caller may pass its own default formatter (see
+        //    `ZonedDateTimeSerializer(DateTimeFormatter)`); if so, must not override it
+        return (defaultFormat == DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                ? SubSecondFormatters.OFFSET_DATE_TIME : null;
     }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
@@ -78,7 +78,10 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
                     value = value.truncatedTo(ChronoUnit.MILLIS);
                 }
                 // write with zone
-                g.writeString(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(value));
+                DateTimeFormatter formatter = ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                        ? SubSecondFormatters.ZONED_DATE_TIME
+                        : DateTimeFormatter.ISO_ZONED_DATE_TIME;
+                g.writeString(formatter.format(value));
                 return;
             }
         }
@@ -110,5 +113,10 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
             return JsonToken.VALUE_STRING;
         }
         return super.serializationShape(ctxt);
+    }
+
+    @Override
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter() {
+        return SubSecondFormatters.OFFSET_DATE_TIME;
     }
 }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
@@ -77,10 +77,13 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
                 if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
                     value = value.truncatedTo(ChronoUnit.MILLIS);
                 }
-                // write with zone
-                DateTimeFormatter formatter = ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
-                        ? SubSecondFormatters.ZONED_DATE_TIME
-                        : DateTimeFormatter.ISO_ZONED_DATE_TIME;
+                // write with zone: sub-second variant only if caller has not provided
+                // its own default format, in which case feature must not change output
+                DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME;
+                if (ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                        && (_defaultFormat() == DateTimeFormatter.ISO_OFFSET_DATE_TIME)) {
+                    formatter = SubSecondFormatters.ZONED_DATE_TIME;
+                }
                 g.writeString(formatter.format(value));
                 return;
             }

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
@@ -68,22 +68,20 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
         throws JacksonException
     {
         if (!useTimestamp(ctxt)) {
-            // [modules-java8#333]: `@JsonFormat` with pattern should override
-            //   `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
-            if ((_formatter != null) && (_shape == JsonFormat.Shape.STRING)) {
+            // [modules-java8#333], [databind#6151]: explicitly configured format should
+            //   override `DateTimeFeature.WRITE_DATES_WITH_ZONE_ID`
+            if (_hasExplicitFormat()) {
                 ; // use default handling
             } else if (shouldWriteWithZoneId(ctxt)) {
                 // Apply millisecond truncation if enabled
                 if (ctxt.isEnabled(DateTimeFeature.TRUNCATE_TO_MSECS_ON_WRITE)) {
                     value = value.truncatedTo(ChronoUnit.MILLIS);
                 }
-                // write with zone: sub-second variant only if caller has not provided
-                // its own default format, in which case feature must not change output
-                DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME;
-                if (ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
-                        && (_defaultFormat() == DateTimeFormatter.ISO_OFFSET_DATE_TIME)) {
-                    formatter = SubSecondFormatters.ZONED_DATE_TIME;
-                }
+                // write with zone (note: only standard default format gets here, so
+                // sub-second variant may be used as-is)
+                DateTimeFormatter formatter = ctxt.isEnabled(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                        ? SubSecondFormatters.ZONED_DATE_TIME
+                        : DateTimeFormatter.ISO_ZONED_DATE_TIME;
                 g.writeString(formatter.format(value));
                 return;
             }
@@ -94,16 +92,35 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     @Override
     protected String formatValue(ZonedDateTime value, SerializationContext ctxt) {
         String formatted = super.formatValue(value, ctxt);
-        // [modules-java8#333]: `@JsonFormat` with pattern should override
-        //   `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
-        if (_formatter != null && _shape == JsonFormat.Shape.STRING) {
+        // [modules-java8#333], [databind#6151]: when an explicitly configured format is
+        //   used, Zone Id is only added if specifically requested (via `@JsonFormat`),
+        //   and NOT due to `DateTimeFeature.WRITE_DATES_WITH_ZONE_ID`
+        if (_hasExplicitFormat()) {
             // Why not `if (shouldWriteWithZoneId(provider))` ?
             if (Boolean.TRUE.equals(_writeZoneId)) {
                 formatted += "[" + value.getZone().getId() + "]";
             }
         }
         return formatted;
-    }    
+    }
+
+    /**
+     * Accessor for checking whether this serializer has an explicitly configured
+     * format that should be used as-is, taking precedence over
+     * {@link DateTimeFeature#WRITE_DATES_WITH_ZONE_ID}: either a {@code @JsonFormat}
+     * pattern (with String shape), or a caller-provided default formatter (see
+     * {@link #ZonedDateTimeSerializer(DateTimeFormatter)}).
+     *
+     * @since 3.3
+     */
+    protected boolean _hasExplicitFormat() {
+        if ((_formatter != null) && (_shape == JsonFormat.Shape.STRING)) {
+            return true;
+        }
+        DateTimeFormatter df = _defaultFormat();
+        return (df != null) && (df != DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
     public boolean shouldWriteWithZoneId(SerializationContext ctxt) {
         return (_writeZoneId != null)
                 ? _writeZoneId

--- a/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerializer.java
@@ -116,7 +116,8 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     }
 
     @Override
-    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(DateTimeFormatter defaultFormat) {
+    protected DateTimeFormatter _alwaysWriteSubSecondDigitsFormatter(ZonedDateTime value,
+            DateTimeFormatter defaultFormat) {
         // 10-Aug-2026, tatu: Caller may pass its own default formatter (see
         //    `ZonedDateTimeSerializer(DateTimeFormatter)`); if so, must not override it
         return (defaultFormat == DateTimeFormatter.ISO_OFFSET_DATE_TIME)

--- a/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
@@ -1,0 +1,147 @@
+package tools.jackson.databind.ext.javatime;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link DateTimeFeature#ALWAYS_WRITE_SUBSECOND_DIGITS}.
+ * <p>
+ * Ported from the equivalent 2.x feature in
+ * {@code jackson-modules-java8} (see
+ * <a href="https://github.com/FasterXML/jackson-modules-java8/pull/386">modules-java8#386</a>,
+ * fixing <a href="https://github.com/FasterXML/jackson-modules-java8/issues/76">modules-java8#76</a>).
+ */
+public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
+{
+    static class Wrapper {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        public OffsetDateTime value;
+
+        Wrapper(OffsetDateTime v) { value = v; }
+    }
+
+    private final ObjectMapper MAPPER = newMapperBuilder()
+            .enable(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+            .build();
+
+    private final ObjectMapper DEFAULT_MAPPER = newMapper();
+
+    @Test
+    public void testInstantZeroSubSecond() throws Exception
+    {
+        Instant value = Instant.parse("2017-09-14T04:28:48Z");
+        // Default: sub-second field omitted entirely
+        assertEquals(q("2017-09-14T04:28:48Z"), DEFAULT_MAPPER.writeValueAsString(value));
+        // Enabled: zero-padded to millisecond precision
+        assertEquals(q("2017-09-14T04:28:48.000Z"), MAPPER.writeValueAsString(value));
+    }
+
+    @Test
+    public void testInstantHigherPrecisionNotTruncated() throws Exception
+    {
+        assertEquals(q("2017-09-14T04:28:48.100Z"),
+                MAPPER.writeValueAsString(Instant.parse("2017-09-14T04:28:48.100Z")));
+        assertEquals(q("2017-09-14T04:28:48.123456Z"),
+                MAPPER.writeValueAsString(Instant.parse("2017-09-14T04:28:48.123456Z")));
+        assertEquals(q("2017-09-14T04:28:48.123456789Z"),
+                MAPPER.writeValueAsString(Instant.parse("2017-09-14T04:28:48.123456789Z")));
+    }
+
+    @Test
+    public void testOffsetDateTime() throws Exception
+    {
+        OffsetDateTime value = OffsetDateTime.parse("2017-09-14T04:28:48+02:00");
+        assertEquals(q("2017-09-14T04:28:48+02:00"), DEFAULT_MAPPER.writeValueAsString(value));
+        assertEquals(q("2017-09-14T04:28:48.000+02:00"), MAPPER.writeValueAsString(value));
+
+        // Note: the JDK ISO formatter renders 100 msec as ".1"; with the feature on,
+        // width is stable at (at least) 3 digits
+        OffsetDateTime millis = OffsetDateTime.parse("2017-09-14T04:28:48.100+02:00");
+        assertEquals(q("2017-09-14T04:28:48.1+02:00"), DEFAULT_MAPPER.writeValueAsString(millis));
+        assertEquals(q("2017-09-14T04:28:48.100+02:00"), MAPPER.writeValueAsString(millis));
+    }
+
+    @Test
+    public void testZonedDateTime() throws Exception
+    {
+        ZonedDateTime value = ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]");
+        assertEquals(q("2017-09-14T04:28:48.000+02:00"), MAPPER.writeValueAsString(value));
+    }
+
+    @Test
+    public void testZonedDateTimeWithZoneId() throws Exception
+    {
+        ObjectMapper mapper = newMapperBuilder()
+                .enable(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                .enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+                .build();
+        ZonedDateTime value = ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]");
+        assertEquals(q("2017-09-14T04:28:48.000+02:00[Europe/Budapest]"),
+                mapper.writeValueAsString(value));
+
+        // Same path, feature disabled: zero sub-second is omitted, matching the JDK formatter
+        ObjectMapper defaultZoneIdMapper = newMapperBuilder()
+                .enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+                .build();
+        assertEquals(q("2017-09-14T04:28:48+02:00[Europe/Budapest]"),
+                defaultZoneIdMapper.writeValueAsString(value));
+    }
+
+    @Test
+    public void testLocalDateTime() throws Exception
+    {
+        LocalDateTime value = LocalDateTime.parse("2017-09-14T04:28:48");
+        assertEquals(q("2017-09-14T04:28:48"), DEFAULT_MAPPER.writeValueAsString(value));
+        assertEquals(q("2017-09-14T04:28:48.000"), MAPPER.writeValueAsString(value));
+
+        // Seconds keep being written even when zero (as with the JDK ISO formatter)
+        LocalDateTime noSeconds = LocalDateTime.parse("2017-09-14T04:28");
+        assertEquals(q("2017-09-14T04:28:00"), DEFAULT_MAPPER.writeValueAsString(noSeconds));
+        assertEquals(q("2017-09-14T04:28:00.000"), MAPPER.writeValueAsString(noSeconds));
+    }
+
+    // Feature must not leak into numeric timestamp serialization
+    @Test
+    public void testTimestampsUnaffected() throws Exception
+    {
+        ObjectMapper mapper = newMapperBuilder()
+                .enable(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+        assertEquals("1505363328.000000000",
+                mapper.writeValueAsString(Instant.parse("2017-09-14T04:28:48Z")));
+    }
+
+    // ... nor override an explicit `@JsonFormat` pattern
+    @Test
+    public void testExplicitPatternWins() throws Exception
+    {
+        assertEquals(a2q("{'value':'2017-09-14T04:28:48'}"),
+                MAPPER.writeValueAsString(new Wrapper(OffsetDateTime.parse("2017-09-14T04:28:48Z"))));
+    }
+
+    // Values written with the feature on must still be readable
+    @Test
+    public void testRoundTrip() throws Exception
+    {
+        for (String raw : new String[] {
+                "2017-09-14T04:28:48Z", "2017-09-14T04:28:48.123456789Z",
+                "1970-01-01T00:00:00Z", "+10000-09-14T04:28:48Z", "-0100-09-14T04:28:48Z" }) {
+            Instant value = Instant.parse(raw);
+            String json = MAPPER.writeValueAsString(value);
+            assertEquals(value, MAPPER.readValue(json, Instant.class),
+                    "Round-trip failed for " + raw + " (serialized as " + json + ")");
+        }
+    }
+}

--- a/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
@@ -151,8 +151,7 @@ public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
                 ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]")));
     }
 
-    // ... including on the separate "write with Zone Id" path, where feature must
-    // stay inert (even though that path does not use the caller's format either)
+    // ... including on the separate "write with Zone Id" path
     @Test
     public void testCallerProvidedDefaultFormatterWithZoneId() throws Exception
     {
@@ -171,8 +170,7 @@ public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
                 .build();
         assertEquals(defaultMapper.writeValueAsString(value),
                 mapper.writeValueAsString(value));
-        assertEquals(q("2017-09-14T04:28:48+02:00[Europe/Budapest]"),
-                mapper.writeValueAsString(value));
+        assertEquals(q("2017_09_14X04:28:48"), mapper.writeValueAsString(value));
     }
 
     // Map keys are written by separate key serializers, not affected by the feature

--- a/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
@@ -151,6 +151,30 @@ public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
                 ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]")));
     }
 
+    // ... including on the separate "write with Zone Id" path, where feature must
+    // stay inert (even though that path does not use the caller's format either)
+    @Test
+    public void testCallerProvidedDefaultFormatterWithZoneId() throws Exception
+    {
+        DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy_MM_dd'X'HH:mm:ss");
+        ZonedDateTime value = ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]");
+        ObjectMapper mapper = newMapperBuilder()
+                .addModule(new SimpleModule()
+                        .addSerializer(new ZonedDateTimeSerializer(df)))
+                .enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+                .enable(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                .build();
+        ObjectMapper defaultMapper = newMapperBuilder()
+                .addModule(new SimpleModule()
+                        .addSerializer(new ZonedDateTimeSerializer(df)))
+                .enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+                .build();
+        assertEquals(defaultMapper.writeValueAsString(value),
+                mapper.writeValueAsString(value));
+        assertEquals(q("2017-09-14T04:28:48+02:00[Europe/Budapest]"),
+                mapper.writeValueAsString(value));
+    }
+
     // Map keys are written by separate key serializers, not affected by the feature
     @Test
     public void testMapKeysUnaffected() throws Exception

--- a/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
@@ -1,8 +1,10 @@
 package tools.jackson.databind.ext.javatime;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -146,6 +148,29 @@ public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
                 .build();
         assertEquals(q("2017_09_14X04:28:48"), mapper.writeValueAsString(
                 ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]")));
+    }
+
+    // Extremes of `Instant` range fall outside `LocalDate` range and cannot be
+    // written using Date/Time fields: must retain default handling, not fail
+    @Test
+    public void testInstantExtremes() throws Exception
+    {
+        assertEquals(q("-1000000000-01-01T00:00:00Z"),
+                MAPPER.writeValueAsString(Instant.MIN));
+        assertEquals(DEFAULT_MAPPER.writeValueAsString(Instant.MIN),
+                MAPPER.writeValueAsString(Instant.MIN));
+        assertEquals(q("+1000000000-12-31T23:59:59.999999999Z"),
+                MAPPER.writeValueAsString(Instant.MAX));
+        assertEquals(DEFAULT_MAPPER.writeValueAsString(Instant.MAX),
+                MAPPER.writeValueAsString(Instant.MAX));
+
+        // But values just inside `LocalDate` range are still padded as usual
+        Instant maxLocal = LocalDate.MAX.atStartOfDay().toInstant(ZoneOffset.UTC);
+        assertEquals(q("+999999999-12-31T00:00:00.000Z"),
+                MAPPER.writeValueAsString(maxLocal));
+        Instant minLocal = LocalDate.MIN.atStartOfDay().toInstant(ZoneOffset.UTC);
+        assertEquals(q("-999999999-01-01T00:00:00.000Z"),
+                MAPPER.writeValueAsString(minLocal));
     }
 
     // Values written with the feature on must still be readable

--- a/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.ext.javatime.ser.ZonedDateTimeSerializer;
+import tools.jackson.databind.module.SimpleModule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -129,6 +132,20 @@ public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
     {
         assertEquals(a2q("{'value':'2017-09-14T04:28:48'}"),
                 MAPPER.writeValueAsString(new Wrapper(OffsetDateTime.parse("2017-09-14T04:28:48Z"))));
+    }
+
+    // ... nor a default formatter passed to the serializer by the caller
+    @Test
+    public void testCallerProvidedDefaultFormatterWins() throws Exception
+    {
+        DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy_MM_dd'X'HH:mm:ss");
+        ObjectMapper mapper = newMapperBuilder()
+                .addModule(new SimpleModule()
+                        .addSerializer(new ZonedDateTimeSerializer(df)))
+                .enable(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                .build();
+        assertEquals(q("2017_09_14X04:28:48"), mapper.writeValueAsString(
+                ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]")));
     }
 
     // Values written with the feature on must still be readable

--- a/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/AlwaysWriteSubSecondDigitsTest.java
@@ -7,6 +7,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -148,6 +149,18 @@ public class AlwaysWriteSubSecondDigitsTest extends DateTimeTestBase
                 .build();
         assertEquals(q("2017_09_14X04:28:48"), mapper.writeValueAsString(
                 ZonedDateTime.parse("2017-09-14T04:28:48+02:00[Europe/Budapest]")));
+    }
+
+    // Map keys are written by separate key serializers, not affected by the feature
+    @Test
+    public void testMapKeysUnaffected() throws Exception
+    {
+        assertEquals(a2q("{'2017-09-14T04:28:48Z':1}"),
+                MAPPER.writeValueAsString(
+                        Collections.singletonMap(Instant.parse("2017-09-14T04:28:48Z"), 1)));
+        assertEquals(a2q("{'2017-09-14T04:28:48':1}"),
+                MAPPER.writeValueAsString(
+                        Collections.singletonMap(LocalDateTime.parse("2017-09-14T04:28:48"), 1)));
     }
 
     // Extremes of `Instant` range fall outside `LocalDate` range and cannot be

--- a/src/test/java/tools/jackson/databind/ext/javatime/TestFeatures.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/TestFeatures.java
@@ -44,4 +44,11 @@ public class TestFeatures
         assertTrue(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE.enabledByDefault(),
                 "Adjust dates to context time zone setting should be enabled by default.");
     }
+
+    @Test
+    public void testAlwaysWriteSubSecondDigitsSettingDisabledByDefault()
+    {
+        assertFalse(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS.enabledByDefault(),
+                "Always write sub-second digits setting should be disabled by default.");
+    }
 }

--- a/src/test/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/ser/LocalDateTimeSerTest.java
@@ -18,6 +18,7 @@ package tools.jackson.databind.ext.javatime.ser;
 
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.ext.javatime.DateTimeTestBase;
 import tools.jackson.databind.ext.javatime.MockObjectConfiguration;
+import tools.jackson.databind.module.SimpleModule;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,6 +41,24 @@ public class LocalDateTimeSerTest
         public LocalDateTime value;
 
         public LDTWrapper(LocalDateTime v) { value = v; }
+    }
+
+    /**
+     * Sub-class that changes the default textual format via {@code _defaultFormatter()};
+     * also has to retain itself through contextualization (see {@code withFormat()}).
+     */
+    static class CustomDefaultLocalDateTimeSerializer extends LocalDateTimeSerializer {
+        private final static DateTimeFormatter DF
+            = DateTimeFormatter.ofPattern("yyyy_MM_dd'X'HH:mm:ss");
+
+        @Override
+        protected DateTimeFormatter _defaultFormatter() { return DF; }
+
+        @Override
+        protected JSR310FormattedSerializerBase<LocalDateTime> withFormat(DateTimeFormatter f,
+                Boolean useTimestamp, JsonFormat.Shape shape) {
+            return this;
+        }
     }
 
     // 05-Feb-2025, tatu: Use Jackson 2.x defaults wrt as-timestamps
@@ -190,5 +210,19 @@ public class LocalDateTimeSerTest
         LocalDateTime time = LocalDateTime.of(2005, Month.NOVEMBER, 5, 22, 31, 5, 829837);
         String value = m.writeValueAsString(time);
         assertEquals("[\"" + LocalDateTime.class.getName() + "\",\"" + time.toString() + "\"]", value);
+    }
+
+    // [databind#6151]: default format provided by a sub-class must not be replaced
+    //   by `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
+    @Test
+    public void serializationWithSubClassDefaultFormat() throws Exception
+    {
+        LocalDateTime time = LocalDateTime.of(2017, Month.SEPTEMBER, 14, 4, 28, 48);
+        ObjectMapper mapper = newMapperBuilder()
+                .addModule(new SimpleModule()
+                        .addSerializer(new CustomDefaultLocalDateTimeSerializer()))
+                .enable(DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS)
+                .build();
+        assertEquals(q("2017_09_14X04:28:48"), mapper.writeValueAsString(time));
     }
 }

--- a/src/test/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/ser/ZonedDateTimeSerTest.java
@@ -283,6 +283,40 @@ public class ZonedDateTimeSerTest
         assertEquals("\"" + DateTimeFormatter.ISO_ZONED_DATE_TIME.format(date) + "\"", value);
     }
 
+    // [databind#6151]: caller-provided default formatter should override
+    //   `WRITE_DATES_WITH_ZONE_ID`, same as `@JsonFormat` pattern does
+    @Test
+    public void testSerializationAsStringWithZoneIdOnAndACustomFormatter() throws Exception {
+        ZonedDateTime date = ZonedDateTime.now(Z3);
+        ObjectMapper mapper = newMapperBuilder().addModule(
+                new SimpleModule().addSerializer(new ZonedDateTimeSerializer(FORMATTER_WITHOUT_ZONEID)))
+                .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID, true)
+                .build();
+        assertEquals(q(FORMATTER_WITHOUT_ZONEID.format(date)),
+                mapper.writeValueAsString(date));
+    }
+
+    // ... but explicitly requested Zone Id (via `@JsonFormat`) is still appended
+    @Test
+    public void testSerializationAsStringWithExplicitZoneIdAndACustomFormatter() throws Exception {
+        ZonedDateTime date = ZonedDateTime.now(Z3);
+        ObjectMapper mapper = newMapperBuilder().addModule(
+                new SimpleModule().addSerializer(new ZonedDateTimeSerializer(FORMATTER_WITHOUT_ZONEID)))
+                .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .build();
+        assertEquals(a2q("{'value':'"
+                        + FORMATTER_WITHOUT_ZONEID.format(date) + "[" + date.getZone().getId() + "]'}"),
+                mapper.writeValueAsString(new ZoneIdRequestedWrapper(date)));
+    }
+
+    static class ZoneIdRequestedWrapper {
+        @JsonFormat(with = JsonFormat.Feature.WRITE_DATES_WITH_ZONE_ID)
+        public ZonedDateTime value;
+
+        public ZoneIdRequestedWrapper(ZonedDateTime v) { value = v; }
+    }
+
     @Test
     public void testSerializationAsStringWithDefaultTimeZoneAndContextTimeZoneOnAndACustomFormatter() throws Exception {
         ZonedDateTime date = ZonedDateTime.now(Z3);


### PR DESCRIPTION
Adds `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`: when enabled, `Instant`, `OffsetDateTime`, `ZonedDateTime` and `LocalDateTime` always serialize with at least millisecond-precision sub-second digits (zero-padded), instead of the JDK-provided ISO formatters omitting the field entirely when it's zero.

Fixes the same underlying issue as [modules-java8#76](https://github.com/FasterXML/jackson-modules-java8/issues/76), where e.g. `Instant.parse("2017-09-14T04:28:48.000Z")` serializes as `"2017-09-14T04:28:48Z"` (no `.000`), breaking systems that expect fixed-width timestamps or that sort them lexicographically.

This ports the 2.x feature of the same name added in [modules-java8#386](https://github.com/FasterXML/jackson-modules-java8/pull/386), adapted to 3.x's architecture:
- 2.x bakes the formatter into each serializer instance at module-setup time (`JavaTimeModule.setupModule()` calling `withFeatures(JacksonFeatureSet<JavaTimeFeature>)`).
- 3.x already has a config-time-immutable, per-call `ctxt.isEnabled(DateTimeFeature.XXX)` pattern for date/time flags (see `TRUNCATE_TO_MSECS_ON_WRITE`), so this follows that pattern instead — no changes needed to `JavaTimeInitializer`.

Scope, matching the 2.x feature: `Instant`, `OffsetDateTime`, `ZonedDateTime`, `LocalDateTime`. `LocalTime`/`OffsetTime` have the same zero-fraction omission but are out of scope here, to match the ported feature's scope.

Only affects the default (no explicit formatter) textual serialization path; an explicit `DateTimeFormatter` / `@JsonFormat` pattern still wins, and numeric-timestamp serialization is unaffected.