### PR TITLE
Apply default null handling to @JsonAnySetter

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/BasicDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BasicDeserializerFactory.java
@@ -623,10 +623,10 @@ public abstract class BasicDeserializerFactory
     }
 
     /**
-     * Helper method copied from {@code POJOPropertyBuilder} since that won't be
-     * applied to creator parameters.
+     * Helper method copied from {@code POJOPropertyBuilder} for synthetic
+     * properties that do not go through regular property collection.
      */
-    private PropertyMetadata _getSetterInfo(MapperConfig<?> config,
+    final PropertyMetadata _getSetterInfo(MapperConfig<?> config,
             BeanProperty prop, PropertyMetadata metadata)
     {
         final AnnotationIntrospector intr = config.getAnnotationIntrospector();
@@ -635,8 +635,8 @@ public abstract class BasicDeserializerFactory
         Nulls valueNulls = null;
         Nulls contentNulls = null;
 
-        // NOTE: compared to `POJOPropertyBuilder`, we only have access to creator
-        // parameter, not other accessors, so code bit simpler
+        // NOTE: compared to `POJOPropertyBuilder`, synthetic properties only
+        // have the primary member, not other accessors, so code bit simpler
         AnnotatedMember prim = prop.getMember();
 
         if (prim != null) {

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -888,13 +888,13 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 fieldType = resolveMemberAndTypeAnnotations(ctxt, mutator, fieldType);
                 keyType = fieldType.getKeyType();
                 valueType = fieldType.getContentType();
-                prop = _constructAnySetterProperty(ctxt, mutator, fieldType);
+                prop = _constructAnySetterProperty(ctxt, mutator, valueType);
             } else if (fieldType.hasRawClass(JsonNode.class)
                     || fieldType.hasRawClass(ObjectNode.class)) {
                 fieldType = resolveMemberAndTypeAnnotations(ctxt, mutator, fieldType);
                 // Deserialize is individual values of ObjectNode, not full ObjectNode, so:
                 valueType = ctxt.constructType(JsonNode.class);
-                prop = _constructAnySetterProperty(ctxt, mutator, fieldType);
+                prop = _constructAnySetterProperty(ctxt, mutator, valueType);
 
                 // Unlike with more complicated types, here we do not allow any annotation
                 // overrides etc but instead short-cut handling:
@@ -915,12 +915,12 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 paramType = resolveMemberAndTypeAnnotations(ctxt, mutator, paramType);
                 keyType = paramType.getKeyType();
                 valueType = paramType.getContentType();
-                prop = _constructAnySetterProperty(ctxt, mutator, paramType);
+                prop = _constructAnySetterProperty(ctxt, mutator, valueType);
             } else if (paramType.hasRawClass(JsonNode.class) || paramType.hasRawClass(ObjectNode.class)) {
                 paramType = resolveMemberAndTypeAnnotations(ctxt, mutator, paramType);
                 // Deserialize is individual values of ObjectNode, not full ObjectNode, so:
                 valueType = ctxt.constructType(JsonNode.class);
-                prop = _constructAnySetterProperty(ctxt, mutator, paramType);
+                prop = _constructAnySetterProperty(ctxt, mutator, valueType);
 
                 // Unlike with more complicated types, here we do not allow any annotation
                 // overrides etc but instead short-cut handling:

--- a/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/tools/jackson/databind/deser/BeanDeserializerFactory.java
@@ -877,9 +877,7 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
             valueType = am.getParameterType(1);
             // Need to resolve for possible generic types (like Maps, Collections)
             valueType = resolveMemberAndTypeAnnotations(ctxt, mutator, valueType);
-            prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
-                    valueType, null, mutator,
-                    PropertyMetadata.STD_OPTIONAL);
+            prop = _constructAnySetterProperty(ctxt, mutator, valueType);
 
         } else if (isField) {
             AnnotatedField af = (AnnotatedField) mutator;
@@ -890,15 +888,13 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 fieldType = resolveMemberAndTypeAnnotations(ctxt, mutator, fieldType);
                 keyType = fieldType.getKeyType();
                 valueType = fieldType.getContentType();
-                prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
-                        fieldType, null, mutator, PropertyMetadata.STD_OPTIONAL);
+                prop = _constructAnySetterProperty(ctxt, mutator, fieldType);
             } else if (fieldType.hasRawClass(JsonNode.class)
                     || fieldType.hasRawClass(ObjectNode.class)) {
                 fieldType = resolveMemberAndTypeAnnotations(ctxt, mutator, fieldType);
                 // Deserialize is individual values of ObjectNode, not full ObjectNode, so:
                 valueType = ctxt.constructType(JsonNode.class);
-                prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
-                        fieldType, null, mutator, PropertyMetadata.STD_OPTIONAL);
+                prop = _constructAnySetterProperty(ctxt, mutator, fieldType);
 
                 // Unlike with more complicated types, here we do not allow any annotation
                 // overrides etc but instead short-cut handling:
@@ -919,14 +915,12 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
                 paramType = resolveMemberAndTypeAnnotations(ctxt, mutator, paramType);
                 keyType = paramType.getKeyType();
                 valueType = paramType.getContentType();
