### PR TITLE
Honor `@JsonView` in `ThrowableDeserializer.deserializeFromObject()`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -397,6 +397,8 @@ Aysha Afrah Ziya (@aysha-afrah26)
   [3.1.6]
  * Fixed #6165: Apply number length limits to `BigDecimal`/`BigInteger`/`Double`/`Float` Map keys
    [3.1.6]
+ * Fixed #6174: Honor `@JsonView` in `ThrowableDeserializer.deserializeFromObject()`
+  [3.1.7]
  * Fixed #6179: Apply `StreamReadConstraints` number length limit when coercing
    String to `double`
   [3.1.7]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -11,6 +11,8 @@ No changes since 3.1
 
 3.1.7 (not yet released)
 
+#6174: Honor `@JsonView` in `ThrowableDeserializer.deserializeFromObject()`
+ (fix by Aysha A-Z)
 #6179: Apply `StreamReadConstraints` number length limit when coercing String
   to `double`
  (fix by Aysha A-Z)

--- a/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
@@ -11,6 +11,7 @@ import tools.jackson.databind.deser.bean.BeanDeserializer;
 import tools.jackson.databind.deser.bean.BeanPropertyMap;
 import tools.jackson.databind.deser.bean.PropertyBasedCreator;
 import tools.jackson.databind.deser.impl.UnwrappedPropertyHandler;
+import tools.jackson.databind.util.ClassUtil;
 import tools.jackson.databind.util.NameTransformer;
 
 /**
@@ -123,11 +124,24 @@ public class ThrowableDeserializer
         Throwable[] suppressed = null;
         int pendingIx = 0;
 
+        final Class<?> activeView = _needViewProcesing ? ctxt.getActiveView() : null;
         int ix = p.currentNameMatch(_propNameMatcher);
         for (; ; ix = p.nextNameMatch(_propNameMatcher)) {
             if (ix >= 0) {
                 p.nextToken();
                 SettableBeanProperty prop = _propsByIndex[ix];
+                // Property not part of the active view must not be set from input
+                if ((activeView != null) && !prop.visibleInView(activeView)) {
+                    // [databind#437]: fields in other views to be considered as unknown properties
+                    if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)) {
+                        ctxt.reportInputMismatch(handledType(),
+                                String.format("Input mismatch while deserializing %s. Property '%s' is not part of current active view '%s'" +
+                                        " (disable 'DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES' to allow)",
+                                        ClassUtil.nameOf(handledType()), prop.getName(), activeView.getName()));
+                    }
+                    p.skipChildren();
+                    continue;
+                }
                 if (throwable != null) {
                     // 07-Dec-2023, tatu: [databind#4248] Interesting that "cause"
                     //    with `null` blows up. So, avoid.

--- a/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/ThrowableDeserializer.java
@@ -131,7 +131,9 @@ public class ThrowableDeserializer
                 p.nextToken();
                 SettableBeanProperty prop = _propsByIndex[ix];
                 // Property not part of the active view must not be set from input
-                if ((activeView != null) && !prop.visibleInView(activeView)) {
+                // (but standard `Throwable` properties always are, see below)
+                if ((activeView != null) && !prop.visibleInView(activeView)
+                        && !_isStandardThrowableProperty(prop.getName())) {
                     // [databind#437]: fields in other views to be considered as unknown properties
                     if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)) {
                         ctxt.reportInputMismatch(handledType(),
@@ -311,5 +313,29 @@ public class ThrowableDeserializer
     private boolean _shouldSkipNullValue(String propertyName) {
         return PROP_NAME_CAUSE.equals(propertyName)
                 || PROP_NAME_STACK_TRACE.equals(propertyName);
+    }
+
+    /**
+     * Helper method to check whether given property is one of the standard
+     * {@link Throwable} properties, which are never subject to {@code @JsonView}
+     * filtering: they carry no View annotations of their own, and since
+     * {@code MapperFeature.DEFAULT_VIEW_INCLUSION} defaults to disabled, would
+     * otherwise be excluded from every view. Note that "message",
+     * "localizedMessage" and "suppressed" are normally handled separately (not as
+     * regular properties) but are included here for consistency.
+     *
+     * @since 3.1
+     */
+    private boolean _isStandardThrowableProperty(String propertyName) {
+        switch (propertyName) {
+        case PROP_NAME_CAUSE:
+        case PROP_NAME_STACK_TRACE:
+        case PROP_NAME_MESSAGE:
+        case PROP_NAME_LOCALIZED_MESSAGE:
+        case PROP_NAME_SUPPRESSED:
+            return true;
+        default:
+            return false;
+        }
     }
 }

