### PR TITLE
Add `TreeTraversingParser` constructors taking explicit `StreamReadConstraints`

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -7,6 +7,8 @@ Versions: 3.x (for earlier see VERSION-2.x)
 
 3.3.0 (not yet released)
 
+#6216: Add `TreeTraversingParser` constructors that take explicit
+  `StreamReadConstraints` (for tree-backed format backends)
 #1127: `@JsonTypeInfo` with `EXTERNAL_PROPERTY` does not handle arrays of
   polymorphic types: now fails eagerly with clear `InvalidDefinitionException`
   (on both serialization and deserialization) instead of confusing low-level error

--- a/src/main/java/tools/jackson/databind/node/TreeTraversingParser.java
+++ b/src/main/java/tools/jackson/databind/node/TreeTraversingParser.java
@@ -58,7 +58,7 @@ public class TreeTraversingParser
     public TreeTraversingParser(JsonNode n) { this(n, ObjectReadContext.empty()); }
 
     public TreeTraversingParser(JsonNode n, ObjectReadContext readContext) {
-        this(n, readContext, null);
+        this(n, readContext, (TokenStreamContext) null);
     }
 
     /**
@@ -80,7 +80,42 @@ public class TreeTraversingParser
     public TreeTraversingParser(JsonNode n, ObjectReadContext readContext,
             TokenStreamContext parentContext)
     {
-        super(readContext);
+        this(n, readContext, parentContext, readContext.streamReadConstraints());
+    }
+
+    /**
+     * Constructor for cases where {@link StreamReadConstraints} to apply come
+     * from a source other than the {@link ObjectReadContext} given: typically
+     * a format backend that parses its input into a tree and then exposes it
+     * through this parser (like TOML backend), and needs constraints of its
+     * {@link TokenStreamFactory} applied, the same way streaming parsers apply
+     * constraints of their {@code IOContext} regardless of read context.
+     *
+     * @param n Tree to traverse
+     * @param readContext Read context to use
+     * @param constraints Constraints to apply (both for {@link #streamReadConstraints()}
+     *    and for token count validation); passing
+     *    {@code readContext.streamReadConstraints()} is equivalent to using
+     *    {@link #TreeTraversingParser(JsonNode, ObjectReadContext)}
+     *
+     * @since 3.3
+     */
+    public TreeTraversingParser(JsonNode n, ObjectReadContext readContext,
+            StreamReadConstraints constraints)
+    {
+        this(n, readContext, null, constraints);
+    }
+
+    /**
+     * Constructor that combines {@link #TreeTraversingParser(JsonNode, ObjectReadContext, TokenStreamContext)}
+     * and {@link #TreeTraversingParser(JsonNode, ObjectReadContext, StreamReadConstraints)}.
+     *
+     * @since 3.3
+     */
+    public TreeTraversingParser(JsonNode n, ObjectReadContext readContext,
+            TokenStreamContext parentContext, StreamReadConstraints constraints)
+    {
+        super(readContext, constraints);
         _source = n;
         _nodeCursor = new NodeCursor.RootCursor(n, parentContext);
     }

