### PR TITLE
Fix #6210: honor `@JsonAlias` on Enum values when `@JsonValue` is present

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -1940,3 +1940,7 @@ Aysha Afrah Ziya (@aysha-afrah26)
 @renechoi
  * Reported #6185: Bracket unresolved IPv6 host name in `InetSocketAddress` serialization
   (2.18.11)
+
+@bugada
+ * Reported #6210: `@JsonAlias` ignored on Enum values if `@JsonValue` is present
+  (2.18.11)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,9 @@ Project: jackson-databind
 
 #6185: Bracket unresolved IPv6 host name in `InetSocketAddress` serialization
  (fix by @pjfanning, w/ Claude code)
+#6210: `@JsonAlias` ignored on Enum values if `@JsonValue` is present
+ (reported by @bugada)
+ (fix by @pjfanning, w/ Claude code)
 
 2.18.10 (15-Aug-2026)
 

--- a/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
+++ b/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java
@@ -448,7 +448,14 @@ public class EnumResolver implements java.io.Serializable
         final Class<?> enumCls0 = annotatedClass.getRawType();
         final Class<Enum<?>> enumCls = _enumClass(enumCls0);
         final Enum<?>[] enumConstants = _enumConstants(enumCls0);
-        
+
+        // introspect
+        // 10-Sep-2026, pjfanning: [databind#6210] Aliases need to be honored here too
+        final String[][] allAliases = new String[enumConstants.length][];
+        if (ai != null) {
+            ai.findEnumAliases(config, annotatedClass, enumConstants, allAliases);
+        }
+
         // build
         HashMap<String, Enum<?>> map = new HashMap<String, Enum<?>>();
         // from last to first, so that in case of duplicate values, first wins
