### PR TITLE
Fix #6136: Apply @JsonFilter to @JsonAnyGetter properties for exclude-style filters and ObjectNode values

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
@@ -7,6 +7,7 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ser.jdk.MapProperty;
 import tools.jackson.databind.ser.jdk.MapSerializer;
 
 /**
@@ -104,8 +105,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
         }
         // [databind#3604]: Support ObjectNode/JsonNode for @JsonAnyGetter
         if (value instanceof JsonNode) {
-            // No special filtering support for ObjectNode (yet); just serialize entries
-            _serializeObjectNodeEntries(_verifyObjectNode(value, ctxt), gen, ctxt);
+            _filterObjectNodeEntries(bean, _verifyObjectNode(value, ctxt), gen, ctxt, filter);
             return;
         }
         if (!(value instanceof Map<?,?>)) {
@@ -115,12 +115,34 @@ public class AnyGetterWriter extends BeanPropertyWriter
         }
         // 19-Oct-2014, tatu: Should we try to support @JsonInclude options here?
         if (_mapSerializer != null) {
-            _mapSerializer.serializeFilteredAnyProperties(ctxt, gen, bean,(Map<?,?>) value,
-                    filter, null);
+            _mapSerializer.serializeFilteredAnyProperties(ctxt, gen, bean, (Map<?,?>) value, filter);
             return;
         }
         // ... not sure how custom handler would do it
         _serializer.serialize(value, gen, ctxt);
+    }
+
+    /**
+     * Helper method for filtering and serializing entries of an {@link ObjectNode}
+     * as individual properties using the provided {@link PropertyFilter}.
+     *
+     * @since 3.3
+     */
+    protected void _filterObjectNodeEntries(Object bean, ObjectNode objectNode,
+            JsonGenerator gen, SerializationContext ctxt, PropertyFilter filter)
+        throws Exception
+    {
+        MapProperty prop = new MapProperty(null, _property);
+        ValueSerializer<Object> keySer = ctxt.findKeySerializer(String.class, _property);
+        for (Map.Entry<String, JsonNode> entry : objectNode.properties()) {
+            String key = entry.getKey();
+            JsonNode val = entry.getValue();
+            ValueSerializer<Object> valSer = (val == null)
+                    ? ctxt.getDefaultNullValueSerializer()
+                    : ctxt.findValueSerializer(val.getClass());
+            prop.reset(key, val, keySer, valSer);
+            filter.serializeAsProperty(bean, gen, ctxt, prop);
+        }
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/ser/jdk/MapSerializer.java
+++ b/src/main/java/tools/jackson/databind/ser/jdk/MapSerializer.java
@@ -468,6 +468,10 @@ public class MapSerializer
         return _valueSerializer;
     }
 
+    public Object getSuppressableValue() {
+        return _suppressableValue;
+    }
+
     @Override
     public boolean isEmpty(SerializationContext prov, Map<?,?> value)
     {
@@ -886,6 +890,23 @@ public class MapSerializer
                 wrapAndThrow(ctxt, e, value, String.valueOf(keyElem));
             }
         }