-                prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
-                        paramType, null, mutator, PropertyMetadata.STD_OPTIONAL);
+                prop = _constructAnySetterProperty(ctxt, mutator, paramType);
             } else if (paramType.hasRawClass(JsonNode.class) || paramType.hasRawClass(ObjectNode.class)) {
                 paramType = resolveMemberAndTypeAnnotations(ctxt, mutator, paramType);
                 // Deserialize is individual values of ObjectNode, not full ObjectNode, so:
                 valueType = ctxt.constructType(JsonNode.class);
-                prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
-                        paramType, null, mutator, PropertyMetadata.STD_OPTIONAL);
+                prop = _constructAnySetterProperty(ctxt, mutator, paramType);
 
                 // Unlike with more complicated types, here we do not allow any annotation
                 // overrides etc but instead short-cut handling:
@@ -978,6 +972,19 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
         }
         return SettableAnyProperty.constructForMethod(ctxt,
                 prop, mutator, valueType, keyDeser, deser, typeDeser);
+    }
+
+    private BeanProperty.Std _constructAnySetterProperty(DeserializationContext ctxt,
+            AnnotatedMember mutator, JavaType propType)
+    {
+        PropertyName name = PropertyName.construct(mutator.getName());
+        BeanProperty.Std prop = new BeanProperty.Std(name, propType, null, mutator,
+                PropertyMetadata.STD_OPTIONAL);
+        PropertyMetadata metadata = _getSetterInfo(ctxt.getConfig(), prop, prop.getMetadata());
+        if (metadata != prop.getMetadata()) {
+            prop = new BeanProperty.Std(name, propType, null, mutator, metadata);
+        }
+        return prop;
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/SettableAnyProperty.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import tools.jackson.core.*;
 import tools.jackson.databind.*;
 import tools.jackson.databind.deser.ReadableObjectId.Referring;
+import tools.jackson.databind.deser.impl.NullsConstantProvider;
 import tools.jackson.databind.deser.jdk.JDKValueInstantiators;
 import tools.jackson.databind.introspect.AnnotatedField;
 import tools.jackson.databind.introspect.AnnotatedMember;
@@ -44,6 +45,14 @@ public abstract class SettableAnyProperty
     protected final TypeDeserializer _valueTypeDeserializer;
     protected final KeyDeserializer _keyDeserializer;
 
+    /**
+     * Entity used for possible translation from explicit JSON {@code null}
+     * into non-null value, or for skipping the any-setter call.
+     */
+    protected final NullValueProvider _nullProvider;
+
+    protected final boolean _skipNulls;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -54,6 +63,14 @@ public abstract class SettableAnyProperty
             KeyDeserializer keyDeser,
             ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser)
     {
+        this(property, setter, type, keyDeser, valueDeser, typeDeser, valueDeser);
+    }
+
+    protected SettableAnyProperty(BeanProperty property, AnnotatedMember setter, JavaType type,
+            KeyDeserializer keyDeser,
+            ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser,
+            NullValueProvider nullProvider)
+    {
         _property = property;
         _setter = setter;
         _type = type;
@@ -61,6 +78,8 @@ public abstract class SettableAnyProperty
         _valueTypeDeserializer = typeDeser;
         _keyDeserializer = keyDeser;
         _setterIsField = setter instanceof AnnotatedField;
+        _nullProvider = nullProvider;
+        _skipNulls = NullsConstantProvider.isSkipper(nullProvider);
     }
 
     public static SettableAnyProperty constructForMethod(DeserializationContext ctxt,
@@ -127,6 +146,8 @@ public abstract class SettableAnyProperty
     // Abstract @since 2.14
     public abstract SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser);
 
