### PR TITLE
Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float` Map keys

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -395,6 +395,9 @@ Aysha Afrah Ziya (@aysha-afrah26)
   [3.1.6]
  * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
   [3.1.6]
+ * Fixed #6153: Apply `StreamReadConstraints` number length limits to `BigInteger`,
+   `BigDecimal`, `Float` and `Double` `Map` keys
+  [3.1.6]
 
 @waydeshi
  * Reported #6127: Add `StreamReadConstraints` number len constraint to

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -395,9 +395,8 @@ Aysha Afrah Ziya (@aysha-afrah26)
   [3.1.6]
  * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
   [3.1.6]
- * Fixed #6165: Apply `StreamReadConstraints` number length limits to `BigInteger`,
-   `BigDecimal`, `Float` and `Double` `Map` keys
-  [3.1.6]
+ * Fixed #6165: Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float` Map keys
+   [3.1.6]
 
 @waydeshi
  * Reported #6127: Add `StreamReadConstraints` number len constraint to

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -395,7 +395,7 @@ Aysha Afrah Ziya (@aysha-afrah26)
   [3.1.6]
  * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
   [3.1.6]
- * Fixed #6153: Apply `StreamReadConstraints` number length limits to `BigInteger`,
+ * Fixed #6165: Apply `StreamReadConstraints` number length limits to `BigInteger`,
    `BigDecimal`, `Float` and `Double` `Map` keys
   [3.1.6]
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -42,8 +42,7 @@ No changes since 3.1
 #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic base types
   [GHSA-gx83-3vf8-gh7j]
  (reported by @prvazsahnazarov)
-#6165: Apply `StreamReadConstraints` number length limits to `BigInteger`,
-  `BigDecimal`, `Float` and `Double` `Map` keys
+#6165: Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float` Map keys
  (fix by Aysha A-Z)
 
 3.1.5 (07-Jul-2026)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -39,12 +39,12 @@ No changes since 3.1
 #6137: `DefaultCacheProvider.Builder` does not preserve default cache sizes
   for unspecified values
  (reported, fixed by DongNyoung L)
-#6153: Apply `StreamReadConstraints` number length limits to `BigInteger`,
-  `BigDecimal`, `Float` and `Double` `Map` keys
- (fix by Aysha A-Z)
 #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic base types
   [GHSA-gx83-3vf8-gh7j]
  (reported by @prvazsahnazarov)