+    }
+
+    /**
+     * Helper method used when we have a JSON Filter to use AND contents are
+     * "any properties" of a POJO.
+     *<p>
+     * NOTE: {@code public} only because it is called by {@code AnyGetterWriter}
+     *
+     * @param bean Enclosing POJO that has any-getter used to obtain "any properties"
+     *
+     * @since 3.3
+     */
+    public void serializeFilteredAnyProperties(SerializationContext ctxt, JsonGenerator gen,
+            Object bean, Map<?,?> value, PropertyFilter filter)
+        throws JacksonException
+    {
+        serializeFilteredAnyProperties(ctxt, gen, bean, value, filter, _suppressableValue);
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
+++ b/src/main/java/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.java
@@ -119,12 +119,12 @@ public class SimpleBeanPropertyFilter
             SerializationContext provider, PropertyWriter writer)
         throws Exception
     {
-        if (include(writer)) {
+        if (writer instanceof AnyGetterWriter anyGetterWriter) {
+            anyGetterWriter.getAndFilter(pojo, g, provider, this);
+        } else if (include(writer)) {
             writer.serializeAsProperty(pojo, g, provider);
         } else if (!g.canOmitProperties()) {
             writer.serializeAsOmittedProperty(pojo, g, provider);
-        } else if (writer instanceof AnyGetterWriter anyGetterWriter) {
-            anyGetterWriter.getAndFilter(pojo, g, provider, this);
         }
     }
 

--- a/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
+++ b/src/test/java/tools/jackson/databind/ser/filter/TestAnyGetterFiltering.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.*;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.ser.FilterProvider;
 import tools.jackson.databind.ser.PropertyWriter;
 import tools.jackson.databind.ser.std.SimpleBeanPropertyFilter;
@@ -146,5 +148,66 @@ public class TestAnyGetterFiltering extends DatabindTestUtil
         if (stuff.size() != 2) {
             fail("Should have 2 properties, got: "+stuff);
         }
-   }
+    }
+
+    // [databind#6136]
+    @JsonFilter("anyFilter6136")
+    public static class AnyBeanWithSecret
+    {
+        public String name = "bob";
+
+        private Map<String, String> properties = new LinkedHashMap<>();
+        {
+            properties.put("a", "1");
+            properties.put("secret", "s3cr3t");
+        }
+
+        @JsonAnyGetter
+        public Map<String, String> anyProperties() {
+            return properties;
+        }
+    }
+
+    @JsonFilter("anyFilter6136")
+    public static class ObjectNodeAnyBeanWithSecret
+    {
+        public String name = "bob";
+
+        @JsonAnyGetter
+        public ObjectNode anyProperties() {
+            return JsonNodeFactory.instance.objectNode()
+                    .put("a", "1")
+                    .put("secret", "s3cr3t");
+        }
+    }
+
+    // [databind#6136]: Exclude-style filter on Map-valued @JsonAnyGetter
+    @Test
+    public void testAnyGetterSerializeAllExcept6136() throws Exception
+    {
+        FilterProvider prov = new SimpleFilterProvider().addFilter("anyFilter6136",
+                SimpleBeanPropertyFilter.serializeAllExcept("secret"));
+        assertEquals(a2q("{'name':'bob','a':'1'}"),
+                MAPPER.writer(prov).writeValueAsString(new AnyBeanWithSecret()));
+    }
+
+    // [databind#6136]: Exclude-style filter on ObjectNode-valued @JsonAnyGetter
+    @Test
+    public void testObjectNodeAnyGetterSerializeAllExcept6136() throws Exception
+    {
+        FilterProvider prov = new SimpleFilterProvider().addFilter("anyFilter6136",
+                SimpleBeanPropertyFilter.serializeAllExcept("secret"));
+        assertEquals(a2q("{'name':'bob','a':'1'}"),
+                MAPPER.writer(prov).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
+    }
+
+    // [databind#6136]: Include-style filter on ObjectNode-valued @JsonAnyGetter
+    @Test
+    public void testObjectNodeAnyGetterFilterOutAllExcept6136() throws Exception
+    {
+        FilterProvider prov = new SimpleFilterProvider().addFilter("anyFilter6136",
+                SimpleBeanPropertyFilter.filterOutAllExcept("name", "a"));
+        assertEquals(a2q("{'name':'bob','a':'1'}"),
+                MAPPER.writer(prov).writeValueAsString(new ObjectNodeAnyBeanWithSecret()));
+    }
 }


### PR DESCRIPTION
Fixes #6136.

### Problem
When a POJO is annotated with `@JsonFilter` and has a `@JsonAnyGetter`:
1. Exclude-style property filters (such as `SimpleBeanPropertyFilter.serializeAllExcept("secret")`) were not applied to the entries emitted by the any-getter. In `SimpleBeanPropertyFilter.serializeAsProperty`, `include(writer)` checked the any-getter accessor's implied method/field name, which was not excluded, causing it to call `writer.serializeAsProperty` directly and bypass per-entry filtering. Only include-style filters (`filterOutAllExcept`) ever reached `anyGetterWriter.getAndFilter()`.
2. For `JsonNode` / `ObjectNode`-valued any-getters (added in #3604), `AnyGetterWriter.getAndFilter()` serialized the entries directly without consulting any filter at all.
3. In `AnyGetterWriter.getAndFilter()`, `null` was passed as `suppressableValue` into `MapSerializer.serializeFilteredAnyProperties()`, ignoring configured content inclusion options on the serializer.

### Solution
1. In `SimpleBeanPropertyFilter.serializeAsProperty`, check if the writer is an `AnyGetterWriter` first and delegate to `anyGetterWriter.getAndFilter(pojo, g, provider, this)`, ensuring both exclude-style and include-style filters are evaluated per emitted entry key.
2. In `AnyGetterWriter`, implement `_filterObjectNodeEntries` to evaluate entries of `ObjectNode` against the property filter using a virtual `MapProperty`.
3. In `MapSerializer`, add an overload `serializeFilteredAnyProperties` that uses the serializer's configured `_suppressableValue`.

### Testing
Added unit tests in `TestAnyGetterFiltering` covering:
- Exclude-style filter (`serializeAllExcept`) on Map-valued `@JsonAnyGetter`
- Exclude-style filter on ObjectNode-valued `@JsonAnyGetter`
- Include-style filter (`filterOutAllExcept`) on ObjectNode-valued `@JsonAnyGetter`