### PR TITLE
Clarify defaultLeniency builder Javadoc

### DIFF
--- a/src/main/java/tools/jackson/databind/cfg/MapperBuilder.java
+++ b/src/main/java/tools/jackson/databind/cfg/MapperBuilder.java
@@ -1004,9 +1004,13 @@ public abstract class MapperBuilder<M extends ObjectMapper,
     }
 
     /**
-     * Method for setting default Setter configuration, regarding things like
-     * merging, null-handling; used for properties for which there are
-     * no per-type or per-property overrides (via annotations or config overrides).
+     * Sets the default value of {@link JsonFormat#lenient()} for types and
+     * properties without a more specific format override.
+     * Whether and how this setting is used depends on the deserializer;
+     * for example, date deserializers use it to control lenient date parsing.
+     *
+     * @param b {@link Boolean#TRUE} to enable leniency, {@link Boolean#FALSE}
+     *   to request strict handling, or {@code null} to leave the default unspecified
      */
     public B defaultLeniency(Boolean b) {
         _configOverrides.setDefaultLeniency(b);


### PR DESCRIPTION
`MapperBuilder.defaultLeniency()` has a copied setter-configuration description referring to merging and null handling. Replace it with the actual format-leniency behavior, describe the true/false/null values, and explain that support depends on the deserializer.

Documentation only. Checked against `ConfigOverrides.findFormatDefaults()` and the date deserialization coverage. `mvn -DskipTests compile javadoc:javadoc` compiled successfully and generated the updated `MapperBuilder` page, including the `JsonFormat.lenient()` link. The full Javadoc report still reports an unrelated existing broken reference in `cfg/EnumFeature.java:34`.