+#6165: Apply `StreamReadConstraints` number length limits to `BigInteger`,
+  `BigDecimal`, `Float` and `Double` `Map` keys
+ (fix by Aysha A-Z)
 
 3.1.5 (07-Jul-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -39,6 +39,9 @@ No changes since 3.1
 #6137: `DefaultCacheProvider.Builder` does not preserve default cache sizes
   for unspecified values
  (reported, fixed by DongNyoung L)
+#6153: Apply `StreamReadConstraints` number length limits to `BigInteger`,
+  `BigDecimal`, `Float` and `Double` `Map` keys
+ (fix by Aysha A-Z)
 #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic base types
   [GHSA-gx83-3vf8-gh7j]
  (reported by @prvazsahnazarov)

--- a/src/main/java/tools/jackson/databind/deser/jdk/JDKKeyDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/JDKKeyDeserializer.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -49,6 +51,8 @@ public class JDKKeyDeserializer extends KeyDeserializer
     public final static int TYPE_CLASS = 15;
     public final static int TYPE_CURRENCY = 16;
     public final static int TYPE_BYTE_ARRAY = 17; // since 2.9
+    public final static int TYPE_BIG_INTEGER = 18;
+    public final static int TYPE_BIG_DECIMAL = 19;
 
     protected final int _kind;
     protected final Class<?> _keyClass;
@@ -102,6 +106,10 @@ public class JDKKeyDeserializer extends KeyDeserializer
             kind = TYPE_FLOAT;
         } else if (raw == Double.class) {
             kind = TYPE_DOUBLE;
+        } else if (raw == BigInteger.class) {
+            kind = TYPE_BIG_INTEGER;
+        } else if (raw == BigDecimal.class) {
+            kind = TYPE_BIG_DECIMAL;
         } else if (raw == URI.class) {
             kind = TYPE_URI;
         } else if (raw == URL.class) {
@@ -197,6 +205,16 @@ public class JDKKeyDeserializer extends KeyDeserializer
             return Float.valueOf((float) _parseDouble(key));
         case TYPE_DOUBLE:
             return _parseDouble(key);
+        case TYPE_BIG_INTEGER:
+            // Cap length before the O(n^2) `BigInteger(String)` parse: the value-side
+            // deserializer applies `validateIntegerLength(...)`, but the key path would
+            // otherwise be bounded only by the (much larger) max-name-length limit.
+            ctxt.streamReadConstraints().validateIntegerLength(key.length());
+            return new BigInteger(key);
+        case TYPE_BIG_DECIMAL:
+            // Same as `BigInteger` above, for the O(n^2) `BigDecimal(String)` parse.
+            ctxt.streamReadConstraints().validateFPLength(key.length());
+            return new BigDecimal(key);
         case TYPE_LOCALE:
         case TYPE_CURRENCY:
             try {

--- a/src/main/java/tools/jackson/databind/deser/jdk/JDKKeyDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/JDKKeyDeserializer.java
@@ -208,13 +208,9 @@ public class JDKKeyDeserializer extends KeyDeserializer
             ctxt.streamReadConstraints().validateFPLength(key.length());
             return _parseDouble(key);
         case TYPE_BIG_INTEGER:
-            // Cap length before the O(n^2) `BigInteger` parse: the value-side
-            // deserializer applies `validateIntegerLength(...)`, but the key path would
-            // otherwise be bounded only by the (much larger) max-name-length limit.
             ctxt.streamReadConstraints().validateIntegerLength(key.length());
             return NumberInput.parseBigInteger(key, true);
         case TYPE_BIG_DECIMAL:
-            // Same as `BigInteger` above, for the O(n^2) `BigDecimal` parse.
             ctxt.streamReadConstraints().validateFPLength(key.length());
             return NumberInput.parseBigDecimal(key, true);
         case TYPE_LOCALE:

--- a/src/main/java/tools/jackson/databind/deser/jdk/JDKKeyDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/JDKKeyDeserializer.java
@@ -202,19 +202,21 @@ public class JDKKeyDeserializer extends KeyDeserializer
 
         case TYPE_FLOAT:
             // Bounds/range checks would be tricky here, so let's not bother even trying...
+            ctxt.streamReadConstraints().validateFPLength(key.length());
             return Float.valueOf((float) _parseDouble(key));
         case TYPE_DOUBLE:
+            ctxt.streamReadConstraints().validateFPLength(key.length());
             return _parseDouble(key);
         case TYPE_BIG_INTEGER:
-            // Cap length before the O(n^2) `BigInteger(String)` parse: the value-side
+            // Cap length before the O(n^2) `BigInteger` parse: the value-side
             // deserializer applies `validateIntegerLength(...)`, but the key path would
             // otherwise be bounded only by the (much larger) max-name-length limit.
             ctxt.streamReadConstraints().validateIntegerLength(key.length());
-            return new BigInteger(key);
+            return NumberInput.parseBigInteger(key, true);
         case TYPE_BIG_DECIMAL:
-            // Same as `BigInteger` above, for the O(n^2) `BigDecimal(String)` parse.
+            // Same as `BigInteger` above, for the O(n^2) `BigDecimal` parse.
             ctxt.streamReadConstraints().validateFPLength(key.length());
-            return new BigDecimal(key);
+            return NumberInput.parseBigDecimal(key, true);
         case TYPE_LOCALE:
         case TYPE_CURRENCY:
             try {

--- a/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
@@ -131,6 +131,25 @@ public class BigNumbersDeserTest
         }
     }
 
+    // Same limit applies to `Float`/`Double` keys as well
+    @Test
+    public void testFloatingPointAsMapKey() throws Exception
+    {
+        final String json = "{\"" + generateDigits(1200) + "\":\"x\"}";
+        try {
+            MAPPER.readValue(json, new TypeReference<Map<Double, String>>() { });
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number value length", "exceeds the maximum allowed");
+        }
+        try {
+            MAPPER.readValue(json, new TypeReference<Map<Float, String>>() { });
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number value length", "exceeds the maximum allowed");
+        }
+    }
+
     @Test
     public void testBigNumberMapKeysWithinLimit() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
@@ -104,6 +104,7 @@ public class BigNumbersDeserTest
         assertNotNull(bdw);
     }
 
+    // [databind#6165]
     // Number length limits must apply to `BigInteger`/`BigDecimal` used as Map keys,
     // not just as values: the key path fed strings straight to the O(n^2)
     // `BigInteger(String)`/`BigDecimal(String)` constructors, bounded only by the far

--- a/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
@@ -2,12 +2,14 @@ package tools.jackson.databind.deser.jdk;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
@@ -101,6 +103,46 @@ public class BigNumbersDeserTest
         assertNotNull(bdw);
     }
 
