### PR TITLE
Cache raw parameter types in `AnnotatedConstructor`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -680,6 +680,8 @@ DongNyoung Lee (@Dongnyoung)
  * Contributed #3182: Add `StringCanonicalizingConverter` for opt-in canonicalization
    ("de-duplication") of low-cardinality `String` values
   [3.3.0]
+ * Fixed #6168: Cache raw parameter types in `AnnotatedConstructor`
+  [3.3.0]
  * Fixed #6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work
    for `java.time.Month`
   [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -44,6 +44,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @Dongnyoung)
 #6151: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
  (contributed by @seonwooj0810)
+#6168: Cache raw parameter types in `AnnotatedConstructor`
+ (fix by @Dongnyoung)
 #6175: Parse object-form `QName` after `As.PROPERTY` type id
  (reported by @jjh75607)
  (fix by @kalayciburak)

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -85,16 +85,12 @@ public final class AnnotatedConstructor
     @Override
     public Class<?> getRawParameterType(int index)
     {
-        Class<?>[] types = getRawParameterTypes();
-        return (index >= types.length) ? null : types[index];
-    }
-
-    public Class<?>[] getRawParameterTypes()
-    {
-        if (_paramClasses == null) {
-            _paramClasses = _constructor.getParameterTypes();
+        Class<?>[] types = _paramClasses;
+        if (types == null) {
+            types = _constructor.getParameterTypes();
+            _paramClasses = types;
         }
-        return _paramClasses;
+        return (index >= types.length) ? null : types[index];
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -24,6 +24,10 @@ public final class AnnotatedConstructor
     private final InvokerHolder _invokerUnary = new InvokerHolder(methodType(Object.class, Object.class));
     private final InvokerHolder _invokerFixedArity = new InvokerHolder(null);
 
+    // // Simple lazy-caching:
+
+    protected Class<?>[] _paramClasses;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -81,8 +85,16 @@ public final class AnnotatedConstructor
     @Override
     public Class<?> getRawParameterType(int index)
     {
-        Class<?>[] types = _constructor.getParameterTypes();
+        Class<?>[] types = getRawParameterTypes();
         return (index >= types.length) ? null : types[index];
+    }
+
+    public Class<?>[] getRawParameterTypes()
+    {
+        if (_paramClasses == null) {
+            _paramClasses = _constructor.getParameterTypes();
+        }
+        return _paramClasses;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -26,7 +26,11 @@ public final class AnnotatedConstructor
 
     // // Simple lazy-caching:
 
-    protected Class<?>[] _paramClasses;
+    /**
+     * Lazily resolved raw parameter types; {@code volatile} to ensure safe
+     * publication of the array contents (racy re-resolution is harmless).
+     */
+    protected volatile Class<?>[] _paramClasses;
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedMethod.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedMethod.java
@@ -28,7 +28,11 @@ public final class AnnotatedMethod
 
     // // Simple lazy-caching:
 
-    protected Class<?>[] _paramClasses;
+    /**
+     * Lazily resolved raw parameter types; {@code volatile} to ensure safe
+     * publication of the array contents (racy re-resolution is harmless).
+     */
+    protected volatile Class<?>[] _paramClasses;
 
     /*
     /**********************************************************************
@@ -214,10 +218,12 @@ public final class AnnotatedMethod
 
     public Class<?>[] getRawParameterTypes()
     {
-        if (_paramClasses == null) {
-            _paramClasses = _method.getParameterTypes();
+        Class<?>[] types = _paramClasses;
+        if (types == null) {
+            types = _method.getParameterTypes();
+            _paramClasses = types;
         }
-        return _paramClasses;
+        return types;
     }
 
     public Class<?> getRawReturnType() {

--- a/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
@@ -50,17 +50,18 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
     }
 
     @Test
-    public void testAnnotatedConstructorRawParameterTypesAreCached() {
+    public void testAnnotatedConstructorRawParameterTypeIsCached() {
         DeserializationConfig context = MAPPER.deserializationConfig();
         JavaType beanType = MAPPER.constructType(SomeBean.class);
 
         AnnotatedClass instance = AnnotatedClassResolver.resolve(context, beanType, context);
         AnnotatedConstructor constructor = instance.getConstructors().get(0);
 
-        Class<?>[] paramTypes = constructor.getRawParameterTypes();
-        assertSame(paramTypes, constructor.getRawParameterTypes());
+        assertNull(constructor._paramClasses);
         assertEquals(String.class, constructor.getRawParameterType(0));
+        Class<?>[] paramTypes = constructor._paramClasses;
         assertNull(constructor.getRawParameterType(1));
+        assertSame(paramTypes, constructor._paramClasses);
     }
 
     // [databind#3187]

--- a/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
@@ -8,6 +8,8 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class AnnotatedMemberEqualityTest extends DatabindTestUtil
 {
@@ -45,6 +47,20 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
         assertEquals(constructor1.getAnnotated(), constructor2.getAnnotated());
         assertEquals(constructor1, constructor2);
         assertEquals(constructor1.getParameter(0), constructor2.getParameter(0));
+    }
+
+    @Test
+    public void testAnnotatedConstructorRawParameterTypesAreCached() {
+        DeserializationConfig context = MAPPER.deserializationConfig();
+        JavaType beanType = MAPPER.constructType(SomeBean.class);
+
+        AnnotatedClass instance = AnnotatedClassResolver.resolve(context, beanType, context);
+        AnnotatedConstructor constructor = instance.getConstructors().get(0);
+
+        Class<?>[] paramTypes = constructor.getRawParameterTypes();
+        assertSame(paramTypes, constructor.getRawParameterTypes());
+        assertEquals(String.class, constructor.getRawParameterType(0));
+        assertNull(constructor.getRawParameterType(1));
     }
 
     // [databind#3187]


### PR DESCRIPTION
## Summary

* Cache raw constructor parameter types in `AnnotatedConstructor`
* Reuse the cached parameter types from `getRawParameterType(int)`
* Add test coverage for repeated raw parameter type lookups

## Details

`AnnotatedMethod` already lazily caches the result of `Method#getParameterTypes()` in `_paramClasses`.

`AnnotatedConstructor` did not use the same caching approach, so repeated raw parameter type lookups called `Constructor#getParameterTypes()` each time.

This change applies the same lazy-caching pattern to `AnnotatedConstructor` and routes `getRawParameterType(int)` through `getRawParameterTypes()`.

Existing parameter lookup behavior remains unchanged:

* valid indexes return the corresponding raw parameter class
* out-of-range indexes return `null`

The added test also verifies that repeated calls to `getRawParameterTypes()` reuse the cached array.

## Tests

```text
./mvnw.cmd -q -DskipTests compile
./mvnw.cmd -q -DskipTests test-compile
./mvnw.cmd -q "-Dtest=AnnotatedMemberEqualityTest" "-Dsurefire.useModulePath=false" test
```