+    public abstract SettableAnyProperty withNullProvider(NullValueProvider nullProvider);
+
     public void fixAccess(DeserializationConfig config) {
         _setter.fixAccess(
                 config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
@@ -142,9 +163,15 @@ public abstract class SettableAnyProperty
 
     public boolean hasValueDeserializer() { return (_valueDeserializer != null); }
 
+    public ValueDeserializer<Object> getValueDeserializer() { return _valueDeserializer; }
+
     public JavaType getType() { return _type; }
 
     public String getPropertyName() { return _property.getName(); }
+
+    public boolean shouldSkipNullValue(JsonParser p) {
+        return _skipNulls && p.hasToken(JsonToken.VALUE_NULL);
+    }
 
     /**
      * Accessor for parameterIndex.
@@ -192,6 +219,9 @@ public abstract class SettableAnyProperty
         throws JacksonException
     {
         try {
+            if (shouldSkipNullValue(p)) {
+                return;
+            }
             Object key = (_keyDeserializer == null) ? propName
                     : _keyDeserializer.deserializeKey(propName, ctxt);
             set(ctxt, instance, key, deserialize(p, ctxt));
@@ -209,7 +239,7 @@ public abstract class SettableAnyProperty
     {
         JsonToken t = p.currentToken();
         if (t == JsonToken.VALUE_NULL) {
-            return _valueDeserializer.getNullValue(ctxt);
+            return _nullProvider.getNullValue(ctxt);
         }
         if (_valueTypeDeserializer != null) {
             return _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
@@ -314,8 +344,16 @@ public abstract class SettableAnyProperty
                 AnnotatedMember field, JavaType valueType,
                 KeyDeserializer keyDeser,
                 ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser) {
+            this(property, field, valueType, keyDeser, valueDeser, typeDeser, valueDeser);
+        }
+
+        protected MethodAnyProperty(BeanProperty property,
+                AnnotatedMember field, JavaType valueType,
+                KeyDeserializer keyDeser,
+                ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser,
+                NullValueProvider nullProvider) {
             super(property, field, valueType,
-                    keyDeser, valueDeser, typeDeser);
+                    keyDeser, valueDeser, typeDeser, nullProvider);
         }
 
         @Override
@@ -328,8 +366,15 @@ public abstract class SettableAnyProperty
 
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser) {
+            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new MethodAnyProperty(_property, _setter, _type,
-                    _keyDeserializer, deser, _valueTypeDeserializer);
+                    _keyDeserializer, deser, _valueTypeDeserializer, nvp);
+        }
+
+        @Override
+        public SettableAnyProperty withNullProvider(NullValueProvider nullProvider) {
+            return new MethodAnyProperty(_property, _setter, _type,
+                    _keyDeserializer, _valueDeserializer, _valueTypeDeserializer, nullProvider);
         }
     }
 
@@ -345,16 +390,32 @@ public abstract class SettableAnyProperty
                 KeyDeserializer keyDeser,
                 ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser,
                 ValueInstantiator inst) {
+            this(property, field, valueType, keyDeser, valueDeser, typeDeser, inst, valueDeser);
+        }
+
+        protected MapFieldAnyProperty(BeanProperty property,
+                AnnotatedMember field, JavaType valueType,
+                KeyDeserializer keyDeser,
+                ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser,
+                ValueInstantiator inst, NullValueProvider nullProvider) {
             super(property, field, valueType,
-                    keyDeser, valueDeser, typeDeser);
+                    keyDeser, valueDeser, typeDeser, nullProvider);
             _valueInstantiator = inst;
         }
 
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser) {
+            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new MapFieldAnyProperty(_property, _setter, _type,
                     _keyDeserializer, deser, _valueTypeDeserializer,
-                    _valueInstantiator);
+                    _valueInstantiator, nvp);
+        }
+
+        @Override
+        public SettableAnyProperty withNullProvider(NullValueProvider nullProvider) {
+            return new MapFieldAnyProperty(_property, _setter, _type,
+                    _keyDeserializer, _valueDeserializer, _valueTypeDeserializer,
+                    _valueInstantiator, nullProvider);
         }
 
         @SuppressWarnings("unchecked")
@@ -396,7 +457,14 @@ public abstract class SettableAnyProperty
                 AnnotatedMember field, JavaType valueType,
                 ValueDeserializer<Object> valueDeser,
                 JsonNodeFactory nodeFactory) {
-            super(property, field, valueType, null, valueDeser, null);
+            this(property, field, valueType, valueDeser, nodeFactory, valueDeser);
+        }
+
+        protected JsonNodeFieldAnyProperty(BeanProperty property,
+                AnnotatedMember field, JavaType valueType,
+                ValueDeserializer<Object> valueDeser,
+                JsonNodeFactory nodeFactory, NullValueProvider nullProvider) {
+            super(property, field, valueType, null, valueDeser, null, nullProvider);
             _nodeFactory = nodeFactory;
         }
 
@@ -406,6 +474,9 @@ public abstract class SettableAnyProperty
                 Object instance, String propName)
             throws JacksonException
         {
+            if (shouldSkipNullValue(p)) {
+                return;
+            }
             setProperty(instance, propName, (JsonNode) deserialize(p, ctxt));
         }
 
@@ -413,6 +484,9 @@ public abstract class SettableAnyProperty
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException
         {
+            if (p.hasToken(JsonToken.VALUE_NULL)) {
+                return _nullProvider.getNullValue(ctxt);
+            }
             return _valueDeserializer.deserialize(p, ctxt);
         }
 
@@ -445,7 +519,18 @@ public abstract class SettableAnyProperty
         // Should not get called but...
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser) {
-            return this;
+            if (_valueDeserializer == deser) {
+                return this;
+            }
+            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
+            return new JsonNodeFieldAnyProperty(_property, _setter, _type,
+                    deser, _nodeFactory, nvp);
+        }
+
+        @Override
+        public SettableAnyProperty withNullProvider(NullValueProvider nullProvider) {
+            return new JsonNodeFieldAnyProperty(_property, _setter, _type,
+                    _valueDeserializer, _nodeFactory, nullProvider);
         }
     }
 
@@ -462,7 +547,14 @@ public abstract class SettableAnyProperty
                 KeyDeserializer keyDeser, ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser,
                 ValueInstantiator inst, int parameterIndex)
         {
-            super(property, field, valueType, keyDeser, valueDeser, typeDeser);
+            this(property, field, valueType, keyDeser, valueDeser, typeDeser, inst, parameterIndex, valueDeser);
+        }
+
+        protected MapParameterAnyProperty(BeanProperty property, AnnotatedMember field, JavaType valueType,
+                KeyDeserializer keyDeser, ValueDeserializer<Object> valueDeser, TypeDeserializer typeDeser,
+                ValueInstantiator inst, int parameterIndex, NullValueProvider nullProvider)
+        {
+            super(property, field, valueType, keyDeser, valueDeser, typeDeser, nullProvider);
             _valueInstantiator = Objects.requireNonNull(inst, "ValueInstantiator for MapParameterAnyProperty cannot be `null`");
             _parameterIndex = parameterIndex;
         }
@@ -470,8 +562,16 @@ public abstract class SettableAnyProperty
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser)
         {
+            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new MapParameterAnyProperty(_property, _setter, _type, _keyDeserializer, deser,
-                    _valueTypeDeserializer, _valueInstantiator, _parameterIndex);
+                    _valueTypeDeserializer, _valueInstantiator, _parameterIndex, nvp);
+        }
+
+        @Override
+        public SettableAnyProperty withNullProvider(NullValueProvider nullProvider)
+        {
+            return new MapParameterAnyProperty(_property, _setter, _type, _keyDeserializer, _valueDeserializer,
+                    _valueTypeDeserializer, _valueInstantiator, _parameterIndex, nullProvider);
         }
 
         @SuppressWarnings("unchecked")
@@ -500,7 +600,14 @@ public abstract class SettableAnyProperty
         public JsonNodeParameterAnyProperty(BeanProperty property, AnnotatedMember field, JavaType valueType,
                 ValueDeserializer<Object> valueDeser, JsonNodeFactory nodeFactory, int parameterIndex)
         {
-            super(property, field, valueType, null, valueDeser, null);
+            this(property, field, valueType, valueDeser, nodeFactory, parameterIndex, valueDeser);
+        }
+
+        protected JsonNodeParameterAnyProperty(BeanProperty property, AnnotatedMember field, JavaType valueType,
+                ValueDeserializer<Object> valueDeser, JsonNodeFactory nodeFactory, int parameterIndex,
+                NullValueProvider nullProvider)
+        {
+            super(property, field, valueType, null, valueDeser, null, nullProvider);
             _nodeFactory = nodeFactory;
             _parameterIndex = parameterIndex;
         }
@@ -510,6 +617,9 @@ public abstract class SettableAnyProperty
         public Object deserialize(JsonParser p, DeserializationContext ctxt)
             throws JacksonException
         {
+            if (p.hasToken(JsonToken.VALUE_NULL)) {
+                return _nullProvider.getNullValue(ctxt);
+            }
             return _valueDeserializer.deserialize(p, ctxt);
         }
 
@@ -524,6 +634,12 @@ public abstract class SettableAnyProperty
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser) {
             throw new UnsupportedOperationException("Cannot call withValueDeserializer() on " + getClass().getName());
+        }
+
+        @Override
+        public SettableAnyProperty withNullProvider(NullValueProvider nullProvider) {
+            return new JsonNodeParameterAnyProperty(_property, _setter, _type,
+                    _valueDeserializer, _nodeFactory, _parameterIndex, nullProvider);
         }
 
         @Override

--- a/src/main/java/tools/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/tools/jackson/databind/deser/SettableAnyProperty.java
@@ -174,6 +174,18 @@ public abstract class SettableAnyProperty
     }
 
     /**
+     * Helper for {@code withValueDeserializer()} implementations: if the current
+     * null provider is simply tracking the current value deserializer (the default,
+     * unconfigured case), keep tracking the new one; otherwise preserve the
+     * explicitly configured null provider as-is.
+     */
+    private static NullValueProvider _nullProviderFor(ValueDeserializer<Object> currentValueDeserializer,
+            NullValueProvider currentNullProvider, ValueDeserializer<Object> newValueDeserializer) {
+        return (currentValueDeserializer == currentNullProvider)
+                ? newValueDeserializer : currentNullProvider;
+    }
+
+    /**
      * Accessor for parameterIndex.
      * @return -1 if not a parameterized setter, otherwise index of parameter
      *
@@ -366,9 +378,9 @@ public abstract class SettableAnyProperty
 
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser) {
-            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new MethodAnyProperty(_property, _setter, _type,
-                    _keyDeserializer, deser, _valueTypeDeserializer, nvp);
+                    _keyDeserializer, deser, _valueTypeDeserializer,
+                    _nullProviderFor(_valueDeserializer, _nullProvider, deser));
         }
 
         @Override
@@ -405,10 +417,10 @@ public abstract class SettableAnyProperty
 
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser) {
-            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new MapFieldAnyProperty(_property, _setter, _type,
                     _keyDeserializer, deser, _valueTypeDeserializer,
-                    _valueInstantiator, nvp);
+                    _valueInstantiator,
+                    _nullProviderFor(_valueDeserializer, _nullProvider, deser));
         }
 
         @Override
@@ -480,16 +492,6 @@ public abstract class SettableAnyProperty
             setProperty(instance, propName, (JsonNode) deserialize(p, ctxt));
         }
 
-        // Let's override since this is much simpler with JsonNodes
-        @Override
-        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException
-        {
-            if (p.hasToken(JsonToken.VALUE_NULL)) {
-                return _nullProvider.getNullValue(ctxt);
-            }
-            return _valueDeserializer.deserialize(p, ctxt);
-        }
-
         @Override
         protected void _set(DeserializationContext ctxt, Object instance, Object propName, Object value) throws Exception {
             setProperty(instance, (String) propName, (JsonNode) value);
@@ -522,9 +524,9 @@ public abstract class SettableAnyProperty
             if (_valueDeserializer == deser) {
                 return this;
             }
-            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new JsonNodeFieldAnyProperty(_property, _setter, _type,
-                    deser, _nodeFactory, nvp);
+                    deser, _nodeFactory,
+                    _nullProviderFor(_valueDeserializer, _nullProvider, deser));
         }
 
         @Override
@@ -562,9 +564,9 @@ public abstract class SettableAnyProperty
         @Override
         public SettableAnyProperty withValueDeserializer(ValueDeserializer<Object> deser)
         {
-            NullValueProvider nvp = (_valueDeserializer == _nullProvider) ? deser : _nullProvider;
             return new MapParameterAnyProperty(_property, _setter, _type, _keyDeserializer, deser,
-                    _valueTypeDeserializer, _valueInstantiator, _parameterIndex, nvp);
+                    _valueTypeDeserializer, _valueInstantiator, _parameterIndex,
+                    _nullProviderFor(_valueDeserializer, _nullProvider, deser));
         }
 
         @Override
@@ -610,17 +612,6 @@ public abstract class SettableAnyProperty
             super(property, field, valueType, null, valueDeser, null, nullProvider);
             _nodeFactory = nodeFactory;
             _parameterIndex = parameterIndex;
-        }
-
-        // Let's override since this is much simpler with JsonNodes
-        @Override
-        public Object deserialize(JsonParser p, DeserializationContext ctxt)
-            throws JacksonException
-        {
-            if (p.hasToken(JsonToken.VALUE_NULL)) {
-                return _nullProvider.getNullValue(ctxt);
-            }
-            return _valueDeserializer.deserialize(p, ctxt);
         }
 
         @Override

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializer.java
@@ -424,8 +424,7 @@ public class BeanDeserializer
                                 _anySetter.deserialize(p, ctxt));
                     } else {
                         */
-                    buffer.bufferAnyParameterProperty(_anySetter, propName,
-                            _anySetter.deserialize(p, ctxt));
+                    buffer.bufferAnyParameterProperty(_anySetter, propName, p, ctxt);
                     //}
                 } catch (Exception e) {
                     throw wrapAndThrow(e, _beanType.getRawClass(), propName, ctxt);
@@ -847,9 +846,9 @@ public class BeanDeserializer
                     if (_anySetter.isFieldType() ||
                             // [databind#4639] 2.18.2: Also should account for setter type :-/
                             _anySetter.isSetterType()) {
-                        buffer.bufferAnyProperty(_anySetter, propName, _anySetter.deserialize(p, ctxt));
+                        buffer.bufferAnyProperty(_anySetter, propName, p, ctxt);
                     } else {
-                        buffer.bufferAnyParameterProperty(_anySetter, propName, _anySetter.deserialize(p, ctxt));
+                        buffer.bufferAnyParameterProperty(_anySetter, propName, p, ctxt);
                     }
                 } catch (Exception e) {
                     throw wrapAndThrow(e, _beanType.getRawClass(), propName, ctxt);
@@ -1321,8 +1320,7 @@ public class BeanDeserializer
                 tokens.writeName(propName);
                 tokens.append(b2);
                 try {
-                    buffer.bufferAnyProperty(_anySetter, propName,
-                            _anySetter.deserialize(b2.asParserOnFirstToken(ctxt), ctxt));
+                    buffer.bufferAnyProperty(_anySetter, propName, b2.asParserOnFirstToken(ctxt), ctxt);
                 } catch (Exception e) {
                     throw wrapAndThrow(e, _beanType.getRawClass(), propName, ctxt);
                 }
@@ -1527,8 +1525,7 @@ public class BeanDeserializer
             }
             // "any property"?
             if (_anySetter != null) {
-                buffer.bufferAnyProperty(_anySetter, propName,
-                        _anySetter.deserialize(p, ctxt));
+                buffer.bufferAnyProperty(_anySetter, propName, p, ctxt);
                 continue;
             }
             // Unknown: let's call handler method

--- a/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BeanDeserializerBase.java
@@ -649,9 +649,17 @@ public abstract class BeanDeserializerBase
         _propertiesContextualized = true;
 
         // "any setter" may also need to be resolved now
-        if ((_anySetter != null) && !_anySetter.hasValueDeserializer()) {
-            _anySetter = _anySetter.withValueDeserializer(findDeserializer(ctxt,
-                    _anySetter.getType(), _anySetter.getProperty()));
+        if (_anySetter != null) {
+            if (!_anySetter.hasValueDeserializer()) {
+                _anySetter = _anySetter.withValueDeserializer(findDeserializer(ctxt,
+                        _anySetter.getType(), _anySetter.getProperty()));
+            }
+            BeanProperty prop = _anySetter.getProperty();
+            NullValueProvider nuller = _findNullProvider(ctxt, prop,
+                    prop.getMetadata().getValueNulls(), _anySetter.getValueDeserializer());
+            if (nuller != null) {
+                _anySetter = _anySetter.withNullProvider(nuller);
+            }
         }
         // as well as delegate-based constructor:
         if (_valueInstantiator.canCreateUsingDelegate()) {

--- a/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/BuilderBasedDeserializer.java
@@ -531,7 +531,7 @@ public class BuilderBasedDeserializer
             }
             // "any" property?
             if (_anySetter != null) {
-                buffer.bufferAnyProperty(_anySetter, propName, _anySetter.deserialize(p, ctxt));
+                buffer.bufferAnyProperty(_anySetter, propName, p, ctxt);
                 continue;
             }
             if (skipUnknown) {
@@ -910,7 +910,7 @@ public class BuilderBasedDeserializer
                 handleUnknownVanilla(p, ctxt, null, propName);
                 continue;
             }
-            buffer.bufferAnyProperty(_anySetter, propName, _anySetter.deserialize(p, ctxt));
+            buffer.bufferAnyProperty(_anySetter, propName, p, ctxt);
         }
         tokens.writeEndObject();
 

--- a/src/main/java/tools/jackson/databind/deser/bean/PropertyValueBuffer.java
+++ b/src/main/java/tools/jackson/databind/deser/bean/PropertyValueBuffer.java
@@ -470,6 +470,13 @@ public class PropertyValueBuffer
         _buffered = new PropertyValue.Any(_buffered, value, prop, propName);
     }
 