--- a/src/test/java/tools/jackson/databind/views/ThrowableViewDeserializationBypassTest.java
+++ b/src/test/java/tools/jackson/databind/views/ThrowableViewDeserializationBypassTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +31,20 @@ public class ThrowableViewDeserializationBypassTest extends DatabindTestUtil
         public ViewException() { super(); }
     }
 
+    // Same, but with a single-String constructor so that "message" is actually settable
+    // (with only a default constructor it is skipped; see [databind#4071])
+    @SuppressWarnings("serial")
+    static class StdPropsException extends RuntimeException {
+        @JsonView(Public.class) public String pub;
+        @JsonView(Internal.class) public String sec; // internal-only
+        public StdPropsException() { super(); }
+        public StdPropsException(String msg) { super(msg); }
+    }
+
     private final ObjectMapper MAPPER = newJsonMapper();
+
+    private final ObjectMapper FAIL_ON_UNEXPECTED_MAPPER = jsonMapperBuilder()
+            .enable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES).build();
 
     // Under the Public view the Internal-only property must not be set from input
     @Test
@@ -50,5 +66,93 @@ public class ThrowableViewDeserializationBypassTest extends DatabindTestUtil
 
         assertEquals("visible", ex.pub);
         assertEquals("kept", ex.sec);
+    }
+
+    // [databind#6174]: view filtering must not affect the standard `Throwable` properties;
+    // "message", "cause", "stackTrace", "suppressed" and "localizedMessage" have no
+    // `@JsonView` of their own and must default to inclusion under any active view.
+    @Test
+    public void standardThrowablePropsIncludedUnderView() throws Exception {
+        final String json = """
+{
+  "message" : "the message",
+  "cause" : { "message" : "root cause" },
+  "stackTrace" : [ {
+    "className" : "some.Class", "methodName" : "someMethod",
+    "fileName" : "Class.java", "lineNumber" : 42
+  } ],
+  "suppressed" : [ { "message" : "suppressed one" } ],
+  "localizedMessage" : "the message",
+  "pub" : "visible",
+  "sec" : "leaked"
+}
+""";
+        StdPropsException ex = MAPPER.readerWithView(Public.class)
+                .forType(StdPropsException.class)
+                .readValue(json);
+
+        // First: view filtering still applies to view-annotated properties
+        assertEquals("visible", ex.pub);
+        assertNull(ex.sec);
+
+        // But none of the standard `Throwable` properties may be dropped:
+        assertEquals("the message", ex.getMessage());
+        assertEquals("the message", ex.getLocalizedMessage());
+
+        assertNotNull(ex.getCause(), "'cause' should be set under active view");
+        assertEquals("root cause", ex.getCause().getMessage());
+
+        // NOTE: only checking that the property itself was applied from input (a
+        // single frame), and not left as the multi-frame fill-in trace. Contents of
+        // the nested `StackTraceElement` follow the regular bean/View rules -- with
+        // `DEFAULT_VIEW_INCLUSION` disabled its un-annotated properties are not part
+        // of any view -- which is out of scope here.
+        StackTraceElement[] trace = ex.getStackTrace();
+        assertEquals(1, trace.length,
+                "'stackTrace' should be set from input under active view");
+
+        Throwable[] suppressed = ex.getSuppressed();
+        assertEquals(1, suppressed.length,
+                "'suppressed' should be set under active view");
+        assertEquals("suppressed one", suppressed[0].getMessage());
+    }
+
+    // [databind#437]: with `FAIL_ON_UNEXPECTED_VIEW_PROPERTIES` enabled, a property
+    // outside the active view is reported as an unexpected property instead of skipped
+    @Test
+    public void throwableFailsOnUnexpectedViewProperty() throws Exception {
+        ObjectReader r = FAIL_ON_UNEXPECTED_MAPPER.readerWithView(Public.class)
+                .forType(ViewException.class);
+        try {
+            r.readValue("{\"pub\":\"visible\",\"sec\":\"leaked\"}");
+            fail("should not pass, but fail with exception with unexpected view");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "Input mismatch while deserializing");
+            verifyException(e, "Property 'sec' is not part of current active view");
+        }
+    }
+
+    // ...but the standard `Throwable` properties are exempt from view filtering, so
+    // they must not trigger the failure either
+    @Test
+    public void throwableStandardPropsDoNotFailOnUnexpectedView() throws Exception {
+        final String json = """
+{
+  "message" : "the message",
+  "cause" : { "message" : "root cause" },
+  "stackTrace" : [ ],
+  "suppressed" : [ ],
+  "localizedMessage" : "the message",
+  "pub" : "visible"
+}
+""";
+        StdPropsException ex = FAIL_ON_UNEXPECTED_MAPPER.readerWithView(Public.class)
+                .forType(StdPropsException.class)
+                .readValue(json);
+
+        assertEquals("visible", ex.pub);
+        assertEquals("the message", ex.getMessage());
+        assertNotNull(ex.getCause());
+        assertEquals(0, ex.getStackTrace().length);
     }
 }

