### PR TITLE
Close generator if initialization fails before any content is written in `ObjectMapper`, `ObjectWriter`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -688,9 +688,6 @@ DongNyoung Lee (@Dongnyoung)
  * Fixed #6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work
    for `java.time.Month`
   [3.3.0]
- * Fixed #6213: Defer unnecessary work in deserialization paths
-   (`EnumMapDeserializer`, `MapDeserializer`, `InetAddressValidator`)
-  [3.3.0]
 
 @prvazsahnazarov
  * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -688,6 +688,9 @@ DongNyoung Lee (@Dongnyoung)
  * Fixed #6178: `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_VALUES` does not work
    for `java.time.Month`
   [3.3.0]
+ * Fixed #6213: Defer unnecessary work in deserialization paths
+   (`EnumMapDeserializer`, `MapDeserializer`, `InetAddressValidator`)
+  [3.3.0]
 
 @prvazsahnazarov
  * Reported #6156: Add `java.lang.Comparable` in set of "unsafe" polymorphic

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -62,6 +62,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6190: Explicit `@JsonView` on a standard `Throwable` property is ignored by
   `ThrowableDeserializer`
  (fix by @adityabagla7)
+#6196: Close `JsonGenerator` if initialization fails before any content is written
+ (fix by @pjfanning)
 #6197: `ClassCastException` for `AutoCloseable` (but not `Closeable`) values in
   `ObjectMapper.writeValue(JsonGenerator, Object)` with `SerializationFeature.CLOSE_CLOSEABLE`
  (fix by @pjfanning)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -65,6 +65,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6197: `ClassCastException` for `AutoCloseable` (but not `Closeable`) values in
   `ObjectMapper.writeValue(JsonGenerator, Object)` with `SerializationFeature.CLOSE_CLOSEABLE`
  (fix by @pjfanning)
+#6213: Defer unnecessary work in deserialization paths (`EnumMapDeserializer`,
+  `MapDeserializer`, `InetAddressValidator`)
+ (fix by @Dongnyoung)
 
 3.2.3 (not yet released)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -67,9 +67,6 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6197: `ClassCastException` for `AutoCloseable` (but not `Closeable`) values in
   `ObjectMapper.writeValue(JsonGenerator, Object)` with `SerializationFeature.CLOSE_CLOSEABLE`
  (fix by @pjfanning)
-#6213: Defer unnecessary work in deserialization paths (`EnumMapDeserializer`,
-  `MapDeserializer`, `InetAddressValidator`)
- (fix by @Dongnyoung)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -1904,7 +1904,14 @@ public class ObjectMapper
             JsonGenerator g, Object value)
         throws JacksonException
     {
-        _initializeGenerator(g);
+        try {
+            _initializeGenerator(g);
+        } catch (Exception e) {
+            // 07-Sep-2026, pjfanning: `GeneratorInitializer` is caller-provided and
+            //   may fail; generator owns the output target so it must not leak
+            ClassUtil.closeOnFailAndThrowAsJacksonE(g, e);
+            return;
+        }
         if (ctxt.isEnabled(SerializationFeature.CLOSE_CLOSEABLE)
                 && (value instanceof AutoCloseable)) {
             _configAndWriteCloseable(ctxt, g, value);

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -767,7 +767,7 @@ public class ObjectMapper
      */
     public JsonGenerator createGenerator(OutputStream out) throws JacksonException {
         _assertNotNull("out", out);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _streamFactory.createGenerator(_serializationContext(), out));
     }
 
@@ -781,7 +781,7 @@ public class ObjectMapper
      */
     public JsonGenerator createGenerator(OutputStream out, JsonEncoding enc) throws JacksonException {
         _assertNotNull("out", out);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _streamFactory.createGenerator(_serializationContext(), out, enc));
     }
 
@@ -795,7 +795,7 @@ public class ObjectMapper
      */
     public JsonGenerator createGenerator(Writer w) throws JacksonException {
         _assertNotNull("w", w);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _streamFactory.createGenerator(_serializationContext(), w));
     }
 
@@ -809,7 +809,7 @@ public class ObjectMapper
      */
     public JsonGenerator createGenerator(File f, JsonEncoding enc) throws JacksonException {
         _assertNotNull("f", f);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _streamFactory.createGenerator(_serializationContext(), f, enc));
     }
 
