### PR TITLE
Add java.lang.Comparable to unsafe polymorphic base types

### DIFF
--- a/src/main/java/tools/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
+++ b/src/main/java/tools/jackson/databind/jsontype/DefaultBaseTypeLimitingValidator.java
@@ -118,6 +118,9 @@ ClassUtil.classNameOf(getClass()), ClassUtil.classNameOf(baseType.getRawClass())
             UNSAFE.add(Cloneable.class.getName());
             // [databind#5014]:
             UNSAFE.add(Runnable.class.getName());
+            // [databind#6156]: implemented across a very wide range of JDK and
+            // application types, so offers no meaningful restriction as a base type
+            UNSAFE.add(Comparable.class.getName());
 
             // and then couple others typically included in JDK, but that we
             // prefer not adding direct reference to

--- a/src/test/java/tools/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
+++ b/src/test/java/tools/jackson/databind/jsontype/vld/AnnotatedPolymorphicValidationTest.java
@@ -35,6 +35,13 @@ public class AnnotatedPolymorphicValidationTest
         protected WrappedPolymorphicUntypedSer() { }
     }
 
+    static class WrappedPolymorphicUntypedComparable {
+        @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS)
+        public Comparable<?> value;
+
+        protected WrappedPolymorphicUntypedComparable() { }
+    }
+
     static class NumbersAreOkValidator extends DefaultBaseTypeLimitingValidator
     {
         private static final long serialVersionUID = 1L;
@@ -90,5 +97,18 @@ public class AnnotatedPolymorphicValidationTest
         verifyException(e2, "all subtypes of base type");
         verifyException(e2, "java.io.Serializable");
 
+    }
+
+    // [databind#6156]: `Comparable` is implemented by a very wide range of types,
+    // so it offers no meaningful restriction and must be blocked like `Serializable`
+    @Test
+    public void testPolymorphicWithComparableBaseType() throws IOException
+    {
+        final String JSON = a2q("{'value':10}");
+        InvalidDefinitionException e = assertThrows(InvalidDefinitionException.class,
+                () -> MAPPER.readValue(JSON, WrappedPolymorphicUntypedComparable.class));
+        verifyException(e, "Configured");
+        verifyException(e, "all subtypes of base type");
+        verifyException(e, "java.lang.Comparable");
     }
 }


### PR DESCRIPTION
Fixes #6156 (GHSA-gx83-3vf8-gh7j).

Adds `java.lang.Comparable` to the unsafe base type set in `DefaultBaseTypeLimitingValidator`, alongside `Object`, `Serializable`, `Closeable`, `AutoCloseable`, `Cloneable`, `Runnable` and the reflectively-named JDK entries:

```java
// [databind#6156]: implemented across a very wide range of JDK and
// application types, so offers no meaningful restriction as a base type
UNSAFE.add(Comparable.class.getName());
```

## Test

Added `testPolymorphicWithComparableBaseType` to `AnnotatedPolymorphicValidationTest`, mirroring the existing `Serializable` assertions — a `@JsonTypeInfo(use=Id.CLASS)` property declared as `Comparable<?>` must be rejected with `InvalidDefinitionException`.

It demonstrates the issue directly. On `3.x` without the change:

```
AnnotatedPolymorphicValidationTest.testPolymorphicWithComparableBaseType
  Expected tools.jackson.databind.exc.InvalidDefinitionException to be thrown, but nothing was thrown.
```

i.e. the `Comparable`-based property was accepted. With the change the test passes, and the full `tools.jackson.databind.jsontype.**` package is green (530 tests).

## Note on branches

Raised against `3.x`, where `DefaultBaseTypeLimitingValidator` is the default validator and so the exposure is reachable without opting in. The issue is tagged `2.18`, and in 2.x the validator only applies when `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES` is enabled — happy to raise the equivalent one-line change against whichever 2.x branch you want it in first if you'd rather it flow forward instead.
