### PR TITLE
Fix #6178: Honor case-insensitive values for Month without custom pattern

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -678,6 +678,9 @@ DongNyoung Lee (@Dongnyoung)
  * Contributed #3182: Add `StringCanonicalizingConverter` for opt-in canonicalization
    ("de-duplication") of low-cardinality `String` values
   [3.3.0]
+ * Fixed #6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work
+   for `java.time.Month`
+  [3.3.0]
 
 @prvazsahnazarov
  * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic
@@ -698,4 +701,9 @@ Fabian Lange (@CodingFabian)
 
 Burak KALAYCI (@kalayciburak)
  * Fixed #6175: Parse object-form `QName` after `As.PROPERTY` type id
+  [3.3.0]
+
+@laech
+ * Reported #6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work
+   for `java.time.Month`
   [3.3.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -47,6 +47,10 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6175: Parse object-form `QName` after `As.PROPERTY` type id
  (reported by @jjh75607)
  (fix by @kalayciburak)
+#6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work for
+  `java.time.Month`
+ (reported by @laech)
+ (fix by @Dongnyoung)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/JSR310DateTimeDeserializerBase.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/JSR310DateTimeDeserializerBase.java
@@ -122,7 +122,8 @@ public abstract class JSR310DateTimeDeserializerBase<T>
             final String pattern = formatOverrides.getPattern();
             final Locale locale = formatOverrides.hasLocale() ? formatOverrides.getLocale() : ctxt.getLocale();
             DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
-            if (acceptCaseInsensitiveValues(ctxt, formatOverrides)) {
+            if (_acceptCaseInsensitiveValues(ctxt,
+                    formatOverrides.getFeature(Feature.ACCEPT_CASE_INSENSITIVE_VALUES))) {
                 builder.parseCaseInsensitive();
             }
             builder.appendPattern(pattern);
@@ -156,13 +157,22 @@ public abstract class JSR310DateTimeDeserializerBase<T>
         return deser;
     }
     
-    private boolean acceptCaseInsensitiveValues(DeserializationContext ctxt, JsonFormat.Value format) 
+    /**
+     * Helper method for resolving effective setting of
+     * {@link Feature#ACCEPT_CASE_INSENSITIVE_VALUES}: explicit per-property override
+     * (if any) takes precedence over global
+     * {@link MapperFeature#ACCEPT_CASE_INSENSITIVE_VALUES} setting.
+     *
+     * @param override Per-property override, if any; {@code null} if none
+     *
+     * @since 3.3
+     */
+    protected boolean _acceptCaseInsensitiveValues(DeserializationContext ctxt, Boolean override)
     {
-        Boolean enabled = format.getFeature(Feature.ACCEPT_CASE_INSENSITIVE_VALUES);
-        if (enabled == null) {
-            enabled = ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES);
+        if (override != null) {
+            return override;
         }
-        return enabled;
+        return ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES);
     }
     
     @SuppressWarnings("unchecked")

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
@@ -7,7 +7,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import tools.jackson.core.*;
+import tools.jackson.databind.BeanProperty;
 import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.cfg.DateTimeFeature;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -24,6 +26,11 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
             .collect(Collectors.toUnmodifiableMap(Month::name, Function.identity()));
 
     /**
+     * Property-level override for {@link JsonFormat.Feature#ACCEPT_CASE_INSENSITIVE_VALUES}.
+     */
+    protected final Boolean _caseInsensitiveValues;
+
+    /**
      * NOTE: only {@code public} so that use via annotations (see [modules-java8#202])
      * is possible
      */
@@ -33,15 +40,25 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
 
     public MonthDeserializer(DateTimeFormatter formatter) {
         super(Month.class, formatter);
+        _caseInsensitiveValues = null;
     }
 
     protected MonthDeserializer(MonthDeserializer base, Boolean leniency) {
         super(base, leniency);
+        _caseInsensitiveValues = base._caseInsensitiveValues;
     }
 
     protected MonthDeserializer(MonthDeserializer base,
             Boolean leniency, DateTimeFormatter formatter, JsonFormat.Shape shape) {
         super(base, leniency, formatter, shape);
+        _caseInsensitiveValues = base._caseInsensitiveValues;
+    }
+
+    protected MonthDeserializer(MonthDeserializer base,
+            Boolean leniency, DateTimeFormatter formatter, JsonFormat.Shape shape,
+            Boolean caseInsensitiveValues) {
+        super(base, leniency, formatter, shape);
+        _caseInsensitiveValues = caseInsensitiveValues;
     }
 
     @Override