@@ -823,7 +823,7 @@ public class ObjectMapper
      */
     public JsonGenerator createGenerator(Path path, JsonEncoding enc) throws JacksonException {
         _assertNotNull("path", path);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _streamFactory.createGenerator(_serializationContext(), path, enc));
     }
 
@@ -837,7 +837,7 @@ public class ObjectMapper
      */
     public JsonGenerator createGenerator(DataOutput out) throws JacksonException {
         _assertNotNull("out", out);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _streamFactory.createGenerator(_serializationContext(), out));
     }
 
@@ -2620,6 +2620,20 @@ public class ObjectMapper
             init.initialize(_serializationConfig, gen);
         }
         return gen;
+    }
+
+    /**
+     * Variant of {@link #_initializeGenerator} for the case where {@code gen}
+     * owns the output target: {@link GeneratorInitializer} is caller-provided
+     * and may fail, and if it does the generator must not leak.
+     */
+    protected JsonGenerator _initializeManagedGenerator(JsonGenerator gen) {
+        try {
+            return _initializeGenerator(gen);
+        } catch (Exception e) {
+            ClassUtil.closeOnFailAndThrowAsJacksonE(gen, e);
+            return null; // never gets here
+        }
     }
 
     /*

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -225,6 +225,26 @@ public class ObjectWriter
             .init(wrapInArray);
     }
 
+    /**
+     * Variant of {@link #_newSequenceWriter} for the case where we created the
+     * generator ourselves (and it owns the output target): initialization may
+     * fail -- either in the caller-provided
+     * {@link tools.jackson.databind.cfg.GeneratorInitializer}, or in
+     * {@link SequenceWriter#init} writing the leading {@code START_ARRAY} --
+     * and if it does, nothing else would ever close the generator.
+     */
+    private SequenceWriter _newManagedSequenceWriter(SerializationContextExt ctxt,
+            boolean wrapInArray, JsonGenerator gen)
+        throws JacksonException
+    {
+        try {
+            return _newSequenceWriter(ctxt, wrapInArray, _initializeGenerator(gen), true);
+        } catch (Exception e) {
+            ClassUtil.closeOnFailAndThrowAsJacksonE(gen, e);
+            return null; // never gets here
+        }
+    }
+
     /*
     /**********************************************************************
     /* Life-cycle, fluent factories for SerializationFeature
@@ -692,8 +712,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, false,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8)), true);
+        return _newManagedSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
     }
 
     /**
@@ -714,8 +734,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, false,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8)), true);
+        return _newManagedSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
     }
 
     /**
@@ -752,8 +772,8 @@ public class ObjectWriter
     public SequenceWriter writeValues(Writer target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, false,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target)), true);
+        return _newManagedSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target));
     }
 
     /**
@@ -770,15 +790,15 @@ public class ObjectWriter
     public SequenceWriter writeValues(OutputStream target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, false,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8)), true);
+        return _newManagedSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
     }
 
     public SequenceWriter writeValues(DataOutput target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, false,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target)), true);
+        return _newManagedSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target));
     }
 
     /**
@@ -799,8 +819,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, true,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8)), true);
+        return _newManagedSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
     }
 
     /**
@@ -823,8 +843,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, true,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8)), true);
+        return _newManagedSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
     }
 
     /**
@@ -864,8 +884,8 @@ public class ObjectWriter
     public SequenceWriter writeValuesAsArray(Writer target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, true,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target)), true);
+        return _newManagedSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target));
     }
 
     /**
@@ -884,15 +904,15 @@ public class ObjectWriter
     public SequenceWriter writeValuesAsArray(OutputStream target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, true,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8)), true);
+        return _newManagedSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
     }
 
     public SequenceWriter writeValuesAsArray(DataOutput target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newSequenceWriter(ctxt, true,
-                _initializeGenerator(_generatorFactory.createGenerator(ctxt, target)), true);
+        return _newManagedSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target));
     }
 
     /*
@@ -1138,7 +1158,14 @@ public class ObjectWriter
     protected final void _configAndWriteValue(SerializationContextExt ctxt,
             JsonGenerator gen, Object value) throws JacksonException
     {
-        _initializeGenerator(gen);
+        try {
+            _initializeGenerator(gen);
+        } catch (Exception e) {
+            // 07-Sep-2026, pjfanning: `GeneratorInitializer` is caller-provided and
+            //   may fail; generator owns the output target so it must not leak
+            ClassUtil.closeOnFailAndThrowAsJacksonE(gen, e);
+            return;
+        }
         if (_config.isEnabled(SerializationFeature.CLOSE_CLOSEABLE)
                 && (value instanceof AutoCloseable)) {
             _writeCloseable(gen, value);

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -601,7 +601,7 @@ public class ObjectWriter
      */
     public JsonGenerator createGenerator(OutputStream target) {
         _assertNotNull("target", target);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _generatorFactory.createGenerator(_serializationContext(), target));
     }
 
