### PR TITLE
Defer unnecessary work in deserialization paths

### DIFF
--- a/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/EnumMapDeserializer.java
@@ -252,13 +252,6 @@ public class EnumMapDeserializer
         // [databind#631]: Assign current value, to be accessible by custom deserializers
         p.assignCurrentValue(result);
 
-        // Need to resolve ObjectIds (forward refs)?
-        final MapDeserializer.MapReferringAccumulator referringAccumulator =
-            (_valueDeserializer.getObjectIdReader(ctxt) == null)
-                    ? null
-                    : new MapDeserializer.MapReferringAccumulator(
-                            _containerType.getContentType().getRawClass(), result);
-
         String keyStr;
         if (p.isExpectedStartObjectToken()) {
             keyStr = p.nextName();
@@ -272,6 +265,16 @@ public class EnumMapDeserializer
             }
             keyStr = p.currentName();
         }
+        if (keyStr == null) {
+            return result;
+        }
+
+        // Need to resolve ObjectIds (forward refs)?
+        final MapDeserializer.MapReferringAccumulator referringAccumulator =
+            (_valueDeserializer.getObjectIdReader(ctxt) == null)
+                    ? null
+                    : new MapDeserializer.MapReferringAccumulator(
+                            _containerType.getContentType().getRawClass(), result);
 
         for (; keyStr != null; keyStr = p.nextName()) {
             // but we need to let key deserializer handle it separately, nonetheless

--- a/src/main/java/tools/jackson/databind/deser/jdk/InetAddressValidator.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/InetAddressValidator.java
@@ -168,12 +168,13 @@ class InetAddressValidator
 
     private static String _convertDottedQuadToHex(String ipString) {
         int lastColon = ipString.lastIndexOf(':');
-        String initialPart = ipString.substring(0, lastColon + 1);
+
         String dottedQuad = ipString.substring(lastColon + 1);
         byte[] quad = _textToNumericFormatV4(dottedQuad);
         if (quad == null) {
             return null;
         }
+        String initialPart = ipString.substring(0, lastColon + 1);
         String penultimate = Integer.toHexString(((quad[0] & 0xff) << 8) | (quad[1] & 0xff));
         String ultimate = Integer.toHexString(((quad[2] & 0xff) << 8) | (quad[3] & 0xff));
         return initialPart + penultimate + ":" + ultimate;

--- a/src/main/java/tools/jackson/databind/deser/jdk/MapDeserializer.java
+++ b/src/main/java/tools/jackson/databind/deser/jdk/MapDeserializer.java
@@ -540,13 +540,6 @@ public class MapDeserializer
     protected final Map<Object,Object> _readAndBind(JsonParser p, DeserializationContext ctxt,
             Map<Object,Object> result) throws JacksonException
     {
-        MapReferringAccumulator referringAccumulator = null;
-        boolean useObjectId = _valueDeserializer.getObjectIdReader(ctxt) != null;
-        if (useObjectId) {
-            referringAccumulator = new MapReferringAccumulator(_containerType.getContentType().getRawClass(),
-                    result);
-        }
-
         String keyStr;
         if (p.isExpectedStartObjectToken()) {
             keyStr = p.nextName();
@@ -557,6 +550,16 @@ public class MapDeserializer
                 return result;
             }
             keyStr = p.currentName();
+        }
+        if (keyStr == null) {
+            return result;
+        }
+
+        MapReferringAccumulator referringAccumulator = null;
+        boolean useObjectId = _valueDeserializer.getObjectIdReader(ctxt) != null;
+        if (useObjectId) {
+            referringAccumulator = new MapReferringAccumulator(_containerType.getContentType().getRawClass(),
+                    result);
         }
 
         // [databind#3188] Cache capability once outside the loop
@@ -621,12 +624,6 @@ public class MapDeserializer
     protected final Map<Object,Object> _readAndBindStringKeyMap(JsonParser p, DeserializationContext ctxt,
             Map<Object,Object> result) throws JacksonException
     {
-        MapReferringAccumulator referringAccumulator = null;
-        boolean useObjectId = (_valueDeserializer.getObjectIdReader(ctxt) != null);
-        if (useObjectId) {
-            referringAccumulator = new MapReferringAccumulator(_containerType.getContentType().getRawClass(), result);
-        }
-
         String key;
         if (p.isExpectedStartObjectToken()) {
             key = p.nextName();
@@ -637,6 +634,15 @@ public class MapDeserializer
                 return result;
             }
             key = p.currentName();
+        }
+        if (key == null) {
+            return result;
+        }
+
+        MapReferringAccumulator referringAccumulator = null;
+        boolean useObjectId = (_valueDeserializer.getObjectIdReader(ctxt) != null);
+        if (useObjectId) {
+            referringAccumulator = new MapReferringAccumulator(_containerType.getContentType().getRawClass(), result);
         }
 
         for (; key != null; key = p.nextName()) {


### PR DESCRIPTION
## Summary

Defer a few operations until they are actually needed in deserialization paths.

This avoids unnecessary setup or allocation on early-return paths without changing deserialization behavior.

## Changes

- `MapDeserializer`
  - Defer ObjectId-related setup until after confirming that there is at least one entry to deserialize.
  - This avoids querying the ObjectId reader and creating a `MapReferringAccumulator` for empty maps.

- `EnumMapDeserializer`
  - Apply the same deferred ObjectId setup for empty `EnumMap` values.

- `InetAddressValidator`
  - Defer creation of the IPv6 prefix substring until after the dotted-quad suffix has been successfully parsed.
  - This avoids creating an unused substring when dotted-quad validation fails.

These changes only move existing setup closer to where it is first needed; the existing successful and early-return behavior remains unchanged.

This may also be applicable to 2.x if considered worth backporting.