### PR TITLE
Two last errorprone - indicated improvements

### DIFF
--- a/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
+++ b/src/main/java/tools/jackson/databind/ser/AnyGetterWriter.java
@@ -21,9 +21,9 @@ public class AnyGetterWriter extends BeanPropertyWriter
     /**
      * Method (or Field) that represents the "any getter"
      */
-    protected final AnnotatedMember _accessor;
+    protected final AnnotatedMember _anyGetter;
 
-    protected ValueSerializer<Object> _serializer;
+    protected ValueSerializer<Object> _anySerializer;
 
     protected MapSerializer _mapSerializer;
 
@@ -35,9 +35,9 @@ public class AnyGetterWriter extends BeanPropertyWriter
             AnnotatedMember accessor, ValueSerializer<?> serializer)
     {
         super(parent);
-        _accessor = accessor;
+        _anyGetter = accessor;
         _property = property;
-        _serializer = (ValueSerializer<Object>) serializer;
+        _anySerializer = (ValueSerializer<Object>) serializer;
         if (serializer instanceof MapSerializer mapSer) {
             _mapSerializer = mapSer;
         }
@@ -45,7 +45,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
 
     @Override
     public void fixAccess(SerializationConfig config) {
-        _accessor.fixAccess(
+        _anyGetter.fixAccess(
                 config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS));
     }
 
@@ -53,13 +53,13 @@ public class AnyGetterWriter extends BeanPropertyWriter
     @SuppressWarnings("unchecked")
     public void resolve(SerializationContext ctxt)
     {
-        // [databind#3604]: _serializer may be null for ObjectNode/JsonNode any-getters
-        if (_serializer == null) {
+        // [databind#3604]: _anySerializer may be null for ObjectNode/JsonNode any-getters
+        if (_anySerializer == null) {
             return;
         }
         // 05-Sep-2013, tatu: I _think_ this can be considered a primary property...
-        ValueSerializer<?> ser = ctxt.handlePrimaryContextualization(_serializer, _property);
-        _serializer = (ValueSerializer<Object>) ser;
+        ValueSerializer<?> ser = ctxt.handlePrimaryContextualization(_anySerializer, _property);
+        _anySerializer = (ValueSerializer<Object>) ser;
         if (ser instanceof MapSerializer mapSer) {
             _mapSerializer = mapSer;
         }
@@ -68,7 +68,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
     public void getAndSerialize(Object bean, JsonGenerator gen, SerializationContext ctxt)
         throws Exception
     {
-        Object value = _accessor.getValue(bean);
+        Object value = _anyGetter.getValue(bean);
         if (value == null) {
             return;
         }
@@ -79,14 +79,14 @@ public class AnyGetterWriter extends BeanPropertyWriter
         }
         if (!(value instanceof Map<?,?>)) {
             ctxt.reportBadDefinition(_property.getType(), "Value returned by 'any-getter' %s() not java.util.Map but %s".formatted(
-                    _accessor.getName(), value.getClass().getName()));
+                    _anyGetter.getName(), value.getClass().getName()));
         }
         // 23-Feb-2015, tatu: Nasty, but has to do (for now)
         if (_mapSerializer != null) {
             _mapSerializer.serializeWithoutTypeInfo((Map<?,?>) value, gen, ctxt);
             return;
         }
-        _serializer.serialize(value, gen, ctxt);
+        _anySerializer.serialize(value, gen, ctxt);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
             PropertyFilter filter)
         throws Exception
     {
-        Object value = _accessor.getValue(bean);
+        Object value = _anyGetter.getValue(bean);
         if (value == null) {
             return;
         }
@@ -111,7 +111,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
         if (!(value instanceof Map<?,?>)) {
             ctxt.reportBadDefinition(_property.getType(),
                     "Value returned by 'any-getter' (%s()) not java.util.Map but %s".formatted(
-                            _accessor.getName(), value.getClass().getName()));
+                            _anyGetter.getName(), value.getClass().getName()));
         }
         // 19-Oct-2014, tatu: Should we try to support @JsonInclude options here?
         if (_mapSerializer != null) {
@@ -120,7 +120,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
             return;
         }
         // ... not sure how custom handler would do it
-        _serializer.serialize(value, gen, ctxt);
+        _anySerializer.serialize(value, gen, ctxt);
     }
 
     /**
@@ -137,7 +137,7 @@ public class AnyGetterWriter extends BeanPropertyWriter
         }
         return ctxt.reportBadDefinition(_property.getType(), String.format(
                 "Value returned by 'any-getter' %s not `ObjectNode` but `%s`; only `ObjectNode`s can be used as `@JsonAnyGetter` values",
-                _accessor.getName(), value.getClass().getName()));
+                _anyGetter.getName(), value.getClass().getName()));
     }
 
     /**

--- a/src/main/java/tools/jackson/databind/util/TokenBuffer.java
+++ b/src/main/java/tools/jackson/databind/util/TokenBuffer.java
@@ -1504,8 +1504,6 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         /******************************************************************
          */
 