@@ -615,7 +615,7 @@ public class ObjectWriter
      */
     public JsonGenerator createGenerator(OutputStream target, JsonEncoding enc) {
         _assertNotNull("target", target);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _generatorFactory.createGenerator(_serializationContext(), target, enc));
     }
 
@@ -629,7 +629,7 @@ public class ObjectWriter
      */
     public JsonGenerator createGenerator(Writer target) {
         _assertNotNull("target", target);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _generatorFactory.createGenerator(_serializationContext(), target));
     }
 
@@ -643,7 +643,7 @@ public class ObjectWriter
      */
     public JsonGenerator createGenerator(File target, JsonEncoding enc) {
         _assertNotNull("target", target);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _generatorFactory.createGenerator(_serializationContext(), target, enc));
     }
 
@@ -657,7 +657,7 @@ public class ObjectWriter
      */
     public JsonGenerator createGenerator(Path target, JsonEncoding enc) {
         _assertNotNull("target", target);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _generatorFactory.createGenerator(_serializationContext(), target, enc));
     }
 
@@ -671,7 +671,7 @@ public class ObjectWriter
      */
     public JsonGenerator createGenerator(DataOutput target) {
         _assertNotNull("target", target);
-        return _initializeGenerator(
+        return _initializeManagedGenerator(
                 _generatorFactory.createGenerator(_serializationContext(), target));
     }
 
@@ -1323,6 +1323,20 @@ public class ObjectWriter
             init.initialize(_config, gen);
         }
         return gen;