+    public void bufferAnyProperty(SettableAnyProperty prop, String propName,
+            JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        if (!prop.shouldSkipNullValue(p)) {
+            bufferAnyProperty(prop, propName, prop.deserialize(p, ctxt));
+        }
+    }
+
     public void bufferMapProperty(Object key, Object value) {
         _buffered = new PropertyValue.Map(_buffered, value, key);
     }
@@ -483,6 +490,13 @@ public class PropertyValueBuffer
             _anyParamBufferedTail.next = newEntry;
         }
         _anyParamBufferedTail = newEntry;
+    }
+
+    public void bufferAnyParameterProperty(SettableAnyProperty prop, String propName,
+            JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        if (!prop.shouldSkipNullValue(p)) {
+            bufferAnyParameterProperty(prop, propName, prop.deserialize(p, ctxt));
+        }
     }
 
     public void bufferMergingProperty(SettableBeanProperty prop, TokenBuffer buffered) {

--- a/src/test/java/tools/jackson/databind/deser/NullHandlingDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/NullHandlingDeserTest.java
@@ -14,6 +14,7 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.exc.InvalidNullException;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -74,6 +75,16 @@ public class NullHandlingDeserTest
             ++callCount;
             any.put(name, value);
         }
+    }
+
+    static class FieldStringAnySetter {
+        @JsonAnySetter
+        Map<String,String> any = new LinkedHashMap<>();
+    }
+
+    static class ObjectNodeAnySetter {
+        @JsonAnySetter
+        ObjectNode any;
     }
 
     static class CreatorWithCountingAnySetter {
@@ -238,6 +249,45 @@ public class NullHandlingDeserTest
         assertEquals(1, result.callCount);
         assertTrue(result.any.containsKey("a"));
         assertNull(result.any.get("a"));
+    }
+
+    // [databind#6169]
+    @Test
+    public void testAnySetterWithValueTypeNullOverride6169() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .withConfigOverride(Map.class,
+                        o -> o.setNullHandling(JsonSetter.Value.forValueNulls(Nulls.FAIL)))
+                .withConfigOverride(String.class,
+                        o -> o.setNullHandling(JsonSetter.Value.forValueNulls(Nulls.SKIP)))
+                .build();
+
+        CountingStringAnySetter methodResult = mapper.readValue(a2q("{'a':null,'b':'value'}"),
+                CountingStringAnySetter.class);
+        assertEquals(1, methodResult.callCount);
+        assertFalse(methodResult.any.containsKey("a"));
+        assertEquals("value", methodResult.any.get("b"));
+
+        FieldStringAnySetter fieldResult = mapper.readValue(a2q("{'a':null,'b':'value'}"),
+                FieldStringAnySetter.class);
+        assertFalse(fieldResult.any.containsKey("a"));
+        assertEquals("value", fieldResult.any.get("b"));
+    }
+
+    // [databind#6169]
+    @Test
+    public void testJsonNodeAnySetterWithValueTypeNullOverride6169() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .withConfigOverride(ObjectNode.class,
+                        o -> o.setNullHandling(JsonSetter.Value.forValueNulls(Nulls.FAIL)))
+                .withConfigOverride(JsonNode.class,
+                        o -> o.setNullHandling(JsonSetter.Value.forValueNulls(Nulls.SKIP)))
+                .build();
+
+        ObjectNodeAnySetter result = mapper.readValue(a2q("{'a':null,'b':13}"),
+                ObjectNodeAnySetter.class);
+
+        assertFalse(result.any.has("a"));
+        assertEquals(13, result.any.get("b").intValue());
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/deser/NullHandlingDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/NullHandlingDeserTest.java
@@ -213,8 +213,7 @@ public class NullHandlingDeserTest
                 CountingAnySetter.class);
 
         assertEquals(1, result.callCount);