@@ -52,6 +69,23 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
     @Override
     protected MonthDeserializer withDateFormat(DateTimeFormatter dtf) {
         return new MonthDeserializer(this, _isLenient, dtf, _shape);
+    }
+
+    protected MonthDeserializer withCaseInsensitiveValues(Boolean state) {
+        if (Objects.equals(_caseInsensitiveValues, state)) {
+            return this;
+        }
+        return new MonthDeserializer(this, _isLenient, _formatter, _shape, state);
+    }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<?> _withFormatOverrides(DeserializationContext ctxt,
+            BeanProperty property, JsonFormat.Value formatOverrides)
+    {
+        MonthDeserializer deser = (MonthDeserializer) super._withFormatOverrides(ctxt,
+                property, formatOverrides);
+        return deser.withCaseInsensitiveValues(formatOverrides.getFeature(
+                JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES));
     }
 
     @Override
@@ -117,6 +151,12 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
                 if (m != null) {
                     return m;
                 }
+                if (_acceptCaseInsensitiveValues(ctxt)) {
+                    m = _findMonthIgnoreCase(string);
+                    if (m != null) {
+                        return m;
+                    }
+                }
                 return (Month) ctxt.handleWeirdStringValue(handledType(), string, 
                         "not one of known `Month` values: %s",
                                 Arrays.toString(Month.values()));
@@ -128,6 +168,22 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
             throw ctxt.weirdStringException(string, handledType(),
                     "not a valid Month value");
         }