+    // Number length limits must apply to `BigInteger`/`BigDecimal` used as Map keys,
+    // not just as values: the key path fed strings straight to the O(n^2)
+    // `BigInteger(String)`/`BigDecimal(String)` constructors, bounded only by the far
+    // larger max-name-length limit.
+    @Test
+    public void testBigIntegerAsMapKey() throws Exception
+    {
+        final String json = "{\"" + generateDigits(1200) + "\":\"x\"}";
+        try {
+            MAPPER.readValue(json, new TypeReference<Map<BigInteger, String>>() { });
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number value length", "exceeds the maximum allowed");
+        }
+    }
+
+    @Test
+    public void testBigDecimalAsMapKey() throws Exception
+    {
+        final String json = "{\"" + generateDigits(1200) + "\":\"x\"}";
+        try {
+            MAPPER.readValue(json, new TypeReference<Map<BigDecimal, String>>() { });
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number value length", "exceeds the maximum allowed");
+        }
+    }
+
+    @Test
+    public void testBigNumberMapKeysWithinLimit() throws Exception
+    {
+        Map<BigInteger, String> mi = MAPPER.readValue("{\"12345678901234567890\":\"a\"}",
+                new TypeReference<Map<BigInteger, String>>() { });
+        assertEquals("a", mi.get(new BigInteger("12345678901234567890")));
+
+        Map<BigDecimal, String> md = MAPPER.readValue("{\"3.14159265358979\":\"b\"}",
+                new TypeReference<Map<BigDecimal, String>>() { });
+        assertEquals("b", md.get(new BigDecimal("3.14159265358979")));
+    }
+
     // [databind#4435]
     @Test
     public void testNumberStartingWithDot() throws Exception {
@@ -122,6 +164,14 @@ public class BigNumbersDeserTest
         BigDecimal exp = new BigDecimal(num);
         BigDecimalWrapper w = MAPPER.readValue("{\"number\":\"" + num + "\"}", BigDecimalWrapper.class);
         assertEquals(exp, w.number);
+    }
+
+    private String generateDigits(final int len) {
+        final StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append('1');
+        }
+        return sb.toString();
     }
 
     private String generateJson(final String fieldName) {

--- a/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/jdk/BigNumbersDeserTest.java
@@ -11,6 +11,7 @@ import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
@@ -108,50 +109,27 @@ public class BigNumbersDeserTest
     // `BigInteger(String)`/`BigDecimal(String)` constructors, bounded only by the far
     // larger max-name-length limit.
     @Test
-    public void testBigIntegerAsMapKey() throws Exception
+    public void bigIntegerAsMapKey() throws Exception
     {
-        final String json = "{\"" + generateDigits(1200) + "\":\"x\"}";
-        try {
-            MAPPER.readValue(json, new TypeReference<Map<BigInteger, String>>() { });
-            fail("expected StreamConstraintsException");
-        } catch (StreamConstraintsException e) {
-            verifyException(e, "Number value length", "exceeds the maximum allowed");
-        }
+        _verifyKeyTooLong(MAPPER, "1".repeat(1200), new TypeReference<Map<BigInteger, String>>() { });
     }
 
     @Test
-    public void testBigDecimalAsMapKey() throws Exception
+    public void bigDecimalAsMapKey() throws Exception
     {
-        final String json = "{\"" + generateDigits(1200) + "\":\"x\"}";
-        try {
-            MAPPER.readValue(json, new TypeReference<Map<BigDecimal, String>>() { });
-            fail("expected StreamConstraintsException");
-        } catch (StreamConstraintsException e) {
-            verifyException(e, "Number value length", "exceeds the maximum allowed");
-        }
+        _verifyKeyTooLong(MAPPER, "1".repeat(1200), new TypeReference<Map<BigDecimal, String>>() { });
     }
 
     // Same limit applies to `Float`/`Double` keys as well
     @Test
-    public void testFloatingPointAsMapKey() throws Exception
+    public void floatingPointAsMapKey() throws Exception
     {
-        final String json = "{\"" + generateDigits(1200) + "\":\"x\"}";
-        try {
-            MAPPER.readValue(json, new TypeReference<Map<Double, String>>() { });
-            fail("expected StreamConstraintsException");
-        } catch (StreamConstraintsException e) {
-            verifyException(e, "Number value length", "exceeds the maximum allowed");
-        }
-        try {
-            MAPPER.readValue(json, new TypeReference<Map<Float, String>>() { });
-            fail("expected StreamConstraintsException");
-        } catch (StreamConstraintsException e) {
-            verifyException(e, "Number value length", "exceeds the maximum allowed");
-        }
+        _verifyKeyTooLong(MAPPER, "1".repeat(1200), new TypeReference<Map<Double, String>>() { });
+        _verifyKeyTooLong(MAPPER, "1".repeat(1200), new TypeReference<Map<Float, String>>() { });
     }
 
     @Test
-    public void testBigNumberMapKeysWithinLimit() throws Exception
+    public void bigNumberMapKeysWithinLimit() throws Exception
     {
         Map<BigInteger, String> mi = MAPPER.readValue("{\"12345678901234567890\":\"a\"}",
                 new TypeReference<Map<BigInteger, String>>() { });
@@ -160,6 +138,57 @@ public class BigNumbersDeserTest
         Map<BigDecimal, String> md = MAPPER.readValue("{\"3.14159265358979\":\"b\"}",
                 new TypeReference<Map<BigDecimal, String>>() { });
         assertEquals("b", md.get(new BigDecimal("3.14159265358979")));
+    }
+
+    // Limit is inclusive: key of exactly `maxNumberLength` digits still accepted,
+    // one digit more is not
+    @Test
+    public void mapKeyAtLengthLimit() throws Exception
+    {
+        final int maxLen = StreamReadConstraints.defaults().getMaxNumberLength();
+        final String key = "1".repeat(maxLen);
+
+        Map<BigInteger, String> m = MAPPER.readValue("{\"" + key + "\":\"a\"}",
+                new TypeReference<Map<BigInteger, String>>() { });
+        assertEquals("a", m.get(new BigInteger(key)));
+
+        _verifyKeyTooLong(MAPPER, "1".repeat(maxLen + 1),
+                new TypeReference<Map<BigInteger, String>>() { });
+    }
+
+    // Limit is configurable for keys just like it is for values
+    @Test
+    public void mapKeyWithLoweredLengthLimit() throws Exception
+    {
+        JsonFactory f = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(20).build())
+                .build();
+        // 25 digits: acceptable with defaults, too long here
+        _verifyKeyTooLong(JsonMapper.builder(f).build(), "1".repeat(25),
+                new TypeReference<Map<BigInteger, String>>() { });
+    }
+
+    // Malformed (but short enough) keys must still fail as regular "weird key" problems
+    @Test
+    public void malformedBigNumberMapKey() throws Exception
+    {
+        try {
+            MAPPER.readValue("{\"abc\":\"a\"}", new TypeReference<Map<BigInteger, String>>() { });
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "Cannot deserialize Map key of type `java.math.BigInteger`");
+        }
+    }
+
+    private void _verifyKeyTooLong(ObjectMapper mapper, String key, TypeReference<?> targetType)
+        throws Exception
+    {
+        try {
+            mapper.readValue("{\"" + key + "\":\"x\"}", targetType);
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number value length ("+key.length()+") exceeds the maximum allowed");
+        }
     }
 
     // [databind#4435]