-        assertFalse(result.any.containsKey("a"));
-        assertEquals(Integer.valueOf(1), result.any.get("b"));
+        assertEquals(Collections.singletonMap("b", Integer.valueOf(1)), result.any);
     }
 
     // [databind#6169]
@@ -229,8 +228,7 @@ public class NullHandlingDeserTest
 
         assertEquals(7, result.id);
         assertEquals(1, result.callCount);
-        assertFalse(result.any.containsKey("a"));
-        assertEquals(Integer.valueOf(1), result.any.get("b"));
+        assertEquals(Collections.singletonMap("b", Integer.valueOf(1)), result.any);
     }
 
     // [databind#6169]
@@ -247,8 +245,7 @@ public class NullHandlingDeserTest
                 CountingStringAnySetter.class);
 
         assertEquals(1, result.callCount);
-        assertTrue(result.any.containsKey("a"));
-        assertNull(result.any.get("a"));
+        assertEquals(Collections.singletonMap("a", null), result.any);
     }
 
     // [databind#6169]
@@ -264,13 +261,11 @@ public class NullHandlingDeserTest
         CountingStringAnySetter methodResult = mapper.readValue(a2q("{'a':null,'b':'value'}"),
                 CountingStringAnySetter.class);
         assertEquals(1, methodResult.callCount);
