### PR TITLE
Document that CacheProvider must return new cache instances

### DIFF
--- a/src/main/java/tools/jackson/databind/cfg/CacheProvider.java
+++ b/src/main/java/tools/jackson/databind/cfg/CacheProvider.java
@@ -11,12 +11,8 @@ import tools.jackson.databind.util.TypeKey;
  * A {@link CacheProvider} instance will be configured through a builder such as
  * {@link tools.jackson.databind.json.JsonMapper.Builder#cacheProvider(CacheProvider)}.
  * <p>
- * Do not return the same {@link LookupCache} instance from
- * {@link #forDeserializerCache} for two mappers that use different
- * {@link tools.jackson.databind.jsontype.PolymorphicTypeValidator}
- * settings. {@link DeserializerCache} keys only on {@link JavaType}, and a
- * {@code TypeDeserializer} keeps the PTV it was built with. A shared cache
- * then keeps serving the first mapper's validator.
+ * Each factory method must construct and return a new {@link LookupCache}
+ * instance. Shared cache instances must not be returned.
  */
 public interface CacheProvider
     extends java.io.Serializable

--- a/src/main/java/tools/jackson/databind/cfg/CacheProvider.java
+++ b/src/main/java/tools/jackson/databind/cfg/CacheProvider.java
@@ -9,7 +9,14 @@ import tools.jackson.databind.util.TypeKey;
  * Interface that defines API Jackson uses for constructing various internal
  * caches. This allows configuring custom caches and cache configurations.
  * A {@link CacheProvider} instance will be configured through a builder such as
- * {@link tools.jackson.databind.json.JsonMapper.Builder#cacheProvider(CacheProvider)}
+ * {@link tools.jackson.databind.json.JsonMapper.Builder#cacheProvider(CacheProvider)}.
+ * <p>
+ * Do not return the same {@link LookupCache} instance from
+ * {@link #forDeserializerCache} for two mappers that use different
+ * {@link tools.jackson.databind.jsontype.PolymorphicTypeValidator}
+ * settings. {@link DeserializerCache} keys only on {@link JavaType}, and a
+ * {@code TypeDeserializer} keeps the PTV it was built with. A shared cache
+ * then keeps serving the first mapper's validator.
  */
 public interface CacheProvider
     extends java.io.Serializable

--- a/src/main/java/tools/jackson/databind/cfg/MapperBuilder.java
+++ b/src/main/java/tools/jackson/databind/cfg/MapperBuilder.java
@@ -1458,17 +1458,6 @@ public abstract class MapperBuilder<M extends ObjectMapper,
         return _this();
     }
 
-    /**
-     * Sets the {@link CacheProvider} used to construct deserializer, serializer
-     * and {@link TypeFactory} caches.
-     * <p>
-     * If the provider returns one shared {@link tools.jackson.databind.util.LookupCache}
-     * from {@link CacheProvider#forDeserializerCache}, do not reuse that cache
-     * across mappers with different
-     * {@link tools.jackson.databind.jsontype.PolymorphicTypeValidator}
-     * configuration. The cache key is only the {@link JavaType}, so the first
-     * mapper's validator wins for later lookups.
-     */
     public B cacheProvider(CacheProvider cacheProvider) {
         _baseSettings = _baseSettings.with(cacheProvider);
         // Unlike Deserializer-/SerializerCaches, need to eagerly update

--- a/src/main/java/tools/jackson/databind/cfg/MapperBuilder.java
+++ b/src/main/java/tools/jackson/databind/cfg/MapperBuilder.java
@@ -1458,6 +1458,17 @@ public abstract class MapperBuilder<M extends ObjectMapper,
         return _this();
     }
 
+    /**
+     * Sets the {@link CacheProvider} used to construct deserializer, serializer
+     * and {@link TypeFactory} caches.
+     * <p>
+     * If the provider returns one shared {@link tools.jackson.databind.util.LookupCache}
+     * from {@link CacheProvider#forDeserializerCache}, do not reuse that cache
+     * across mappers with different
+     * {@link tools.jackson.databind.jsontype.PolymorphicTypeValidator}
+     * configuration. The cache key is only the {@link JavaType}, so the first
+     * mapper's validator wins for later lookups.
+     */
     public B cacheProvider(CacheProvider cacheProvider) {
         _baseSettings = _baseSettings.with(cacheProvider);
         // Unlike Deserializer-/SerializerCaches, need to eagerly update

--- a/src/main/java/tools/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/tools/jackson/databind/deser/DeserializerCache.java
@@ -22,6 +22,11 @@ import tools.jackson.databind.util.SimpleLookupCache;
  * {@link tools.jackson.databind.DeserializationContext})
  * and classes that construct deserializers
  * ({@link tools.jackson.databind.deser.DeserializerFactory}).
+ * <p>
+ * Entries are keyed only by {@link JavaType}. A {@code TypeDeserializer}
+ * stores the {@code PolymorphicTypeValidator} it was constructed with, so
+ * sharing one cache across mappers with different validators makes the
+ * first-seen validator stick. Give each such mapper its own cache.
  */
 public final class DeserializerCache
     implements java.io.Serializable

--- a/src/main/java/tools/jackson/databind/deser/DeserializerCache.java
+++ b/src/main/java/tools/jackson/databind/deser/DeserializerCache.java
@@ -23,10 +23,7 @@ import tools.jackson.databind.util.SimpleLookupCache;
  * and classes that construct deserializers
  * ({@link tools.jackson.databind.deser.DeserializerFactory}).
  * <p>
- * Entries are keyed only by {@link JavaType}. A {@code TypeDeserializer}
- * stores the {@code PolymorphicTypeValidator} it was constructed with, so
- * sharing one cache across mappers with different validators makes the
- * first-seen validator stick. Give each such mapper its own cache.
+ * Instances are not to be shared across mappers.
  */
 public final class DeserializerCache
     implements java.io.Serializable


### PR DESCRIPTION
CacheProvider factory methods should construct and return a new LookupCache each time, not a shared instance.

Also noted on DeserializerCache that instances are not shared across mappers.

Fixes #6149