### PR TITLE
Report cycle through `@JsonValue` accessor as JsonMappingException

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
@@ -374,7 +374,7 @@ public class JsonValueSerializer
      * {@code @JsonValue} based serializer: custom serializers (and Object Id
      * handling) may well handle self-reference just fine.
      *
-     * @since 2.21
+     * @since 2.21.7
      */
     protected void _checkSelfReference(SerializerProvider ctxt, Object bean,
             JsonSerializer<?> ser)

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
@@ -282,10 +282,20 @@ public class JsonValueSerializer
             if (ser == null) {
                 ser = _findDynamicSerializer(ctxt, value.getClass());
             }
-            if (_valueTypeSerializer != null) {
-                ser.serializeWithType(value, gen, ctxt, _valueTypeSerializer);
-            } else {
-                ser.serialize(value, gen, ctxt);
+            try {
+                if (_valueTypeSerializer != null) {
+                    ser.serializeWithType(value, gen, ctxt, _valueTypeSerializer);
+                } else {
+                    ser.serialize(value, gen, ctxt);
+                }
+            } catch (StackOverflowError e) {
+                // 09-Sep-2026, pjfanning: [databind#6206] Accessor value may lead back to
+                //   a value serialized the same way, and such a cycle writes no structural
+                //   tokens -- so `StreamWriteConstraints` nesting limit never trips.
+                // Minimize call depth since we are close to fail, as `BeanSerializerBase` does:
+                DatabindException mapE = new JsonMappingException(gen, "Infinite recursion (StackOverflowError)", e);
+                mapE.prependPath(bean, _accessor.getName() + "()");
+                throw mapE;
             }
         }
     }
@@ -318,7 +328,14 @@ public class JsonValueSerializer
                 // Confusing? Type id is for POJO and NOT for value returned by JsonValue accessor...
                 WritableTypeId typeIdDef = typeSer0.writeTypePrefix(gen,
                         typeSer0.typeId(bean, JsonToken.VALUE_STRING));
-                ser.serialize(value, gen, ctxt);
+                try {
+                    ser.serialize(value, gen, ctxt);
+                } catch (StackOverflowError e) {
+                    // [databind#6206]: see `serialize()`
+                    DatabindException mapE = new JsonMappingException(gen, "Infinite recursion (StackOverflowError)", e);
+                    mapE.prependPath(bean, _accessor.getName() + "()");
+                    throw mapE;
+                }
                 typeSer0.writeTypeSuffix(gen, typeIdDef);
 
                 return;
@@ -328,7 +345,14 @@ public class JsonValueSerializer
         //    to use different Object for type id (logical type) and actual serialization
         //    (delegate type).
         TypeSerializerRerouter rr = new TypeSerializerRerouter(typeSer0, bean);
-        ser.serializeWithType(value, gen, ctxt, rr);
+        try {
+            ser.serializeWithType(value, gen, ctxt, rr);
+        } catch (StackOverflowError e) {
+            // [databind#6206]: see `serialize()`
+            DatabindException mapE = new JsonMappingException(gen, "Infinite recursion (StackOverflowError)", e);
+            mapE.prependPath(bean, _accessor.getName() + "()");
+            throw mapE;
+        }
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/JsonValueSerializer.java
@@ -282,6 +282,10 @@ public class JsonValueSerializer
             if (ser == null) {
                 ser = _findDynamicSerializer(ctxt, value.getClass());
             }
