### PR TITLE
Allow `BeanSerializerModifier` to override property serializers

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
@@ -412,6 +412,10 @@ public class BeanPropertyWriter
      * Method called to assign value serializer for property
      */
     public void assignSerializer(ValueSerializer<Object> ser) {
+        if ((_serializer != null) && (ser == null)) {
+            throw new IllegalStateException("Cannot override _serializer: had a %s, trying to set to %s".formatted(
+                    ClassUtil.classNameOf(_serializer), ClassUtil.classNameOf(ser)));
+        }
         _serializer = ser;
     }
 

--- a/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/BeanPropertyWriter.java
@@ -412,11 +412,6 @@ public class BeanPropertyWriter
      * Method called to assign value serializer for property
      */
     public void assignSerializer(ValueSerializer<Object> ser) {
-        // may need to disable check in future?
-        if ((_serializer != null) && (_serializer != ser)) {
-            throw new IllegalStateException("Cannot override _serializer: had a %s, trying to set to %s".formatted(
-                    ClassUtil.classNameOf(_serializer), ClassUtil.classNameOf(ser)));
-        }
         _serializer = ser;
     }
 

--- a/src/test/java/tools/jackson/databind/ser/PropertySerializerModifier4385Test.java
+++ b/src/test/java/tools/jackson/databind/ser/PropertySerializerModifier4385Test.java
@@ -17,6 +17,7 @@ import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PropertySerializerModifier4385Test
 {
@@ -110,10 +111,30 @@ public class PropertySerializerModifier4385Test
         }
     }
 
+    static class NullingPropertySerializerModifier extends ValueSerializerModifier {
+        @Override
+        public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
+                BeanDescription.Supplier beanDesc, List<BeanPropertyWriter> beanProperties) {
+            if (beanDesc.getBeanClass() == TargetBean.class) {
+                for (BeanPropertyWriter property : beanProperties) {
+                    if ("selected".equals(property.getName())) {
+                        property.assignSerializer(null);
+                    }
+                }
+            }
+            return beanProperties;
+        }
+    }
+
     private final JsonMapper MAPPER = JsonMapper.builder()
             .addModule(new SimpleModule()
                     .addSerializer(Value.class, new GlobalValueSerializer())
                     .setSerializerModifier(new PropertySerializerModifier()))
+            .build();
+
+    private final JsonMapper NULLING_MAPPER = JsonMapper.builder()
+            .addModule(new SimpleModule()
+                    .setSerializerModifier(new NullingPropertySerializerModifier()))
             .build();
 
     @Test
@@ -132,5 +153,11 @@ public class PropertySerializerModifier4385Test
                 + "\"annotatedOther\":\"annotation:annotated\","
                 + "\"plainOther\":\"global:plain\"}",
                 MAPPER.writeValueAsString(new TargetBean(null)));