@@ -183,14 +212,6 @@ public class BigNumbersDeserTest
         BigDecimal exp = new BigDecimal(num);
         BigDecimalWrapper w = MAPPER.readValue("{\"number\":\"" + num + "\"}", BigDecimalWrapper.class);
         assertEquals(exp, w.number);
-    }
-
-    private String generateDigits(final int len) {
-        final StringBuilder sb = new StringBuilder(len);
-        for (int i = 0; i < len; i++) {
-            sb.append('1');
-        }
-        return sb.toString();
     }
 
     private String generateJson(final String fieldName) {


### PR DESCRIPTION
Retargets #6153 from `3.x` to `3.1`, so the fix lands on the oldest maintained
affected line and merges forward. Same change, rebased onto `3.1` (the touched
sources are identical on both branches); the original commits by @aysha-afrah26
are preserved.

Reading a `Map<BigInteger, ?>` / `Map<BigDecimal, ?>` from untrusted JSON, keys at
the default max-name-length (49999):

    1 BigInteger key  (49999 digits)     ->     53 ms
    40 such keys in a 1.9 MB document    ->   1131 ms
    same value as a BigInteger *value*   ->      4 ms  (rejected)

`BigIntegerDeserializer`/`BigDecimalDeserializer` cap numeric strings at
`StreamReadConstraints.getMaxNumberLength()` (default 1000) before the O(n^2)
`BigInteger(String)`/`BigDecimal(String)` constructors. As Map keys these types
fell through `JDKKeyDeserializer.forType()` to the reflective single-`String`
constructor, bounded only by the much larger max-name-length, so the cap never
applied.

Handle both on the well-known-key path with the same
`validateIntegerLength`/`validateFPLength` check the value side uses. Keys within
the limit deserialize as before.

Note: the same limit now also applies to `Float`/`Double` keys, for parity with
`DoubleDeserializer`/`FloatDeserializer`. That is a behavior change (an overlong
key previously yielded `Infinity`), called out in the release notes.

Tests cover: over-limit rejection for all four key types, keys within the limit,
the inclusive boundary at `maxNumberLength`, a lowered `maxNumberLength`, and
malformed-but-short keys still failing as regular weird-key problems.

Supersedes #6153.
