### PR TITLE
Fix `ClassCastException` for `AutoCloseable` values in `ObjectMapper.writeValue(JsonGenerator, ...)`

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -56,6 +56,9 @@ Versions: 3.x (for earlier see VERSION-2.x)
 #6188: `ThrowableDeserializer` does not resolve standard `Throwable` property
   names against `PropertyNamingStrategy`
  (fix by @cowtowncoder, w/ Claude code)
+#6197: `ClassCastException` for `AutoCloseable` (but not `Closeable`) values in
+  `ObjectMapper.writeValue(JsonGenerator, Object)` with `SerializationFeature.CLOSE_CLOSEABLE`
+ (fix by @pjfanning)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -1920,7 +1920,7 @@ public class ObjectMapper
     }
 
     /**
-     * Helper method used when value to serialize is {@link Closeable} and its <code>close()</code>
+     * Helper method used when value to serialize is {@link AutoCloseable} and its <code>close()</code>
      * method is to be called right after serialization has been called
      */
     private final void _configAndWriteCloseable(SerializationContextExt ctxt,

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -1965,7 +1965,13 @@ public class ObjectMapper
         } catch (IOException e) {
             throw JacksonIOException.construct(e, g);
         } catch (Exception e) {
-            ClassUtil.closeOnFailAndThrowAsJacksonE(g, e);
+            // 07-Sep-2026, tatu: Two things to note here: caller-owned Generator must NOT
+            //   be closed (see `writeValue(JsonGenerator, Object)`); and since
+            //   `AutoCloseable.close()` may throw any checked `Exception`, need to wrap
+            //   as `JacksonException` (and not leak as plain `RuntimeException`)
+            throw DatabindException.from(g, String.format(
+                    "Failed to close value of type %s: %s",
+                    ClassUtil.classNameOf(toClose), ClassUtil.exceptionMessage(e)), e);
         }
     }
 

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -1927,14 +1927,18 @@ public class ObjectMapper
             JsonGenerator g, AutoCloseable value)
         throws JacksonException
     {
-        // Sentinel for `catch`: cleared once value no longer needs closing by it
-        AutoCloseable toClose = value;
         try {
             ctxt.serializeValue(g, value);
-            toClose = null;
+        } catch (Exception e) {
+            ClassUtil.closeOnFailAndThrowAsJacksonE(g, value, e);
+            return;
+        }
+        try {
             value.close();
         } catch (Exception e) {
-            ClassUtil.closeOnFailAndThrowAsJacksonE(g, toClose, e);
+            // Generator is ours to close, but `close()` failure still needs wrapping
+            ClassUtil.closeOnFailAndThrowAsJacksonE(g,
+                    ClassUtil.closeFailureAsJacksonE(g, value, e));
             return;
         }
         g.close();
@@ -1962,18 +1966,10 @@ public class ObjectMapper
         }
         try {
             toClose.close();
-        } catch (IOException e) {
-            throw JacksonIOException.construct(e, g);
-        } catch (JacksonException e) { // pass through as-is
-            throw e;
         } catch (Exception e) {
-            // 07-Sep-2026, tatu: Two things to note here: caller-owned Generator must NOT
-            //   be closed (see `writeValue(JsonGenerator, Object)`); and since
-            //   `AutoCloseable.close()` may throw any checked `Exception`, need to wrap
-            //   as `JacksonException` (and not leak as plain `RuntimeException`)
-            throw DatabindException.from(g, String.format(
-                    "Failed to close value of type %s: %s",
-                    ClassUtil.classNameOf(toClose), ClassUtil.exceptionMessage(e)), e);
+            // 07-Sep-2026, tatu: Note that caller-owned Generator must NOT be closed
+            //   here (see `writeValue(JsonGenerator, Object)`)
+            throw ClassUtil.closeFailureAsJacksonE(g, toClose, e);
         }
     }
 

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -1906,8 +1906,8 @@ public class ObjectMapper
     {
         _initializeGenerator(g);
         if (ctxt.isEnabled(SerializationFeature.CLOSE_CLOSEABLE)
-                && (value instanceof AutoCloseable)) {
-            _configAndWriteCloseable(ctxt, g, value);
+                && (value instanceof AutoCloseable toClose)) {
+            _configAndWriteCloseable(ctxt, g, toClose);
             return;
         }
         try {
@@ -1924,15 +1924,15 @@ public class ObjectMapper
      * method is to be called right after serialization has been called
      */
     private final void _configAndWriteCloseable(SerializationContextExt ctxt,
-            JsonGenerator g, Object value)
+            JsonGenerator g, AutoCloseable value)
         throws JacksonException
     {
-        AutoCloseable toClose = (AutoCloseable) value;
+        // Sentinel for `catch`: cleared once value no longer needs closing by it
+        AutoCloseable toClose = value;
         try {
             ctxt.serializeValue(g, value);
-            AutoCloseable tmpToClose = toClose;
             toClose = null;
-            tmpToClose.close();
+            value.close();
         } catch (Exception e) {
             ClassUtil.closeOnFailAndThrowAsJacksonE(g, toClose, e);
             return;
@@ -1964,6 +1964,8 @@ public class ObjectMapper
             toClose.close();
         } catch (IOException e) {
             throw JacksonIOException.construct(e, g);
+        } catch (JacksonException e) { // pass through as-is
+            throw e;
         } catch (Exception e) {
             // 07-Sep-2026, tatu: Two things to note here: caller-owned Generator must NOT
             //   be closed (see `writeValue(JsonGenerator, Object)`); and since

--- a/src/main/java/tools/jackson/databind/ObjectMapper.java
+++ b/src/main/java/tools/jackson/databind/ObjectMapper.java
@@ -1941,13 +1941,16 @@ public class ObjectMapper
     }
 
     /**
-     * Helper method used when value to serialize is {@link Closeable} and its <code>close()</code>
-     * method is to be called right after serialization has been called
+     * Helper method used when value to serialize is {@link AutoCloseable} and its
+     * <code>close()</code> method is to be called right after serialization has been called
      */
     protected final void _writeCloseableValue(JsonGenerator g, Object value, SerializationConfig cfg)
         throws JacksonException
     {
-        Closeable toClose = (Closeable) value;
+        // 07-Sep-2026, pjfanning: caller checks for `AutoCloseable`, not `Closeable`,
+        //   so casting to the latter would fail for f.ex `Stream`s (see also
+        //   `ObjectWriter.writeValue(JsonGenerator, Object)` which got this right)
+        AutoCloseable toClose = (AutoCloseable) value;
         try {
             _serializationContext(cfg).serializeValue(g, value);
             if (cfg.isEnabled(SerializationFeature.FLUSH_AFTER_WRITE_VALUE)) {
@@ -1960,7 +1963,9 @@ public class ObjectMapper
         try {
             toClose.close();
         } catch (IOException e) {
-            throw JacksonIOException.construct(e);
+            throw JacksonIOException.construct(e, g);
+        } catch (Exception e) {
+            ClassUtil.closeOnFailAndThrowAsJacksonE(g, e);
         }
     }
 

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -994,7 +994,13 @@ public class ObjectWriter
             } catch (IOException e) {
                 throw JacksonIOException.construct(e, g);
             } catch (Exception e) {
-                ClassUtil.closeOnFailAndThrowAsJacksonE(g, e);
+                // 07-Sep-2026, tatu: Two things to note here: caller-owned Generator must
+                //   NOT be closed; and since `AutoCloseable.close()` may throw any checked
+                //   `Exception`, need to wrap as `JacksonException` (and not leak as plain
+                //   `RuntimeException`)
+                throw DatabindException.from(g, String.format(
+                        "Failed to close value of type %s: %s",
+                        ClassUtil.classNameOf(toClose), ClassUtil.exceptionMessage(e)), e);
             }
         } else {
             _prefetch.serialize(g, value, _serializationContext());

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import tools.jackson.core.*;
-import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.core.io.CharacterEscapes;
 import tools.jackson.core.io.SegmentedStringWriter;
 import tools.jackson.core.type.TypeReference;
@@ -991,18 +990,9 @@ public class ObjectWriter
             }
             try {
                 toClose.close();
-            } catch (IOException e) {
-                throw JacksonIOException.construct(e, g);
-            } catch (JacksonException e) { // pass through as-is
-                throw e;
             } catch (Exception e) {
-                // 07-Sep-2026, tatu: Two things to note here: caller-owned Generator must
-                //   NOT be closed; and since `AutoCloseable.close()` may throw any checked
-                //   `Exception`, need to wrap as `JacksonException` (and not leak as plain
-                //   `RuntimeException`)
-                throw DatabindException.from(g, String.format(
-                        "Failed to close value of type %s: %s",
-                        ClassUtil.classNameOf(toClose), ClassUtil.exceptionMessage(e)), e);
+                // 07-Sep-2026, tatu: Note that caller-owned Generator must NOT be closed here
+                throw ClassUtil.closeFailureAsJacksonE(g, toClose, e);
             }
         } else {
             _prefetch.serialize(g, value, _serializationContext());
@@ -1168,14 +1158,18 @@ public class ObjectWriter
     private final void _writeCloseable(JsonGenerator gen, AutoCloseable value)
         throws JacksonException
     {
-        // Sentinel for `catch`: cleared once value no longer needs closing by it
-        AutoCloseable toClose = value;
         try {
             _prefetch.serialize(gen, value, _serializationContext());
-            toClose = null;
+        } catch (Exception e) {
+            ClassUtil.closeOnFailAndThrowAsJacksonE(gen, value, e);
+            return;
+        }
+        try {
             value.close();
         } catch (Exception e) {
-            ClassUtil.closeOnFailAndThrowAsJacksonE(gen, toClose, e);
+            // Generator is ours to close, but `close()` failure still needs wrapping
+            ClassUtil.closeOnFailAndThrowAsJacksonE(gen,
+                    ClassUtil.closeFailureAsJacksonE(gen, value, e));
             return;
         }
         gen.close();

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -1160,7 +1160,7 @@ public class ObjectWriter
     }
 
     /**
-     * Helper method used when value to serialize is {@link Closeable} and its <code>close()</code>
+     * Helper method used when value to serialize is {@link AutoCloseable} and its <code>close()</code>
      * method is to be called right after serialization has been called
      */
     private final void _writeCloseable(JsonGenerator gen, Object value)

--- a/src/main/java/tools/jackson/databind/ObjectWriter.java
+++ b/src/main/java/tools/jackson/databind/ObjectWriter.java
@@ -993,6 +993,8 @@ public class ObjectWriter
                 toClose.close();
             } catch (IOException e) {
                 throw JacksonIOException.construct(e, g);
+            } catch (JacksonException e) { // pass through as-is
+                throw e;
             } catch (Exception e) {
                 // 07-Sep-2026, tatu: Two things to note here: caller-owned Generator must
                 //   NOT be closed; and since `AutoCloseable.close()` may throw any checked
@@ -1146,8 +1148,8 @@ public class ObjectWriter
     {
         _initializeGenerator(gen);
         if (_config.isEnabled(SerializationFeature.CLOSE_CLOSEABLE)
-                && (value instanceof AutoCloseable)) {
-            _writeCloseable(gen, value);
+                && (value instanceof AutoCloseable toClose)) {
+            _writeCloseable(gen, toClose);
             return;
         }
         try {
@@ -1163,15 +1165,15 @@ public class ObjectWriter
      * Helper method used when value to serialize is {@link AutoCloseable} and its <code>close()</code>
      * method is to be called right after serialization has been called
      */
-    private final void _writeCloseable(JsonGenerator gen, Object value)
+    private final void _writeCloseable(JsonGenerator gen, AutoCloseable value)
         throws JacksonException
     {
-        AutoCloseable toClose = (AutoCloseable) value;
+        // Sentinel for `catch`: cleared once value no longer needs closing by it
+        AutoCloseable toClose = value;
         try {
             _prefetch.serialize(gen, value, _serializationContext());
-            AutoCloseable tmpToClose = toClose;
             toClose = null;
-            tmpToClose.close();
+            value.close();
         } catch (Exception e) {
             ClassUtil.closeOnFailAndThrowAsJacksonE(gen, toClose, e);
             return;

--- a/src/main/java/tools/jackson/databind/SequenceWriter.java
+++ b/src/main/java/tools/jackson/databind/SequenceWriter.java
@@ -1,6 +1,5 @@
 package tools.jackson.databind;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -10,6 +9,7 @@ import tools.jackson.databind.jsontype.TypeSerializer;
 import tools.jackson.databind.ser.SerializationContextExt;
 import tools.jackson.databind.ser.impl.PropertySerializerMap;
 import tools.jackson.databind.ser.impl.TypeWrappedSerializer;
+import tools.jackson.databind.util.ClassUtil;
 
 /**
  * Writer class similar to {@link ObjectWriter}, except that it can be used
@@ -137,7 +137,7 @@ public class SequenceWriter
             return this;
         }
 
-        if (_cfgCloseCloseable && (value instanceof Closeable)) {
+        if (_cfgCloseCloseable && (value instanceof AutoCloseable)) {
             return _writeCloseableValue(value);
         }
         ValueSerializer<Object> ser = _rootSerializer;
@@ -171,7 +171,7 @@ public class SequenceWriter
             return this;
         }
 
-        if (_cfgCloseCloseable && (value instanceof Closeable)) {
+        if (_cfgCloseCloseable && (value instanceof AutoCloseable)) {
             return _writeCloseableValue(value, type);
         }
         /* 15-Dec-2014, tatu: I wonder if this could become problematic. It shouldn't
@@ -245,7 +245,7 @@ public class SequenceWriter
 
     protected SequenceWriter _writeCloseableValue(Object value) throws JacksonException
     {
-        Closeable toClose = (Closeable) value;
+        AutoCloseable toClose = (AutoCloseable) value;
         try {
             ValueSerializer<Object> ser = _rootSerializer;
             if (ser == null) {
@@ -259,18 +259,24 @@ public class SequenceWriter
             if (_cfgFlush) {
                 _generator.flush();
             }
-            Closeable tmpToClose = toClose;
+            AutoCloseable tmpToClose = toClose;
             toClose = null;
             try {
                 tmpToClose.close();
             } catch (IOException e) {
                 throw JacksonIOException.construct(e, _generator);
+            } catch (JacksonException e) { // pass through as-is
+                throw e;
+            } catch (Exception e) {
+                throw DatabindException.from(_generator, String.format(
+                        "Failed to close value of type %s: %s",
+                        ClassUtil.classNameOf(tmpToClose), ClassUtil.exceptionMessage(e)), e);
             }
         } finally {
             if (toClose != null) { // only if there was other throwable
                 try {
                     toClose.close();
-                } catch (IOException ioe) { }
+                } catch (Exception e) { }
             }
         }
         return this;
@@ -279,7 +285,7 @@ public class SequenceWriter
     protected SequenceWriter _writeCloseableValue(Object value, JavaType type)
         throws JacksonException
     {
-        Closeable toClose = (Closeable) value;
+        AutoCloseable toClose = (AutoCloseable) value;
         try {
             // 15-Dec-2014, tatu: As per above, could be problem that we do not pass generic type
             ValueSerializer<Object> ser = _dynamicSerializers.serializerFor(type.getRawClass());
@@ -290,18 +296,24 @@ public class SequenceWriter
             if (_cfgFlush) {
                 _generator.flush();
             }
-            Closeable tmpToClose = toClose;
+            AutoCloseable tmpToClose = toClose;
             toClose = null;
             try {
                 tmpToClose.close();
             } catch (IOException e) {
                 throw JacksonIOException.construct(e);
+            } catch (JacksonException e) { // pass through as-is
+                throw e;
+            } catch (Exception e) {
+                throw DatabindException.from(_generator, String.format(
+                        "Failed to close value of type %s: %s",
+                        ClassUtil.classNameOf(tmpToClose), ClassUtil.exceptionMessage(e)), e);
             }
         } finally {
             if (toClose != null) { // only if there was another throwable
                 try {
                     toClose.close();
-                } catch (IOException ioe) { }
+                } catch (Exception e) { }
             }
         }
         return this;

--- a/src/main/java/tools/jackson/databind/SequenceWriter.java
+++ b/src/main/java/tools/jackson/databind/SequenceWriter.java
@@ -257,19 +257,16 @@ public class SequenceWriter
             if (_cfgFlush) {
                 _generator.flush();
             }
-            AutoCloseable tmpToClose = toClose;
-            toClose = null;
+        } catch (Throwable e) {
             try {
-                tmpToClose.close();
-            } catch (Exception e) {
-                throw ClassUtil.closeFailureAsJacksonE(_generator, tmpToClose, e);
-            }
-        } finally {
-            if (toClose != null) { // only if there was other throwable
-                try {
-                    toClose.close();
-                } catch (Exception e) { }
-            }
+                toClose.close();
+            } catch (Exception e2) { }
+            throw e;
+        }
+        try {
+            toClose.close();
+        } catch (Exception e) {
+            throw ClassUtil.closeFailureAsJacksonE(_generator, toClose, e);
         }
         return this;
     }
@@ -288,19 +285,16 @@ public class SequenceWriter
             if (_cfgFlush) {
                 _generator.flush();
             }
-            AutoCloseable tmpToClose = toClose;
-            toClose = null;
+        } catch (Throwable e) {
             try {
-                tmpToClose.close();
-            } catch (Exception e) {
-                throw ClassUtil.closeFailureAsJacksonE(_generator, tmpToClose, e);
-            }
-        } finally {
-            if (toClose != null) { // only if there was another throwable
-                try {
-                    toClose.close();
-                } catch (Exception e) { }
-            }
+                toClose.close();
+            } catch (Exception e2) { }
+            throw e;
+        }
+        try {
+            toClose.close();
+        } catch (Exception e) {
+            throw ClassUtil.closeFailureAsJacksonE(_generator, toClose, e);
         }
         return this;
     }

--- a/src/main/java/tools/jackson/databind/SequenceWriter.java
+++ b/src/main/java/tools/jackson/databind/SequenceWriter.java
@@ -258,9 +258,13 @@ public class SequenceWriter
                 _generator.flush();
             }
         } catch (Throwable e) {
+            // Failed to serialize: value still needs closing, but original failure
+            // must not be lost if closing fails as well
             try {
                 toClose.close();
-            } catch (Exception e2) { }
+            } catch (Exception e2) {
+                e.addSuppressed(e2);
+            }
             throw e;
         }
         try {
@@ -286,9 +290,13 @@ public class SequenceWriter
                 _generator.flush();
             }
         } catch (Throwable e) {
+            // Failed to serialize: value still needs closing, but original failure
+            // must not be lost if closing fails as well
             try {
                 toClose.close();
-            } catch (Exception e2) { }
+            } catch (Exception e2) {
+                e.addSuppressed(e2);
+            }
             throw e;
         }
         try {

--- a/src/main/java/tools/jackson/databind/SequenceWriter.java
+++ b/src/main/java/tools/jackson/databind/SequenceWriter.java
@@ -1,10 +1,8 @@
 package tools.jackson.databind;
 
-import java.io.IOException;
 import java.util.Collection;
 
 import tools.jackson.core.*;
-import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.databind.jsontype.TypeSerializer;
 import tools.jackson.databind.ser.SerializationContextExt;
 import tools.jackson.databind.ser.impl.PropertySerializerMap;
@@ -263,14 +261,8 @@ public class SequenceWriter
             toClose = null;
             try {
                 tmpToClose.close();
-            } catch (IOException e) {
-                throw JacksonIOException.construct(e, _generator);
-            } catch (JacksonException e) { // pass through as-is
-                throw e;
             } catch (Exception e) {
-                throw DatabindException.from(_generator, String.format(
-                        "Failed to close value of type %s: %s",
-                        ClassUtil.classNameOf(tmpToClose), ClassUtil.exceptionMessage(e)), e);
+                throw ClassUtil.closeFailureAsJacksonE(_generator, tmpToClose, e);
             }
         } finally {
             if (toClose != null) { // only if there was other throwable
@@ -300,14 +292,8 @@ public class SequenceWriter
             toClose = null;
             try {
                 tmpToClose.close();
-            } catch (IOException e) {
-                throw JacksonIOException.construct(e);
-            } catch (JacksonException e) { // pass through as-is
-                throw e;
             } catch (Exception e) {
-                throw DatabindException.from(_generator, String.format(
-                        "Failed to close value of type %s: %s",
-                        ClassUtil.classNameOf(tmpToClose), ClassUtil.exceptionMessage(e)), e);
+                throw ClassUtil.closeFailureAsJacksonE(_generator, tmpToClose, e);
             }
         } finally {
             if (toClose != null) { // only if there was another throwable

--- a/src/main/java/tools/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/tools/jackson/databind/util/ClassUtil.java
@@ -12,6 +12,7 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.StreamWriteFeature;
 import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.core.util.Named;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.PropertyName;
 import tools.jackson.databind.annotation.JacksonStdImpl;
@@ -442,6 +443,27 @@ public final class ClassUtil
             throw JacksonIOException.construct(ioException, g);
         }
         throw new RuntimeException(fail);
+    }
+
+    /**
+     * Helper method for converting an exception thrown by {@link AutoCloseable#close()}
+     * into {@link JacksonException}: needed since {@code close()} may throw any checked
+     * {@code Exception} (and not just {@link IOException} as {@link Closeable} does), and
+     * such failure must not be leaked as plain {@link RuntimeException}.
+     *
+     * @since 3.3
+     */
+    public static JacksonException closeFailureAsJacksonE(JsonGenerator g,
+            AutoCloseable value, Exception fail)
+    {
+        if (fail instanceof JacksonException jacksonException) { // pass through as-is
+            return jacksonException;
+        }
+        if (fail instanceof IOException ioException) {
+            return JacksonIOException.construct(ioException, g);
+        }
+        return DatabindException.from(g, String.format("Failed to close value of type %s: %s",
+                classNameOf(value), exceptionMessage(fail)), fail);
     }
 
     /*

--- a/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
+++ b/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
@@ -1,14 +1,18 @@
 package tools.jackson.databind.ser;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.StringWriter;
 
 import org.junit.jupiter.api.Test;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.exc.JacksonIOException;
 
 import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SequenceWriter;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.testutil.DatabindTestUtil;
 
@@ -125,5 +129,80 @@ public class CloseAutoCloseableTest extends DatabindTestUtil
         assertEquals("""
                 {"a":3,"wasClosed":false}""", MAPPER.writeValueAsString(bean));
         assertTrue(bean.wasClosed);
+    }
+
+    // [databind#6197]: `SequenceWriter` also needs to handle `AutoCloseable`,
+    // not just `Closeable` (before fix: value simply never closed)
+    @Test
+    public void sequenceWriterWriteValue() throws Exception
+    {
+        AutoCloseableBean bean = new AutoCloseableBean();
+        StringWriter sw = new StringWriter();
+        try (SequenceWriter seq = MAPPER.writer().writeValues(sw)) {
+            seq.write(bean);
+        }
+        assertEquals("""
+                {"a":3,"wasClosed":false}""", sw.toString());
+        assertTrue(bean.wasClosed);
+    }
+
+    @Test
+    public void sequenceWriterWriteValueWithType() throws Exception
+    {
+        AutoCloseableBean bean = new AutoCloseableBean();
+        StringWriter sw = new StringWriter();
+        try (SequenceWriter seq = MAPPER.writer().writeValues(sw)) {
+            seq.write(bean, MAPPER.constructType(AutoCloseableBean.class));
+        }
+        assertEquals("""
+                {"a":3,"wasClosed":false}""", sw.toString());
+        assertTrue(bean.wasClosed);
+    }
+
+    @Test
+    public void sequenceWriterCloseFailure() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (SequenceWriter seq = MAPPER.writer().writeValues(sw)) {
+            DatabindException e = assertThrows(DatabindException.class,
+                    () -> seq.write(new FailingAutoCloseableBean()));
+            verifyException(e, "Failed to close value of type");
+        }
+    }
+
+    // `JacksonException` from `close()` must be passed through as-is, not re-wrapped
+    static class JacksonFailOnCloseBean implements AutoCloseable {
+        public final static JacksonException FAILURE
+            = JacksonIOException.construct(new IOException("Fail on close()"));
+
+        public int a = 3;
+
+        @Override
+        public void close() {
+            throw FAILURE;
+        }
+    }
+
+    @Test
+    public void jacksonExceptionFromCloseNotRewrapped() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = MAPPER.createGenerator(sw)) {
+            assertSame(JacksonFailOnCloseBean.FAILURE,
+                    assertThrows(JacksonException.class,
+                            () -> MAPPER.writeValue(g, new JacksonFailOnCloseBean())));
+            assertSame(JacksonFailOnCloseBean.FAILURE,
+                    assertThrows(JacksonException.class,
+                            () -> MAPPER.writer().writeValue(g, new JacksonFailOnCloseBean())));
+        }
+        try (SequenceWriter seq = MAPPER.writer().writeValues(new StringWriter())) {
+            assertSame(JacksonFailOnCloseBean.FAILURE,
+                    assertThrows(JacksonException.class,
+                            () -> seq.write(new JacksonFailOnCloseBean())));
+            assertSame(JacksonFailOnCloseBean.FAILURE,
+                    assertThrows(JacksonException.class,
+                            () -> seq.write(new JacksonFailOnCloseBean(),
+                                    MAPPER.constructType(JacksonFailOnCloseBean.class))));
+        }
     }
 }

--- a/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
+++ b/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
@@ -131,6 +131,20 @@ public class CloseAutoCloseableTest extends DatabindTestUtil
         assertTrue(bean.wasClosed);
     }
 
+    // Mapper-owned Generator paths must not leak `close()` failure as plain
+    // `RuntimeException` either
+    @Test
+    public void mapperOwnedGeneratorCloseFailure() throws Exception
+    {
+        DatabindException e = assertThrows(DatabindException.class,
+                () -> MAPPER.writeValueAsString(new FailingAutoCloseableBean()));
+        verifyException(e, "Failed to close value of type");
+
+        e = assertThrows(DatabindException.class,
+                () -> MAPPER.writer().writeValueAsString(new FailingAutoCloseableBean()));
+        verifyException(e, "Failed to close value of type");
+    }
+
     // [databind#6197]: `SequenceWriter` also needs to handle `AutoCloseable`,
     // not just `Closeable` (before fix: value simply never closed)
     @Test
@@ -195,6 +209,12 @@ public class CloseAutoCloseableTest extends DatabindTestUtil
                     assertThrows(JacksonException.class,
                             () -> MAPPER.writer().writeValue(g, new JacksonFailOnCloseBean())));
         }
+        assertSame(JacksonFailOnCloseBean.FAILURE,
+                assertThrows(JacksonException.class,
+                        () -> MAPPER.writeValueAsString(new JacksonFailOnCloseBean())));
+        assertSame(JacksonFailOnCloseBean.FAILURE,
+                assertThrows(JacksonException.class,
+                        () -> MAPPER.writer().writeValueAsString(new JacksonFailOnCloseBean())));
         try (SequenceWriter seq = MAPPER.writer().writeValues(new StringWriter())) {
             assertSame(JacksonFailOnCloseBean.FAILURE,
                     assertThrows(JacksonException.class,

--- a/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
+++ b/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonGenerator;
 
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.testutil.DatabindTestUtil;
@@ -30,6 +31,16 @@ public class CloseAutoCloseableTest extends DatabindTestUtil
         @Override
         public void close() throws Exception {
             wasClosed = true;
+        }
+    }
+
+    static class FailingAutoCloseableBean implements AutoCloseable {
+        public int a = 3;
+
+        // Checked, non-`IOException` failure: only possible for `AutoCloseable`
+        @Override
+        public void close() throws Exception {
+            throw new Exception("Fail on close()");
         }
     }
 
@@ -62,6 +73,38 @@ public class CloseAutoCloseableTest extends DatabindTestUtil
         assertEquals("""
                 {"a":3,"wasClosed":false}""", sw.toString());
         assertTrue(bean.wasClosed);
+    }
+
+    // Failure to `close()` the value must not close (or otherwise mess with) the
+    // caller-owned Generator, and must be reported as `JacksonException`
+    @Test
+    public void mapperCloseFailureWithGenerator() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = MAPPER.createGenerator(sw)) {
+            DatabindException e = assertThrows(DatabindException.class,
+                    () -> MAPPER.writeValue(g, new FailingAutoCloseableBean()));
+            verifyException(e, "Failed to close value of type");
+            assertFalse(g.isClosed());
+            g.writeString("after");
+        }
+        assertEquals("""
+                {"a":3} "after\"""", sw.toString());
+    }
+
+    @Test
+    public void writerCloseFailureWithGenerator() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = MAPPER.createGenerator(sw)) {
+            DatabindException e = assertThrows(DatabindException.class,
+                    () -> MAPPER.writer().writeValue(g, new FailingAutoCloseableBean()));
+            verifyException(e, "Failed to close value of type");
+            assertFalse(g.isClosed());
+            g.writeString("after");
+        }
+        assertEquals("""
+                {"a":3} "after\"""", sw.toString());
     }
 
     @Test

--- a/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
+++ b/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
@@ -1,0 +1,86 @@
+package tools.jackson.databind.ser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link SerializationFeature#CLOSE_CLOSEABLE} handling of values that
+ * implement {@link AutoCloseable} but not {@link java.io.Closeable}: the feature
+ * checks for the former, so all code paths need to handle it.
+ */
+public class CloseAutoCloseableTest extends DatabindTestUtil
+{
+    static class AutoCloseableBean implements AutoCloseable {
+        public int a = 3;
+
+        public boolean wasClosed = false;
+
+        // Note: `AutoCloseable.close()` may throw checked `Exception`, unlike
+        // `Closeable.close()` which is limited to `IOException`
+        @Override
+        public void close() throws Exception {
+            wasClosed = true;
+        }
+    }
+
+    private final ObjectMapper MAPPER = jsonMapperBuilder()
+            .enable(SerializationFeature.CLOSE_CLOSEABLE)
+            .build();
+
+    @Test
+    public void mapperWriteValueToGenerator() throws Exception
+    {
+        AutoCloseableBean bean = new AutoCloseableBean();
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = MAPPER.createGenerator(sw)) {
+            MAPPER.writeValue(g, bean);
+        }
+        assertEquals("""
+                {"a":3,"wasClosed":false}""", sw.toString());
+        assertTrue(bean.wasClosed);
+    }
+
+    // Same case, via `ObjectWriter`: has always worked, guard against regression
+    @Test
+    public void writerWriteValueToGenerator() throws Exception
+    {
+        AutoCloseableBean bean = new AutoCloseableBean();
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = MAPPER.createGenerator(sw)) {
+            MAPPER.writer().writeValue(g, bean);
+        }
+        assertEquals("""
+                {"a":3,"wasClosed":false}""", sw.toString());
+        assertTrue(bean.wasClosed);
+    }
+
+    @Test
+    public void mapperWriteValueToStream() throws Exception
+    {
+        AutoCloseableBean bean = new AutoCloseableBean();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MAPPER.writeValue(out, bean);
+        assertEquals("""
+                {"a":3,"wasClosed":false}""", out.toString("UTF-8"));
+        assertTrue(bean.wasClosed);
+    }
+
+    @Test
+    public void mapperWriteValueAsString() throws Exception
+    {
+        AutoCloseableBean bean = new AutoCloseableBean();
+        assertEquals("""
+                {"a":3,"wasClosed":false}""", MAPPER.writeValueAsString(bean));
+        assertTrue(bean.wasClosed);
+    }
+}

--- a/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
+++ b/src/test/java/tools/jackson/databind/ser/CloseAutoCloseableTest.java
@@ -184,6 +184,41 @@ public class CloseAutoCloseableTest extends DatabindTestUtil
         }
     }
 
+    // If both serialization and the recovery `close()` fail, the original failure
+    // must survive, with close failure merely added as "suppressed"
+    static class FailOnSerializeAndCloseBean implements AutoCloseable {
+        public int getA() {
+            throw new IllegalArgumentException("Fail on serialize");
+        }
+
+        @Override
+        public void close() {
+            throw new IllegalStateException("Fail on close");
+        }
+    }
+
+    @Test
+    public void sequenceWriterSerializationFailureKeepsCloseFailure() throws Exception
+    {
+        SequenceWriter seq = MAPPER.writer().writeValues(new StringWriter());
+        Exception e = assertThrows(Exception.class,
+                () -> seq.write(new FailOnSerializeAndCloseBean()));
+        verifyException(e, "Fail on serialize");
+        Throwable[] suppressed = e.getSuppressed();
+        assertEquals(1, suppressed.length);
+        verifyException(suppressed[0], "Fail on close");
+
+        // and same for the `JavaType`-taking variant
+        SequenceWriter seq2 = MAPPER.writer().writeValues(new StringWriter());
+        e = assertThrows(Exception.class,
+                () -> seq2.write(new FailOnSerializeAndCloseBean(),
+                        MAPPER.constructType(FailOnSerializeAndCloseBean.class)));
+        verifyException(e, "Fail on serialize");
+        suppressed = e.getSuppressed();
+        assertEquals(1, suppressed.length);
+        verifyException(suppressed[0], "Fail on close");
+    }
+
     // `JacksonException` from `close()` must be passed through as-is, not re-wrapped
     static class JacksonFailOnCloseBean implements AutoCloseable {
         public final static JacksonException FAILURE


### PR DESCRIPTION
`ObjectMapper.writeValue(JsonGenerator, Object)` guards on `AutoCloseable`:

```java
if (config.isEnabled(SerializationFeature.CLOSE_CLOSEABLE)
        && (value instanceof AutoCloseable)) {
    _writeCloseableValue(g, value, config);
```

but the helper it dispatches to casts to the narrower `Closeable`:

```java
protected final void _writeCloseableValue(JsonGenerator g, Object value, SerializationConfig cfg) {
    Closeable toClose = (Closeable) value;
```

So with `CLOSE_CLOSEABLE` enabled, serializing any value that is `AutoCloseable` but
not `Closeable` — `java.util.stream.Stream`, `java.sql.Connection`, and most
user-defined resource types — throws `ClassCastException` instead of serializing.

`ObjectWriter` handles the same case correctly (`writeValue(JsonGenerator, Object)`
and `_writeCloseable()` both use `AutoCloseable`), as does
`ObjectMapper._configAndWriteCloseable()`. `_writeCloseableValue()` is the one place
that was not updated when the checks moved from `Closeable` to `AutoCloseable`.

Reproduction with a bean implementing `AutoCloseable` (before the fix):

```
mapper.writeValue(gen, autoCloseable)   -> ClassCastException: ... cannot be cast to java.io.Closeable
writer().writeValue(gen, autoCloseable) -> OK, value closed
```

### Changes

- `_writeCloseableValue()` now holds the value as `AutoCloseable`.
- Since `AutoCloseable.close()` may throw a checked `Exception` rather than only
  `IOException`, the close is now also guarded for the non-`IOException` case, matching
  `ObjectWriter.writeValue(JsonGenerator, Object)`. The `JacksonIOException` construction
  also now passes the generator, as `ObjectWriter` does, so the exception carries the
  processor reference.

### Tests

New `ser/WriteAutoCloseableTest`. Fails on 3.x without the main-source change, passes
with it.
