### PR TITLE
Add `java.lang.Comparable` as an "unsafe" polymorphic base type

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1928,3 +1928,8 @@ Aysha Afrah Ziya (@aysha-afrah26)
  * Reported #6129: Limit the supported URL schemes for `java.nio.file.Path`
    deserialization
   (2.18.10)
+
+@prvazsahnazarov
+ * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic
+   base types
+  (2.18.10)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,9 @@ Project: jackson-databind
   deserialization [CVE-2026-19032]
  (reported by @waydeshi)
  (fix by @pjfanning)
+#6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic base types
+  [GHSA-gx83-3vf8-gh7j]
+ (reported by @prvazsahnazarov)
 
 2.18.9 (07-Jul-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
@@ -62,6 +62,7 @@ public class DefaultBaseTypeLimitingValidator
      *  <li>{@link java.io.Serializable}</li>
      *  <li>{@link java.lang.AutoCloseable}</li>
      *  <li>{@link java.lang.Cloneable}</li>
+     *  <li>{@link java.lang.Comparable}</li>
      *  <li>{@link java.util.logging.Handler}</li>
      *  <li>{@link javax.naming.Referenceable}</li>
      *  <li>{@link javax.sql.DataSource}</li>
@@ -103,6 +104,10 @@ public class DefaultBaseTypeLimitingValidator
             UNSAFE.add(java.io.Serializable.class.getName());
             UNSAFE.add(AutoCloseable.class.getName());
             UNSAFE.add(Cloneable.class.getName());
+            // 10-Aug-2026, tatu: [GHSA-gx83-3vf8-gh7j] "Comparable" is implemented
+            //    by a very wide range of JDK and application types, similar to
+            //    "Serializable", so block it as base type as well
+            UNSAFE.add(Comparable.class.getName());
 
             // and then couple others typically included in JDK, but that we
             // prefer not adding direct reference to

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
@@ -104,9 +104,9 @@ public class DefaultBaseTypeLimitingValidator
             UNSAFE.add(java.io.Serializable.class.getName());
             UNSAFE.add(AutoCloseable.class.getName());
             UNSAFE.add(Cloneable.class.getName());
-            // 10-Aug-2026, tatu: [GHSA-gx83-3vf8-gh7j] "Comparable" is implemented
-            //    by a very wide range of JDK and application types, similar to
-            //    "Serializable", so block it as base type as well
+            // [databind#6156]: "Comparable" is implemented by a very wide range
+            //    of JDK and application types, similar to "Serializable", so
+            //    block it as base type as well
             UNSAFE.add(Comparable.class.getName());
 
             // and then couple others typically included in JDK, but that we

--- a/src/main/java/com/fasterxml/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
+++ b/src/main/java/com/fasterxml/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
@@ -62,7 +62,7 @@ public class DefaultBaseTypeLimitingValidator
      *  <li>{@link java.io.Serializable}</li>
      *  <li>{@link java.lang.AutoCloseable}</li>
      *  <li>{@link java.lang.Cloneable}</li>
-     *  <li>{@link java.lang.Comparable}</li>
+     *  <li>{@link java.lang.Comparable} (2.18.10+)</li>
      *  <li>{@link java.util.logging.Handler}</li>
      *  <li>{@link javax.naming.Referenceable}</li>
      *  <li>{@link javax.sql.DataSource}</li>
@@ -104,9 +104,7 @@ public class DefaultBaseTypeLimitingValidator
             UNSAFE.add(java.io.Serializable.class.getName());
             UNSAFE.add(AutoCloseable.class.getName());
             UNSAFE.add(Cloneable.class.getName());
-            // [databind#6156]: "Comparable" is implemented by a very wide range
-            //    of JDK and application types, similar to "Serializable", so
-            //    block it as base type as well
+            // [databind#6156]: "Comparable" added as well.
             UNSAFE.add(Comparable.class.getName());
 
             // and then couple others typically included in JDK, but that we

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
@@ -37,7 +37,7 @@ public class AnnotatedPolymorphicValidationTest
         protected WrappedPolymorphicUntypedSer() { }
     }
 
-    // [GHSA-gx83-3vf8-gh7j]
+    // [databind#6156]
     static class WrappedPolymorphicComparable {
         @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS)
         public Comparable<?> value;
@@ -66,7 +66,7 @@ public class AnnotatedPolymorphicValidationTest
         }
     }
 
