### PR TITLE
Fix #6175: parse QName object form after As.PROPERTY type id

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -684,3 +684,11 @@ DongNyoung Lee (@Dongnyoung)
 Fabian Lange (@CodingFabian)
  * Requested #3182: Support value deduplication for enumeration like values
   [3.3.0]
+
+@jjh75607
+ * Reported #6175: Parse object-form `QName` after `As.PROPERTY` type id
+  [3.3.0]
+
+Burak KALAYCI (@kalayciburak)
+ * Fixed #6175: Parse object-form `QName` after `As.PROPERTY` type id
+  [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -44,6 +44,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
  (fix by @Dongnyoung)
 #6151: Add `DateTimeFeature.ALWAYS_WRITE_SUBSECOND_DIGITS`
  (contributed by @seonwooj0810)
+#6175: Parse object-form `QName` after `As.PROPERTY` type id
+ (reported by @jjh75607)
+ (fix by @kalayciburak)
 
 3.2.2 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
@@ -93,12 +93,14 @@ public class CoreXMLDeserializers
                 }
             }
             // QName also allows object value, which needs separate handling.
-            // PROPERTY_NAME: As.PROPERTY type deserializer has already consumed
-            // START_OBJECT (and the type id), so the parser sits on the first
-            // payload property: same object form as START_OBJECT. [databind#6175]
+            // PROPERTY_NAME (or END_OBJECT, if there are no other properties):
+            // As.PROPERTY type deserializer has already consumed START_OBJECT
+            // (and the type id), so the parser sits within the same object form
+            // that START_OBJECT starts. [databind#6175]
             if (_kind == TYPE_QNAME) {
                 if (p.hasToken(JsonToken.START_OBJECT)
-                        || p.hasToken(JsonToken.PROPERTY_NAME)) {
+                        || p.hasToken(JsonToken.PROPERTY_NAME)
+                        || p.hasToken(JsonToken.END_OBJECT)) {
                     return _parseQNameObject(p, ctxt);
                 }
             }

--- a/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
+++ b/src/main/java/tools/jackson/databind/ext/CoreXMLDeserializers.java
@@ -92,9 +92,13 @@ public class CoreXMLDeserializers
                     return _gregorianFromDate(ctxt, _parseDate(p, ctxt));
                 }
             }