-        protected StreamReadConstraints _streamReadConstraints;
-
         protected final TokenBuffer _source;
 
         protected final boolean _hasNativeTypeIds;
@@ -1559,11 +1557,10 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
             // 25-Jun-2022, tatu: This should pass stream read features as
             //    per [databind#3528]) but for now at very least should get
             //    sane defaults
-            super(readCtxt);
+            super(readCtxt, streamReadConstraints);
             _source = source;
             _segment = firstSeg;
             _segmentPtr = -1; // not yet read
-            _streamReadConstraints = streamReadConstraints;
             _parsingContext = TokenBufferReadContext.createRootContext(parentContext);
             _hasNativeTypeIds = hasNativeTypeIds;
             _hasNativeObjectIds = hasNativeObjectIds;
@@ -1598,11 +1595,6 @@ sb.append("NativeObjectIds=").append(_hasNativeObjectIds).append(",");
         @Override
         public TokenBuffer streamReadInputSource() {
             return _source;
-        }
-
-        @Override
-        public StreamReadConstraints streamReadConstraints() {
-            return _streamReadConstraints;
         }
 
         /*

--- a/src/test/java/tools/jackson/databind/util/TokenBufferReadConstraintsTest.java
+++ b/src/test/java/tools/jackson/databind/util/TokenBufferReadConstraintsTest.java
@@ -1,0 +1,84 @@
+package tools.jackson.databind.util;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests to verify that {@link StreamReadConstraints} a {@link TokenBuffer} was
+ * built with are actually applied when buffered contents are replayed: they need
+ * to be used by token-count validation inherited from {@code ParserMinimalBase},
+ * and not just by the {@code streamReadConstraints()} accessor.
+ */
+public class TokenBufferReadConstraintsTest extends DatabindTestUtil
+{
+    private final static int MAX_TOKENS = 4;
+
+    private final JsonFactory CONSTRAINED_F = JsonFactory.builder()
+            .streamReadConstraints(StreamReadConstraints.builder()
+                    .maxTokenCount(MAX_TOKENS).build())
+            .build();
+
+    // 10 tokens: START_ARRAY, 8 x VALUE_NUMBER_INT, END_ARRAY
+    private TokenBuffer _constrainedBuffer() throws Exception
+    {
+        // Parser only used as carrier of constraints; never advanced, so that
+        // only replay is measured against the limit
+        try (JsonParser p = CONSTRAINED_F.createParser(ObjectReadContext.empty(), "0")) {
+            TokenBuffer buf = new TokenBuffer(p, null);
+            buf.writeStartArray();
+            for (int i = 0; i < 8; ++i) {
+                buf.writeNumber(i);
+            }
+            buf.writeEndArray();
+            return buf;
+        }
+    }
+
+    @Test
+    void constraintsRetainedByAsParser() throws Exception
+    {
+        try (JsonParser p = _constrainedBuffer().asParser()) {
+            assertEquals(MAX_TOKENS, p.streamReadConstraints().getMaxTokenCount());
+        }
+    }
+
+    @Test
+    void tokenCountEnforcedOnReplay() throws Exception
+    {
+        // Before fix: `ParserMinimalBase` got its (final) constraints from
+        // `ObjectReadContext.empty()` -- that is, defaults, with no token limit --
+        // so replay was effectively unconstrained
+        try (JsonParser p = _constrainedBuffer().asParser()) {
+            while (p.nextToken() != null) { }
+            fail("Should not pass; should fail with token count limit of "+MAX_TOKENS);
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Token count");
+        }
+    }
+
+    @Test
+    void defaultConstraintsAllowSmallBuffer() throws Exception
+    {
+        // Sanity check: buffer with default constraints must not fail on a tiny doc
+        TokenBuffer buf = new TokenBuffer(false);
+        buf.writeStartArray();
+        for (int i = 0; i < 8; ++i) {
+            buf.writeNumber(i);
+        }
+        buf.writeEndArray();
+        try (JsonParser p = buf.asParser()) {
+            int count = 0;
+            while (p.nextToken() != null) { ++count; }
+            assertEquals(10, count);
+        }
+    }
+}


### PR DESCRIPTION
as per title.

----
## Summary by Gitar

- **Bug fixes:**
    - Ensure `TokenBuffer` parser passes `streamReadConstraints` to `super` constructor
    - Renamed fields in `AnyGetterWriter` from `_accessor` and `_serializer` to `_anyGetter` and `_anySerializer` for error-prone compliance
- **Tests:**
    - Added `TokenBufferReadConstraintsTest` to verify token count constraint enforcement during replay

<sub>This will update automatically on new commits.</sub>