### PR TITLE
Fix #6144: withCreatorVisibility(ANY) now enables private scalar delegating constructors

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -582,3 +582,8 @@ Alex Crowell (@alex-crowell)
  * Reported #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle
    arrays of polymorphic types
   [3.3.0]
+
+Seonwoo Jung (@seonwooj0810)
+ * Contributed #6144: Fix `withCreatorVisibility(ANY)` to also enable
+   implicit private single-arg scalar delegating constructors
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -12,6 +12,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
   (on both serialization and deserialization) instead of confusing low-level error
  (reported by Alex C)
  (fix by @cowtowncoder, w/ Claude code)
+#6144: `withCreatorVisibility(Visibility.ANY)` does not enable implicit
+  private single-arg (scalar) delegating constructors
+ (reported by @user)
+ (fix by @seonwooj0810)
 
 3.2.1 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
+++ b/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java
@@ -888,9 +888,17 @@ public class POJOPropertiesCollector
         Iterator<PotentialCreator> it = ctors.iterator();
         while (it.hasNext()) {
             PotentialCreator ctor = it.next();
-            boolean visible = (ctor.paramCount() == 1)
-                    ? _visibilityChecker.isScalarConstructorVisible(ctor.creator())
-                    : _visibilityChecker.isCreatorVisible(ctor.creator());
+            boolean visible;
+            if (ctor.paramCount() == 1) {
+                // For single-arg constructors, accept if EITHER scalar-constructor
+                // visibility OR general creator visibility is satisfied.
+                // This allows `withCreatorVisibility(Visibility.ANY)` to restore
+                // Jackson 2 behaviour where private scalar constructors were accepted.
+                visible = _visibilityChecker.isScalarConstructorVisible(ctor.creator())
+                        || _visibilityChecker.isCreatorVisible(ctor.creator());
+            } else {
+                visible = _visibilityChecker.isCreatorVisible(ctor.creator());
+            }
             if (!visible) {
                 it.remove();
             }

--- a/src/test/java/tools/jackson/databind/introspect/TestAutoDetect.java
+++ b/src/test/java/tools/jackson/databind/introspect/TestAutoDetect.java
@@ -37,6 +37,15 @@ public class TestAutoDetect extends DatabindTestUtil
         private PrivateBeanNonAnnotated(String a) { this.a = a; }
     }
 
+    // [databind#6144]: private long/String delegating ctors with creatorVisibility(ANY)
+    static class PrivateLongDelegating {
+        public long longValue;
+        public String stringValue;
+        public PrivateLongDelegating() {}
+        private PrivateLongDelegating(long v) { this.longValue = v; }
+        private PrivateLongDelegating(String v) { this.stringValue = v; }
+    }
+
     // test for [databind#1347], config overrides for visibility
     @JsonPropertyOrder(alphabetic=true)
     static class Feature1347SerBean {
@@ -144,6 +153,28 @@ public class TestAutoDetect extends DatabindTestUtil
                 .build();
         bean = m.readValue(q("xyz"), PrivateBeanAnnotated.class);
         assertEquals("xyz", bean.a);
+    }
+
+    // [databind#6144]: withCreatorVisibility(ANY) should enable private scalar (long/String)
+    //   delegating constructors, matching Jackson 2 behaviour
+    @Test
+    public void testPrivateLongDelegatingCtorWithCreatorVisibilityAny() throws Exception
+    {
+        // default: both private scalar constructors are not visible
+        assertThrows(JacksonException.class,
+                () -> MAPPER.readValue("2", PrivateLongDelegating.class));
+        assertThrows(JacksonException.class,
+                () -> MAPPER.readValue(q("hi"), PrivateLongDelegating.class));
+
+        // but when creatorVisibility is ANY, private scalar ctors should be accepted
+        ObjectMapper m = jsonMapperBuilder()
+                .changeDefaultVisibility(vc -> vc.withCreatorVisibility(Visibility.ANY))
+                .build();
+        PrivateLongDelegating fromLong = m.readValue("42", PrivateLongDelegating.class);
+        assertEquals(42L, fromLong.longValue);
+
+        PrivateLongDelegating fromString = m.readValue(q("hello"), PrivateLongDelegating.class);
+        assertEquals("hello", fromString.stringValue);
     }
 
     // [databind#1347]


### PR DESCRIPTION
## Problem

`FasterXML/jackson-databind#6144`

In Jackson 3, implicit single-arg (scalar) constructors (`String`, `long`, etc.) used as
delegating creators go through `_removeNonVisibleCreators`, which checks
`isScalarConstructorVisible` against the new `scalarConstructorMinLevel` axis (defaulting to
`NON_PRIVATE`).

When users migrate from Jackson 2 — where creator visibility defaulted to `ANY` — the natural
fix attempt is `changeDefaultVisibility(vc -> vc.withCreatorVisibility(Visibility.ANY))`.
This has **no effect** on scalar constructors because `withCreatorVisibility` does not touch
`_scalarConstructorMinLevel`, leaving private scalar constructors still filtered out.

### Repro

```java
static class OneOf {
    public long longValue;
    public String stringValue;
    public OneOf() {}
    private OneOf(long v)   { this.longValue = v; }
    private OneOf(String v) { this.stringValue = v; }
}

// Works in Jackson 2, fails in Jackson 3 with default settings:
ObjectMapper mapper = JsonMapper.builder()
    .changeDefaultVisibility(vc -> vc.withCreatorVisibility(Visibility.ANY))
    .build();

OneOf fromLong = mapper.readValue("42", OneOf.class); // MismatchedInputException
```

## Fix

In `POJOPropertiesCollector._removeNonVisibleCreators`, for single-arg constructors, accept when
**either** `isScalarConstructorVisible` **or** `isCreatorVisible` passes:

```java
visible = _visibilityChecker.isScalarConstructorVisible(ctor.creator())
        || _visibilityChecker.isCreatorVisible(ctor.creator());
```

This means:
- **Default behaviour unchanged**: both `isScalarConstructorVisible` (NON_PRIVATE) and
  `isCreatorVisible` (PUBLIC_ONLY) return `false` for private constructors — they are still
  filtered out.
- **`withCreatorVisibility(ANY)` now works**: `isCreatorVisible` returns `true` for private
  constructors, so they are kept — restoring Jackson 2 migration behaviour.
- **`withScalarConstructorVisibility(ANY)` continues to work** as before.

## Tests

Added `testPrivateLongDelegatingCtorWithCreatorVisibilityAny` to `TestAutoDetect`:
- Verifies that with default settings, private scalar constructors are still filtered (no
  regression).
- Verifies that with `withCreatorVisibility(ANY)`, both private `long` and private `String`
  constructors work as implicit delegating creators.

All existing `TestAutoDetect` tests pass.

> Note: This fix was authored with the assistance of Claude AI (Anthropic).