-        assertFalse(methodResult.any.containsKey("a"));
-        assertEquals("value", methodResult.any.get("b"));
+        assertEquals(Collections.singletonMap("b", "value"), methodResult.any);
 
         FieldStringAnySetter fieldResult = mapper.readValue(a2q("{'a':null,'b':'value'}"),
                 FieldStringAnySetter.class);
-        assertFalse(fieldResult.any.containsKey("a"));
-        assertEquals("value", fieldResult.any.get("b"));
+        assertEquals(Collections.singletonMap("b", "value"), fieldResult.any);
     }
 
     // [databind#6169]
@@ -286,8 +281,7 @@ public class NullHandlingDeserTest
         ObjectNodeAnySetter result = mapper.readValue(a2q("{'a':null,'b':13}"),
                 ObjectNodeAnySetter.class);
 
-        assertFalse(result.any.has("a"));
-        assertEquals(13, result.any.get("b").intValue());
+        assertEquals(a2q("{'b':13}"), ""+result.any);
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/deser/NullHandlingDeserTest.java
+++ b/src/test/java/tools/jackson/databind/deser/NullHandlingDeserTest.java
@@ -32,6 +32,14 @@ public class NullHandlingDeserTest
         public String getNullValue(DeserializationContext ctxt) { return "funny"; }
     }
 
