### PR TITLE
Fix #6164: pass non-String scalars to enum @JsonCreator

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -684,3 +684,11 @@ DongNyoung Lee (@Dongnyoung)
 Fabian Lange (@CodingFabian)
  * Requested #3182: Support value deduplication for enumeration like values
   [3.3.0]
+
+Mateusz Hubert Stefaniak (@EmhyrVarEmreis)
+ * Reported #6164: `@JsonCreator` for enums converts value to String even if it is not
+  [3.3.0]
+
+@arimu1
+ * Fixed #6164: `@JsonCreator` for enums converts value to String even if it is not
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -44,6 +44,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @Dongnyoung)
 #6151: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
  (contributed by @seonwooj0810)
+#6164: `@JsonCreator` for enums no longer coerces non-String scalars (JSON
+  numbers) to `String` before invoking the factory method
+ (reported by @EmhyrVarEmreis)
+ (fix by @arimu1)
 
 3.2.2 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/databind/deser/jdk/FactoryBasedEnumDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/FactoryBasedEnumDeserializer.java
@@ -89,10 +89,11 @@ class FactoryBasedEnumDeserializer
     public ValueDeserializer<?> createContextual(DeserializationContext ctxt,
             BeanProperty property)
     {
-        // So: no need to fetch if we had it; or if target is `String`(-like); or
-        // if we have properties-based Creator (for which we probably SHOULD do
-        // different contextualization?)
-        if ((_deser == null) && (_inputType != null) && (_creatorProps == null)) {
+        // Need deserializer for non-String factory parameter even when a
+        // properties-based Creator is also present: JSON Object still uses
+        // `_creatorProps`, but scalar input (JSON Number etc) must not be
+        // coerced to String (see [databind#6164]).
+        if ((_deser == null) && (_inputType != null)) {
             return new FactoryBasedEnumDeserializer(this,
                     ctxt.findContextualValueDeserializer(_inputType, property));
         }
@@ -121,6 +122,20 @@ class FactoryBasedEnumDeserializer
     {
         Object value;
 
+        // 16-Aug-2026, [databind#6164]: properties-based Creator must see JSON Object
+        // first. Otherwise a matching accessor (e.g. `getValue()`) would skip the
+        // typed `_deser` and coerce scalars via `getValueAsString()`.
+        if (_hasArgs && (_creatorProps != null) && p.isExpectedStartObjectToken()) {
+            PropertyBasedCreator pc = _propCreator;
+            if (pc == null) {
+                _propCreator = pc = PropertyBasedCreator.construct(ctxt,
+                        _valueInstantiator, _creatorProps,
+                        ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES));
+            }
+            p.nextToken();
+            return deserializeEnumUsingPropertyBased(p, ctxt, pc);
+        }
+
         // First: the case of having deserializer for non-String input for delegating
         // Creator method
         if (_deser != null) {
@@ -131,16 +146,6 @@ class FactoryBasedEnumDeserializer
             // 30-Mar-2020, tatu: For properties-based one, MUST get JSON Object (before
             //   2.11, was just assuming match)
             if (_creatorProps != null) {
-                if (p.isExpectedStartObjectToken()) {
-                    PropertyBasedCreator pc = _propCreator;
-                    if (pc == null) {
-                        _propCreator = pc = PropertyBasedCreator.construct(ctxt,
-                                _valueInstantiator, _creatorProps,
-                                ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES));
-                    }
-                    p.nextToken();
-                    return deserializeEnumUsingPropertyBased(p, ctxt, pc);
-                }
                 // If value cannot possibly be delegating-creator,
                 if (!_valueInstantiator.canCreateFromString()) {
                     final JavaType targetType = getValueType(ctxt);

--- a/src/test/java/tools/jackson/databind/deser/creators/EnumCreatorTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/EnumCreatorTest.java
@@ -536,8 +536,37 @@ public class EnumCreatorTest extends DatabindTestUtil
         }
     }
 
+    // [databind#6164]: same factory + getter, but mode=DELEGATING (not guessed PROPERTIES)
+    enum DataSetType6164Delegating {
+        ZERO(0), FIVE(5);
+
+        private final int value;
+
+        DataSetType6164Delegating(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public static DataSetType6164Delegating getDataSetTypeByValue(int value) {
+            for (DataSetType6164Delegating type : values()) {
+                if (type.value == value) {
+                    return type;
+                }
+            }
+            return null;
+        }
+    }
+
     static class DataSet6164 {
         public DataSetType6164 dataSetType;
+    }
+
+    static class DataSet6164Delegating {
+        public DataSetType6164Delegating dataSetType;
     }
 
     // [databind#6164]
@@ -551,5 +580,14 @@ public class EnumCreatorTest extends DatabindTestUtil
 
         // Matching getter still allows properties-based Object form
         assertSame(DataSetType6164.FIVE, MAPPER.readValue("{\"value\":5}", DataSetType6164.class));
+    }
+
+    // [databind#6164]: explicit DELEGATING already accepts JSON numbers
+    @Test
+    public void enumCreatorDelegatingFromJsonNumber6164() throws Exception {
+        assertSame(DataSetType6164Delegating.FIVE, MAPPER.readValue("5", DataSetType6164Delegating.class));
+        assertSame(DataSetType6164Delegating.ZERO, MAPPER.readValue("0", DataSetType6164Delegating.class));
+        DataSet6164Delegating wrapper = MAPPER.readValue("{\"dataSetType\":5}", DataSet6164Delegating.class);
+        assertSame(DataSetType6164Delegating.FIVE, wrapper.dataSetType);
     }
 }

--- a/src/test/java/tools/jackson/databind/deser/creators/EnumCreatorTest.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/EnumCreatorTest.java
@@ -510,4 +510,46 @@ public class EnumCreatorTest extends DatabindTestUtil
         ChannelEnum channel = MAPPER.readValue(json, ChannelEnum.class);
         assertNull(channel);
     }
