### PR TITLE
Fix #6182: build the RFC1123 blueprint format lazily, not in <clinit>

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -418,3 +418,8 @@ DongNyoung Lee (@Dongnyoung)
  * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic
    base types
   [3.1.6]
+
+Francesco Nigro (@franz1981)
+ * Reported, contributed fix for #6182: `StdDateFormat.<clinit>` degrades JIT
+   compilation of `UTF8JsonGenerator._writeStringSegment`
+  [3.1.7]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -14,6 +14,10 @@ No changes since 3.1
 #6179: Apply `StreamReadConstraints` number length limit when coercing String
   to `double`
  (fix by Aysha A-Z)
+#6182: `StdDateFormat.<clinit>` degrades JIT compilation of
+  `UTF8JsonGenerator._writeStringSegment`
+ (reported by Francesco N)
+ (fix by Francesco N)
 
 3.1.6 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/tools/jackson/databind/util/StdDateFormat.java
@@ -95,17 +95,26 @@ public class StdDateFormat
 
     protected final static Locale DEFAULT_LOCALE = Locale.US;
 
-    protected final static DateFormat DATE_FORMAT_RFC1123;
-
     /* Let's construct "blueprint" date format instances: cannot be used
      * as is, due to thread-safety issues, but can be used for constructing
      * actual instances more cheaply (avoids re-parsing).
      */
-    static {
-        // Another important thing: let's force use of default timezone for
-        // baseline DataFormat objects
-        DATE_FORMAT_RFC1123 = new SimpleDateFormat(DATE_FORMAT_STR_RFC1123, DEFAULT_LOCALE);
-        DATE_FORMAT_RFC1123.setTimeZone(DEFAULT_TIMEZONE);
+    // 01-Sep-2026, franz1981: [databind#6182] Built lazily, not in <clinit>: constructing a
+    //   SimpleDateFormat reaches DecimalFormatSymbols, which calls String.charAt on the
+    //   locale per-mille sign -- a UTF-16 String. String.charAt has one process-wide
+    //   MethodData and C2 prunes its isLatin1 branch only at a zero UTF-16 count, so that
+    //   one call leaves a cold StringUTF16.charAt in every ASCII charAt loop compiled
+    //   later, including UTF8JsonGenerator._writeStringSegment. MapperBuilder's <clinit>
+    //   references StdDateFormat.instance, so building an ObjectMapper was enough to
+    //   trigger it. Only parseAsRFC1123() reads this.
+    private static final class RFC1123Holder {
+        static final DateFormat DATE_FORMAT_RFC1123;
+        static {
+            // Another important thing: let's force use of default timezone for
+            // baseline DataFormat objects
+            DATE_FORMAT_RFC1123 = new SimpleDateFormat(DATE_FORMAT_STR_RFC1123, DEFAULT_LOCALE);
+            DATE_FORMAT_RFC1123.setTimeZone(DEFAULT_TIMEZONE);
+        }
     }
 
     /**
@@ -772,7 +781,7 @@ public class StdDateFormat
     protected Date parseAsRFC1123(String dateStr, ParsePosition pos)
     {
         if (_formatRFC1123 == null) {
-            _formatRFC1123 = _cloneFormat(DATE_FORMAT_RFC1123, DATE_FORMAT_STR_RFC1123,
+            _formatRFC1123 = _cloneFormat(RFC1123Holder.DATE_FORMAT_RFC1123, DATE_FORMAT_STR_RFC1123,
                     _timezone, _locale, _lenient);
         }
         return _formatRFC1123.parse(dateStr, pos);

--- a/src/main/java/tools/jackson/databind/util/StdDateFormat.java
+++ b/src/main/java/tools/jackson/databind/util/StdDateFormat.java
@@ -95,10 +95,6 @@ public class StdDateFormat
 
     protected final static Locale DEFAULT_LOCALE = Locale.US;
 
-    /* Let's construct "blueprint" date format instances: cannot be used
-     * as is, due to thread-safety issues, but can be used for constructing
-     * actual instances more cheaply (avoids re-parsing).
-     */
     // 01-Sep-2026, franz1981: [databind#6182] Built lazily, not in <clinit>: constructing a
     //   SimpleDateFormat reaches DecimalFormatSymbols, which calls String.charAt on the
     //   locale per-mille sign -- a UTF-16 String. String.charAt has one process-wide
@@ -108,6 +104,10 @@ public class StdDateFormat
     //   references StdDateFormat.instance, so building an ObjectMapper was enough to
     //   trigger it. Only parseAsRFC1123() reads this.
     private static final class RFC1123Holder {
+        /* Let's construct "blueprint" date format instance: cannot be used
+         * as is, due to thread-safety issues, but can be used for constructing
+         * actual instances more cheaply (avoids re-parsing).
+         */
         static final DateFormat DATE_FORMAT_RFC1123;
         static {
             // Another important thing: let's force use of default timezone for


### PR DESCRIPTION
Constructing a SimpleDateFormat reaches DecimalFormatSymbols, which calls String.charAt on the locale per-mille sign -- a UTF-16 String. String.charAt has one process-wide MethodData; C2 prunes its isLatin1 branch only when the profiled UTF-16 count is zero. That single call therefore leaves a cold StringUTF16.charAt call inside every ASCII charAt loop compiled afterwards, which sets IdealLoopTree::_has_call and disables unrolling and range check elimination -- including UTF8JsonGenerator._writeStringSegment.

MapperBuilder's <clinit> references StdDateFormat.instance, so simply building an ObjectMapper triggered it. DATE_FORMAT_RFC1123 is read only by parseAsRFC1123(), so a holder class defers it; instrumenting String.charAt shows the UTF-16 count go 1 -> 0 for apps that never parse RFC1123 dates.

JDK 25/x86_64, one String property per object, 3 forks, 5x5, pinned:
  3.1.5   444.2 +/- 5.6 -> 356.5 +/- 6.4 ns/op  (-19.7%)
  2.22.0  426.7 +/- 7.4 -> 331.9 +/- 5.2 ns/op  (-22.2%)
The copy loop goes from 33 instructions and 13 stack operands per character,
not unrolled, to 15.5 and 2, unrolled by 2.

Defers rather than removes: an app that does parse RFC1123 dates still pollutes, just later. The unconditional fix belongs in java.text.DecimalFormatSymbols.findNonFormatChar.