### PR TITLE
Add JsonPointer property deserialization support

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.3.0 (not yet released)
 
+#357 (annotations): Support deserialization of properties selected by
+  `@JsonPointer`
 #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle arrays of
   polymorphic types: now fails eagerly with clear `InvalidDefinitionException`
   (on both serialization and deserialization) instead of confusing low-level error

--- a/src/main/java/tools/jackson/databind/AnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/databind/AnnotationIntrospector.java
@@ -552,6 +552,16 @@ public abstract class AnnotationIntrospector
     public NameTransformer findUnwrappingNameTransformer(MapperConfig<?> config, AnnotatedMember member) { return null; }
 
     /**
+     * Method called to find a JSON Pointer expression used as the source of
+     * the value for a property during deserialization.
+     *
+     * @return JSON Pointer expression, if defined; {@code null} otherwise
+     *
+     * @since 3.3
+     */
+    public String findPropertyJsonPointer(MapperConfig<?> config, AnnotatedMember member) { return null; }
+
+    /**
      * Method called to check whether given property is marked to
      * be ignored. This is used to determine whether to ignore
      * properties, on per-property basis, usually combining

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -14,6 +14,7 @@ import tools.jackson.databind.deser.SettableBeanProperty;
 import tools.jackson.databind.deser.UnresolvedForwardReference;
 import tools.jackson.databind.deser.impl.*;
 import tools.jackson.databind.exc.UnrecognizedPropertyException;
+import tools.jackson.databind.node.TreeTraversingParser;
 import tools.jackson.databind.util.ClassUtil;
 import tools.jackson.databind.util.IgnorePropertiesUtil;
 import tools.jackson.databind.util.NameTransformer;
@@ -186,6 +187,24 @@ public class BeanDeserializer
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException
     {
+        if (_jsonPointerPropertyHandler != null && p.isExpectedStartObjectToken()) {
+            JsonNode source = ctxt.readTree(p);
+            JsonNode beanSource = _jsonPointerPropertyHandler
+                    .prepareForBeanBinding(source, _beanProperties);
+            Object bean;
+            try (JsonParser treeParser = new TreeTraversingParser(beanSource, ctxt)) {
+                treeParser.nextToken();
+                bean = _deserializeWithoutJsonPointer(treeParser, ctxt);
+            }
+            _jsonPointerPropertyHandler.process(ctxt, bean, source);
+            return bean;
+        }
+        return _deserializeWithoutJsonPointer(p, ctxt);
+    }
+
+    private Object _deserializeWithoutJsonPointer(JsonParser p, DeserializationContext ctxt)
+            throws JacksonException
+    {
         // common case first
         if (p.isExpectedStartObjectToken()) {
             if (_vanillaProcessing) {
@@ -246,6 +265,24 @@ public class BeanDeserializer
      */
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt, Object bean) throws JacksonException
+    {
+        if (_jsonPointerPropertyHandler != null && p.isExpectedStartObjectToken()) {
+            JsonNode source = ctxt.readTree(p);
+            JsonNode beanSource = _jsonPointerPropertyHandler
+                    .prepareForBeanBinding(source, _beanProperties);
+            Object updated;
+            try (JsonParser treeParser = new TreeTraversingParser(beanSource, ctxt)) {
+                treeParser.nextToken();
+                updated = _deserializeWithoutJsonPointer(treeParser, ctxt, bean);
+            }
+            _jsonPointerPropertyHandler.process(ctxt, updated, source);
+            return updated;
+        }
+        return _deserializeWithoutJsonPointer(p, ctxt, bean);
+    }
+
+    private Object _deserializeWithoutJsonPointer(JsonParser p, DeserializationContext ctxt,
+            Object bean) throws JacksonException
     {
         // [databind#631]: Assign current value, to be accessible by custom serializers
         p.assignCurrentValue(bean);

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -195,6 +195,13 @@ public abstract class BeanDeserializerBase
     protected UnwrappedPropertyHandler _unwrappedPropertyHandler;
 
     /**
+     * Handler for properties bound from JSON Pointer expressions.
+     *
+     * @since 3.3
+     */
+    protected JsonPointerPropertyHandler _jsonPointerPropertyHandler;
+
+    /**
      * Handler that we need if any of properties uses external
      * type id.
      */
@@ -322,6 +329,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _jsonPointerPropertyHandler = src._jsonPointerPropertyHandler;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -357,6 +365,7 @@ public abstract class BeanDeserializerBase
         _nonStandardCreation = src._nonStandardCreation;
 
         _unwrappedPropertyHandler = unwrapHandler;
+        _jsonPointerPropertyHandler = src._jsonPointerPropertyHandler;
         _propertyBasedCreator = propertyBasedCreator;
         _beanProperties = renamedProperties;
 
@@ -388,6 +397,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _jsonPointerPropertyHandler = src._jsonPointerPropertyHandler;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -435,6 +445,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _jsonPointerPropertyHandler = src._jsonPointerPropertyHandler;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -469,6 +480,7 @@ public abstract class BeanDeserializerBase
 
         _nonStandardCreation = src._nonStandardCreation;
         _unwrappedPropertyHandler = src._unwrappedPropertyHandler;
+        _jsonPointerPropertyHandler = src._jsonPointerPropertyHandler;
         _needViewProcesing = src._needViewProcesing;
         _serializationShape = src._serializationShape;
 
@@ -592,6 +604,28 @@ public abstract class BeanDeserializerBase
                 if (!(prop instanceof ManagedReferenceProperty)) {
                     prop = _resolvedObjectIdProperty(ctxt, prop);
                 }
+                String jsonPointer = ctxt.getAnnotationIntrospector()
+                        .findPropertyJsonPointer(ctxt.getConfig(), prop.getMember());
+                if (jsonPointer != null) {
+                    if (prop.isCreatorProperty()) {
+                        ctxt.reportBadDefinition(_beanType,
+                                "Cannot use @JsonPointer on Creator property '"+prop.getName()+"'");
+                    }
+                    if (_jsonPointerPropertyHandler == null) {
+                        _jsonPointerPropertyHandler = new JsonPointerPropertyHandler();
+                    }
+                    tools.jackson.core.JsonPointer compiledPointer;
+                    try {
+                        compiledPointer = tools.jackson.core.JsonPointer.compile(jsonPointer);
+                    } catch (IllegalArgumentException e) {
+                        compiledPointer = ctxt.reportBadDefinition(_beanType,
+                                "Invalid @JsonPointer value '"+jsonPointer+"' for property '"
+                                +prop.getName()+"': "+e.getMessage());
+                    }
+                    _jsonPointerPropertyHandler.addProperty(compiledPointer, prop);
+                    _beanProperties.remove(prop);
+                    continue;
+                }
                 // Support unwrapped values (via @JsonUnwrapped)
                 NameTransformer xform = _findPropertyUnwrapper(ctxt, prop);
                 if (xform != null) {
@@ -647,6 +681,10 @@ public abstract class BeanDeserializerBase
         }
         // [databind#1755]: mark that bean properties are fully contextualized
         _propertiesContextualized = true;
+
+        if (_jsonPointerPropertyHandler != null) {
+            _vanillaProcessing = false;
+        }
 
         // "any setter" may also need to be resolved now
         if ((_anySetter != null) && !_anySetter.hasValueDeserializer()) {

--- a/src/main/java/tools/jackson/databind/deser/impl/JsonPointerPropertyHandler.java
+++ b/src/main/java/tools/jackson/databind/deser/impl/JsonPointerPropertyHandler.java
@@ -1,0 +1,90 @@
+package tools.jackson.databind.deser.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.SettableBeanProperty;
+import tools.jackson.databind.deser.bean.BeanPropertyMap;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.TreeTraversingParser;
+
+/**
+ * Helper used for properties whose input values are selected with
+ * {@link com.fasterxml.jackson.annotation.JsonPointer}.
+ *
+ * @since 3.3
+ */
+public final class JsonPointerPropertyHandler
+{
+    private final List<PointerProperty> _properties = new ArrayList<>();
+
+    public void addProperty(JsonPointer pointer, SettableBeanProperty property) {
+        _properties.add(new PointerProperty(pointer, property));
+    }
+
+    public JsonNode prepareForBeanBinding(JsonNode source, BeanPropertyMap beanProperties) {
+        if (!(source instanceof ObjectNode)) {
+            return source;
+        }
+        Set<String> pointerRoots = new LinkedHashSet<>();
+        for (PointerProperty pointerProperty : _properties) {
+            JsonPointer pointer = pointerProperty.pointer;
+            if (pointer.matches() || !pointer.mayMatchProperty()) {
+                continue;
+            }
+            String rootName = pointer.getMatchingProperty();
+            if (beanProperties.findDefinition(rootName) == null) {
+                pointerRoots.add(rootName);
+            }
+        }
+        if (pointerRoots.isEmpty()) {
+            return source;
+        }
+        ObjectNode sourceObject = (ObjectNode) source;
+        ObjectNode filtered = sourceObject.objectNode();
+        for (var entry : sourceObject.properties()) {
+            if (!pointerRoots.contains(entry.getKey())) {
+                filtered.set(entry.getKey(), entry.getValue());
+            }
+        }
+        return filtered;
+    }
+
+    public void process(DeserializationContext ctxt, Object bean, JsonNode source)
+            throws JacksonException {
+        for (PointerProperty pointerProperty : _properties) {
+            JsonNode value = source.at(pointerProperty.pointer);
+            if (value.isMissingNode()) {
+                continue;
+            }
+            try (JsonParser p = new TreeTraversingParser(value, ctxt)) {
+                p.nextToken();
+                try {
+                    pointerProperty.property.deserializeAndSet(p, ctxt, bean);
+                } catch (Exception e) {
+                    throw DatabindException.wrapWithPath(ctxt, e,
+                            new JacksonException.Reference(bean,
+                                    pointerProperty.property.getName()));
+                }
+            }
+        }
+    }
+
+    private static final class PointerProperty {
+        final JsonPointer pointer;
+        final SettableBeanProperty property;
+
+        PointerProperty(JsonPointer pointer, SettableBeanProperty property) {
+            this.pointer = pointer;
+            this.property = property;
+        }
+    }
+}

--- a/src/main/java/tools/jackson/databind/introspect/AnnotationIntrospectorPair.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotationIntrospectorPair.java
@@ -272,6 +272,12 @@ public class AnnotationIntrospectorPair
     }
 
     @Override
+    public String findPropertyJsonPointer(MapperConfig<?> config, AnnotatedMember member) {
+        String r = _primary.findPropertyJsonPointer(config, member);
+        return (r == null) ? _secondary.findPropertyJsonPointer(config, member) : r;
+    }
+
+    @Override
     public JacksonInject.Value findInjectableValue(MapperConfig<?> config, AnnotatedMember m) {
         JacksonInject.Value r = _primary.findInjectableValue(config, m);
         if (r == null || r.getUseInput() == null) {

--- a/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
+++ b/src/main/java/tools/jackson/databind/introspect/JacksonAnnotationIntrospector.java
@@ -518,6 +518,12 @@ public class JacksonAnnotationIntrospector
         return NameTransformer.simpleTransformer(prefix, suffix);
     }
 
+    @Override
+    public String findPropertyJsonPointer(MapperConfig<?> config, AnnotatedMember member) {
+        JsonPointer ann = _findAnnotation(member, JsonPointer.class);
+        return (ann == null) ? null : ann.value();
+    }
+
     @Override // since 2.9
     public JacksonInject.Value findInjectableValue(MapperConfig<?> config, AnnotatedMember m) {
         JacksonInject ann = _findAnnotation(m, JacksonInject.class);

--- a/src/test/java/tools/jackson/databind/deser/JsonPointerDeserializationTest.java
+++ b/src/test/java/tools/jackson/databind/deser/JsonPointerDeserializationTest.java
@@ -1,0 +1,114 @@
+package tools.jackson.databind.deser;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonPointer;
+
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidDefinitionException;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JsonPointerDeserializationTest
+{
+    private final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+    static class FieldBean {
+        public String name;
+
+        @JsonPointer("/employee/details/departmentId")
+        public Integer departmentId = 99;
+    }
+
+    static class SetterBean {
+        private String value;
+
+        @JsonPointer("/data/a~1b/c~0d")
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    static class InvalidPointerBean {
+        @JsonPointer("not-a-pointer")
+        public String value;
+    }
+
+    @Test
+    public void testPointerBoundField() throws Exception {
+        FieldBean bean = MAPPER.readValue(
+                "{\"name\":\"Bob\",\"employee\":{\"details\":{\"departmentId\":123}}}",
+                FieldBean.class);
+
+        assertEquals("Bob", bean.name);
+        assertEquals(123, bean.departmentId);
+    }
+
+    @Test
+    public void testPointerEscapingOnSetter() throws Exception {
+        SetterBean bean = MAPPER.readValue(
+                "{\"data\":{\"a/b\":{\"c~d\":\"found\"}}}", SetterBean.class);
+
+        assertEquals("found", bean.value);
+    }
+
+    @Test
+    public void testMissingPointerLeavesPropertyAbsent() throws Exception {
+        FieldBean bean = MAPPER.readValue("{\"name\":\"Bob\"}", FieldBean.class);
+
+        assertEquals(99, bean.departmentId);
+    }
+
+    @Test
+    public void testExplicitNullIsBound() throws Exception {
+        FieldBean bean = MAPPER.readValue(
+                "{\"employee\":{\"details\":{\"departmentId\":null}}}", FieldBean.class);
+
+        assertNull(bean.departmentId);
+    }
+
+    @Test
+    public void testPointerBoundFieldWhenUpdating() throws Exception {
+        FieldBean bean = new FieldBean();
+        bean.name = "before";
+
+        FieldBean updated = MAPPER.readerForUpdating(bean).readValue(
+                "{\"name\":\"after\",\"employee\":{\"details\":{\"departmentId\":123}}}");
+
+        assertEquals("after", updated.name);
+        assertEquals(123, updated.departmentId);
+    }
+
+    @Test
+    public void testInvalidPointerReportsDefinitionProblem() {
+        InvalidDefinitionException e = assertThrows(InvalidDefinitionException.class,
+                () -> MAPPER.readValue("{}", InvalidPointerBean.class));
+
+        assertTrue(e.getMessage().contains("Invalid @JsonPointer value 'not-a-pointer'"));
+    }
+
+    @Test
+    public void testPointerPropertyFailureHasPropertyPath() {
+        InvalidFormatException e = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(
+                        "{\"employee\":{\"details\":{\"departmentId\":\"not-an-integer\"}}}",
+                        FieldBean.class));
+
+        assertEquals("departmentId", e.getPath().get(0).getPropertyName());
+    }
+
+    @Test
+    public void testUnrelatedUnknownPropertyStillFails() {
+        assertThrows(UnrecognizedPropertyException.class,
+                () -> MAPPER.readerFor(FieldBean.class)
+                        .with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                        .readValue("{\"unknown\":true}"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds databind support for deserializing POJO properties from nested JSON values selected with `@JsonPointer`.

References:

- Annotation API: https://github.com/FasterXML/jackson-annotations/pull/358
- Original feature request: https://github.com/FasterXML/jackson-annotations/issues/357

## Example

Given:

```json
{
  "name": "Bob",
  "employee": {
    "details": {
      "departmentId": 123
    }
  }
}
```

A property can be bound directly using:

```java
public class Employee {
    public String name;

    @JsonPointer("/employee/details/departmentId")
    public Integer departmentId;
}
```

## Implementation

- Adds `@JsonPointer` support to `AnnotationIntrospector`.
- Supports annotation-introspector pairs and `JacksonAnnotationIntrospector`.
- Detects and contextualizes pointer-bound properties during bean deserializer resolution.
- Buffers input only for POJOs containing pointer-bound properties.
- Uses the existing property deserializer when binding the selected value, preserving standard type coercion, custom deserializers, null handling, and assignment behavior.
- Removes pointer-only top-level source properties from regular bean binding so they are not treated as unknown.
- Continues to report unrelated unknown properties when `FAIL_ON_UNKNOWN_PROPERTIES` is enabled.

## Initial scope

- Deserialization only.
- Supports fields and setter methods.
- Creator properties are explicitly rejected.
- A missing pointer target leaves the property unchanged.
- An explicit JSON `null` uses normal property null handling.
- Pointer syntax and escaping follow RFC 6901.

## Testing

Focused coverage includes:

- Nested field binding
- Setter binding
- RFC 6901 escaping
- Missing pointer targets
- Explicit JSON `null`
- Unrelated unknown-property handling

```shell
./mvnw -Dtest=JsonPointerDeserializationTest test
```

Result:

```text
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```