### PR TITLE
Honor `@JsonIncludeProperties` in `ThrowableDeserializer` any-setter path

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -395,6 +395,9 @@ Aysha Afrah Ziya (@aysha-afrah26)
   [3.1.6]
  * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
   [3.1.6]
+ * Fixed #6157: `@JsonIncludeProperties` not honored for `Throwable` types with
+   `@JsonAnySetter`
+  [3.1.7]
  * Fixed #6165: Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float` Map keys
    [3.1.6]
  * Fixed #6174: Honor `@JsonView` in `ThrowableDeserializer.deserializeFromObject()`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -11,6 +11,9 @@ No changes since 3.1
 
 3.1.7 (not yet released)
 
+#6157: `@JsonIncludeProperties` not honored for `Throwable` types with
+  `@JsonAnySetter`
+ (fix by Aysha A-Z)
 #6174: Honor `@JsonView` in `ThrowableDeserializer.deserializeFromObject()`
  (fix by Aysha A-Z)
 #6179: Apply `StreamReadConstraints` number length limit when coercing String

--- a/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
@@ -202,12 +202,6 @@ public class ThrowableDeserializer
                 continue;
             }
 
-            // Things marked as ignorable (or not in the "include" allow-list) should
-            // not be passed to any setter
-            if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
-                handleIgnoredProperty(p, ctxt, handledType(), propName);
-                continue;
-            }
             if (PROP_NAME_SUPPRESSED.equalsIgnoreCase(propName)) { // or "suppressed"?
                 // 07-Dec-2023, tatu: Not sure how/why, but JSON Null is otherwise
                 //    not handled with such call so...
@@ -223,6 +217,14 @@ public class ThrowableDeserializer
             }
             if (PROP_NAME_LOCALIZED_MESSAGE.equalsIgnoreCase(propName)) {
                 p.skipChildren();
+                continue;
+            }
+            // Things marked as ignorable (or not in the "include" allow-list) should
+            // not be passed to any setter. NOTE: checked only after the standard
+            // `Throwable` properties above, which are never subject to filtering
+            // (same rationale as `_isStandardThrowableProperty()`)
+            if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
+                handleIgnoredProperty(p, ctxt, handledType(), propName);
                 continue;
             }
             if (_anySetter != null) {

--- a/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
@@ -11,6 +11,7 @@ import tools.jackson.databind.deser.bean.BeanDeserializer;
 import tools.jackson.databind.deser.bean.BeanPropertyMap;
 import tools.jackson.databind.deser.bean.PropertyBasedCreator;
 import tools.jackson.databind.deser.impl.UnwrappedPropertyHandler;
+import tools.jackson.databind.util.IgnorePropertiesUtil;
 import tools.jackson.databind.util.NameTransformer;
 
 /**
@@ -185,9 +186,10 @@ public class ThrowableDeserializer
                 continue;
             }
 
-            // Things marked as ignorable should not be passed to any setter
-            if ((_ignorableProps != null) && _ignorableProps.contains(propName)) {
-                p.skipChildren();
+            // Things marked as ignorable (or not in the "include" allow-list) should
+            // not be passed to any setter
+            if (IgnorePropertiesUtil.shouldIgnore(propName, _ignorableProps, _includableProps)) {
+                handleIgnoredProperty(p, ctxt, handledType(), propName);
                 continue;
             }
             if (PROP_NAME_SUPPRESSED.equalsIgnoreCase(propName)) { // or "suppressed"?

--- a/src/test/java/tools/jackson/databind/exc/ThrowableDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/exc/ThrowableDeserializerTest.java
@@ -60,6 +60,17 @@ public class ThrowableDeserializerTest extends DatabindTestUtil
         public AnySetterException(String msg) { super(msg); }
     }
 
+    // Exception combining @JsonIncludeProperties allow-list with @JsonAnySetter
+    @JsonIncludeProperties({"message"})
+    @SuppressWarnings("serial")
+    static class IncludePropsAnySetterException extends Exception {
+        @JsonAnySetter
+        public Map<String, Object> extra = new LinkedHashMap<>();
+
+        public IncludePropsAnySetterException() { super(); }
+        public IncludePropsAnySetterException(String msg) { super(msg); }
+    }
+
     // Exception with @JsonCreator, @JsonAnySetter and extra props
     @SuppressWarnings("serial")
     static class MyException extends Exception
@@ -411,6 +422,20 @@ public class ThrowableDeserializerTest extends DatabindTestUtil
         assertNotNull(result);
         assertNull(result.getMessage());
         assertTrue(result.extra.containsKey("unknownProp"));
+    }
+
+    @Test
+    public void includePropertiesHonoredWithAnySetter() throws Exception
+    {
+        // a property outside the @JsonIncludeProperties allow-list must not be
+        // routed to the any-setter
+        String json = """
+                {"message":"the msg","secret":"leaked","admin":true}""";
+        IncludePropsAnySetterException result = MAPPER.readValue(json, IncludePropsAnySetterException.class);
+        assertNotNull(result);
+        assertEquals("the msg", result.getMessage());
+        assertTrue(result.extra.isEmpty(),
+                "non-included properties leaked into any-setter: " + result.extra.keySet());
     }
 
     /*

--- a/src/test/java/tools/jackson/databind/exc/ThrowableDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/exc/ThrowableDeserializerTest.java
@@ -438,6 +438,43 @@ public class ThrowableDeserializerTest extends DatabindTestUtil
                 "non-included properties leaked into any-setter: " + result.extra.keySet());
     }
 
+    @Test
+    public void includePropertiesDoesNotDropStandardProps() throws Exception
+    {
+        // ...but the standard `Throwable` properties are not subject to the
+        // allow-list: they carry no annotations of their own and so would
+        // otherwise be dropped by every allow-list that fails to name them
+        String json = """
+                {"message":"the msg","localizedMessage":"the msg",\
+                "suppressed":[{"message":"suppressed one"}]}""";
+        IncludePropsAnySetterException result = MAPPER.readValue(json,
+                IncludePropsAnySetterException.class);
+        assertNotNull(result);
+        assertEquals("the msg", result.getMessage());
+        assertTrue(result.extra.isEmpty(),
+                "standard properties leaked into any-setter: " + result.extra.keySet());
+
+        Throwable[] suppressed = result.getSuppressed();
+        assertEquals(1, suppressed.length,
+                "'suppressed' should be set despite @JsonIncludeProperties allow-list");
+        assertEquals("suppressed one", suppressed[0].getMessage());
+    }
+
+    @Test
+    public void includePropertiesStandardPropsWithFailOnIgnored() throws Exception
+    {
+        // and, being exempt, they must not trigger FAIL_ON_IGNORED_PROPERTIES either
+        ObjectMapper mapper = jsonMapperBuilder()
+                .enable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+                .build();
+        String json = """
+                {"message":"the msg","localizedMessage":"the msg","suppressed":[]}""";
+        IncludePropsAnySetterException result = mapper.readValue(json,
+                IncludePropsAnySetterException.class);
+        assertEquals("the msg", result.getMessage());
+        assertEquals(0, result.getSuppressed().length);
+    }
+
     /*
     /**********************************************************
     /* Tests for localizedMessage handling


### PR DESCRIPTION
`ThrowableDeserializer` keeps its own property loop, separate from `BeanDeserializer`, because the message and cause have to be resolved before other values are applied. When that loop hits a name that isn't a known property it decides whether to drop it by testing `_ignorableProps.contains(name)`, which only covers the `@JsonIgnoreProperties` deny-list and never looks at `_includableProps`, so `@JsonIncludeProperties` is not applied on this path at all. On an exception type that also has an `@JsonAnySetter`, a property left out of the include allow-list is then not skipped and lands in the any-setter map instead, which defeats the point of the allow-list. The matching `BeanDeserializer` paths guard the same spot with `IgnorePropertiesUtil.shouldIgnore(name, _ignorableProps, _includableProps)`, so a plain bean with the same annotations already behaves correctly and only `Throwable` subtypes diverge. I came across it while checking that the include allow-list was honored wherever the deny-list is, and this was the one path that missed it. Routing the drop through `handleIgnoredProperty` also lets `FAIL_ON_IGNORED_PROPERTIES` apply, matching the sibling paths. Reported in #6157; affects 3.1, 3.2 and 3.x.