+    }
+
+    /**
+     * Variant of {@link #_initializeGenerator} for the case where {@code gen}
+     * owns the output target: {@link GeneratorInitializer} is caller-provided
+     * and may fail, and if it does the generator must not leak.
+     */
+    protected JsonGenerator _initializeManagedGenerator(JsonGenerator gen) {
+        try {
+            return _initializeGenerator(gen);
+        } catch (Exception e) {
+            ClassUtil.closeOnFailAndThrowAsJacksonE(gen, e);
+            return null; // never gets here
+        }
     }
 
     protected final void _assertNotNull(String paramName, Object src) {

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -214,30 +214,25 @@ public class ObjectWriter
     /**
      * Overridable factory method called by {@link #writeValues(OutputStream)}
      * method (and its various overrides), and initializes it as necessary.
+     * <p>
+     * When {@code managedInput} is {@code true}, {@code gen} was created by us and
+     * owns the output target: {@code gen} still needs
+     * {@link #_initializeGenerator} applied, and if that -- or writing the leading
+     * {@code START_ARRAY} in {@link SequenceWriter#init} -- fails, {@code gen} must
+     * be closed since nothing else would ever do so.
      */
     @SuppressWarnings("resource")
     protected final SequenceWriter _newSequenceWriter(SerializationContextExt ctxt,
             boolean wrapInArray, JsonGenerator gen, boolean managedInput)
         throws JacksonException
     {
-        return new SequenceWriter(ctxt, gen, managedInput, _prefetch)
-            .init(wrapInArray);
-    }
-
-    /**
-     * Variant of {@link #_newSequenceWriter} for the case where we created the
-     * generator ourselves (and it owns the output target): initialization may
-     * fail -- either in the caller-provided
-     * {@link tools.jackson.databind.cfg.GeneratorInitializer}, or in
-     * {@link SequenceWriter#init} writing the leading {@code START_ARRAY} --
-     * and if it does, nothing else would ever close the generator.
-     */
-    private SequenceWriter _newManagedSequenceWriter(SerializationContextExt ctxt,
-            boolean wrapInArray, JsonGenerator gen)
-        throws JacksonException
-    {
+        if (!managedInput) {
+            return new SequenceWriter(ctxt, gen, false, _prefetch)
+                .init(wrapInArray);
+        }
         try {
-            return _newSequenceWriter(ctxt, wrapInArray, _initializeGenerator(gen), true);
+            return new SequenceWriter(ctxt, _initializeGenerator(gen), true, _prefetch)
+                .init(wrapInArray);
         } catch (Exception e) {
             ClassUtil.closeOnFailAndThrowAsJacksonE(gen, e);
             return null; // never gets here
@@ -711,8 +706,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, false,
-                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
+        return _newSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8), true);
     }
 
     /**
@@ -733,8 +728,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, false,
-                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
+        return _newSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8), true);
     }
 
     /**
@@ -771,8 +766,8 @@ public class ObjectWriter
     public SequenceWriter writeValues(Writer target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, false,
-                _generatorFactory.createGenerator(ctxt, target));
+        return _newSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target), true);
     }
 
     /**
@@ -789,15 +784,15 @@ public class ObjectWriter
     public SequenceWriter writeValues(OutputStream target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, false,
-                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
+        return _newSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8), true);
     }
 
     public SequenceWriter writeValues(DataOutput target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, false,
-                _generatorFactory.createGenerator(ctxt, target));
+        return _newSequenceWriter(ctxt, false,
+                _generatorFactory.createGenerator(ctxt, target), true);
     }
 
     /**
@@ -818,8 +813,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, true,
-                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
+        return _newSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8), true);
     }
 
     /**
@@ -842,8 +837,8 @@ public class ObjectWriter
     {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, true,
-                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
+        return _newSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8), true);
     }
 
     /**
@@ -883,8 +878,8 @@ public class ObjectWriter
     public SequenceWriter writeValuesAsArray(Writer target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, true,
-                _generatorFactory.createGenerator(ctxt, target));
+        return _newSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target), true);
     }
 
     /**
@@ -903,15 +898,15 @@ public class ObjectWriter
     public SequenceWriter writeValuesAsArray(OutputStream target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, true,
-                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8));
+        return _newSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target, JsonEncoding.UTF8), true);
     }
 
     public SequenceWriter writeValuesAsArray(DataOutput target) throws JacksonException {
         _assertNotNull("target", target);
         SerializationContextExt ctxt = _serializationContext();
-        return _newManagedSequenceWriter(ctxt, true,
-                _generatorFactory.createGenerator(ctxt, target));
+        return _newSequenceWriter(ctxt, true,
+                _generatorFactory.createGenerator(ctxt, target), true);
     }
 
     /*

--- a/src/test/java/tools/jackson/databind/seq/SequenceWriterLeakTest.java
+++ b/src/test/java/tools/jackson/databind/seq/SequenceWriterLeakTest.java
@@ -1,0 +1,115 @@
+package tools.jackson.databind.seq;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationConfig;
+import tools.jackson.databind.cfg.GeneratorInitializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests to verify that a generator we constructed ourselves -- and which owns the
+ * output target -- gets closed if initialization fails before any content is written.
+ */
+public class SequenceWriterLeakTest extends DatabindTestUtil
+{
+    static class FailingInitializer implements GeneratorInitializer {
+        @Override
+        public void initialize(SerializationConfig config, JsonGenerator g) {
+            throw new IllegalStateException("Initialization failed");
+        }
+    }
+
+    static class CloseTrackingOutputStream extends ByteArrayOutputStream {
+        public boolean closed = false;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    static class CloseTrackingWriter extends StringWriter {
+        public boolean closed = false;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    private final ObjectMapper FAILING_MAPPER = JsonMapper.builder()
+            .generatorInitializer(new FailingInitializer())
+            .build();
+
+    private final Object VALUE = Map.of("a", 1);
+
+    @Test
+    public void mapperWriteValueClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingOutputStream out = new CloseTrackingOutputStream();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.writeValue(out, VALUE));
+        assertTrue(out.closed, "OutputStream should have been closed by failed writeValue()");
+    }
+
+    @Test
+    public void writerWriteValueClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingWriter w = new CloseTrackingWriter();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.writer().writeValue(w, VALUE));
+        assertTrue(w.closed, "Writer should have been closed by failed writeValue()");
+    }
+
+    @Test
+    public void writeValuesClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingOutputStream out = new CloseTrackingOutputStream();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.writer().writeValues(out));
+        assertTrue(out.closed, "OutputStream should have been closed by failed writeValues()");
+    }
+
+    @Test
+    public void writeValuesAsArrayClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingOutputStream out = new CloseTrackingOutputStream();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.writer().writeValuesAsArray(out));
+        assertTrue(out.closed, "OutputStream should have been closed by failed writeValuesAsArray()");
+    }
+
+    @Test
+    public void writeValuesAsArrayToWriterClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingWriter w = new CloseTrackingWriter();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.writer().writeValuesAsArray(w));
+        assertTrue(w.closed, "Writer should have been closed by failed writeValuesAsArray()");
+    }
+
+    // But a caller-supplied generator is neither initialized nor closed by us
+    @Test
+    public void callerSuppliedGeneratorNotTouched() throws Exception
+    {
+        CloseTrackingOutputStream out = new CloseTrackingOutputStream();
+        ObjectMapper plain = newJsonMapper();
+        try (JsonGenerator g = plain.createGenerator(out)) {
+            FAILING_MAPPER.writer().writeValuesAsArray(g);
+            assertFalse(out.closed);
+        }
+    }
+}