+
+    // [databind#6164]: @JsonCreator(int) must accept JSON number, not coerce to String
+    enum DataSetType6164 {
+        ZERO(0), FIVE(5);
+
+        private final int value;
+
+        DataSetType6164(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @JsonCreator
+        public static DataSetType6164 getDataSetTypeByValue(int value) {
+            for (DataSetType6164 type : values()) {
+                if (type.value == value) {
+                    return type;
+                }
+            }
+            return null;
+        }
+    }
+
+    static class DataSet6164 {
+        public DataSetType6164 dataSetType;
+    }
+
+    // [databind#6164]
+    @Test
+    public void enumCreatorFromJsonNumber6164() throws Exception {
+        assertSame(DataSetType6164.FIVE, MAPPER.readValue("5", DataSetType6164.class));
+        assertSame(DataSetType6164.ZERO, MAPPER.readValue("0", DataSetType6164.class));
+
+        DataSet6164 wrapper = MAPPER.readValue("{\"dataSetType\":5}", DataSet6164.class);
+        assertSame(DataSetType6164.FIVE, wrapper.dataSetType);
+
+        // Matching getter still allows properties-based Object form
+        assertSame(DataSetType6164.FIVE, MAPPER.readValue("{\"value\":5}", DataSetType6164.class));
+    }
 }


### PR DESCRIPTION
Fixes #6164

## Root cause

`FactoryBasedEnumDeserializer` skipped resolving a typed deserializer for the `@JsonCreator` parameter whenever a properties-based creator was also present (`_creatorProps != null`).

A matching accessor such as `getValue()` next to `@JsonCreator static T from(int value)` is enough to populate `_creatorProps`. For a JSON number the deserializer then fell through to `getValueAsString()` and invoked the `int` factory with a `String`, producing:

`class java.lang.String cannot be cast to class java.lang.Number`

Enums also expose `valueOf(String)`, so `canCreateFromString()` does not reject that fallback.

This worked for factories without a matching accessor (existing `TestEnumFromInt`) because `_creatorProps` stayed null and the `int` deserializer was used.

## Change

- Resolve the parameter-type deserializer even when `_creatorProps` is present.
- Handle JSON Object via the properties-based creator first; use the typed deserializer for scalar input (JSON Number, etc.).
- Leave the `String`/`CharSequence` factory path (`getValueAsString()`) unchanged, including dual-mode cases such as #5395.

## Test plan

- [x] `EnumCreatorTest#enumCreatorFromJsonNumber6164` — JSON `5` / `0`, wrapper `{"dataSetType":5}`, and object form `{"value":5}`
- [x] Existing enum/`@JsonCreator` suite: `EnumCreatorTest` (22), `JsonCreatorModeForEnum3566Test` (8), `EnumDeserialization3369Test` (1), `EnumDeserializationTest` (39) — 70/70 on JDK 21