+    static class NullReturningDeserializer extends ValueDeserializer<String>
+    {
+        @Override
+        public String deserialize(JsonParser jp, DeserializationContext ctxt) {
+            return null;
+        }
+    }
+
     static class AnySetter{
 
         private Map<String,String> any = new HashMap<String,String>();
@@ -43,6 +51,45 @@ public class NullHandlingDeserTest
 
         public Map<String,String> getAny(){
             return this.any;
+        }
+    }
+
+    static class CountingAnySetter {
+        int callCount;
+        Map<String,Object> any = new LinkedHashMap<>();
+
+        @JsonAnySetter
+        public void setAny(String name, Object value) {
+            ++callCount;
+            any.put(name, value);
+        }
+    }
+
+    static class CountingStringAnySetter {
+        int callCount;
+        Map<String,String> any = new LinkedHashMap<>();
+
+        @JsonAnySetter
+        public void setAny(String name, String value) {
+            ++callCount;
+            any.put(name, value);
+        }
+    }
+
+    static class CreatorWithCountingAnySetter {
+        final int id;
+        int callCount;
+        Map<String,Object> any = new LinkedHashMap<>();
+
+        @JsonCreator
+        CreatorWithCountingAnySetter(@JsonProperty("id") int id) {
+            this.id = id;
+        }
+
+        @JsonAnySetter
+        public void setAny(String name, Object value) {
+            ++callCount;
+            any.put(name, value);
         }
     }
 
@@ -142,6 +189,55 @@ public class NullHandlingDeserTest
         assertEquals(1, result.getAny().size());
         assertNotNull(result.getAny().get(fieldName));
         assertEquals("funny", result.getAny().get(fieldName));