--- a/src/test/java/tools/jackson/databind/seq/SequenceWriterLeakTest.java
+++ b/src/test/java/tools/jackson/databind/seq/SequenceWriterLeakTest.java
@@ -112,4 +112,22 @@ public class SequenceWriterLeakTest extends DatabindTestUtil
             assertFalse(out.closed);
         }
     }
+
+    @Test
+    public void mapperCreateGeneratorClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingOutputStream out = new CloseTrackingOutputStream();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.createGenerator(out));
+        assertTrue(out.closed, "OutputStream should have been closed by failed createGenerator()");
+    }
+
+    @Test
+    public void writerCreateGeneratorClosesOnInitFailure() throws Exception
+    {
+        CloseTrackingOutputStream out = new CloseTrackingOutputStream();
+        assertThrows(IllegalStateException.class,
+                () -> FAILING_MAPPER.writer().createGenerator(out));
+        assertTrue(out.closed, "OutputStream should have been closed by failed createGenerator()");
+    }
 }


### PR DESCRIPTION
Two related spots where a `JsonGenerator` we created — and which owns the
`OutputStream`/`Writer`/`File`/`Path` behind it — is dropped without being closed
if setup fails.

**1. `_configAndWriteValue()`** (both `ObjectMapper` and `ObjectWriter`) calls
`_initializeGenerator(g)` outside the `try`:

```java
_initializeGenerator(g);   // caller-supplied GeneratorInitializer; can throw
...
try { ctxt.serializeValue(g, value); }
catch (Exception e) { ClassUtil.closeOnFailAndThrowAsJacksonE(g, e); return; }
g.close();
```

A `GeneratorInitializer` is user code, so it can throw for any reason. Everything
after it is protected; the initializer itself is not.

**2. `ObjectWriter._newSequenceWriter()`** has the same exposure plus one more:

```java
@SuppressWarnings("resource")
protected final SequenceWriter _newSequenceWriter(..., JsonGenerator gen, boolean managedInput) {
    return new SequenceWriter(ctxt, gen, managedInput, _prefetch).init(wrapInArray);
}
```

`init(true)` calls `gen.writeStartArray()`, which can fail. For
`writeValuesAsArray(File)` / `writeValues(Path)` etc. the generator holds an open
`FileOutputStream` at that point, and the `@SuppressWarnings("resource")` acknowledges
the leak without handling it. The ten managed call sites also each call
`_initializeGenerator(...)` inline, outside any protection.

Reproduction with a `GeneratorInitializer` that throws (before the fix):

```
writeValue(initializer throws)        -> IllegalStateException; stream closed = false
writeValuesAsArray(initializer throws) -> IllegalStateException; stream closed = false
```

### Changes

- `_configAndWriteValue()` in both classes: `_initializeGenerator()` moved inside a
  `try`, closing the generator via the existing
  `ClassUtil.closeOnFailAndThrowAsJacksonE()` on failure.
- New private `ObjectWriter._newManagedSequenceWriter()` that does the
  `_initializeGenerator()` + `_newSequenceWriter()` pair under one `try`, closing the
  generator if either step fails. The ten managed `writeValues*` /
  `writeValuesAsArray*` overloads now call it.

`_newSequenceWriter()` itself is unchanged in signature and behaviour, so the two
`writeValues(JsonGenerator)` overloads still neither initialize nor close a
caller-supplied generator.

### Tests

New `seq/SequenceWriterLeakTest`. Fails on 3.x without the main-source change,
passes with it.