-            // QName also allows object value, which needs separate handling
+            // QName also allows object value, which needs separate handling.
+            // PROPERTY_NAME: As.PROPERTY type deserializer has already consumed
+            // START_OBJECT (and the type id), so the parser sits on the first
+            // payload property: same object form as START_OBJECT. [databind#6175]
             if (_kind == TYPE_QNAME) {
-                if (p.hasToken(JsonToken.START_OBJECT)) {
+                if (p.hasToken(JsonToken.START_OBJECT)
+                        || p.hasToken(JsonToken.PROPERTY_NAME)) {
                     return _parseQNameObject(p, ctxt);
                 }
             }

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -306,7 +306,8 @@ public class MiscJavaXMLTypesReadWriteTest
     {
         ObjectMapper mapper = mapperWithQNameObjectTyping(JsonTypeInfo.As.PROPERTY);
         String json = """
-                {"qname":{"@class":"javax.xml.namespace.QName"}}
+                {"@class":"java.util.LinkedHashMap",
+                 "qname":{"@class":"javax.xml.namespace.QName"}}
                 """;
         try {
             mapper.readValue(json, Map.class);

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -1,10 +1,14 @@
 package tools.jackson.databind.ext.xml;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import javax.xml.datatype.*;
 import javax.xml.namespace.QName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.exc.StreamConstraintsException;
@@ -261,6 +265,54 @@ public class MiscJavaXMLTypesReadWriteTest
             fail("Expected a `XMLGregorianCalendar`, got: "+result.getClass());
         }
         assertEquals(cal, result);
+    }
+
+    // [databind#6175] Object-shaped QName must round-trip when polymorphic type
+    // id is written as a property (type deserializer consumes START_OBJECT).
+    @Test
+    public void testQNameObjectFormWithAsPropertyTyping() throws Exception
+    {
+        QName original = new QName("http://namespace", "test", "p");
+        ObjectMapper mapper = mapperWithQNameObjectTyping(JsonTypeInfo.As.PROPERTY);
+
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("qname", original);
+
+        String json = mapper.writeValueAsString(value);
+        QName back = (QName) mapper.readValue(json, Map.class).get("qname");
+        assertQNameEquals(original, back);
+    }
+
+    // WRAPPER_ARRAY / WRAPPER_OBJECT leave START_OBJECT for the QName deserializer
+    @Test
+    public void testQNameObjectFormWithWrapperTyping() throws Exception
+    {
+        QName original = new QName("http://namespace", "test", "p");
+        for (JsonTypeInfo.As inclusion : new JsonTypeInfo.As[] {
+                JsonTypeInfo.As.WRAPPER_ARRAY, JsonTypeInfo.As.WRAPPER_OBJECT }) {
+            ObjectMapper mapper = mapperWithQNameObjectTyping(inclusion);
+            Map<String, Object> value = new LinkedHashMap<>();
+            value.put("qname", original);
+            QName back = (QName) mapper.readValue(mapper.writeValueAsString(value), Map.class)
+                    .get("qname");
+            assertQNameEquals(original, back);
+        }
+    }
+
+    private ObjectMapper mapperWithQNameObjectTyping(JsonTypeInfo.As inclusion) {
+        return jsonMapperBuilder()
+                .activateDefaultTyping(NoCheckSubTypeValidator.instance,
+                        DefaultTyping.NON_FINAL, inclusion)
+                .withConfigOverride(QName.class,
+                        cfg -> cfg.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.OBJECT)))
+                .build();
+    }
+
+    // QName.equals() ignores prefix
+    private static void assertQNameEquals(QName expected, QName actual) {
+        assertEquals(expected.getLocalPart(), actual.getLocalPart());
+        assertEquals(expected.getNamespaceURI(), actual.getNamespaceURI());
+        assertEquals(expected.getPrefix(), actual.getPrefix());
     }
 
     /*

--- a/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
+++ b/src/test/java/tools/jackson/databind/ext/xml/MiscJavaXMLTypesReadWriteTest.java
@@ -270,7 +270,7 @@ public class MiscJavaXMLTypesReadWriteTest
     // [databind#6175] Object-shaped QName must round-trip when polymorphic type
     // id is written as a property (type deserializer consumes START_OBJECT).
     @Test
-    public void testQNameObjectFormWithAsPropertyTyping() throws Exception
+    public void qnameObjectFormWithAsPropertyTyping() throws Exception
     {
         QName original = new QName("http://namespace", "test", "p");
         ObjectMapper mapper = mapperWithQNameObjectTyping(JsonTypeInfo.As.PROPERTY);
@@ -285,7 +285,7 @@ public class MiscJavaXMLTypesReadWriteTest
 
     // WRAPPER_ARRAY / WRAPPER_OBJECT leave START_OBJECT for the QName deserializer
     @Test
-    public void testQNameObjectFormWithWrapperTyping() throws Exception
+    public void qnameObjectFormWithWrapperTyping() throws Exception
     {
         QName original = new QName("http://namespace", "test", "p");
         for (JsonTypeInfo.As inclusion : new JsonTypeInfo.As[] {
@@ -296,6 +296,23 @@ public class MiscJavaXMLTypesReadWriteTest
             QName back = (QName) mapper.readValue(mapper.writeValueAsString(value), Map.class)
                     .get("qname");
             assertQNameEquals(original, back);
+        }
+    }
+
+    // [databind#6175] Type id as the only property leaves parser on END_OBJECT:
+    // should still report the missing 'localPart', not an unexpected-token failure
+    @Test
+    public void qnameObjectFormWithOnlyTypeIdProperty() throws Exception
+    {
+        ObjectMapper mapper = mapperWithQNameObjectTyping(JsonTypeInfo.As.PROPERTY);
+        String json = """
+                {"qname":{"@class":"javax.xml.namespace.QName"}}
+                """;
+        try {
+            mapper.readValue(json, Map.class);
+            fail("Should not pass");
+        } catch (MismatchedInputException e) {
+            verifyException(e, "missing required property 'localPart'");
         }
     }
 


### PR DESCRIPTION
Fixes #6175

`CoreXMLDeserializers.Std` only treated `QName` as object form when the parser was on `START_OBJECT`. With `JsonTypeInfo.As.PROPERTY`, the type deserializer consumes that token (and the type id) before delegating, so the remaining properties were read as a String. On 3.x that then fails `FAIL_ON_TRAILING_TOKENS`.

Also enter `_parseQNameObject` on `PROPERTY_NAME`. `DeserializationContext.readTree()` already reconstructs the object from that token.

WRAPPER_ARRAY and WRAPPER_OBJECT still leave `START_OBJECT` for the delegate and keep working.

## Tests

- `./mvnw -q test -Dtest=MiscJavaXMLTypesReadWriteTest#testQNameObjectFormWithAsPropertyTyping` (RED before the change: trailing `PROPERTY_NAME`; GREEN after)
- `./mvnw -q test -Dtest=MiscJavaXMLTypesReadWriteTest,QNameAsObjectReadWrite4771Test`
- `./mvnw -q test -Dtest=DOMElementWithCustomSerializerTest,DOMTypeReadWriteTest,MiscJavaXMLTypesReadWriteTest,QNameAsObjectReadWrite4771Test`
- `./mvnw -q test`: 6221 tests, 1 skipped. `MapDeserializationTest.testCalendarMap` and `testDateMap` fail on this host on unmodified `3.x` as well (timezone baseline), not introduced by this change.