--- a/src/test/java/tools/jackson/databind/node/TreeTraversingParserReadConstraintsTest.java
+++ b/src/test/java/tools/jackson/databind/node/TreeTraversingParserReadConstraintsTest.java
@@ -1,0 +1,99 @@
+package tools.jackson.databind.node;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.*;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+import tools.jackson.databind.*;
+import tools.jackson.databind.testutil.DatabindTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link TreeTraversingParser} constructors that take explicit
+ * {@link StreamReadConstraints}, for use by tree-backed format backends
+ * that need their {@code TokenStreamFactory}'s constraints applied
+ * regardless of {@link ObjectReadContext} given.
+ */
+public class TreeTraversingParserReadConstraintsTest extends DatabindTestUtil
+{
+    private final static int MAX_TOKENS = 4;
+
+    private final static StreamReadConstraints CONSTRAINTS = StreamReadConstraints.builder()
+            .maxTokenCount(MAX_TOKENS).build();
+
+    private final ObjectMapper MAPPER = newJsonMapper();
+
+    // 10 tokens: START_ARRAY, 8 x VALUE_NUMBER_INT, END_ARRAY
+    private JsonNode _tree() throws Exception {
+        return MAPPER.readTree("[0,1,2,3,4,5,6,7]");
+    }
+
+    @Test
+    void constraintsExposed() throws Exception
+    {
+        try (JsonParser p = new TreeTraversingParser(_tree(), ObjectReadContext.empty(), CONSTRAINTS)) {
+            assertSame(CONSTRAINTS, p.streamReadConstraints());
+        }
+        try (JsonParser p = new TreeTraversingParser(_tree(), ObjectReadContext.empty(), null, CONSTRAINTS)) {
+            assertSame(CONSTRAINTS, p.streamReadConstraints());
+        }
+        // and without explicit constraints, those of read context (here: defaults)
+        try (JsonParser p = new TreeTraversingParser(_tree(), ObjectReadContext.empty())) {
+            assertSame(StreamReadConstraints.defaults(), p.streamReadConstraints());
+            assertFalse(p.streamReadConstraints().hasMaxTokenCount());
+        }
+    }
+
+    @Test
+    void tokenCountEnforced() throws Exception
+    {
+        try (JsonParser p = new TreeTraversingParser(_tree(), ObjectReadContext.empty(), CONSTRAINTS)) {
+            for (int i = 0; i < MAX_TOKENS; ++i) {
+                assertNotNull(p.nextToken());
+            }
+            try {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (StreamConstraintsException e) {
+                verifyException(e, "Token count (" + (MAX_TOKENS + 1) + ")");
+                verifyException(e, "exceeds the maximum allowed (" + MAX_TOKENS);
+            }
+        }
+    }
+
+    @Test
+    void tokenCountNotEnforcedWithoutConstraints() throws Exception
+    {
+        // Same tree, read context with default (unlimited) constraints: fine
+        try (JsonParser p = new TreeTraversingParser(_tree(), ObjectReadContext.empty())) {
+            int count = 0;
+            while (p.nextToken() != null) {
+                ++count;
+            }
+            assertEquals(10, count);
+        }
+    }
+
+    // Parent context variant must retain both the parent and the constraints
+    @Test
+    void withParentContext() throws Exception
+    {
+        JsonNode root = MAPPER.readTree("{\"a\":[0,1,2,3,4,5,6,7]}");
+        try (JsonParser outer = new TreeTraversingParser(root)) {
+            assertToken(JsonToken.START_OBJECT, outer.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, outer.nextToken());
+            assertToken(JsonToken.START_ARRAY, outer.nextToken());
+            JsonNode sub = root.get("a");
+            try (JsonParser p = new TreeTraversingParser(sub, ObjectReadContext.empty(),
+                    outer.streamReadContext().getParent(), CONSTRAINTS)) {
+                assertToken(JsonToken.START_ARRAY, p.nextToken());
+                assertEquals("/a", p.streamReadContext().pathAsPointer().toString());
+                assertSame(CONSTRAINTS, p.streamReadConstraints());
+                p.nextToken(); p.nextToken(); p.nextToken();
+                assertThrows(StreamConstraintsException.class, p::nextToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
`TreeTraversingParser` always takes its `StreamReadConstraints` from the `ObjectReadContext`. For a tree-backed format backend — TOML parses its input into an `ObjectNode` and exposes it through a `TreeTraversingParser` — that means the `TokenStreamFactory`'s constraints are only applied when the caller is an `ObjectMapper` (whose `DeserializationContext.streamReadConstraints()` delegates to the factory). With `tomlFactory.createParser(ObjectReadContext.empty(), …)` a configured `maxTokenCount` is silently ignored, unlike every streaming parser, which takes constraints from its `IOContext` regardless of read context.

`ParserMinimalBase` already has a `(ObjectReadContext, StreamReadConstraints)` constructor for exactly this situation (added in 3.3 for `TokenBuffer` replay). This exposes it via two new `TreeTraversingParser` constructors:

- `(JsonNode, ObjectReadContext, StreamReadConstraints)`
- `(JsonNode, ObjectReadContext, TokenStreamContext parentContext, StreamReadConstraints)` — the new primary; the existing `(JsonNode, ObjectReadContext, TokenStreamContext)` delegates to it with `readContext.streamReadConstraints()`, so existing behaviour is unchanged.

One wrinkle: the 2-arg constructor delegated with a bare `null`, which becomes ambiguous between the two 3-arg overloads — now `(TokenStreamContext) null`. External callers passing a literal `null` as the third argument would hit the same ambiguity at compile time; nothing in databind or its tests does.

Follow-up in dataformats-text: `TomlFactory._createParser()` will pass `ctxt.streamReadConstraints()` once this is in a snapshot.

Tests: `TreeTraversingParserReadConstraintsTest` — constraints exposed via `streamReadConstraints()`, `maxTokenCount` enforced during traversal, unconstrained default unchanged, and the parent-context variant retaining both parent path and constraints. Full suite passes (6,194 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