+            // [databind#6206]: simple check for direct cycle through accessor
+            if (value == bean) {
+                _checkSelfReference(ctxt, bean, ser);
+            }
             try {
                 if (_valueTypeSerializer != null) {
                     ser.serializeWithType(value, gen, ctxt, _valueTypeSerializer);
@@ -319,9 +323,15 @@ public class JsonValueSerializer
             return;
         }
         JsonSerializer<Object> ser = _valueSerializer;
-        if (ser == null) { // no serializer yet? Need to fetch
+        final boolean staticSer = (ser != null);
+        if (!staticSer) { // no serializer yet? Need to fetch
             ser = _findDynamicSerializer(ctxt, value.getClass());
-        } else {
+        }
+        // [databind#6206]: simple check for direct cycle through accessor
+        if (value == bean) {
+            _checkSelfReference(ctxt, bean, ser);
+        }
+        if (staticSer) {
             // 09-Dec-2010, tatu: To work around natural type's refusal to add type info, we do
             //    this (note: type is for the wrapper type, not enclosed value!)
             if (_forceTypeInformation) {
@@ -352,6 +362,30 @@ public class JsonValueSerializer
             DatabindException mapE = new JsonMappingException(gen, "Infinite recursion (StackOverflowError)", e);
             mapE.prependPath(bean, _accessor.getName() + "()");
             throw mapE;
+        }
+    }
+
+    /**
+     * Method called when {@code @JsonValue} accessor returned the POJO itself:
+     * that is a direct (immediate) cycle, and unlike deeper cycles it can be
+     * detected before recursing (and running out of stack).
+     *<p>
+     * Only reported as a problem if the value would be serialized by another
+     * {@code @JsonValue} based serializer: custom serializers (and Object Id
+     * handling) may well handle self-reference just fine.
+     *
+     * @since 2.21
+     */
+    protected void _checkSelfReference(SerializerProvider ctxt, Object bean,
+            JsonSerializer<?> ser)
+        throws JsonMappingException
+    {
+        if ((ser instanceof JsonValueSerializer)
+                && !ser.usesObjectId()
+                && ctxt.isEnabled(SerializationFeature.FAIL_ON_SELF_REFERENCES)) {
+            ctxt.reportBadDefinition(bean.getClass(), String.format(
+                    "Direct self-reference leading to cycle (through `@JsonValue` accessor `%s()`)",
+                    _accessor.getName()));
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/databind/ser/JsonValueCycleSer6206Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/JsonValueCycleSer6206Test.java
@@ -4,10 +4,16 @@ import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -48,6 +54,28 @@ public class JsonValueCycleSer6206Test extends DatabindTestUtil
         public ValueA value() { return a; }
     }
 
+    static class TypedSelf {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_ARRAY)
+        @JsonValue
+        public TypedSelf value() { return this; }
+    }
+
+    // Self-reference is fine if the value is NOT serialized the same way
+    static class SelfWithCustomSerializer {
+        @JsonValue
+        @JsonSerialize(using = FixedSerializer.class)
+        public SelfWithCustomSerializer value() { return this; }
+    }
+
+    static class FixedSerializer extends JsonSerializer<SelfWithCustomSerializer> {
+        @Override
+        public void serialize(SelfWithCustomSerializer value, JsonGenerator gen, SerializerProvider ctxt)
+            throws IOException
+        {
+            gen.writeString("fixed");
+        }
+    }
+
     static class Typed {
         public Typed other;
 
@@ -68,9 +96,33 @@ public class JsonValueCycleSer6206Test extends DatabindTestUtil
 
     private final ObjectMapper MAPPER = newJsonMapper();
 
+    // Immediate self-reference: detected before recursing, with a specific message
     @Test
     public void accessorReturningItself() throws Exception {
-        _verifyInfiniteRecursion(new SelfValue());
+        _verifySelfReference(new SelfValue());
+    }
+
+    @Test
+    public void accessorReturningItselfWithTypeInformation() throws Exception {
+        _verifySelfReference(new TypedSelf());
+    }
+
+    @Test
+    public void selfReferenceAllowedIfDisabled() throws Exception {
+        ObjectMapper mapper = jsonMapperBuilder()
+                .disable(SerializationFeature.FAIL_ON_SELF_REFERENCES)
+                .build();
+        try {
+            String json = mapper.writeValueAsString(new SelfValue());
+            fail("Should not pass, produced: "+json);
+        } catch (JsonMappingException e) {
+            verifyException(e, "Infinite recursion (StackOverflowError)");
+        }
+    }
+
+    @Test
+    public void selfReferenceWithCustomSerializer() throws Exception {
+        assertEquals(q("fixed"), MAPPER.writeValueAsString(new SelfWithCustomSerializer()));
     }
 
     @Test
@@ -106,6 +158,17 @@ public class JsonValueCycleSer6206Test extends DatabindTestUtil
         assertEquals(q("abc"), MAPPER.writeValueAsString(new Plain("abc")));
         assertEquals(a2q("['a','b']"),
                 MAPPER.writeValueAsString(Arrays.asList(new Plain("a"), new Plain("b"))));
+    }
+
+    private void _verifySelfReference(Object value) throws Exception
+    {
+        try {
+            String json = MAPPER.writeValueAsString(value);
+            fail("Should not pass, produced: "+json);
+        } catch (InvalidDefinitionException e) {
+            verifyException(e, "Direct self-reference leading to cycle");
+            verifyException(e, "value()");
+        }
     }
 
     private void _verifyInfiniteRecursion(Object value) throws Exception

--- a/src/test/java/com/fasterxml/jackson/databind/ser/JsonValueCycleSer6206Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/JsonValueCycleSer6206Test.java
@@ -1,0 +1,120 @@
+package com.fasterxml.jackson.databind.ser;
+
+import java.util.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// [databind#6206]
+/**
+ * Serializing through a {@code @JsonValue} accessor writes no structural tokens of its
+ * own, so a cycle in which every value is serialized that way never trips the nesting
+ * limit of {@code StreamWriteConstraints}. Verify it is reported as a
+ * {@link JsonMappingException}, the way cycles through bean properties are, rather than
+ * letting a {@link StackOverflowError} escape.
+ */
+public class JsonValueCycleSer6206Test extends DatabindTestUtil
+{
+    static class SelfValue {
+        @JsonValue
+        public SelfValue value() { return this; }
+    }
+
+    static class ValueCycle {
+        public ValueCycle other;
+
+        @JsonValue
+        public ValueCycle value() { return other; }
+    }
+
+    static class ValueA {
+        public ValueB b;
+
+        @JsonValue
+        public ValueB value() { return b; }
+    }
+
+    static class ValueB {
+        public ValueA a;
+
+        @JsonValue
+        public ValueA value() { return a; }
+    }
+
+    static class Typed {
+        public Typed other;
+
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_ARRAY)
+        @JsonValue
+        public Typed value() { return other; }
+    }
+
+    // Non-cyclic use of `@JsonValue` must keep working
+    static class Plain {
+        private final String _value;
+
+        Plain(String value) { _value = value; }
+
+        @JsonValue
+        public String value() { return _value; }
+    }
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    @Test
+    public void accessorReturningItself() throws Exception {
+        _verifyInfiniteRecursion(new SelfValue());
+    }
+
+    @Test
+    public void cycleBetweenTwoValues() throws Exception {
+        ValueCycle v1 = new ValueCycle();
+        ValueCycle v2 = new ValueCycle();
+        v1.other = v2;
+        v2.other = v1;
+        _verifyInfiniteRecursion(v1);
+    }
+
+    @Test
+    public void cycleAcrossTwoTypes() throws Exception {
+        ValueA a = new ValueA();
+        ValueB b = new ValueB();
+        a.b = b;
+        b.a = a;
+        _verifyInfiniteRecursion(a);
+    }
+
+    @Test
+    public void cycleWithTypeInformation() throws Exception {
+        Typed t1 = new Typed();
+        Typed t2 = new Typed();
+        t1.other = t2;
+        t2.other = t1;
+        _verifyInfiniteRecursion(t1);
+    }
+
+    // Ordinary `@JsonValue` handling must be unaffected
+    @Test
+    public void plainValueStillWorks() throws Exception {
+        assertEquals(q("abc"), MAPPER.writeValueAsString(new Plain("abc")));
+        assertEquals(a2q("['a','b']"),
+                MAPPER.writeValueAsString(Arrays.asList(new Plain("a"), new Plain("b"))));
+    }
+
+    private void _verifyInfiniteRecursion(Object value) throws Exception
+    {
+        try {
+            String json = MAPPER.writeValueAsString(value);
+            fail("Should not pass, produced: "+json);
+        } catch (JsonMappingException e) {
+            verifyException(e, "Infinite recursion (StackOverflowError)");
+        }
+    }
+}


### PR DESCRIPTION
### Problem

Cyclic object graphs are reported as exceptions, not `Error`s -- through two
separate mechanisms:

* the generator's nesting limit (`StreamWriteConstraints.maxNestingDepth`) trips
  once a cycle has written 1000 levels of structure, and
* `BeanSerializerBase.serializeFields()`, `serializeFieldsFiltered()` and
  `BeanAsArraySerializer.serializeAsArray()` each `catch (StackOverflowError)`
  and rethrow it as `JsonMappingException("Infinite recursion (StackOverflowError)")`.

A cycle in which every value is serialized through a `@JsonValue` accessor is
caught by neither. `JsonValueSerializer` passes the accessor value straight to
the next serializer without writing any structural token, so the nesting depth
never moves; and no `BeanSerializerBase` frame is on the stack to catch the
`StackOverflowError`, which therefore escapes to the caller as an `Error`.

Three shapes reach it -- an accessor returning `this`, two values of one type
referring to each other, and two types whose accessors point at each other:

```java
static class ValueA {
    public ValueB b;
    @JsonValue public ValueB value() { return b; }
}
static class ValueB {
    public ValueA a;
    @JsonValue public ValueA value() { return a; }
}
```

For comparison, these neighbouring shapes are all already reported cleanly:
bean cycles, direct self-references, `List`/`Map` containing themselves, cyclic
`ObjectNode`/`ArrayNode`, converter (`StdConverter`) cycles, mutual
`@JsonUnwrapped`, and a `@JsonValue` accessor that returns a `Map` holding the
cycle (that one writes an object, so the nesting limit sees it).

### Fix

Catch `StackOverflowError` at each point where `JsonValueSerializer` passes the
accessor value on -- in `serialize()`, and in both delegations of
`serializeWithType()` -- and rethrow as `JsonMappingException` with the same
"Infinite recursion (StackOverflowError)" message and path prepending the bean
serializers use. Constructed directly rather than via `JsonMappingException.from()`,
following the note in `BeanSerializerBase` about having very little stack left at
that point.

Only the deepest frame wraps: once the error becomes a `JsonMappingException` it
passes through the outer `catch (StackOverflowError)` clauses untouched, so there
is no repeated re-wrapping on the way out.

### Tests

`JsonValueCycleSer6206Test` covers the three cycle shapes plus one going through
`serializeWithType()` (`@JsonTypeInfo` on the accessor); all four fail with
`StackOverflowError` without the change and pass with it. Further tests cover the
immediate self-reference (plain and through `@JsonTypeInfo`), the same case with
`FAIL_ON_SELF_REFERENCES` disabled, a self-returning accessor with a custom
serializer, and ordinary non-cyclic `@JsonValue` serialization.

Full suite green on `2.21`: 3881 tests.

### Immediate self-reference

Per review comment: the one-hop case -- an accessor returning the bean itself --
does not need to run out of stack to be recognised, so it is now checked directly,
right after the value serializer is resolved. That is where `BeanPropertyWriter`
checks the same thing for bean properties, and it reports through
`reportBadDefinition()` with the same `"Direct self-reference leading to cycle"`
wording, naming the accessor.

Guarded the way `BeanPropertyWriter._handleSelfReference()` guards its own check:
only reported when the value would be serialized by another `@JsonValue` based
serializer, so an accessor returning `this` alongside an explicit
`@JsonSerialize(using=...)` keeps working. Object Id handling is left alone, and
`FAIL_ON_SELF_REFERENCES` is honoured -- disabling it falls through to the
`StackOverflowError` handling above. `WRITE_SELF_REFERENCES_AS_NULL` is *not*
wired up: writing null in the typed path means juggling the type prefix/suffix,
which seemed past "trivially easy" -- happy to add it if wanted.

Cycles spanning two or more values still have to run out of stack; this only
front-runs the one-hop case, buying a failure at depth 1 instead of ~10k frames
down and an exception naming the offending type and accessor.

### Notes

This is old behaviour, not new in 2.21 -- happy to rebase onto an older branch
and merge forward from there.