+    }
+
+    // [databind#6169]
+    @Test
+    public void testAnySetterWithDefaultNullSkip6169() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .changeDefaultNullHandling(v -> v.withValueNulls(Nulls.SKIP))
+                .build();
+
+        CountingAnySetter result = mapper.readValue(a2q("{'a':null,'b':1}"),
+                CountingAnySetter.class);
+
+        assertEquals(1, result.callCount);
+        assertFalse(result.any.containsKey("a"));
+        assertEquals(Integer.valueOf(1), result.any.get("b"));
+    }
+
+    // [databind#6169]
+    @Test
+    public void testBufferedAnySetterWithDefaultNullSkip6169() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .changeDefaultNullHandling(v -> v.withValueNulls(Nulls.SKIP))
+                .build();
+
+        CreatorWithCountingAnySetter result = mapper.readValue(a2q("{'a':null,'id':7,'b':1}"),
+                CreatorWithCountingAnySetter.class);
+
+        assertEquals(7, result.id);
+        assertEquals(1, result.callCount);
+        assertFalse(result.any.containsKey("a"));
+        assertEquals(Integer.valueOf(1), result.any.get("b"));
+    }
+
+    // [databind#6169]
+    @Test
+    public void testAnySetterNonNullTokenReturningNull6169() throws Exception {
+        SimpleModule module = new SimpleModule("test", Version.unknownVersion());
+        module.addDeserializer(String.class, new NullReturningDeserializer());
+        ObjectMapper mapper = jsonMapperBuilder()
+                .addModule(module)
+                .changeDefaultNullHandling(v -> v.withValueNulls(Nulls.SKIP))
+                .build();
+
+        CountingStringAnySetter result = mapper.readValue(a2q("{'a':'value'}"),
+                CountingStringAnySetter.class);
+
+        assertEquals(1, result.callCount);
+        assertTrue(result.any.containsKey("a"));
+        assertNull(result.any.get("a"));
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/deser/creators/AnySetterForCreator562Test.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/AnySetterForCreator562Test.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 
 import tools.jackson.databind.DeserializationFeature;
@@ -32,6 +33,20 @@ public class AnySetterForCreator562Test extends DatabindTestUtil
         @JsonCreator
         public POJO562(@JsonProperty("a") String a,
             @JsonAnySetter Map<String, Object> leftovers
+        ) {
+            this.a = a;
+            stuff = leftovers;
+        }
+    }
+
+    static class POJO562WithStringValues
+    {
+        String a;
+        Map<String,String> stuff;
+
+        @JsonCreator
+        public POJO562WithStringValues(@JsonProperty("a") String a,
+            @JsonAnySetter Map<String, String> leftovers
         ) {
             this.a = a;
             stuff = leftovers;
@@ -155,6 +170,26 @@ public class AnySetterForCreator562Test extends DatabindTestUtil
 
         assertEquals("value", pojo.a);
         assertEquals(Collections.singletonMap("c", Integer.valueOf(111)), pojo.stuff);
+    }
+
+    // [databind#6169]
+    @Test
+    public void mapAnySetterViaCreatorWithValueTypeNullOverride6169() throws Exception
+    {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .withConfigOverride(Map.class,
+                        o -> o.setNullHandling(JsonSetter.Value.forValueNulls(Nulls.FAIL)))
+                .withConfigOverride(String.class,
+                        o -> o.setNullHandling(JsonSetter.Value.forValueNulls(Nulls.SKIP)))
+                .build();
+
+        POJO562WithStringValues pojo = mapper.readValue(a2q(
+                "{'a':'value', 'b':null, 'c':'text'}"
+                ),
+                POJO562WithStringValues.class);
+
+        assertEquals("value", pojo.a);
+        assertEquals(Collections.singletonMap("c", "text"), pojo.stuff);
     }
 
     // [databind#4634]

--- a/src/test/java/tools/jackson/databind/deser/creators/AnySetterForCreator562Test.java
+++ b/src/test/java/tools/jackson/databind/deser/creators/AnySetterForCreator562Test.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.Nulls;
 
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
@@ -137,6 +138,23 @@ public class AnySetterForCreator562Test extends DatabindTestUtil
         pojo = MAPPER.readValue(a2q("{'a':'value2'}"), POJO562.class);
         assertEquals("value2", pojo.a);
         assertEquals(new HashMap<>(), pojo.stuff);
+    }
+
+    // [databind#6169]
+    @Test
+    public void mapAnySetterViaCreatorWithDefaultNullSkip6169() throws Exception
+    {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .changeDefaultNullHandling(v -> v.withValueNulls(Nulls.SKIP))
+                .build();
+
+        POJO562 pojo = mapper.readValue(a2q(
+                "{'a':'value', 'b':null, 'c': 111}"
+                ),
+                POJO562.class);
+
+        assertEquals("value", pojo.a);
+        assertEquals(Collections.singletonMap("c", Integer.valueOf(111)), pojo.stuff);
     }
 
     // [databind#4634]


### PR DESCRIPTION
### Problem

Mapper-level default null handling was not applied to properties handled by `@JsonAnySetter`.

For regular bean properties, `valueNulls(Nulls.SKIP)` is propagated through property metadata and resolved to a skipping `NullValueProvider`, so an input `VALUE_NULL` skips assignment.

`@JsonAnySetter` uses a separate path: its synthetic `BeanProperty` was created with `PropertyMetadata.STD_OPTIONAL`, without applying default null-handling configuration. As a result, null-valued unknown properties were still passed to the any-setter.

Issue fixed is #6170, discussed in #6169; 

### Fix

Apply the existing null-handling flow to `@JsonAnySetter`:

- Resolve null-handling metadata for the synthetic any-setter `BeanProperty` using the existing setter-info logic.
- Resolve and attach a `NullValueProvider` to `SettableAnyProperty`.
- Skip any-setter assignment when the input token is `VALUE_NULL` and `Nulls.SKIP` is configured.
- Apply the same behavior to buffered and creator-based any-setter paths.
- Preserve existing custom value deserializer `getNullValue()` behavior when null skipping is not configured.

The skip decision is based on the input token being `VALUE_NULL`, not on the deserialized Java value being `null`. This preserves behavior for non-null input tokens that deserialize into Java `null`.

### Tests

Added regression coverage for:

- mapper-level `valueNulls(Nulls.SKIP)` with method-based `@JsonAnySetter`
- buffered method-based any-setter handling
- creator-based any-setter handling
- non-null input tokens that deserialize to Java `null`
- existing custom `getNullValue()` behavior

Fixes: #6170 