+    }
+
+    private boolean _acceptCaseInsensitiveValues(DeserializationContext ctxt) {
+        if (_caseInsensitiveValues != null) {
+            return _caseInsensitiveValues;
+        }
+        return ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES);
+    }
+
+    private Month _findMonthIgnoreCase(String key) {
+        for (Month month : Month.values()) {
+            if (month.name().equalsIgnoreCase(key)) {
+                return month;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import tools.jackson.core.*;
 import tools.jackson.databind.BeanProperty;
 import tools.jackson.databind.DeserializationContext;
-import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.cfg.DateTimeFeature;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -50,8 +49,7 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
 
     protected MonthDeserializer(MonthDeserializer base,
             Boolean leniency, DateTimeFormatter formatter, JsonFormat.Shape shape) {
-        super(base, leniency, formatter, shape);
-        _caseInsensitiveValues = base._caseInsensitiveValues;
+        this(base, leniency, formatter, shape, base._caseInsensitiveValues);
     }
 
     protected MonthDeserializer(MonthDeserializer base,
@@ -157,7 +155,7 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
                 if (m != null) {
                     return m;
                 }
-                if (_acceptCaseInsensitiveValues(ctxt)) {
+                if (_acceptCaseInsensitiveValues(ctxt, _caseInsensitiveValues)) {
                     m = _findMonthIgnoreCase(string);
                     if (m != null) {
                         return m;
@@ -174,13 +172,6 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
             throw ctxt.weirdStringException(string, handledType(),
                     "not a valid Month value");
         }
-    }
-
-    private boolean _acceptCaseInsensitiveValues(DeserializationContext ctxt) {
-        if (_caseInsensitiveValues != null) {
-            return _caseInsensitiveValues;
-        }
-        return ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES);
     }
 
     private Month _findMonthIgnoreCase(String key) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
@@ -9,12 +9,21 @@ import java.util.stream.Collectors;
 import tools.jackson.core.*;
 import tools.jackson.databind.BeanProperty;
 import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.cfg.DateTimeFeature;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 /**
  * Deserializer for Java 8 temporal {@link Month}s.
+ *<p>
+ * Note that unlike most other date/time types {@link Month} is also an {@link Enum}:
+ * because of this, case-insensitive matching of textual values (like {@code "January"})
+ * is enabled by either date/time-specific
+ * {@link MapperFeature#ACCEPT_CASE_INSENSITIVE_VALUES} or Enum-specific
+ * {@link MapperFeature#ACCEPT_CASE_INSENSITIVE_ENUMS}; and may also be overridden
+ * per-property with
+ * {@link JsonFormat.Feature#ACCEPT_CASE_INSENSITIVE_VALUES}.
  */
 public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
 {
@@ -155,7 +164,7 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
                 if (m != null) {
                     return m;
                 }
-                if (_acceptCaseInsensitiveValues(ctxt, _caseInsensitiveValues)) {
+                if (_acceptCaseInsensitiveNames(ctxt)) {
                     m = _findMonthIgnoreCase(string);
                     if (m != null) {
                         return m;
@@ -172,6 +181,21 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
             throw ctxt.weirdStringException(string, handledType(),
                     "not a valid Month value");
         }
+    }
+
+    /**
+     * Helper method for checking whether textual {@link Month} names (like {@code "JANUARY"})
+     * may be matched case-insensitively: explicit per-property override, if any, takes
+     * precedence over either of the two applicable global settings.
+     */
+    private boolean _acceptCaseInsensitiveNames(DeserializationContext ctxt) {
+        if (_caseInsensitiveValues != null) {
+            return _caseInsensitiveValues;
+        }
+        // [databind#6178]: `Month` is an `Enum`, so honor Enum-specific setting as well
+        // as the date/time-specific one
+        return _acceptCaseInsensitiveValues(ctxt, null)
+                || ctxt.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
     }
 
     private Month _findMonthIgnoreCase(String key) {

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
@@ -84,8 +84,14 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
     {
         MonthDeserializer deser = (MonthDeserializer) super._withFormatOverrides(ctxt,
                 property, formatOverrides);
-        return deser.withCaseInsensitiveValues(formatOverrides.getFeature(
-                JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES));
+        Boolean caseInsensitive = formatOverrides.getFeature(
+                JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES);
+        // Only override if explicitly specified: `null` means "no setting", must not
+        // clear a value possibly set earlier
+        if (caseInsensitive != null) {
+            deser = deser.withCaseInsensitiveValues(caseInsensitive);
+        }
+        return deser;
     }
 
     @Override

--- a/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
+++ b/src/main/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializer.java
@@ -18,11 +18,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
  */
 public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
 {
-    public static final MonthDeserializer INSTANCE = new MonthDeserializer();
-
     // @since 3.1
-    private final Map<String, Month> _byNameLookup = Arrays.stream(Month.values())
+    private final static Map<String, Month> _byNameLookup = Arrays.stream(Month.values())
             .collect(Collectors.toUnmodifiableMap(Month::name, Function.identity()));
+
+    public static final MonthDeserializer INSTANCE = new MonthDeserializer();
 
     /**
      * Property-level override for {@link JsonFormat.Feature#ACCEPT_CASE_INSENSITIVE_VALUES}.
@@ -175,9 +175,12 @@ public class MonthDeserializer extends JSR310DateTimeDeserializerBase<Month>
     }
 
     private Month _findMonthIgnoreCase(String key) {
-        for (Month month : Month.values()) {
-            if (month.name().equalsIgnoreCase(key)) {
-                return month;
+        // Iterate over lookup Map (and not `Month.values()`, which allocates a new
+        // array on every call); matching same way as case-insensitive `Enum` lookup
+        // (see `CompactStringObjectMap.findCaseInsensitive()`)
+        for (Map.Entry<String, Month> entry : _byNameLookup.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(key)) {
+                return entry.getValue();
             }
         }
         return null;

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
@@ -516,6 +516,18 @@ public class MonthDeserializerTest extends DateTimeTestBase
         public Month value;
     }
 
+    record Estimate(
+            @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
+            Month month) { }
+
+    // [databind#6178]
+    @Test
+    public void testDeserializationWithCaseInsensitiveValues() throws Exception
+    {
+        Estimate result = MAPPER.readValue("{\"month\":\"January\"}", Estimate.class);
+        assertEquals(Month.JANUARY, result.month());
+    }
+
     @Test
     public void testDeserializationWithFullMonthFormat() throws Exception
     {

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
@@ -43,6 +43,14 @@ public class MonthDeserializerTest extends DateTimeTestBase
         public Month value;
     }
 
+    record Estimate(
+            @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
+            Month month) { }
+
+    record StrictEstimate(
+            @JsonFormat(without = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
+            Month month) { }
+
     @ParameterizedTest
     @EnumSource(Month.class)
     public void testDeserializationAsString01_oneBased(Month expectedMonth) throws Exception
@@ -516,13 +524,13 @@ public class MonthDeserializerTest extends DateTimeTestBase
         public Month value;
     }
 
-    record Estimate(
-            @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
-            Month month) { }
-
-    record StrictEstimate(
-            @JsonFormat(without = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
-            Month month) { }
+    @Test
+    public void testDeserializationWithFullMonthFormat() throws Exception
+    {
+        WrapperWithFullMonthFormat result = MAPPER.readValue(
+                "{\"value\":\"January\"}", WrapperWithFullMonthFormat.class);
+        assertEquals(Month.JANUARY, result.value);
+    }
 
     // [databind#6178]
     @ParameterizedTest
@@ -554,14 +562,6 @@ public class MonthDeserializerTest extends DateTimeTestBase
 
         assertThrows(InvalidFormatException.class,
                 () -> mapper.readValue("{\"month\":\"January\"}", StrictEstimate.class));
-    }
-
-    @Test
-    public void testDeserializationWithFullMonthFormat() throws Exception
-    {
-        WrapperWithFullMonthFormat result = MAPPER.readValue(
-                "{\"value\":\"January\"}", WrapperWithFullMonthFormat.class);
-        assertEquals(Month.JANUARY, result.value);
     }
 
     /*

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
@@ -520,12 +520,40 @@ public class MonthDeserializerTest extends DateTimeTestBase
             @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
             Month month) { }
 
+    record StrictEstimate(
+            @JsonFormat(without = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES)
+            Month month) { }
+
+    // [databind#6178]
+    @ParameterizedTest
+    @ValueSource(strings = {"JANUARY", "January", "january"})
+    public void testDeserializationWithCaseInsensitiveValues(String input) throws Exception
+    {
+        Estimate result = MAPPER.readValue("{\"month\":\"" + input + "\"}", Estimate.class);
+        assertEquals(Month.JANUARY, result.month());
+    }
+
     // [databind#6178]
     @Test
-    public void testDeserializationWithCaseInsensitiveValues() throws Exception
+    public void testDeserializationWithGlobalCaseInsensitiveValues() throws Exception
     {
-        Estimate result = MAPPER.readValue("{\"month\":\"January\"}", Estimate.class);
-        assertEquals(Month.JANUARY, result.month());
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
+                .build();
+
+        assertEquals(Month.JANUARY, mapper.readValue("\"january\"", Month.class));
+    }
+
+    // [databind#6178]
+    @Test
+    public void testDeserializationWithCaseInsensitiveValuesDisabledForProperty() throws Exception
+    {
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
+                .build();
+
+        assertThrows(InvalidFormatException.class,
+                () -> mapper.readValue("{\"month\":\"January\"}", StrictEstimate.class));
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
+++ b/src/test/java/tools/jackson/databind/ext/javatime/deser/MonthDeserializerTest.java
@@ -564,6 +564,37 @@ public class MonthDeserializerTest extends DateTimeTestBase
                 () -> mapper.readValue("{\"month\":\"January\"}", StrictEstimate.class));
     }
 
+    // [databind#6178]: `Month` is an `Enum` so Enum-specific setting applies too
+    @Test
+    public void testDeserializationWithGlobalCaseInsensitiveEnums() throws Exception
+    {
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .build();
+
+        assertEquals(Month.JANUARY, mapper.readValue("\"january\"", Month.class));
+    }
+
+    // [databind#6178]
+    @Test
+    public void testDeserializationWithCaseInsensitiveEnumsDisabledForProperty() throws Exception
+    {
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .build();
+
+        assertThrows(InvalidFormatException.class,
+                () -> mapper.readValue("{\"month\":\"January\"}", StrictEstimate.class));
+    }
+
+    // [databind#6178]: neither global setting enabled -> still strict
+    @Test
+    public void testDeserializationCaseSensitiveByDefault() throws Exception
+    {
+        assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue("\"January\"", Month.class));
+    }
+
     /*
     /**********************************************************************
     /* Tests for leniency settings


### PR DESCRIPTION
## Summary

Fixes #6178.

`JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` was not honored by the default textual deserialization path for `java.time.Month`.

Case-insensitive handling was applied when a custom `@JsonFormat(pattern = ...)` formatter was created, but the default path used exact `_byNameLookup.get(string)` matching. As a result, values such as `"January"` failed even when case-insensitive values were enabled.

## Changes

* Preserve the contextual `ACCEPT_CASE_INSENSITIVE_VALUES` override in `MonthDeserializer`.
* Keep the existing exact month-name lookup as the first path.
* Fall back to case-insensitive month-name lookup when enabled.
* Fall back to the global `MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES` setting when there is no contextual override.
* Preserve an explicit contextual disable when the global feature is enabled.

## Tests

Added coverage for:

* property-level case-insensitive Month deserialization
* global `MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES`
* property-level disable overriding global enable

Ran:

```bash
./mvnw -pl . -Dtest=tools.jackson.databind.ext.javatime.deser.MonthDeserializerTest -Dsurefire.useModulePath=false test
```