### PR TITLE
Fix #6187: make AnnotatedConstructor InvokerHolder access lazy

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -714,6 +714,8 @@ Fabian Lange (@CodingFabian)
 Burak KALAYCI (@kalayciburak)
  * Fixed #6175: Parse object-form `QName` after `As.PROPERTY` type id
   [3.3.0]
+ * Fixed #6187: Make `InvokerHolder` access in `AnnotatedConstructor` lazy
+  [3.3.0]
 
 @laech
  * Reported #6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -53,6 +53,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
   `java.time.Month`
  (reported by @laech)
  (fix by @Dongnyoung)
+#6187: Make `InvokerHolder` access in `AnnotatedConstructor` lazy
+ (requested by @cowtowncoder)
+ (fix by @kalayciburak)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -20,9 +20,14 @@ public final class AnnotatedConstructor
     extends AnnotatedWithParams
 {
     protected final Constructor<?> _constructor;
-    private final InvokerHolder _invokerNullary = new InvokerHolder(methodType(Object.class));
-    private final InvokerHolder _invokerUnary = new InvokerHolder(methodType(Object.class, Object.class));
-    private final InvokerHolder _invokerFixedArity = new InvokerHolder(null);
+
+    /**
+     * Lazily constructed invokers; {@code volatile} so a racy first use is
+     * safely published (duplicate construction is harmless).
+     */
+    private volatile InvokerHolder _invokerNullary;
+    private volatile InvokerHolder _invokerUnary;
+    private volatile InvokerHolder _invokerFixedArity;
 
     // // Simple lazy-caching:
 
@@ -114,7 +119,7 @@ public final class AnnotatedConstructor
     @Override
     public final Object call() throws Exception {
         try {
-            return _invokerNullary.get().invokeExact();
+            return invokerNullary().get().invokeExact();
         } catch (Throwable e) {
             throw ClassUtil.sneakyThrow(e);
         }
@@ -123,7 +128,7 @@ public final class AnnotatedConstructor
     @Override
     public final Object call(Object[] args) throws Exception {
         try {
-            return _invokerFixedArity.get().invokeWithArguments(args);
+            return invokerFixedArity().get().invokeWithArguments(args);
         } catch (Throwable e) {
             throw ClassUtil.sneakyThrow(e);
         }
@@ -132,10 +137,37 @@ public final class AnnotatedConstructor
     @Override
     public final Object call1(Object arg) throws Exception {
         try {
-            return _invokerUnary.get().invokeExact(arg);
+            return invokerUnary().get().invokeExact(arg);
         } catch (Throwable e) {
             throw ClassUtil.sneakyThrow(e);
         }
+    }
+
+    private InvokerHolder invokerNullary() {
+        InvokerHolder h = _invokerNullary;
+        if (h == null) {
+            h = new InvokerHolder(methodType(Object.class));
+            _invokerNullary = h;
+        }
+        return h;
+    }
+
+    private InvokerHolder invokerUnary() {
+        InvokerHolder h = _invokerUnary;
+        if (h == null) {
+            h = new InvokerHolder(methodType(Object.class, Object.class));
+            _invokerUnary = h;
+        }
+        return h;
+    }
+
+    private InvokerHolder invokerFixedArity() {
+        InvokerHolder h = _invokerFixedArity;
+        if (h == null) {
+            h = new InvokerHolder(null);
+            _invokerFixedArity = h;
+        }
+        return h;
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -1,9 +1,7 @@
 package tools.jackson.databind.introspect;
 
-import java.io.Serial;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;
 import java.lang.reflect.Parameter;
@@ -12,7 +10,6 @@ import java.util.Objects;
 
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.util.ClassUtil;
-import tools.jackson.databind.util.internal.UnreflectHandleSupplier;
 
 import static java.lang.invoke.MethodType.methodType;
 
@@ -22,12 +19,13 @@ public final class AnnotatedConstructor
     protected final Constructor<?> _constructor;
 
     /**
-     * Lazily constructed invokers; {@code volatile} so a racy first use is
-     * safely published (duplicate construction is harmless).
+     * Lazily resolved invocation handles, one per arity we support;
+     * {@code volatile} so a racy first use is safely published (duplicate
+     * resolution is harmless, handles are equivalent).
      */
-    protected volatile InvokerHolder _invokerNullary;
-    protected volatile InvokerHolder _invokerUnary;
-    protected volatile InvokerHolder _invokerFixedArity;
+    protected volatile MethodHandle _invokerNullary;
+    protected volatile MethodHandle _invokerUnary;
+    protected volatile MethodHandle _invokerFixedArity;
 
     // // Simple lazy-caching:
 
@@ -119,7 +117,7 @@ public final class AnnotatedConstructor
     @Override
     public final Object call() throws Exception {
         try {
-            return invokerNullary().get().invokeExact();
+            return invokerNullary().invokeExact();
         } catch (Throwable e) {
             throw ClassUtil.sneakyThrow(e);
         }
@@ -128,7 +126,7 @@ public final class AnnotatedConstructor
     @Override
     public final Object call(Object[] args) throws Exception {
         try {
-            return invokerFixedArity().get().invokeWithArguments(args);
+            return invokerFixedArity().invokeWithArguments(args);
         } catch (Throwable e) {
             throw ClassUtil.sneakyThrow(e);
         }
@@ -137,37 +135,45 @@ public final class AnnotatedConstructor
     @Override
     public final Object call1(Object arg) throws Exception {
         try {
-            return invokerUnary().get().invokeExact(arg);
+            return invokerUnary().invokeExact(arg);
         } catch (Throwable e) {
             throw ClassUtil.sneakyThrow(e);
         }
     }
 
-    private InvokerHolder invokerNullary() {
-        InvokerHolder h = _invokerNullary;
+    private MethodHandle invokerNullary() throws IllegalAccessException {
+        MethodHandle h = _invokerNullary;
         if (h == null) {
-            h = new InvokerHolder(methodType(Object.class));
+            h = unreflect().asType(methodType(Object.class));
             _invokerNullary = h;
         }
         return h;
     }
 
-    private InvokerHolder invokerUnary() {
-        InvokerHolder h = _invokerUnary;
+    private MethodHandle invokerUnary() throws IllegalAccessException {
+        MethodHandle h = _invokerUnary;
         if (h == null) {
-            h = new InvokerHolder(methodType(Object.class, Object.class));
+            h = unreflect().asType(methodType(Object.class, Object.class));
             _invokerUnary = h;
         }
         return h;
     }
 
-    private InvokerHolder invokerFixedArity() {
-        InvokerHolder h = _invokerFixedArity;
+    private MethodHandle invokerFixedArity() throws IllegalAccessException {
+        MethodHandle h = _invokerFixedArity;
         if (h == null) {
-            h = new InvokerHolder(null);
+            h = unreflect().asFixedArity();
             _invokerFixedArity = h;
         }
         return h;
+    }
+
+    /**
+     * Note: caller is expected to have called {@code ClassUtil.checkAndFixAccess()}
+     * already; access checks are suppressed for an accessible {@link Constructor}.
+     */
+    private MethodHandle unreflect() throws IllegalAccessException {
+        return MethodHandles.lookup().unreflectConstructor(_constructor);
     }
 
     /*
@@ -226,19 +232,5 @@ public final class AnnotatedConstructor
         }
         AnnotatedConstructor other = (AnnotatedConstructor) o;
         return Objects.equals(_constructor, other._constructor);
-    }
-
-    class InvokerHolder extends UnreflectHandleSupplier {
-        @Serial
-        private static final long serialVersionUID = 1L;
-
-        InvokerHolder(MethodType asType) {
-            super(asType);
-        }
-
-        @Override
-        protected MethodHandle unreflect() throws IllegalAccessException {
-            return MethodHandles.lookup().unreflectConstructor(_constructor);
-        }
     }
 }

--- a/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
+++ b/src/main/java/tools/jackson/databind/introspect/AnnotatedConstructor.java
@@ -25,9 +25,9 @@ public final class AnnotatedConstructor
      * Lazily constructed invokers; {@code volatile} so a racy first use is
      * safely published (duplicate construction is harmless).
      */
-    private volatile InvokerHolder _invokerNullary;
-    private volatile InvokerHolder _invokerUnary;
-    private volatile InvokerHolder _invokerFixedArity;
+    protected volatile InvokerHolder _invokerNullary;
+    protected volatile InvokerHolder _invokerUnary;
+    protected volatile InvokerHolder _invokerFixedArity;
 
     // // Simple lazy-caching:
 

--- a/src/main/java/tools/jackson/databind/util/internal/UnreflectHandleSupplier.java
+++ b/src/main/java/tools/jackson/databind/util/internal/UnreflectHandleSupplier.java
@@ -7,10 +7,23 @@ import java.util.function.Supplier;
 import tools.jackson.databind.util.ClassUtil;
 
 /**
- * Lazy memoized holder for MethodHandles.
- * Defers binding of the method handle until after access checks are suppressed
- * (which happens in a virtual method call after construction) and avoids serialization of
- * MethodHandle.
+ * Lazy, memoized holder for a {@link MethodHandle} unreflected from a
+ * {@link java.lang.reflect.Member}.
+ *<p>
+ * Resolution is deferred until first actual use, for two reasons:
+ *<ul>
+ * <li>Access to non-public members is only enabled by
+ *   {@code ClassUtil.checkAndFixAccess()}, which callers apply via
+ *   {@code AnnotatedMember.fixAccess()} <i>after</i> the owning member has been
+ *   constructed. Unreflecting during construction could hence fail.
+ *   </li>
+ * <li>Many members are introspected but never actually invoked, so the handle
+ *   lookup is often avoidable altogether.
+ *   </li>
+ * </ul>
+ * The resolved handle is adapted once -- to the {@link MethodType} given to the
+ * constructor, or {@link MethodHandle#asFixedArity()} if that is {@code null} --
+ * and then memoized; resolution happens at most once per holder.
  */
 public abstract class UnreflectHandleSupplier implements Supplier<MethodHandle> {
     private final MethodType asType;

--- a/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
@@ -8,6 +8,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -27,6 +28,10 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
         public void setValue(String value) {
             this.value = value;
         }
+    }
+
+    static class NoArgBean {
+        public NoArgBean() { }
     }
 
     private final ObjectMapper MAPPER = newJsonMapper();
@@ -62,6 +67,66 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
         Class<?>[] paramTypes = constructor._paramClasses;
         assertNull(constructor.getRawParameterType(1));
         assertSame(paramTypes, constructor._paramClasses);
+    }
+
+    // [databind#6187]
+    @Test
+    public void annotatedConstructorDoesNotEagerlyConstructInvokers() throws Exception {
+        DeserializationConfig context = MAPPER.deserializationConfig();
+        JavaType beanType = MAPPER.constructType(SomeBean.class);
+
+        AnnotatedClass instance = AnnotatedClassResolver.resolve(context, beanType, context);
+        AnnotatedConstructor constructor = instance.getConstructors().get(0);
+
+        assertNull(invokerField(constructor, "_invokerNullary"));
+        assertNull(invokerField(constructor, "_invokerUnary"));
+        assertNull(invokerField(constructor, "_invokerFixedArity"));
+    }
+
+    // [databind#6187]
+    @Test
+    public void annotatedConstructorBuildsOnlyTheInvokerItUses() throws Exception {
+        DeserializationConfig context = MAPPER.deserializationConfig();
+        JavaType beanType = MAPPER.constructType(SomeBean.class);
+
+        AnnotatedClass instance = AnnotatedClassResolver.resolve(context, beanType, context);
+        AnnotatedConstructor constructor = instance.getConstructors().get(0);
+
+        SomeBean created = (SomeBean) constructor.call(new Object[] { "x" });
+        assertEquals("x", created.getValue());
+        assertNull(invokerField(constructor, "_invokerNullary"));
+        assertNull(invokerField(constructor, "_invokerUnary"));
+        assertNotNull(invokerField(constructor, "_invokerFixedArity"));
+
+        SomeBean viaCall1 = (SomeBean) constructor.call1("y");
+        assertEquals("y", viaCall1.getValue());
+        assertNull(invokerField(constructor, "_invokerNullary"));
+        assertNotNull(invokerField(constructor, "_invokerUnary"));
+        assertNotNull(invokerField(constructor, "_invokerFixedArity"));
+    }
+
+    // [databind#6187]
+    @Test
+    public void annotatedConstructorNullaryCallBuildsOnlyNullaryInvoker() throws Exception {
+        DeserializationConfig context = MAPPER.deserializationConfig();
+        JavaType beanType = MAPPER.constructType(NoArgBean.class);
+
+        AnnotatedClass instance = AnnotatedClassResolver.resolve(context, beanType, context);
+        AnnotatedConstructor constructor = instance.getDefaultConstructor();
+        assertNotNull(constructor);
+
+        assertNull(invokerField(constructor, "_invokerNullary"));
+        Object created = constructor.call();
+        assertEquals(NoArgBean.class, created.getClass());
+        assertNotNull(invokerField(constructor, "_invokerNullary"));
+        assertNull(invokerField(constructor, "_invokerUnary"));
+        assertNull(invokerField(constructor, "_invokerFixedArity"));
+    }
+
+    private static Object invokerField(AnnotatedConstructor constructor, String name) throws Exception {
+        java.lang.reflect.Field field = AnnotatedConstructor.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(constructor);
     }
 
     // [databind#3187]

--- a/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
+++ b/src/test/java/tools/jackson/databind/introspect/AnnotatedMemberEqualityTest.java
@@ -71,16 +71,16 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
 
     // [databind#6187]
     @Test
-    public void annotatedConstructorDoesNotEagerlyConstructInvokers() throws Exception {
+    public void annotatedConstructorDoesNotEagerlyConstructInvokers() {
         DeserializationConfig context = MAPPER.deserializationConfig();
         JavaType beanType = MAPPER.constructType(SomeBean.class);
 
         AnnotatedClass instance = AnnotatedClassResolver.resolve(context, beanType, context);
         AnnotatedConstructor constructor = instance.getConstructors().get(0);
 
-        assertNull(invokerField(constructor, "_invokerNullary"));
-        assertNull(invokerField(constructor, "_invokerUnary"));
-        assertNull(invokerField(constructor, "_invokerFixedArity"));
+        assertNull(constructor._invokerNullary);
+        assertNull(constructor._invokerUnary);
+        assertNull(constructor._invokerFixedArity);
     }
 
     // [databind#6187]
@@ -94,15 +94,15 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
 
         SomeBean created = (SomeBean) constructor.call(new Object[] { "x" });
         assertEquals("x", created.getValue());
-        assertNull(invokerField(constructor, "_invokerNullary"));
-        assertNull(invokerField(constructor, "_invokerUnary"));
-        assertNotNull(invokerField(constructor, "_invokerFixedArity"));
+        assertNull(constructor._invokerNullary);
+        assertNull(constructor._invokerUnary);
+        assertNotNull(constructor._invokerFixedArity);
 
         SomeBean viaCall1 = (SomeBean) constructor.call1("y");
         assertEquals("y", viaCall1.getValue());
-        assertNull(invokerField(constructor, "_invokerNullary"));
-        assertNotNull(invokerField(constructor, "_invokerUnary"));
-        assertNotNull(invokerField(constructor, "_invokerFixedArity"));
+        assertNull(constructor._invokerNullary);
+        assertNotNull(constructor._invokerUnary);
+        assertNotNull(constructor._invokerFixedArity);
     }
 
     // [databind#6187]
@@ -115,18 +115,12 @@ public class AnnotatedMemberEqualityTest extends DatabindTestUtil
         AnnotatedConstructor constructor = instance.getDefaultConstructor();
         assertNotNull(constructor);
 
-        assertNull(invokerField(constructor, "_invokerNullary"));
+        assertNull(constructor._invokerNullary);
         Object created = constructor.call();
         assertEquals(NoArgBean.class, created.getClass());
-        assertNotNull(invokerField(constructor, "_invokerNullary"));
-        assertNull(invokerField(constructor, "_invokerUnary"));
-        assertNull(invokerField(constructor, "_invokerFixedArity"));
-    }
-
-    private static Object invokerField(AnnotatedConstructor constructor, String name) throws Exception {
-        java.lang.reflect.Field field = AnnotatedConstructor.class.getDeclaredField(name);
-        field.setAccessible(true);
-        return field.get(constructor);
+        assertNotNull(constructor._invokerNullary);
+        assertNull(constructor._invokerUnary);
+        assertNull(constructor._invokerFixedArity);
     }
 
     // [databind#3187]


### PR DESCRIPTION
Fixes #6187

`AnnotatedConstructor` built three `InvokerHolder`s in the instance initializer even though most constructors never use all of `call()`, `call1()`, and `call(Object[])`. `UnreflectHandleSupplier` already defers the `MethodHandle`, but constructing the holders still eagerly creates `MethodType`s.

Holders are now `volatile` and created on first use, same racy-publication pattern as `_paramClasses`. `call()`, `call1()`, and `call(Object[])` behavior is unchanged.

## Tests

- `./mvnw test -Dtest=AnnotatedMemberEqualityTest`: 7/7 (RED on the three #6187 cases before the change: holders were non-null after construction; GREEN after)
- `./mvnw test -Dtest='**/introspect/*Test'`: 241/241
- `./mvnw test -Dtest='**/deser/creators/*Test'`: 176/176