+    }
+
+    @Test
+    public void testNullAssignmentIsRejected() {
+        assertThrows(IllegalStateException.class,
+                () -> NULLING_MAPPER.writeValueAsString(new TargetBean(new Value("selected"))));
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/PropertySerializerModifier4385Test.java
+++ b/src/test/java/tools/jackson/databind/ser/PropertySerializerModifier4385Test.java
@@ -1,0 +1,136 @@
+package tools.jackson.databind.ser;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.SerializationConfig;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PropertySerializerModifier4385Test
+{
+    static class Value {
+        public String value;
+
+        public Value(String value) {
+            this.value = value;
+        }
+    }
+
+    @JsonPropertyOrder({"selected", "annotatedOther", "plainOther"})
+    static class TargetBean {
+        @JsonSerialize(using = AnnotationValueSerializer.class,
+                nullsUsing = AnnotationNullSerializer.class)
+        public Value selected;
+
+        @JsonSerialize(using = AnnotationValueSerializer.class)
+        public Value annotatedOther;
+
+        public Value plainOther;
+
+        public TargetBean(Value selected) {
+            this.selected = selected;
+            annotatedOther = new Value("annotated");
+            plainOther = new Value("plain");
+        }
+    }
+
+    static class OtherBean {
+        public Value value = new Value("other");
+    }
+
+    static class AnnotationValueSerializer extends StdSerializer<Value> {
+        public AnnotationValueSerializer() {
+            super(Value.class);
+        }
+
+        @Override
+        public void serialize(Value value, JsonGenerator gen, SerializationContext ctxt) {
+            gen.writeString("annotation:" + value.value);
+        }
+    }
+
+    static class ModifierValueSerializer extends StdSerializer<Object> {
+        public ModifierValueSerializer() {
+            super(Object.class);
+        }
+
+        @Override
+        public void serialize(Object value, JsonGenerator gen, SerializationContext ctxt) {
+            Value typedValue = (Value) value;
+            gen.writeString("modifier:" + typedValue.value);
+        }
+    }
+
+    static class GlobalValueSerializer extends StdSerializer<Value> {
+        public GlobalValueSerializer() {
+            super(Value.class);
+        }
+
+        @Override
+        public void serialize(Value value, JsonGenerator gen, SerializationContext ctxt) {
+            gen.writeString("global:" + value.value);
+        }
+    }
+
+    static class AnnotationNullSerializer extends StdSerializer<Object> {
+        public AnnotationNullSerializer() {
+            super(Object.class);
+        }
+
+        @Override
+        public void serialize(Object value, JsonGenerator gen, SerializationContext ctxt) {
+            gen.writeString("annotation-null");
+        }
+    }
+
+    static class PropertySerializerModifier extends ValueSerializerModifier {
+        @Override
+        public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
+                BeanDescription.Supplier beanDesc, List<BeanPropertyWriter> beanProperties) {
+            if (beanDesc.getBeanClass() == TargetBean.class) {
+                for (BeanPropertyWriter property : beanProperties) {
+                    if ("selected".equals(property.getName())) {
+                        property.assignSerializer(new ModifierValueSerializer());
+                    }
+                }
+            }
+            return beanProperties;
+        }
+    }
+
+    private final JsonMapper MAPPER = JsonMapper.builder()
+            .addModule(new SimpleModule()
+                    .addSerializer(Value.class, new GlobalValueSerializer())
+                    .setSerializerModifier(new PropertySerializerModifier()))
+            .build();
+
+    @Test
+    public void testOnlySelectedPropertyIsReplaced() throws Exception {
+        assertEquals("{\"selected\":\"modifier:selected\","
+                + "\"annotatedOther\":\"annotation:annotated\","
+                + "\"plainOther\":\"global:plain\"}",
+                MAPPER.writeValueAsString(new TargetBean(new Value("selected"))));
+        assertEquals("{\"value\":\"global:other\"}",
+                MAPPER.writeValueAsString(new OtherBean()));
+    }
+
+    @Test
+    public void testNullSerializerIsNotReplaced() throws Exception {
+        assertEquals("{\"selected\":\"annotation-null\","
+                + "\"annotatedOther\":\"annotation:annotated\","
+                + "\"plainOther\":\"global:plain\"}",
+                MAPPER.writeValueAsString(new TargetBean(null)));
+    }
+}


### PR DESCRIPTION
## Summary

`ValueSerializerModifier.changeProperties()` (the 3.x equivalent of `BeanSerializerModifier`) receives `BeanPropertyWriter` instances after annotation-based serializers have already been assigned. The existing `assignSerializer()` guard rejects replacing those serializers, so a modifier cannot change one annotated property without copying the writer.

This change allows the existing public `BeanPropertyWriter.assignSerializer()` extension point to replace an existing non-null value serializer while continuing to reject clearing an assigned serializer with `null`. The separate `assignNullSerializer()` guard is unchanged, so a modifier can replace regular serialization while preserving an explicitly configured null serializer.

Rejecting `null` assignment preserves the `_serializer`/`_dynamicSerializers` invariant: writers with no statically assigned serializer own a dynamic lookup map, while writers with an assigned serializer do not.

No new public API is added. The change is binary compatible; the behavior of `assignSerializer()` changes only to permit intentional non-null replacement of an existing value serializer.

## Tests

- `PropertySerializerModifier4385Test`: verifies one of two same-type properties is replaced, annotation serializer precedence is changed only for the selected property, global/type serializers and other properties are unaffected, the annotation null serializer is preserved, and null assignment is rejected.
- Related serializer, contextual, annotation, null-serializer, and unwrapped/view tests: 155 tests passed.
- `./mvnw.cmd -B -ntp clean verify`: 6,222 tests passed, 0 failures, 0 errors, 1 skipped.
- `./mvnw.cmd -B -q -ff -ntp -DskipTests animal-sniffer:check`: passed.
- `git diff --check`: passed.

Fixes #4385