### PR TITLE
Fix #6185: bracket unresolved IPv6 host name in `InetSocketAddress` serialization

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -14,7 +14,7 @@ Co-Authors (with only partial listings below):
 
 ----------------------------------------------------------------------------
 
-Pascal Glinas:
+Pascal Gélinas:
   * Contributed fixes to 'MappingIterator' handling (Pull#58 and Pull#59)
    (2.1.0)
   * Reported #220: ContainerNode missing 'createNumber(BigInteger)'
@@ -1936,3 +1936,7 @@ Aysha Afrah Ziya (@aysha-afrah26)
  * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic
    base types
   (2.18.10)
+
+@renechoi
+ * Reported #6186: Bracket unresolved IPv6 host name in InetSocketAddress serialization
+  (2.18.11)

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1938,5 +1938,5 @@ Aysha Afrah Ziya (@aysha-afrah26)
   (2.18.10)
 
 @renechoi
- * Reported #6186: Bracket unresolved IPv6 host name in InetSocketAddress serialization
+ * Reported #6185: Bracket unresolved IPv6 host name in `InetSocketAddress` serialization
   (2.18.11)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -6,7 +6,7 @@ Project: jackson-databind
 
 2.18.11 (Not yet released)
 
-#6186: Bracket unresolved IPv6 host name in InetSocketAddress serialization
+#6185: Bracket unresolved IPv6 host name in `InetSocketAddress` serialization
  (fix by @pjfanning, w/ Claude code)
 
 2.18.10 (15-Aug-2026)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -4,6 +4,11 @@ Project: jackson-databind
 === Releases === 
 ------------------------------------------------------------------------
 
+2.18.11 (Not yet released)
+
+#6186: Bracket unresolved IPv6 host name in InetSocketAddress serialization
+ (fix by @pjfanning, w/ Claude code)
+
 2.18.10 (15-Aug-2026)
 
 #6099: Resolve classes without initialization in `TypeFactory.findClass()`

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/InetSocketAddressSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/InetSocketAddressSerializer.java
@@ -34,6 +34,11 @@ public class InetSocketAddressSerializer
             } else { // otherwise use name
                 str = str.substring(0, ix);
             }
+        } else if ((str.indexOf(':') >= 0) && !str.startsWith("[")) {
+            // [databind#6185]: unresolved addresses have no InetAddress, but an IPv6
+            //   literal host name still needs bracketing so port remains unambiguous
+            //   (host names stored already-bracketed must not be bracketed twice)
+            str = "[" + str + "]";
         }
 
         g.writeString(str + ":" + value.getPort());

--- a/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/jdk/JDKTypeSerializationTest.java
@@ -142,6 +142,24 @@ public class JDKTypeSerializationTest
                 MAPPER.writeValueAsString(new InetSocketAddress("2001:db8:85a3:8d3:1319:8a2e:370:7348", 443)));
     }
 
+    // [databind#6185]: unresolved IPv6 literal must be bracketed like resolved one
+    @Test
+    public void testInetSocketAddressIPv6Unresolved() throws IOException
+    {
+        assertEquals(q("[2001:db8::1]:443"),
+                MAPPER.writeValueAsString(InetSocketAddress.createUnresolved("2001:db8::1", 443)));
+        // if host name is stored with brackets, must not bracket twice
+        assertEquals(q("[2001:db8::1]:443"),
+                MAPPER.writeValueAsString(InetSocketAddress.createUnresolved("[2001:db8::1]", 443)));
+        // and IPv6 value read by Jackson must survive a full round-trip with port intact
+        InetSocketAddress addr = MAPPER.readValue(q("[2001:db8::1]:443"), InetSocketAddress.class);
+        String json = MAPPER.writeValueAsString(addr);
+        assertEquals(q("[2001:db8::1]:443"), json);
+        InetSocketAddress result = MAPPER.readValue(json, InetSocketAddress.class);
+        assertEquals(addr.getHostName(), result.getHostName());
+        assertEquals(443, result.getPort());
+    }
+
     // [JACKSON-597]
     @Test
     public void testClass() throws IOException


### PR DESCRIPTION
Fixes #6185.

`InetSocketAddressSerializer` writes `host + ":" + port`. The resolved branch already brackets IPv6 literals, but the unresolved branch (no `InetAddress`) falls back to `getHostName()` and writes the literal bare, so `InetSocketAddress.createUnresolved("2001:db8::1", 443)` came out as `"2001:db8::1:443"` — the port indistinguishable from a hextet. Since #5951 deserialization always produces unresolved addresses, so bare IPv6 values no longer survived a Jackson round-trip.

Fix: in the unresolved branch, bracket the host name when it contains `:` (never legal in a host name, so it can only be an IPv6 literal) unless it already starts with `[` — the deserializer stores the host *with* brackets for `"[...]:port"` input, and those must not be bracketed twice.

New test `JDKTypeSerializationTest#testInetSocketAddressIPv6Unresolved` fails on `2.18` without the serializer change (`expected: <"[2001:db8::1]:443"> but was: <"2001:db8::1:443">`) and passes with it. Full `./mvnw verify` on the branch: 3470 tests, with the only failure being the pre-existing local-environment timezone-name issue in `DateSerializationTest#testWithTimeZoneOverride` (PST vs GMT-08:00), unrelated to this change.

This is an independent implementation from the bug report in #6125 (closed without CLA; that PR's code was not used). Credit to @renechoi for reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