-    // [GHSA-gx83-3vf8-gh7j]
+    // [databind#6156]
     static class ComparablesAreOkValidator extends DefaultBaseTypeLimitingValidator
     {
         private static final long serialVersionUID = 1L;
@@ -126,7 +126,7 @@ public class AnnotatedPolymorphicValidationTest
         }
     }
 
-    // [GHSA-gx83-3vf8-gh7j]: `Comparable` is too wide a base type to allow
+    // [databind#6156]: `Comparable` is too wide a base type to allow
     @Test
     public void testPolymorphicWithComparableBaseType() throws IOException
     {

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.DefaultBaseTypeLimitingValidator;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
@@ -80,6 +81,18 @@ public class AnnotatedPolymorphicValidationTest
             }
             return super.isUnsafeBaseType(config, baseType);
         }
+
+        @Override
+        protected boolean isSafeSubType(MapperConfig<?> config,
+                JavaType baseType, JavaType subType)
+        {
+            // ... but only allow a small set of known-safe subtypes: relaxing the
+            // base type check alone would leave all "gadget" types accessible
+            if (baseType.hasRawClass(Comparable.class)) {
+                return subType.hasRawClass(java.io.File.class);
+            }
+            return super.isSafeSubType(config, baseType, subType);
+        }
     }
 
     /*
@@ -149,5 +162,15 @@ public class AnnotatedPolymorphicValidationTest
         WrappedPolymorphicComparable w = customMapper.readValue(JSON,
                 WrappedPolymorphicComparable.class);
         assertEquals(new java.io.File("/tmp/stuff"), w.value);
+
+        // ... but that validator still only allows the subtypes it knows to be safe
+        try {
+            customMapper.readValue(a2q("{'value':['java.lang.String','stuff']}"),
+                    WrappedPolymorphicComparable.class);
+            fail("Should not pass");
+        } catch (InvalidTypeIdException e) {
+            verifyException(e, "Could not resolve type id 'java.lang.String'");
+            verifyException(e, "denied resolution");
+        }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
@@ -37,6 +37,14 @@ public class AnnotatedPolymorphicValidationTest
         protected WrappedPolymorphicUntypedSer() { }
     }
 
+    // [GHSA-gx83-3vf8-gh7j]
+    static class WrappedPolymorphicComparable {
+        @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS)
+        public Comparable<?> value;
+
+        protected WrappedPolymorphicComparable() { }
+    }
+
     static class NumbersAreOkValidator extends DefaultBaseTypeLimitingValidator
     {
         private static final long serialVersionUID = 1L;
@@ -55,6 +63,22 @@ public class AnnotatedPolymorphicValidationTest
         protected boolean isSafeSubType(MapperConfig<?> config,
                 JavaType baseType, JavaType subType) {
             return baseType.isTypeOrSubTypeOf(Number.class);
+        }
+    }
+
+    // [GHSA-gx83-3vf8-gh7j]
+    static class ComparablesAreOkValidator extends DefaultBaseTypeLimitingValidator
+    {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected boolean isUnsafeBaseType(MapperConfig<?> config, JavaType baseType)
+        {
+            // only override handling for `Comparable`
+            if (baseType.hasRawClass(Comparable.class)) {
+                return false;
+            }
+            return super.isUnsafeBaseType(config, baseType);
         }
     }
 
@@ -100,5 +124,30 @@ public class AnnotatedPolymorphicValidationTest
             verifyException(e, "all subtypes of base type");
             verifyException(e, "java.io.Serializable");
         }
+    }
+
+    // [GHSA-gx83-3vf8-gh7j]: `Comparable` is too wide a base type to allow
+    @Test
+    public void testPolymorphicWithComparableBaseType() throws IOException
+    {
+        final String JSON = a2q("{'value':['java.io.File','/tmp/stuff']}");
+
+        try {
+            /*w =*/ MAPPER.readValue(JSON, WrappedPolymorphicComparable.class);
+            fail("Should not pass");
+        } catch (InvalidDefinitionException e) {
+            verifyException(e, "Configured");
+            verifyException(e, "all subtypes of base type");
+            verifyException(e, "java.lang.Comparable");
+        }
+
+        // but may be allowed with custom validator that overrides base type check
+        ObjectMapper customMapper = JsonMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .polymorphicTypeValidator(new ComparablesAreOkValidator())
+                .build();
+        WrappedPolymorphicComparable w = customMapper.readValue(JSON,
+                WrappedPolymorphicComparable.class);
+        assertEquals(new java.io.File("/tmp/stuff"), w.value);
     }
 }


### PR DESCRIPTION
Fixes #6156.