### PR TITLE
Backport #6165 to 2.18: number length limits for BigDecimal/BigInteger/Double/Float Map keys

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1920,6 +1920,9 @@ Aysha Afrah Ziya (@aysha-afrah26)
   (2.18.10)
  * Fixed #6116: Reject non-ASCII digits in `InetAddress` literal validation
   (2.18.10)
+ * Fixed #6165: Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float`
+   Map keys
+  (2.18.10)
 
 @waydeshi
  * Reported #6127: Add `StreamReadConstraints` number len constraint to

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -21,6 +21,8 @@ Project: jackson-databind
 #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic base types
   [GHSA-gx83-3vf8-gh7j]
  (reported by @prvazsahnazarov)
+#6165: Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float` Map keys
+ (fix by Aysha A-Z)
 
 2.18.9 (07-Jul-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/std/StdKeyDeserializer.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.io.NumberInput;
 
 import com.fasterxml.jackson.databind.*;
@@ -50,6 +54,8 @@ public class StdKeyDeserializer extends KeyDeserializer
     public final static int TYPE_CLASS = 15;
     public final static int TYPE_CURRENCY = 16;
     public final static int TYPE_BYTE_ARRAY = 17; // since 2.9
+    public final static int TYPE_BIG_INTEGER = 18; // since 2.18.10
+    public final static int TYPE_BIG_DECIMAL = 19; // since 2.18.10
 
     final protected int _kind;
     final protected Class<?> _keyClass;
@@ -103,6 +109,10 @@ public class StdKeyDeserializer extends KeyDeserializer
             kind = TYPE_FLOAT;
         } else if (raw == Double.class) {
             kind = TYPE_DOUBLE;
+        } else if (raw == BigInteger.class) {
+            kind = TYPE_BIG_INTEGER;
+        } else if (raw == BigDecimal.class) {
+            kind = TYPE_BIG_DECIMAL;
         } else if (raw == URI.class) {
             kind = TYPE_URI;
         } else if (raw == URL.class) {
@@ -135,6 +145,10 @@ public class StdKeyDeserializer extends KeyDeserializer
             if (result != null) {
                 return result;
             }
+        } catch (StreamConstraintsException e) {
+            // 3.x rethrows these via its `JacksonException` branch: a constraint
+            // violation is not a "weird key" problem and must not be swallowed
+            throw e;
         } catch (Exception re) {
             return ctxt.handleWeirdKey(_keyClass, key, "not a valid representation, problem: (%s) %s",
                     re.getClass().getName(),
@@ -191,9 +205,17 @@ public class StdKeyDeserializer extends KeyDeserializer
 
         case TYPE_FLOAT:
             // Bounds/range checks would be tricky here, so let's not bother even trying...
+            _streamReadConstraints(ctxt).validateFPLength(key.length());
             return Float.valueOf((float) _parseDouble(key));
         case TYPE_DOUBLE:
+            _streamReadConstraints(ctxt).validateFPLength(key.length());
             return _parseDouble(key);
+        case TYPE_BIG_INTEGER:
+            _streamReadConstraints(ctxt).validateIntegerLength(key.length());
+            return NumberInput.parseBigInteger(key, true);
+        case TYPE_BIG_DECIMAL:
+            _streamReadConstraints(ctxt).validateFPLength(key.length());
+            return NumberInput.parseBigDecimal(key, true);
         case TYPE_LOCALE:
             try {
                 return _deser._deserialize(key, ctxt);
@@ -261,6 +283,14 @@ public class StdKeyDeserializer extends KeyDeserializer
 
     protected double _parseDouble(String key) throws IllegalArgumentException {
         return NumberInput.parseDouble(key, false);
+    }
+
+    // Note: 2.x has no `DeserializationContext.streamReadConstraints()`, so read them
+    // off the active parser (same instance the value-side number deserializers use)
+    // @since 2.18.10
+    protected StreamReadConstraints _streamReadConstraints(DeserializationContext ctxt) {
+        JsonParser p = ctxt.getParser();
+        return (p == null) ? StreamReadConstraints.defaults() : p.streamReadConstraints();
     }
 
     // @since 2.9

--- a/src/test/java/com/fasterxml/jackson/databind/deser/jdk/BigNumbersDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/jdk/BigNumbersDeserTest.java
@@ -2,14 +2,17 @@ package com.fasterxml.jackson.databind.deser.jdk;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
@@ -100,6 +103,102 @@ public class BigNumbersDeserTest
                 newJsonMapperWithUnlimitedNumberSizeSupport()
                         .readValue(generateJson("number"), BigIntegerWrapper.class);
         assertNotNull(bdw);
+    }
+
+    // [databind#6165]
+    // Number length limits must apply to `BigInteger`/`BigDecimal` used as Map keys,
+    // not just as values: the key path fed strings straight to the O(n^2)
+    // `BigInteger(String)`/`BigDecimal(String)` constructors, bounded only by the far
+    // larger max-name-length limit.
+    @Test
+    public void testBigIntegerAsMapKey() throws Exception
+    {
+        _verifyKeyTooLong(MAPPER, _digits(1200), new TypeReference<Map<BigInteger, String>>() { });
+    }
+
+    @Test
+    public void testBigDecimalAsMapKey() throws Exception
+    {
+        _verifyKeyTooLong(MAPPER, _digits(1200), new TypeReference<Map<BigDecimal, String>>() { });
+    }
+
+    // Same limit applies to `Float`/`Double` keys as well
+    @Test
+    public void testFloatingPointAsMapKey() throws Exception
+    {
+        _verifyKeyTooLong(MAPPER, _digits(1200), new TypeReference<Map<Double, String>>() { });
+        _verifyKeyTooLong(MAPPER, _digits(1200), new TypeReference<Map<Float, String>>() { });
+    }
+
+    @Test
+    public void testBigNumberMapKeysWithinLimit() throws Exception
+    {
+        Map<BigInteger, String> mi = MAPPER.readValue("{\"12345678901234567890\":\"a\"}",
+                new TypeReference<Map<BigInteger, String>>() { });
+        assertEquals("a", mi.get(new BigInteger("12345678901234567890")));
+
+        Map<BigDecimal, String> md = MAPPER.readValue("{\"3.14159265358979\":\"b\"}",
+                new TypeReference<Map<BigDecimal, String>>() { });
+        assertEquals("b", md.get(new BigDecimal("3.14159265358979")));
+    }
+
+    // Limit is inclusive: key of exactly `maxNumberLength` digits still accepted,
+    // one digit more is not
+    @Test
+    public void testMapKeyAtLengthLimit() throws Exception
+    {
+        final int maxLen = StreamReadConstraints.defaults().getMaxNumberLength();
+        final String key = _digits(maxLen);
+
+        Map<BigInteger, String> m = MAPPER.readValue("{\"" + key + "\":\"a\"}",
+                new TypeReference<Map<BigInteger, String>>() { });
+        assertEquals("a", m.get(new BigInteger(key)));
+
+        _verifyKeyTooLong(MAPPER, _digits(maxLen + 1),
+                new TypeReference<Map<BigInteger, String>>() { });
+    }
+
+    // Limit is configurable for keys just like it is for values
+    @Test
+    public void testMapKeyWithLoweredLengthLimit() throws Exception
+    {
+        JsonFactory f = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(20).build())
+                .build();
+        // 25 digits: acceptable with defaults, too long here
+        _verifyKeyTooLong(JsonMapper.builder(f).build(), _digits(25),
+                new TypeReference<Map<BigInteger, String>>() { });
+    }
+
+    // Malformed (but short enough) keys must still fail as regular "weird key" problems
+    @Test
+    public void testMalformedBigNumberMapKey() throws Exception
+    {
+        try {
+            MAPPER.readValue("{\"abc\":\"a\"}", new TypeReference<Map<BigInteger, String>>() { });
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            verifyException(e, "Cannot deserialize Map key of type `java.math.BigInteger`");
+        }
+    }
+
+    private void _verifyKeyTooLong(ObjectMapper mapper, String key, TypeReference<?> targetType)
+        throws Exception
+    {
+        try {
+            mapper.readValue("{\"" + key + "\":\"x\"}", targetType);
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number value length ("+key.length()+") exceeds the maximum allowed");
+        }
+    }
+
+    private String _digits(final int len) {
+        final StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append('1');
+        }
+        return sb.toString();
     }
 
     // [databind#4435]


### PR DESCRIPTION
Backport of #6165 (3.1) to `2.18`, so the oldest LTS line gets the fix and it can
merge forward `2.18` -> `2.21` -> `2.22` -> `2.x`. Original fix by @aysha-afrah26.

### 2.x-specific differences from the 3.1 change

* 2.x has no `DeserializationContext.streamReadConstraints()`, so the new
  `_streamReadConstraints(ctxt)` helper reads them off the active parser -- the
  same instance the value-side number deserializers use -- falling back to
  `StreamReadConstraints.defaults()` if there is no parser.
* `deserializeKey()` funnels everything through a single `catch (Exception re)`,
  which wrapped the constraint failure into `InvalidFormatException`. 3.x already
  rethrows via its `catch (JacksonException e)` branch, so this adds a narrow
  `StreamConstraintsException` rethrow. Nothing else on this path throws that
  type today, so no existing key type changes behavior.

Note: the same limit now also applies to `Float`/`Double` keys, for parity with
`DoubleDeserializer`/`FloatDeserializer`. That is a behavior change (an overlong
key previously yielded `Infinity`), called out in the release notes.