--- a/src/test/java/tools/jackson/databind/views/ThrowableViewDeserializationBypassTest.java
+++ b/src/test/java/tools/jackson/databind/views/ThrowableViewDeserializationBypassTest.java
@@ -1,0 +1,54 @@
+package tools.jackson.databind.views;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@code @JsonView} filtering is applied by {@code BeanDeserializer} (and the array/builder
+ * variants), but {@link tools.jackson.databind.deser.jdk.ThrowableDeserializer} overrides
+ * {@code deserializeFromObject} wholesale and never consulted the active view. For an
+ * exception type that reaches that loop (default-constructor, no property-based creator),
+ * a view-hidden property was populated from input even when the active view excluded it.
+ */
+public class ThrowableViewDeserializationBypassTest extends DatabindTestUtil
+{
+    static class Public {}
+    static class Internal {}
+
+    @SuppressWarnings("serial")
+    static class ViewException extends RuntimeException {
+        @JsonView(Public.class) public String pub;
+        @JsonView(Internal.class) public String sec; // internal-only
+        public ViewException() { super(); }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // Under the Public view the Internal-only property must not be set from input
+    @Test
+    public void throwableHonorsViewOnDeserialize() throws Exception {
+        ViewException ex = MAPPER.readerWithView(Public.class)
+                .forType(ViewException.class)
+                .readValue("{\"pub\":\"visible\",\"sec\":\"leaked\"}");
+
+        assertEquals("visible", ex.pub);
+        assertNull(ex.sec,
+                "view-hidden 'sec' should stay null under the Public view but was: " + ex.sec);
+    }
+
+    // Control: with no active view every property is set as before
+    @Test
+    public void throwableWithoutViewSetsAll() throws Exception {
+        ViewException ex = MAPPER.readerFor(ViewException.class)
+                .readValue("{\"pub\":\"visible\",\"sec\":\"kept\"}");
+
+        assertEquals("visible", ex.pub);
+        assertEquals("kept", ex.sec);
+    }
+}


### PR DESCRIPTION
BeanDeserializer and its array and builder variants skip properties that fall outside the active @JsonView, but ThrowableDeserializer overrides deserializeFromObject on its own to handle the special message and cause construction, and that override never looked at the view. It only bites exceptions that reach this loop rather than the property-based-creator path: a Throwable with a default constructor and no @JsonCreator, where the remaining fields are plain setters. Under a restricted view those fields are still read straight from input, so a property that belongs only to another view (say an internal-only field on a custom exception) gets populated by a caller reading under a narrower view. I noticed it while checking which deserializers consult _needViewProcesing and this was the only property loop that did not. The fix reads the active view once and skips any property not visible in it before the value is set or deferred, matching what deserializeWithView already does, including the FAIL_ON_UNEXPECTED_VIEW_PROPERTIES behavior. I kept the change inside deserializeFromObject so the creator and any-setter paths are untouched.