@@ -461,6 +468,13 @@ public class EnumResolver implements java.io.Serializable
                 }
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to access @JsonValue of Enum value "+en+": "+e.getMessage());
+            }
+            String[] aliases = allAliases[i];
+            if (aliases != null) {
+                for (String alias : aliases) {
+                    // Avoid overriding any primary names
+                    map.putIfAbsent(alias, en);
+                }
             }
         }
         return new EnumResolver(enumCls, enumConstants, map,

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAliasWithJsonValue6210Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAliasWithJsonValue6210Test.java
@@ -1,0 +1,109 @@
+package com.fasterxml.jackson.databind.deser.enums;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import com.fasterxml.jackson.databind.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.q;
+
+// [databind#6210]: `@JsonAlias` ignored on Enum values if `@JsonValue` is present
+public class EnumAliasWithJsonValue6210Test
+{
+    enum Versus6210 {
+        @JsonAlias({ "A", "B" })
+        BUY("B"),
+        @JsonAlias({ "V", "S" })
+        SELL("S");
+
+        private final String value;
+
+        Versus6210(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+
+    enum IntValued6210 {
+        @JsonAlias({ "one" })
+        FIRST(1),
+        @JsonAlias({ "two", "second" })
+        SECOND(2);
+
+        private final int value;
+
+        IntValued6210(int value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public int getValue() {
+            return value;
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // [databind#6210]
+    @Test
+    public void testAliasesWithJsonValue() throws Exception {
+        ObjectReader r = MAPPER.readerFor(Versus6210.class);
+
+        // First: values from `@JsonValue` accessor still work
+        assertEquals(Versus6210.BUY, r.readValue(q("B")));
+        assertEquals(Versus6210.SELL, r.readValue(q("S")));
+
+        // and then aliases, which used to fail
+        assertEquals(Versus6210.BUY, r.readValue(q("A")));
+        assertEquals(Versus6210.SELL, r.readValue(q("V")));
+    }
+
+    // [databind#6210]: aliases must not override `@JsonValue`-provided ids
+    @Test
+    public void testJsonValueWinsOverAlias() throws Exception {
+        // "B" is both `@JsonValue` of BUY and an alias of BUY itself, "S"
+        // similarly for SELL: primary mapping must be retained
+        assertEquals(Versus6210.BUY, MAPPER.readValue(q("B"), Versus6210.class));
+        assertEquals(Versus6210.SELL, MAPPER.readValue(q("S"), Versus6210.class));
+    }
+
+    // [databind#6210]: aliases are Strings even if `@JsonValue` is of int type
+    @Test
+    public void testAliasesWithIntJsonValue() throws Exception {
+        ObjectReader r = MAPPER.readerFor(IntValued6210.class);
+
+        assertEquals(IntValued6210.FIRST, r.readValue("1"));
+        assertEquals(IntValued6210.SECOND, r.readValue("2"));
+
+        assertEquals(IntValued6210.FIRST, r.readValue(q("one")));
+        assertEquals(IntValued6210.SECOND, r.readValue(q("two")));
+        assertEquals(IntValued6210.SECOND, r.readValue(q("second")));
+    }
+
+    // [databind#6210]: also verify Enum-as-Map-key path
+    @Test
+    public void testAliasesWithJsonValueAsMapKey() throws Exception {
+        java.util.Map<Versus6210, String> map = MAPPER.readValue(
+                "{\"V\":\"x\", \"B\":\"y\"}",
+                MAPPER.getTypeFactory().constructMapType(java.util.LinkedHashMap.class,
+                        Versus6210.class, String.class));
+        assertEquals(2, map.size());
+        assertEquals("x", map.get(Versus6210.SELL));
+        assertEquals("y", map.get(Versus6210.BUY));
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAliasWithJsonValue6210Test.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumAliasWithJsonValue6210Test.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.a2q;
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.newJsonMapper;
 import static com.fasterxml.jackson.databind.testutil.DatabindTestUtil.q;
 
@@ -99,7 +100,7 @@ public class EnumAliasWithJsonValue6210Test
     @Test
     public void testAliasesWithJsonValueAsMapKey() throws Exception {
         java.util.Map<Versus6210, String> map = MAPPER.readValue(
-                "{\"V\":\"x\", \"B\":\"y\"}",
+                a2q("{'V':'x', 'B':'y'}"),
                 MAPPER.getTypeFactory().constructMapType(java.util.LinkedHashMap.class,
                         Versus6210.class, String.class));
         assertEquals(2, map.size());


### PR DESCRIPTION
Fixes #6210.

### Problem

`@JsonAlias` on Enum values is silently ignored as soon as the Enum also has a `@JsonValue` accessor:

```java
public enum Versus {
    @JsonAlias({ "A", "B" }) BUY("B"),
    @JsonAlias({ "V", "S" }) SELL("S");

    private final String value;
    Versus(String value) { this.value = value; }

    @JsonValue public String getValue() { return value; }
}
```

Before this change, `"S"` and `"B"` deserialize fine but `"V"` and `"A"` fail with:

```
Cannot deserialize value of type `Versus` from String "V":
  not one of the values accepted for Enum class: [B, S]
```

### Cause

`BasicDeserializerFactory.constructEnumResolver()` routes to `EnumResolver.constructUsingMethod()` whenever `findJsonValueAccessor()` is non-null. That factory was the only String-based one that never called `AnnotationIntrospector.findEnumAliases()` — it built its lookup map purely from `accessor.getValue(en)`. `constructFor()`, `constructUsingToString()` and `constructUsingEnumNamingStrategy()` all introspect aliases.

### Fix

Introspect aliases in `constructUsingMethod()` the same way the sibling factories do, registering them with `putIfAbsent` inside the existing reverse loop so `@JsonValue`-provided ids keep priority over aliases.

3 of the 4 new tests fail without the `EnumResolver` change (`testJsonValueWinsOverAlias` is behaviour-pinning and passes either way).

### Note on merge-forward

Now targeting `2.18`, rebased from `2.21`. `constructUsingMethod()` has the same
gap there and the 4-arg `findEnumAliases(MapperConfig, AnnotatedClass, ...)` the
fix calls has been available since 2.16, so `EnumResolver.java` merged without
conflict. Re-verified against `2.18` rather than assuming: the three tests fail
on an unmodified `2.18` checkout, including the Map-key path. Full suite green
on `2.18`: 3474 tests, bar `DateSerializationTest.testWithTimeZoneOverride`,
which fails the same way on unmodified `2.18` here (JDK tzdata, `PST` vs
`GMT-08:00`).

The release-notes entries moved from the `2.21.7` section to `2.18.11`, using
the `(2.18.11)` marker style that `CREDITS-2.x` uses on this branch.

`2.18` still has a deprecated `constructUsingMethod(DeserializationConfig, Class<?>, AnnotatedMember)`
overload with the same gap. It has no callers left in `src/main`, and it takes a
raw `Class` rather than the `AnnotatedClass` the alias lookup needs, so I left it
alone -- say the word if you would rather it were fixed too.

The head branch is still named `...2.21...`; renaming would close this PR.

